### PR TITLE
fix(auth): stage email challenges until delivery

### DIFF
--- a/packages/api/src/__tests__/auth-email-delivery-failclosed.test.ts
+++ b/packages/api/src/__tests__/auth-email-delivery-failclosed.test.ts
@@ -5,7 +5,7 @@
  * unless the provider ACCEPTED the message:
  *   - production with no delivery-capable provider  → 503, no challenge issued
  *   - tenant with partial/unsupported email config  → 503, no challenge issued
- *   - provider rejects the send                     → 502, challenge invalidated
+ *   - provider rejects the send                     → 502, challenge remains staged
  *   - provider returns an acceptance receipt        → 200, challenge live
  */
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
@@ -135,7 +135,7 @@ describe("fail-closed email delivery routes (production)", () => {
     expect(body.error).toBe("Email delivery is not configured");
   });
 
-  it("returns 502, invalidates the challenge, and keeps logs redacted when the provider rejects", async () => {
+  it("returns 502, keeps the challenge staged, and redacts logs when the provider rejects", async () => {
     // Prime the tenant cache with a delivery-capable EmailAuth (Resend key
     // present), then swap in a rejecting provider — the seam a Resend outage
     // or invalid key hits in production.
@@ -174,7 +174,7 @@ describe("fail-closed email delivery routes (production)", () => {
     expect(body.ok).toBe(false);
     expect(body.error).toBe("Email could not be sent. Please try again later.");
 
-    // The would-be credentials must not redeem (challenge invalidated).
+    // The would-be credentials must not redeem while delivery remains staged.
     const token = text.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
     const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
     expect(token).not.toBe("");

--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -14,6 +14,7 @@ import {
   ConsoleProvider,
   EmailDeliveryError,
   EmailDeliveryNotConfiguredError,
+  type EmailDeliveryReceipt,
   type EmailProvider,
   MockEmailInbox,
   MockEmailProvider,
@@ -155,6 +156,28 @@ describe("fail-closed magic-link delivery", () => {
     ).toBe(false);
 
     auth.destroy();
+  });
+
+  it("rejects oversized and accessor-backed acceptance receipts without activating", async () => {
+    for (const receipt of [
+      { provider: "x".repeat(65) },
+      { provider: "test", id: "x".repeat(513) },
+      Object.defineProperty({}, "provider", {
+        get() {
+          throw new Error("receipt getter must not run");
+        },
+      }),
+    ]) {
+      const backend = new CapturingBackend();
+      const auth = buildAuth({ send: async () => receipt as EmailDeliveryReceipt }, backend);
+      await expect(
+        auth.sendMagicLink("receipt@example.com", { tenantId: "tenant-a" }),
+      ).rejects.toThrow(EmailDeliveryError);
+      expect(
+        [...backend.values.values()].some((entry) => entry.value.includes('"status":"active"')),
+      ).toBe(false);
+      auth.destroy();
+    }
   });
 
   it("succeeds and keeps the challenge redeemable when the provider returns a receipt", async () => {

--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -24,9 +24,20 @@ import { TokenStore } from "../token-store";
 
 class CapturingBackend implements StoreBackend {
   values = new Map<string, { value: string; expiresAt: number }>();
+  failWrites = false;
+  failActiveWrites = false;
+  failActiveWritesAfterCommit = false;
+  failDeletes = false;
 
   async set(key: string, value: string, ttlMs: number): Promise<void> {
+    if (this.failWrites) throw new Error("durable store unavailable");
+    if (this.failActiveWrites && value.includes('"status":"active"')) {
+      throw new Error("durable activation unavailable");
+    }
     this.values.set(key, { value, expiresAt: Date.now() + ttlMs });
+    if (this.failActiveWritesAfterCommit && value.includes('"status":"active"')) {
+      throw new Error("durable activation response lost");
+    }
   }
 
   async setIfNotExists(key: string, value: string, ttlMs: number): Promise<boolean> {
@@ -52,6 +63,7 @@ class CapturingBackend implements StoreBackend {
   }
 
   async delete(key: string): Promise<void> {
+    if (this.failDeletes) throw new Error("durable delete unavailable");
     this.values.delete(key);
   }
 }
@@ -87,8 +99,9 @@ describe("fail-closed magic-link delivery", () => {
     restoreEnv();
   });
 
-  it("invalidates the challenge and throws EmailDeliveryError when the provider rejects", async () => {
+  it("leaves a delivered-but-rejected challenge durably staged even when delete is unavailable", async () => {
     const backend = new CapturingBackend();
+    backend.failDeletes = true;
     let text = "";
     const auth = buildAuth(
       {
@@ -104,10 +117,14 @@ describe("fail-closed magic-link delivery", () => {
       auth.sendMagicLink("victim@example.com", { tenantId: "tenant-a" }),
     ).rejects.toThrow(EmailDeliveryError);
 
-    // The pre-fix false green: these credentials stayed redeemable. Now every
-    // record of the challenge must be gone.
     const remaining = [...backend.values.keys()].filter((k) => k.startsWith("email-login:"));
-    expect(remaining).toEqual([]);
+    expect(remaining.length).toBeGreaterThan(0);
+    expect(
+      [...backend.values.values()].some((entry) => entry.value.includes('"delivery_pending"')),
+    ).toBe(true);
+    expect(
+      [...backend.values.values()].some((entry) => entry.value.includes('"status":"active"')),
+    ).toBe(false);
 
     const token = text.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
     const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
@@ -121,7 +138,7 @@ describe("fail-closed magic-link delivery", () => {
     auth.destroy();
   });
 
-  it("treats a missing acceptance receipt as delivery failure and invalidates", async () => {
+  it("treats a missing acceptance receipt as delivery failure without activating", async () => {
     const backend = new CapturingBackend();
     // Legacy void-returning provider: resolves but produces NO receipt.
     const voidProvider = { send: async () => undefined } as unknown as EmailProvider;
@@ -132,7 +149,10 @@ describe("fail-closed magic-link delivery", () => {
     );
 
     const remaining = [...backend.values.keys()].filter((k) => k.startsWith("email-login:"));
-    expect(remaining).toEqual([]);
+    expect(remaining.length).toBeGreaterThan(0);
+    expect(
+      [...backend.values.values()].some((entry) => entry.value.includes('"status":"active"')),
+    ).toBe(false);
 
     auth.destroy();
   });
@@ -206,8 +226,9 @@ describe("fail-closed magic-link delivery", () => {
     }
   });
 
-  it("deletes the stored OTP code when the provider rejects a sendOtp", async () => {
+  it("leaves a rejected OTP durably staged and non-redeemable", async () => {
     const backend = new CapturingBackend();
+    backend.failDeletes = true;
     let text = "";
     const auth = buildAuth(
       {
@@ -223,12 +244,285 @@ describe("fail-closed magic-link delivery", () => {
       EmailDeliveryError,
     );
 
-    expect(backend.values.size).toBe(0);
+    expect(backend.values.size).toBeGreaterThan(0);
+    expect(
+      [...backend.values.values()].some((entry) => entry.value.includes('"delivery_pending"')),
+    ).toBe(true);
     const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
     expect(code).not.toBe("");
     expect(await auth.verifyOtp("otp@example.com", code, "tenant-a")).toBe(false);
 
     auth.destroy();
+  });
+
+  it("does not redeem a magic link or companion code while delivery is in flight", async () => {
+    const backend = new CapturingBackend();
+    let text = "";
+    let accept!: () => void;
+    const accepted = new Promise<void>((resolve) => {
+      accept = resolve;
+    });
+    const auth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          text = body;
+          await accepted;
+          return { provider: "test", id: "accepted-after-race" };
+        },
+      },
+      backend,
+    );
+
+    const sending = auth.sendMagicLink("race@example.com", { tenantId: "tenant-a" });
+    while (!text) await Bun.sleep(1);
+    const token = text.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
+
+    expect(await auth.verifyMagicLink(token, "race@example.com", "tenant-a")).toMatchObject({
+      valid: false,
+    });
+    expect(await auth.verifyEmailLoginCode("race@example.com", code, "tenant-a")).toMatchObject({
+      valid: false,
+    });
+
+    accept();
+    await sending;
+    expect(await auth.verifyMagicLink(token, "race@example.com", "tenant-a")).toMatchObject({
+      valid: true,
+    });
+    auth.destroy();
+  });
+
+  it("does not redeem an OTP while delivery is in flight", async () => {
+    const backend = new CapturingBackend();
+    let text = "";
+    let accept!: () => void;
+    const accepted = new Promise<void>((resolve) => {
+      accept = resolve;
+    });
+    const auth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          text = body;
+          await accepted;
+          return { provider: "test", id: "accepted-otp-after-race" };
+        },
+      },
+      backend,
+    );
+
+    const sending = auth.sendOtp("otp-race@example.com", { tenantId: "tenant-a" });
+    while (!text) await Bun.sleep(1);
+    const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
+    expect(await auth.verifyOtp("otp-race@example.com", code, "tenant-a")).toBe(false);
+
+    accept();
+    await sending;
+    expect(await auth.verifyOtp("otp-race@example.com", code, "tenant-a")).toBe(true);
+    auth.destroy();
+  });
+
+  it("does not call the provider when durable staging fails", async () => {
+    const backend = new CapturingBackend();
+    backend.failWrites = true;
+    let sends = 0;
+    const auth = buildAuth(
+      {
+        send: async () => {
+          sends += 1;
+          return { provider: "test" };
+        },
+      },
+      backend,
+    );
+
+    await expect(
+      auth.sendMagicLink("store-down@example.com", { tenantId: "tenant-a" }),
+    ).rejects.toThrow("durable store unavailable");
+    await expect(auth.sendOtp("store-down@example.com", { tenantId: "tenant-a" })).rejects.toThrow(
+      "durable store unavailable",
+    );
+    expect(sends).toBe(0);
+    auth.destroy();
+  });
+
+  it("keeps accepted magic-link and OTP credentials non-redeemable when activation storage fails", async () => {
+    const magicBackend = new CapturingBackend();
+    let magicText = "";
+    const magicAuth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          magicText = body;
+          magicBackend.failActiveWrites = true;
+          return { provider: "test", id: "accepted-magic" };
+        },
+      },
+      magicBackend,
+    );
+    await expect(
+      magicAuth.sendMagicLink("activation@example.com", { tenantId: "tenant-a" }),
+    ).rejects.toThrow(EmailDeliveryError);
+    const token = magicText.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    const companionCode = magicText.match(/\b(\d{6})\b/)?.[1] ?? "";
+    expect(
+      await magicAuth.verifyMagicLink(token, "activation@example.com", "tenant-a"),
+    ).toMatchObject({ valid: false });
+    expect(
+      await magicAuth.verifyEmailLoginCode("activation@example.com", companionCode, "tenant-a"),
+    ).toMatchObject({ valid: false });
+
+    const otpBackend = new CapturingBackend();
+    let otpText = "";
+    const otpAuth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          otpText = body;
+          otpBackend.failActiveWrites = true;
+          return { provider: "test", id: "accepted-otp" };
+        },
+      },
+      otpBackend,
+    );
+    await expect(
+      otpAuth.sendOtp("activation-otp@example.com", { tenantId: "tenant-a" }),
+    ).rejects.toThrow(EmailDeliveryError);
+    const otpCode = otpText.match(/\b(\d{6})\b/)?.[1] ?? "";
+    expect(await otpAuth.verifyOtp("activation-otp@example.com", otpCode, "tenant-a")).toBe(false);
+
+    magicAuth.destroy();
+    otpAuth.destroy();
+  });
+
+  it("confirms a committed activation when the storage acknowledgement is lost", async () => {
+    const backend = new CapturingBackend();
+    let text = "";
+    const auth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          text = body;
+          backend.failActiveWritesAfterCommit = true;
+          return { provider: "test", id: "accepted-before-ack-loss" };
+        },
+      },
+      backend,
+    );
+
+    await auth.sendMagicLink("ack-loss@example.com", { tenantId: "tenant-a" });
+    const token = text.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    expect(await auth.verifyMagicLink(token, "ack-loss@example.com", "tenant-a")).toMatchObject({
+      valid: true,
+    });
+    auth.destroy();
+  });
+
+  it("keeps only the newest concurrently delivered challenge redeemable", async () => {
+    const backend = new CapturingBackend();
+    const messages: string[] = [];
+    const accepts: Array<() => void> = [];
+    const auth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          messages.push(body);
+          await new Promise<void>((resolve) => accepts.push(resolve));
+          return { provider: "test", id: `accepted-${messages.length}` };
+        },
+      },
+      backend,
+    );
+
+    const firstSend = auth.sendMagicLink("supersede@example.com", { tenantId: "tenant-a" });
+    while (messages.length < 1) await Bun.sleep(1);
+    const secondSend = auth.sendMagicLink("supersede@example.com", { tenantId: "tenant-a" });
+    while (messages.length < 2) await Bun.sleep(1);
+    accepts[1]?.();
+    await secondSend;
+    accepts[0]?.();
+    await expect(firstSend).rejects.toThrow(EmailDeliveryError);
+
+    const firstToken = messages[0]?.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    const secondToken = messages[1]?.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    expect(
+      await auth.verifyMagicLink(firstToken, "supersede@example.com", "tenant-a"),
+    ).toMatchObject({ valid: false });
+    expect(
+      await auth.verifyMagicLink(secondToken, "supersede@example.com", "tenant-a"),
+    ).toMatchObject({ valid: true });
+    auth.destroy();
+  });
+
+  it("supersedes an accepted OTP when the same target retries", async () => {
+    const backend = new CapturingBackend();
+    const messages: string[] = [];
+    const auth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          messages.push(body);
+          return { provider: "test", id: `accepted-${messages.length}` };
+        },
+      },
+      backend,
+    );
+
+    await auth.sendOtp("otp-retry@example.com", { tenantId: "tenant-a" });
+    await auth.sendOtp("otp-retry@example.com", { tenantId: "tenant-a" });
+    const firstCode = messages[0]?.match(/\b(\d{6})\b/)?.[1] ?? "";
+    const secondCode = messages[1]?.match(/\b(\d{6})\b/)?.[1] ?? "";
+    expect(await auth.verifyOtp("otp-retry@example.com", firstCode, "tenant-a")).toBe(false);
+    expect(await auth.verifyOtp("otp-retry@example.com", secondCode, "tenant-a")).toBe(true);
+    auth.destroy();
+  });
+
+  it("rejects malformed active magic-link and OTP records", async () => {
+    const magicBackend = new CapturingBackend();
+    let magicText = "";
+    const magicAuth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          magicText = body;
+          return { provider: "test" };
+        },
+      },
+      magicBackend,
+    );
+    await magicAuth.sendMagicLink("malformed@example.com", { tenantId: "tenant-a" });
+    const magicRecord = [...magicBackend.values.entries()].find(([, entry]) =>
+      entry.value.includes('"purpose":"email-login"'),
+    );
+    expect(magicRecord).toBeDefined();
+    if (magicRecord) magicRecord[1].value = "{";
+    const token = magicText.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    expect(
+      await magicAuth.verifyMagicLink(token, "malformed@example.com", "tenant-a"),
+    ).toMatchObject({ valid: false });
+
+    const otpBackend = new CapturingBackend();
+    let otpText = "";
+    const otpAuth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          otpText = body;
+          return { provider: "test" };
+        },
+      },
+      otpBackend,
+    );
+    await otpAuth.sendOtp("malformed-otp@example.com", { tenantId: "tenant-a" });
+    const otpRecord = [...otpBackend.values.entries()].find(
+      ([key, entry]) => key.length === 64 && entry.value.includes('"status":"active"'),
+    );
+    expect(otpRecord).toBeDefined();
+    if (otpRecord) {
+      otpRecord[1].value = JSON.stringify({
+        status: "failed",
+        email: "malformed-otp@example.com",
+        tenantId: "tenant-a",
+      });
+    }
+    const otpCode = otpText.match(/\b(\d{6})\b/)?.[1] ?? "";
+    expect(await otpAuth.verifyOtp("malformed-otp@example.com", otpCode, "tenant-a")).toBe(false);
+
+    magicAuth.destroy();
+    otpAuth.destroy();
   });
 });
 

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -297,6 +297,39 @@ type OtpChallengeRecord = {
   payload: MagicLinkPayload;
 };
 
+const MAX_EMAIL_RECEIPT_PROVIDER_LENGTH = 64;
+const MAX_EMAIL_RECEIPT_ID_LENGTH = 512;
+
+function boundedReceiptText(value: unknown, maxLength: number): value is string {
+  if (typeof value !== "string" || value.length === 0 || value.length > maxLength) return false;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code < 0x20 || code === 0x7f) return false;
+  }
+  return value.trim().length > 0;
+}
+
+function isValidDeliveryReceipt(value: unknown): value is EmailDeliveryReceipt {
+  if (!value || typeof value !== "object") return false;
+  try {
+    const provider = Object.getOwnPropertyDescriptor(value, "provider");
+    if (
+      !provider ||
+      !("value" in provider) ||
+      !boundedReceiptText(provider.value, MAX_EMAIL_RECEIPT_PROVIDER_LENGTH)
+    ) {
+      return false;
+    }
+    const id = Object.getOwnPropertyDescriptor(value, "id");
+    return (
+      id === undefined ||
+      ("value" in id && boundedReceiptText(id.value, MAX_EMAIL_RECEIPT_ID_LENGTH))
+    );
+  } catch {
+    return false;
+  }
+}
+
 function encodeOtpChallenge(
   status: OtpChallengeRecord["status"],
   payload: MagicLinkPayload,
@@ -425,13 +458,7 @@ export class EmailAuth {
       console.error("[steward:auth] email provider rejected send", redactedThrownDiagnostics(err));
       throw new EmailDeliveryError();
     }
-    if (
-      !receipt ||
-      typeof receipt.provider !== "string" ||
-      receipt.provider.trim().length === 0 ||
-      (receipt.id !== undefined &&
-        (typeof receipt.id !== "string" || receipt.id.trim().length === 0))
-    ) {
+    if (!isValidDeliveryReceipt(receipt)) {
       console.error("[steward:auth] email provider returned no acceptance receipt");
       throw new EmailDeliveryError("Email provider returned no acceptance receipt");
     }

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -151,8 +151,8 @@ type MagicLinkPayload = {
   tenantId?: string;
 };
 
-type EmailLoginPendingChallenge = {
-  status: "pending";
+type EmailLoginChallengeRecord = {
+  status: "delivery_pending" | "active";
   challengeId: string;
   emailHash: string;
   tenantId?: string;
@@ -163,7 +163,7 @@ type EmailLoginPendingChallenge = {
 };
 
 type EmailLoginStatusRecord = {
-  status: "pending" | "consumed" | "locked";
+  status: "delivery_pending" | "pending" | "consumed" | "locked";
   challengeId: string;
   pollSecretHash: string;
   expiresAt: string;
@@ -183,6 +183,10 @@ function otpStoreKey(email: string, tenantId: string | undefined, code: string):
   return hashSha256Hex(`email-otp:${tenantId ?? ""}:${email}:${code}`);
 }
 
+function otpTargetKey(email: string, tenantId: string | undefined): string {
+  return `email-otp:active:${hashSha256Hex(`${tenantId ?? ""}:${email}`)}`;
+}
+
 function emailLoginBinding(email: string, tenantId: string | undefined): string {
   return `${tenantId ?? ""}:${email}:${EMAIL_LOGIN_PURPOSE}`;
 }
@@ -191,7 +195,8 @@ function emailLoginTargetKey(email: string, tenantId: string | undefined): strin
   return `email-login:active:${hashSha256Hex(emailLoginBinding(email, tenantId))}`;
 }
 
-function emailLoginPendingKey(challengeId: string): string {
+function emailLoginChallengeKey(challengeId: string): string {
+  // Keep the established durable key prefix for rolling-deploy compatibility.
   return `email-login:pending:${challengeId}`;
 }
 
@@ -211,12 +216,16 @@ function emailLoginFailureKey(challengeId: string, slot: number): string {
   return `email-login:failure:${challengeId}:${slot}`;
 }
 
-function parsePendingChallenge(value: string | null): EmailLoginPendingChallenge | null {
+function parseEmailLoginChallenge(value: string | null): EmailLoginChallengeRecord | null {
   if (!value) return null;
   try {
-    const parsed = JSON.parse(value) as Partial<EmailLoginPendingChallenge>;
+    const parsed = JSON.parse(value) as Omit<Partial<EmailLoginChallengeRecord>, "status"> & {
+      status?: string;
+    };
     if (
-      parsed.status === "pending" &&
+      (parsed.status === "delivery_pending" ||
+        parsed.status === "active" ||
+        parsed.status === "pending") &&
       typeof parsed.challengeId === "string" &&
       typeof parsed.emailHash === "string" &&
       parsed.purpose === EMAIL_LOGIN_PURPOSE &&
@@ -224,7 +233,10 @@ function parsePendingChallenge(value: string | null): EmailLoginPendingChallenge
       typeof parsed.pollSecretHash === "string" &&
       typeof parsed.expiresAt === "string"
     ) {
-      return parsed as EmailLoginPendingChallenge;
+      return {
+        ...(parsed as EmailLoginChallengeRecord),
+        status: parsed.status === "pending" ? "active" : parsed.status,
+      };
     }
   } catch {
     return null;
@@ -240,7 +252,10 @@ function parseStatusRecord(value: string | null): EmailLoginStatusRecord | null 
       typeof parsed.challengeId === "string" &&
       typeof parsed.pollSecretHash === "string" &&
       typeof parsed.expiresAt === "string" &&
-      (parsed.status === "pending" || parsed.status === "consumed" || parsed.status === "locked")
+      (parsed.status === "delivery_pending" ||
+        parsed.status === "pending" ||
+        parsed.status === "consumed" ||
+        parsed.status === "locked")
     ) {
       return parsed as EmailLoginStatusRecord;
     }
@@ -248,10 +263,6 @@ function parseStatusRecord(value: string | null): EmailLoginStatusRecord | null 
     return null;
   }
   return null;
-}
-
-function encodeMagicLinkPayload(payload: MagicLinkPayload): string {
-  return JSON.stringify(payload);
 }
 
 function decodeMagicLinkPayload(value: string): MagicLinkPayload {
@@ -262,6 +273,53 @@ function decodeMagicLinkPayload(value: string): MagicLinkPayload {
     // Backward-compatible legacy tokens stored the email as the raw value.
   }
   return { email: value };
+}
+
+function decodeLegacyOtpPayload(value: string): MagicLinkPayload | null {
+  try {
+    const parsed = JSON.parse(value) as Record<string, unknown>;
+    if (
+      typeof parsed.email === "string" &&
+      (parsed.tenantId === undefined || typeof parsed.tenantId === "string") &&
+      Object.keys(parsed).every((key) => key === "email" || key === "tenantId")
+    ) {
+      return parsed as MagicLinkPayload;
+    }
+  } catch {
+    // The earliest OTP records stored the email directly.
+    return value.startsWith("{") ? null : { email: value };
+  }
+  return null;
+}
+
+type OtpChallengeRecord = {
+  status: "delivery_pending" | "active";
+  payload: MagicLinkPayload;
+};
+
+function encodeOtpChallenge(
+  status: OtpChallengeRecord["status"],
+  payload: MagicLinkPayload,
+): string {
+  return JSON.stringify({ status, payload } satisfies OtpChallengeRecord);
+}
+
+function decodeOtpChallenge(value: string | null): OtpChallengeRecord | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as Partial<OtpChallengeRecord>;
+    if (
+      (parsed.status === "delivery_pending" || parsed.status === "active") &&
+      parsed.payload &&
+      typeof parsed.payload.email === "string" &&
+      (parsed.payload.tenantId === undefined || typeof parsed.payload.tenantId === "string")
+    ) {
+      return parsed as OtpChallengeRecord;
+    }
+  } catch {
+    return null;
+  }
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -351,18 +409,13 @@ export class EmailAuth {
     }
   }
 
-  /**
-   * Dispatch through the provider and require an acceptance receipt.
-   * Fail closed: on provider throw/rejection OR a missing receipt, run
-   * `invalidate` (best-effort) so any just-minted challenge state is no
-   * longer redeemable, then surface a typed EmailDeliveryError. Only the
-   * error NAME is logged — never the recipient, subject, token, code, or
-   * raw provider error text.
-   */
-  private async sendOrInvalidate(
-    message: { to: string; subject: string; text: string; html?: string },
-    invalidate: () => Promise<void>,
-  ): Promise<EmailDeliveryReceipt> {
+  /** Dispatch through the provider and require a redacted acceptance receipt. */
+  private async sendAccepted(message: {
+    to: string;
+    subject: string;
+    text: string;
+    html?: string;
+  }): Promise<EmailDeliveryReceipt> {
     let receipt: EmailDeliveryReceipt | undefined;
     try {
       receipt = await this.provider.send(message.to, message.subject, message.text, message.html, {
@@ -370,34 +423,19 @@ export class EmailAuth {
       });
     } catch (err) {
       console.error("[steward:auth] email provider rejected send", redactedThrownDiagnostics(err));
-      await invalidate().catch(() => {});
       throw new EmailDeliveryError();
     }
-    if (!receipt || typeof receipt.provider !== "string" || receipt.provider.length === 0) {
+    if (
+      !receipt ||
+      typeof receipt.provider !== "string" ||
+      receipt.provider.trim().length === 0 ||
+      (receipt.id !== undefined &&
+        (typeof receipt.id !== "string" || receipt.id.trim().length === 0))
+    ) {
       console.error("[steward:auth] email provider returned no acceptance receipt");
-      await invalidate().catch(() => {});
       throw new EmailDeliveryError("Email provider returned no acceptance receipt");
     }
     return receipt;
-  }
-
-  /**
-   * Remove every record of a pending email-login challenge so neither the
-   * magic link nor the companion code can ever redeem it. Aliases go first
-   * (they are the redemption entry points); all deletes are idempotent.
-   */
-  private async invalidateEmailLoginChallenge(params: {
-    challengeId: string;
-    tokenHash: string;
-    codeVerifier: string;
-    email: string;
-    tenantId?: string;
-  }): Promise<void> {
-    await this.tokenStore.delete(emailLoginLinkAliasKey(params.tokenHash));
-    await this.tokenStore.delete(emailLoginCodeAliasKey(params.codeVerifier));
-    await this.tokenStore.delete(emailLoginPendingKey(params.challengeId));
-    await this.tokenStore.delete(emailLoginStatusKey(params.challengeId));
-    await this.tokenStore.delete(emailLoginTargetKey(params.email, params.tenantId));
   }
 
   private async markEmailLoginConsumed(challengeId: string): Promise<void> {
@@ -433,7 +471,7 @@ export class EmailAuth {
     const targetKey = emailLoginTargetKey(email, context.tenantId);
     const priorChallengeId = await this.tokenStore.verify(targetKey);
     if (priorChallengeId) {
-      await this.tokenStore.consume(emailLoginPendingKey(priorChallengeId));
+      await this.tokenStore.consume(emailLoginChallengeKey(priorChallengeId));
       const priorStatus = parseStatusRecord(
         await this.tokenStore.verify(emailLoginStatusKey(priorChallengeId)),
       );
@@ -450,8 +488,8 @@ export class EmailAuth {
     }
 
     const codeVerifier = this.codeVerifier(email, context.tenantId, code);
-    const pending: EmailLoginPendingChallenge = {
-      status: "pending",
+    const challenge: EmailLoginChallengeRecord = {
+      status: "delivery_pending",
       challengeId,
       emailHash: this.emailHash(email, context.tenantId),
       tenantId: context.tenantId,
@@ -461,13 +499,17 @@ export class EmailAuth {
       expiresAt: expiresAt.toISOString(),
     };
     const status: EmailLoginStatusRecord = {
-      status: "pending",
+      status: "delivery_pending",
       challengeId,
-      pollSecretHash: pending.pollSecretHash,
-      expiresAt: pending.expiresAt,
+      pollSecretHash: challenge.pollSecretHash,
+      expiresAt: challenge.expiresAt,
     };
 
-    await this.tokenStore.store(emailLoginPendingKey(challengeId), JSON.stringify(pending), ttlMs);
+    await this.tokenStore.store(
+      emailLoginChallengeKey(challengeId),
+      JSON.stringify(challenge),
+      ttlMs,
+    );
     await this.tokenStore.store(emailLoginStatusKey(challengeId), JSON.stringify(status), ttlMs);
     await this.tokenStore.store(emailLoginLinkAliasKey(tokenHash), challengeId, ttlMs);
     await this.tokenStore.store(emailLoginCodeAliasKey(codeVerifier), challengeId, ttlMs);
@@ -492,18 +534,53 @@ export class EmailAuth {
     const body = rendered.text;
     const html = rendered.html;
 
-    // Fail closed: success only after the provider ACCEPTED the message. On
-    // rejection or a missing receipt the just-minted challenge is invalidated
-    // so a false ok:true can never leave a live, undeliverable challenge.
-    await this.sendOrInvalidate({ to: email, subject, text: body, html }, () =>
-      this.invalidateEmailLoginChallenge({
-        challengeId,
-        tokenHash,
-        codeVerifier,
-        email,
-        tenantId: context.tenantId,
-      }),
-    );
+    // Provider ambiguity never requires cleanup for safety: every persisted
+    // record remains non-redeemable until the acceptance receipt is validated.
+    await this.sendAccepted({ to: email, subject, text: body, html });
+
+    const remainingTtlMs = expiresAt.getTime() - Date.now();
+    if (remainingTtlMs <= 0) {
+      console.error("[steward:auth] email challenge expired before activation");
+      throw new EmailDeliveryError("Email challenge activation failed");
+    }
+    try {
+      if ((await this.tokenStore.verify(targetKey)) !== challengeId) {
+        throw new Error("challenge superseded before activation");
+      }
+      await this.tokenStore.store(
+        emailLoginStatusKey(challengeId),
+        JSON.stringify({ ...status, status: "pending" } satisfies EmailLoginStatusRecord),
+        remainingTtlMs,
+      );
+      // This is the activation commit point. Verification rejects every other
+      // state, so an earlier write failure cannot expose a redeemable secret.
+      await this.tokenStore.store(
+        emailLoginChallengeKey(challengeId),
+        JSON.stringify({ ...challenge, status: "active" } satisfies EmailLoginChallengeRecord),
+        remainingTtlMs,
+      );
+      if ((await this.tokenStore.verify(targetKey)) !== challengeId) {
+        throw new Error("challenge superseded during activation");
+      }
+    } catch (err) {
+      let activationConfirmed = false;
+      try {
+        activationConfirmed =
+          (await this.tokenStore.verify(targetKey)) === challengeId &&
+          parseEmailLoginChallenge(
+            await this.tokenStore.verify(emailLoginChallengeKey(challengeId)),
+          )?.status === "active";
+      } catch {
+        // The activation outcome is still ambiguous, so do not report success.
+      }
+      if (!activationConfirmed) {
+        console.error(
+          "[steward:auth] email challenge activation failed",
+          redactedThrownDiagnostics(err),
+        );
+        throw new EmailDeliveryError("Email challenge activation failed");
+      }
+    }
 
     return { tokenHash, expiresAt, challengeId, pollSecret };
   }
@@ -518,14 +595,21 @@ export class EmailAuth {
     context: { tenantId?: string; tenantName?: string } = {},
   ): Promise<{ expiresAt: Date }> {
     this.assertDeliveryConfigured();
+    email = email.toLowerCase().trim();
     const code = generateOtpCode();
     const expiresAt = new Date(Date.now() + this.tokenTtlMs);
 
+    const storeKey = otpStoreKey(email, context.tenantId, code);
+    const targetKey = otpTargetKey(email, context.tenantId);
+    const priorStoreKey = await this.tokenStore.verify(targetKey);
+    if (priorStoreKey) await this.tokenStore.consume(priorStoreKey);
+    const payload = { email, tenantId: context.tenantId };
     await this.tokenStore.store(
-      otpStoreKey(email, context.tenantId, code),
-      encodeMagicLinkPayload({ email, tenantId: context.tenantId }),
+      storeKey,
+      encodeOtpChallenge("delivery_pending", payload),
       this.tokenTtlMs,
     );
+    await this.tokenStore.store(targetKey, storeKey, this.tokenTtlMs);
 
     const minutes = Math.floor(this.tokenTtlMs / (60 * 1000));
     const brand = context.tenantName || "Steward";
@@ -536,12 +620,39 @@ export class EmailAuth {
       expiresInMinutes: minutes,
     });
 
-    // Fail closed: delete the just-stored code if the provider did not accept
-    // the message, so an unsendable code is never left redeemable.
-    await this.sendOrInvalidate(
-      { to: email, subject: rendered.subject, text: rendered.text, html: rendered.html },
-      () => this.tokenStore.delete(otpStoreKey(email, context.tenantId, code)),
-    );
+    await this.sendAccepted({
+      to: email,
+      subject: rendered.subject,
+      text: rendered.text,
+      html: rendered.html,
+    });
+    const remainingTtlMs = expiresAt.getTime() - Date.now();
+    if (remainingTtlMs <= 0) {
+      console.error("[steward:auth] email OTP expired before activation");
+      throw new EmailDeliveryError("Email challenge activation failed");
+    }
+    try {
+      if ((await this.tokenStore.verify(targetKey)) !== storeKey) {
+        throw new Error("OTP superseded before activation");
+      }
+      await this.tokenStore.store(storeKey, encodeOtpChallenge("active", payload), remainingTtlMs);
+      if ((await this.tokenStore.verify(targetKey)) !== storeKey) {
+        throw new Error("OTP superseded during activation");
+      }
+    } catch (err) {
+      let activationConfirmed = false;
+      try {
+        activationConfirmed =
+          (await this.tokenStore.verify(targetKey)) === storeKey &&
+          decodeOtpChallenge(await this.tokenStore.verify(storeKey))?.status === "active";
+      } catch {
+        // The activation outcome is still ambiguous, so do not report success.
+      }
+      if (!activationConfirmed) {
+        console.error("[steward:auth] email OTP activation failed", redactedThrownDiagnostics(err));
+        throw new EmailDeliveryError("Email challenge activation failed");
+      }
+    }
 
     return { expiresAt };
   }
@@ -552,10 +663,31 @@ export class EmailAuth {
    */
   async verifyOtp(email: string, code: string, tenantId?: string): Promise<boolean> {
     if (!/^\d{6}$/.test(code)) return false;
-    const stored = await this.tokenStore.consume(otpStoreKey(email, tenantId, code));
-    if (!stored) return false;
-    const payload = decodeMagicLinkPayload(stored);
-    return payload.email === email && (payload.tenantId ?? undefined) === (tenantId ?? undefined);
+    email = email.toLowerCase().trim();
+    const storeKey = otpStoreKey(email, tenantId, code);
+    const stored = await this.tokenStore.verify(storeKey);
+    const current = decodeOtpChallenge(stored);
+    if (!current) {
+      // Rolling-deploy compatibility for codes issued before staged delivery.
+      if (!stored) return false;
+      const consumed = await this.tokenStore.consume(storeKey);
+      if (!consumed) return false;
+      const legacy = decodeLegacyOtpPayload(consumed);
+      if (!legacy) return false;
+      return legacy.email === email && (legacy.tenantId ?? undefined) === (tenantId ?? undefined);
+    }
+    if (
+      current.status !== "active" ||
+      (await this.tokenStore.verify(otpTargetKey(email, tenantId))) !== storeKey
+    ) {
+      return false;
+    }
+    const consumed = decodeOtpChallenge(await this.tokenStore.consume(storeKey));
+    if (!consumed || consumed.status !== "active") return false;
+    return (
+      consumed.payload.email === email &&
+      (consumed.payload.tenantId ?? undefined) === (tenantId ?? undefined)
+    );
   }
 
   async sendTenantInvitation(email: string, context: TenantInvitationEmailContext): Promise<void> {
@@ -610,7 +742,7 @@ export class EmailAuth {
     // hashed in tenant_invitations before this call); surface a typed error so
     // callers report emailSent=false instead of a false green. Nothing here is
     // invalidated because EmailAuth does not own that record.
-    await this.sendOrInvalidate({ to: email, subject, text, html }, async () => {});
+    await this.sendAccepted({ to: email, subject, text, html });
   }
 
   /**
@@ -623,7 +755,7 @@ export class EmailAuth {
     tenantId?: string,
   ): Promise<EmailLoginVerifyResult> {
     const tokenHash = hashToken(token);
-    const challengeId = await this.tokenStore.consume(emailLoginLinkAliasKey(tokenHash));
+    const challengeId = await this.tokenStore.verify(emailLoginLinkAliasKey(tokenHash));
 
     if (!challengeId) {
       const legacy = await this.tokenStore.consume(tokenHash);
@@ -631,9 +763,10 @@ export class EmailAuth {
       const payload = decodeMagicLinkPayload(legacy);
       return { email: payload.email, tenantId: payload.tenantId, valid: true, challengeId: "" };
     }
-    const stored = await this.tokenStore.consume(emailLoginPendingKey(challengeId));
-    const payload = parsePendingChallenge(stored);
-    if (!payload) {
+    const payload = parseEmailLoginChallenge(
+      await this.tokenStore.verify(emailLoginChallengeKey(challengeId)),
+    );
+    if (!payload || payload.status !== "active") {
       return { email: "", valid: false };
     }
 
@@ -646,7 +779,17 @@ export class EmailAuth {
     ) {
       return { email: "", valid: false };
     }
-    await this.tokenStore.delete(emailLoginTargetKey(normalizedEmail, resolvedTenantId));
+    if (
+      (await this.tokenStore.verify(emailLoginTargetKey(normalizedEmail, resolvedTenantId))) !==
+      challengeId
+    ) {
+      return { email: "", valid: false };
+    }
+    const consumed = parseEmailLoginChallenge(
+      await this.tokenStore.consume(emailLoginChallengeKey(challengeId)),
+    );
+    if (!consumed || consumed.status !== "active") return { email: "", valid: false };
+    await this.tokenStore.delete(emailLoginLinkAliasKey(tokenHash));
     await this.tokenStore.delete(emailLoginCodeAliasKey(payload.codeVerifier));
     await this.markEmailLoginConsumed(challengeId);
     return { email: normalizedEmail, tenantId: payload.tenantId, valid: true, challengeId };
@@ -663,21 +806,30 @@ export class EmailAuth {
       return { email: "", valid: false, reason: reason === "locked" ? "locked" : "invalid" };
     }
     const verifier = this.codeVerifier(email, tenantId, code);
-    const challengeId = await this.tokenStore.consume(emailLoginCodeAliasKey(verifier));
+    const challengeId = await this.tokenStore.verify(emailLoginCodeAliasKey(verifier));
     if (!challengeId) {
       const reason = await this.recordEmailLoginCodeFailure(email, tenantId);
       return { email: "", valid: false, reason: reason === "locked" ? "locked" : "invalid" };
     }
-    const stored = await this.tokenStore.consume(emailLoginPendingKey(challengeId));
-    const payload = parsePendingChallenge(stored);
+    const payload = parseEmailLoginChallenge(
+      await this.tokenStore.verify(emailLoginChallengeKey(challengeId)),
+    );
     if (
       !payload ||
+      payload.status !== "active" ||
       (payload.tenantId ?? undefined) !== (tenantId ?? undefined) ||
       payload.emailHash !== this.emailHash(email, tenantId)
     ) {
       return { email: "", valid: false };
     }
-    await this.tokenStore.delete(emailLoginTargetKey(email, tenantId));
+    if ((await this.tokenStore.verify(emailLoginTargetKey(email, tenantId))) !== challengeId) {
+      return { email: "", valid: false };
+    }
+    const consumed = parseEmailLoginChallenge(
+      await this.tokenStore.consume(emailLoginChallengeKey(challengeId)),
+    );
+    if (!consumed || consumed.status !== "active") return { email: "", valid: false };
+    await this.tokenStore.delete(emailLoginCodeAliasKey(verifier));
     await this.markEmailLoginConsumed(challengeId);
     return { email, tenantId: payload.tenantId, valid: true, challengeId };
   }
@@ -699,16 +851,16 @@ export class EmailAuth {
   ): Promise<"failed" | "locked"> {
     const challengeId = await this.tokenStore.verify(emailLoginTargetKey(email, tenantId));
     if (!challengeId) return "failed";
-    const pending = parsePendingChallenge(
-      await this.tokenStore.verify(emailLoginPendingKey(challengeId)),
+    const challenge = parseEmailLoginChallenge(
+      await this.tokenStore.verify(emailLoginChallengeKey(challengeId)),
     );
-    if (!pending) {
+    if (!challenge || challenge.status !== "active") {
       const status = parseStatusRecord(
         await this.tokenStore.verify(emailLoginStatusKey(challengeId)),
       );
       return status?.status === "locked" ? "locked" : "failed";
     }
-    const ttlMs = Math.max(1, new Date(pending.expiresAt).getTime() - Date.now());
+    const ttlMs = Math.max(1, new Date(challenge.expiresAt).getTime() - Date.now());
     for (let i = 1; i <= MAX_EMAIL_LOGIN_CODE_ATTEMPTS; i++) {
       const reserved = await this.tokenStore.setIfNotExists(
         emailLoginFailureKey(challengeId, i),
@@ -717,15 +869,15 @@ export class EmailAuth {
       );
       if (reserved) {
         if (i === MAX_EMAIL_LOGIN_CODE_ATTEMPTS) {
-          await this.tokenStore.consume(emailLoginPendingKey(challengeId));
-          await this.tokenStore.delete(emailLoginCodeAliasKey(pending.codeVerifier));
+          await this.tokenStore.consume(emailLoginChallengeKey(challengeId));
+          await this.tokenStore.delete(emailLoginCodeAliasKey(challenge.codeVerifier));
           await this.tokenStore.store(
             emailLoginStatusKey(challengeId),
             JSON.stringify({
               status: "locked",
               challengeId,
-              pollSecretHash: pending.pollSecretHash,
-              expiresAt: pending.expiresAt,
+              pollSecretHash: challenge.pollSecretHash,
+              expiresAt: challenge.expiresAt,
             } satisfies EmailLoginStatusRecord),
             ttlMs,
           );
@@ -750,7 +902,9 @@ export class EmailAuth {
     }
     return current.status === "pending"
       ? { status: "pending", expiresAt: current.expiresAt }
-      : { status: current.status };
+      : current.status === "delivery_pending"
+        ? { status: "invalid" }
+        : { status: current.status };
   }
 
   /**


### PR DESCRIPTION
Closes #512

## Summary

- persist magic-link, companion-code, and standalone OTP credentials as durable `delivery_pending` records before provider I/O
- validate a bounded provider acceptance receipt, then commit activation; provider rejection or ambiguity leaves every delivered credential non-redeemable without cleanup
- resolve lost activation acknowledgements by reading back the durable active record rather than returning an ambiguous failure
- preserve rolling-deploy compatibility for previously issued magic-link and OTP records
- supersede prior magic-link and OTP challenges before publishing a retry, while keeping link/code redemption atomic through their shared record
- retain bounded redacted diagnostics with no recipient, token, code, provider body, or raw error text

## Behavioral coverage

- provider throw after capturing the deliverable secret, with delete storage unavailable
- missing/malformed acceptance receipt
- durable staging outage before provider invocation
- activation failure before commit for magic-link and OTP
- lost storage acknowledgement after a committed activation
- simultaneous redemption while provider delivery is in flight
- atomic link-vs-code redemption
- concurrent magic-link retry/supersession and OTP retry/supersession
- malformed/failed stored records, TTL expiry, tenant/email binding, and one-time consumption
- API route behavior: 502 + non-redeemable staged credentials on rejection, 200 only after acceptance

## Exact-head validation

Validated commit `7522b578b8a51e7cc52ac3d782dcee4d9120c935` on develop `37d60fa1064b53b92889d1e6a1f36b0431bf975e`:

- `bunx turbo run build --filter=@stwd/api...` — 24/24 package builds pass
- `cd packages/auth && bun test --timeout 120000 src/__tests__` — 295 pass, 1 skipped integration test, 0 fail, 893 expectations
- API email suite (delivery, OTP signup, login-code contract, tenant config, platform config) — 36 pass, 0 fail, 184 expectations
- `bunx biome check` on all three changed files — pass
- `git diff --check origin/develop...HEAD` — pass
- worktree clean; final diff limited to auth email implementation and targeted auth/API behavioral tests
