### PR TITLE
fix(seed): use public auth package boundary

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -493,6 +493,7 @@
       "name": "@stwd/seed",
       "version": "0.4.0",
       "dependencies": {
+        "@stwd/auth": "workspace:*",
         "@stwd/db": "workspace:*",
         "@stwd/shared": "workspace:*",
         "@stwd/vault": "workspace:*",

--- a/packages/seed/package.json
+++ b/packages/seed/package.json
@@ -14,6 +14,7 @@
     "test": "bun test --timeout 30000"
   },
   "dependencies": {
+    "@stwd/auth": "workspace:*",
     "@stwd/db": "workspace:*",
     "@stwd/shared": "workspace:*",
     "@stwd/vault": "workspace:*",

--- a/packages/seed/src/__tests__/demo-api-key.test.ts
+++ b/packages/seed/src/__tests__/demo-api-key.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { lstatSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { validateApiKey } from "../../../auth/src/api-keys";
+import { validateApiKey } from "@stwd/auth";
 import { generateDemoApiKey, writeDemoCredentials } from "../demo-api-key";
 
 describe("demo API key", () => {

--- a/packages/seed/src/demo-api-key.ts
+++ b/packages/seed/src/demo-api-key.ts
@@ -10,8 +10,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { generateApiKey } from "../../auth/src/api-keys";
-import type { ApiKeyPair } from "../../auth/src/types";
+import { type ApiKeyPair, generateApiKey } from "@stwd/auth";
 
 /**
  * Mint a fresh credential for each demo seed run.


### PR DESCRIPTION
## Summary
- replace the seed package private `packages/auth/src/*` imports with the public `@stwd/auth` entrypoint
- declare `@stwd/auth` as a workspace dependency and regenerate `bun.lock` with Bun
- keep the behavioral API-key verification and owner-only credential persistence coverage running through the public package boundary

Fixes #527
Follow-up to #514.

## Exact validation
Base: `37d60fa1064b53b92889d1e6a1f36b0431bf975e`
Head: `64081f155f3d068f9f96bd32a46df17554e53110`

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run typecheck` (36/36 workspace build tasks)
- CI-equivalent `bun test --isolate packages/seed` (8 pass)
- public runtime import/key verification from `packages/seed` (pass)
- `bun test scripts/__tests__/check-ci-test-inventory.test.ts` (11 pass)
- `bun scripts/check-ci-test-inventory.ts` (47 targets covered)
- Biome on all changed source/manifests
- `git diff --check origin/develop...HEAD`

`@stwd/seed` has no standalone build script; the root typecheck/workspace build and CI-equivalent seed suite validate its dependency graph.