### PR TITLE
fix(cli): preserve redacted migration TLS diagnostics

### DIFF
--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -342,10 +342,12 @@ describe("steward init", () => {
       );
       const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
       expect(exitCode).toBe(1);
-      // SEC-087: the gate now demands a server-authenticating TLS mode —
-      // sslmode=require alone no longer satisfies it.
-      expect(stderr).toContain("sslmode=verify-full");
-      expect(stderr).toContain("sslmode=verify-ca");
+      // SEC-087: the child reached the TLS gate rather than attempting a
+      // network connection. The migrator exposes only this fixed diagnostic
+      // code; raw exception text and the connection URL remain redacted.
+      expect(stderr).toContain('errorCode: "DB_TLS_REQUIRED"');
+      expect(stderr).not.toContain("192.0.2.1");
+      expect(stderr).not.toContain("sslmode=verify-full");
       expect(stderr).not.toContain("STEWARD_ALLOW_INSECURE_DB=true —");
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -78,6 +78,12 @@ type DatabaseSecurityEnv = {
   STEWARD_ALLOW_UNVERIFIED_DB_TLS?: string;
 };
 
+function databaseTlsRequiredError(message: string): Error & { code: "DB_TLS_REQUIRED" } {
+  const error = new Error(message) as Error & { code: "DB_TLS_REQUIRED" };
+  error.code = "DB_TLS_REQUIRED";
+  return error;
+}
+
 export function assertDatabaseUrlTls(
   connectionString: string,
   securityEnv: DatabaseSecurityEnv = process.env,
@@ -139,7 +145,7 @@ export function assertDatabaseUrlTls(
     return;
   }
 
-  throw new Error(
+  throw databaseTlsRequiredError(
     "DATABASE_URL must include sslmode=verify-full (recommended) or sslmode=verify-ca in production. " +
       "Set STEWARD_ALLOW_INSECURE_DB=true to override for private-network deployments.",
   );

--- a/packages/shared/src/__tests__/safe-error.test.ts
+++ b/packages/shared/src/__tests__/safe-error.test.ts
@@ -136,6 +136,11 @@ describe("redactedThrownDiagnostics", () => {
     });
     expect(
       redactedThrownDiagnostics(
+        Object.assign(new Error("database-url-canary"), { code: "DB_TLS_REQUIRED" }),
+      ),
+    ).toEqual({ errorClass: "Error", errorCode: "DB_TLS_REQUIRED" });
+    expect(
+      redactedThrownDiagnostics(
         Object.assign(new Error("message-canary"), { code: "SECRET code canary" }),
       ),
     ).toEqual({ errorClass: "Error", errorCode: null });

--- a/packages/shared/src/safe-error.ts
+++ b/packages/shared/src/safe-error.ts
@@ -40,6 +40,7 @@ export interface RedactedThrownDiagnostics {
 
 const SAFE_ERROR_CODES = new Set([
   "ABORT_ERR",
+  "DB_TLS_REQUIRED",
   "EAI_AGAIN",
   "ECONNREFUSED",
   "ECONNRESET",


### PR DESCRIPTION
## Summary
- tag the production missing-TLS database rejection with a fixed `DB_TLS_REQUIRED` code
- allow only that bounded code through the existing redacted diagnostic helper
- update the CLI migration regression to distinguish the TLS gate from a network failure without exposing the database URL or raw error text

## Validation
- 34 focused CLI, database-security, and safe-error tests pass (148 assertions)
- six dependency-aware builds pass
- Biome and `git diff --check` pass

Fixes the current `develop` CLI test failure introduced when migration errors were correctly redacted.