### PR TITLE
fix(seed): make credential rotation crash recoverable

### DIFF
--- a/packages/seed/src/__tests__/demo-api-key.test.ts
+++ b/packages/seed/src/__tests__/demo-api-key.test.ts
@@ -1,15 +1,31 @@
 import { describe, expect, test } from "bun:test";
-import { lstatSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
+import {
+  lstatSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { validateApiKey } from "@stwd/auth";
-import { generateDemoApiKey, writeDemoCredentials } from "../demo-api-key";
+import {
+  generateDemoApiKey,
+  promoteDemoCredentials,
+  rotateDemoCredentials,
+  stageDemoCredentials,
+} from "../demo-api-key";
+
+function tempRoot(prefix: string): string {
+  return realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+}
 
 describe("demo API key", () => {
   test("is fresh, high-entropy, and verifies only against its own hash", () => {
     const first = generateDemoApiKey();
     const second = generateDemoApiKey();
-
     expect(first.key).toMatch(/^stw_[0-9a-f]{32}$/);
     expect(first.hash).toMatch(/^[0-9a-f]{64}$/);
     expect(second.key).not.toBe(first.key);
@@ -17,29 +33,128 @@ describe("demo API key", () => {
     expect(validateApiKey(second.key, first.hash)).toBe(false);
   });
 
-  test("writes tenant-bound credentials owner-only and rejects symlink targets", () => {
-    const root = mkdtempSync(join(tmpdir(), "steward-demo-credentials-"));
+  test("stages owner-only tenant-bound credentials without replacing the canonical file", () => {
+    const root = tempRoot("steward-demo-stage-");
     try {
-      const pair = generateDemoApiKey();
       const path = join(root, "private", "demo.env");
-      expect(writeDemoCredentials("waifu.fun", pair.key, path)).toBe(path);
+      const oldKey = generateDemoApiKey().key;
+      promoteDemoCredentials(stageDemoCredentials("waifu.fun", oldKey, path));
+      const nextKey = generateDemoApiKey().key;
+      const pending = stageDemoCredentials("waifu.fun", nextKey, path);
       expect(lstatSync(dirname(path)).mode & 0o777).toBe(0o700);
-      expect(lstatSync(path).mode & 0o777).toBe(0o600);
-      expect(readFileSync(path, "utf8")).toBe(
-        `STEWARD_TENANT_ID=waifu.fun\nSTEWARD_API_KEY=${pair.key}\n`,
+      expect(lstatSync(pending.pendingPath).mode & 0o777).toBe(0o600);
+      expect(readFileSync(path, "utf8")).toContain(`STEWARD_API_KEY=${oldKey}`);
+      expect(readFileSync(pending.pendingPath, "utf8")).toBe(
+        `STEWARD_TENANT_ID=waifu.fun\nSTEWARD_API_KEY=${nextKey}\n`,
       );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 
-      const symlink = join(root, "linked.env");
-      symlinkSync(path, symlink);
-      expect(() => writeDemoCredentials("other", pair.key, symlink)).toThrow();
-      expect(readFileSync(path, "utf8")).toContain("STEWARD_TENANT_ID=waifu.fun");
+  test("keeps prior and pending credentials on a pre-commit failure", async () => {
+    const root = tempRoot("steward-demo-precommit-");
+    try {
+      const path = join(root, "demo.env");
+      const oldKey = generateDemoApiKey().key;
+      promoteDemoCredentials(stageDemoCredentials("waifu.fun", oldKey, path));
+      const nextKey = generateDemoApiKey().key;
+      const operation = rotateDemoCredentials(
+        "waifu.fun",
+        nextKey,
+        async () => {
+          throw new Error("database canary");
+        },
+        path,
+      );
+      await expect(operation).rejects.toThrow("rotation outcome is uncertain");
+      const error = await operation.catch((caught) => (caught as Error).message);
+      expect(error).not.toContain("database canary");
+      expect(readFileSync(path, "utf8")).toContain(`STEWARD_API_KEY=${oldKey}`);
+      const pending = readdirSync(root).find((name) => name.includes(".pending-"));
+      expect(pending).toBeTruthy();
+      expect(readFileSync(join(root, pending!), "utf8")).toContain(`STEWARD_API_KEY=${nextKey}`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 
+  test("retains the committed credential when atomic promotion fails", async () => {
+    const root = tempRoot("steward-demo-postcommit-");
+    try {
+      const path = join(root, "demo.env");
+      const oldKey = generateDemoApiKey().key;
+      promoteDemoCredentials(stageDemoCredentials("waifu.fun", oldKey, path));
+      const nextKey = generateDemoApiKey().key;
+      let committed = false;
+      const operation = rotateDemoCredentials(
+        "waifu.fun",
+        nextKey,
+        async () => {
+          committed = true;
+        },
+        path,
+        () => {
+          throw new Error("rename canary");
+        },
+      );
+      await expect(operation).rejects.toThrow("Credential hash committed");
+      const error = await operation.catch((caught) => (caught as Error).message);
+      expect(committed).toBe(true);
+      expect(error).not.toContain("rename canary");
+      expect(readFileSync(path, "utf8")).toContain(`STEWARD_API_KEY=${oldKey}`);
+      const pending = readdirSync(root).find((name) => name.includes(".pending-"));
+      expect(readFileSync(join(root, pending!), "utf8")).toContain(`STEWARD_API_KEY=${nextKey}`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("promotes only after a successful commit", async () => {
+    const root = tempRoot("steward-demo-success-");
+    try {
+      const path = join(root, "demo.env");
+      const nextKey = generateDemoApiKey().key;
+      let committed = false;
+      expect(
+        await rotateDemoCredentials(
+          "waifu.fun",
+          nextKey,
+          async () => {
+            committed = true;
+          },
+          path,
+        ),
+      ).toBe(path);
+      expect(committed).toBe(true);
+      expect(readFileSync(path, "utf8")).toContain(`STEWARD_API_KEY=${nextKey}`);
+      expect(readdirSync(root).some((name) => name.includes(".pending-"))).toBe(false);
+      expect(readdirSync(root).some((name) => name.includes(".promote-"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects redirected parents and replaces file symlinks rather than following them", () => {
+    const root = tempRoot("steward-demo-links-");
+    try {
+      const real = join(root, "real");
+      const canonical = join(real, "demo.env");
+      promoteDemoCredentials(
+        stageDemoCredentials("waifu.fun", generateDemoApiKey().key, canonical),
+      );
       const linkedParent = join(root, "linked-parent");
-      symlinkSync(dirname(path), linkedParent);
+      symlinkSync(real, linkedParent);
       expect(() =>
-        writeDemoCredentials("other", pair.key, join(linkedParent, "other.env")),
-      ).toThrow("parent must be a real directory");
-      expect(() => readFileSync(join(dirname(path), "other.env"), "utf8")).toThrow();
+        stageDemoCredentials("other", generateDemoApiKey().key, join(linkedParent, "other.env")),
+      ).toThrow("redirected directories");
+
+      const linkedFile = join(root, "linked.env");
+      symlinkSync(canonical, linkedFile);
+      const pending = stageDemoCredentials("waifu.fun", generateDemoApiKey().key, linkedFile);
+      promoteDemoCredentials(pending);
+      expect(lstatSync(linkedFile).isSymbolicLink()).toBe(false);
+      expect(readFileSync(canonical, "utf8")).not.toBe(readFileSync(linkedFile, "utf8"));
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/seed/src/demo-api-key.ts
+++ b/packages/seed/src/demo-api-key.ts
@@ -1,50 +1,73 @@
+import { randomBytes } from "node:crypto";
 import {
   closeSync,
   fchmodSync,
   constants as fsConstants,
   fstatSync,
-  ftruncateSync,
+  fsyncSync,
+  linkSync,
   lstatSync,
   mkdirSync,
   openSync,
+  realpathSync,
+  renameSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { type ApiKeyPair, generateApiKey } from "@stwd/auth";
 
-/**
- * Mint a fresh credential for each demo seed run.
- *
- * Demo data may be loaded into an internet-reachable environment, so a
- * repository-known key is unsafe even when the package is primarily intended
- * for local development.
- */
+export type PendingDemoCredentials = {
+  finalPath: string;
+  pendingPath: string;
+  parentDevice: number;
+  parentInode: number;
+};
+
 export function generateDemoApiKey(): ApiKeyPair {
   return generateApiKey();
 }
 
-/** Persist the one-time credential without exposing it to terminal/CI logs. */
-export function writeDemoCredentials(
-  tenantId: string,
-  apiKey: string,
-  outputPath = process.env.STEWARD_DEMO_CREDENTIALS_FILE ?? ".steward/demo-credentials.env",
-): string {
+function assertTenantId(tenantId: string): void {
   if (!/^[A-Za-z0-9_.:-]{1,64}$/.test(tenantId)) {
     throw new Error("Demo credential tenant id is invalid");
   }
-  const path = resolve(outputPath);
+}
+
+function credentialParent(path: string): { device: number; inode: number } {
   const parentPath = dirname(path);
   mkdirSync(parentPath, { recursive: true, mode: 0o700 });
   const parent = lstatSync(parentPath);
-  if (!parent.isDirectory() || parent.isSymbolicLink()) {
-    throw new Error("Demo credentials parent must be a real directory");
+  if (!parent.isDirectory() || parent.isSymbolicLink() || realpathSync(parentPath) !== parentPath) {
+    throw new Error("Demo credentials parent must not contain redirected directories");
   }
   if (typeof process.geteuid === "function" && parent.uid !== process.geteuid()) {
     throw new Error("Demo credentials parent must be owned by the current user");
   }
   const fd = openSync(
+    parentPath,
+    fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+  );
+  try {
+    const opened = fstatSync(fd);
+    if (!opened.isDirectory() || opened.dev !== parent.dev || opened.ino !== parent.ino) {
+      throw new Error("Demo credentials parent changed during validation");
+    }
+    fchmodSync(fd, 0o700);
+    return { device: opened.dev, inode: opened.ino };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function writeNewCredentialFile(path: string, contents: string): void {
+  const fd = openSync(
     path,
-    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK,
+    fsConstants.O_WRONLY |
+      fsConstants.O_CREAT |
+      fsConstants.O_EXCL |
+      fsConstants.O_NOFOLLOW |
+      fsConstants.O_NONBLOCK,
     0o600,
   );
   try {
@@ -56,10 +79,111 @@ export function writeDemoCredentials(
       throw new Error("Demo credentials output must be owned by the current user");
     }
     fchmodSync(fd, 0o600);
-    ftruncateSync(fd, 0);
-    writeFileSync(fd, `STEWARD_TENANT_ID=${tenantId}\nSTEWARD_API_KEY=${apiKey}\n`, "utf8");
+    writeFileSync(fd, contents, "utf8");
+    fsyncSync(fd);
   } finally {
     closeSync(fd);
   }
-  return path;
+}
+
+function syncDirectory(path: string, expected: { device: number; inode: number }): void {
+  const fd = openSync(
+    path,
+    fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+  );
+  try {
+    const opened = fstatSync(fd);
+    if (!opened.isDirectory() || opened.dev !== expected.device || opened.ino !== expected.inode) {
+      throw new Error("Demo credentials parent changed before durable storage");
+    }
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/** Stage a unique credential without replacing the currently valid one. */
+export function stageDemoCredentials(
+  tenantId: string,
+  apiKey: string,
+  outputPath = process.env.STEWARD_DEMO_CREDENTIALS_FILE ?? ".steward/demo-credentials.env",
+): PendingDemoCredentials {
+  assertTenantId(tenantId);
+  const finalPath = resolve(outputPath);
+  const parent = credentialParent(finalPath);
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const pendingPath = `${finalPath}.pending-${randomBytes(12).toString("hex")}`;
+    try {
+      writeNewCredentialFile(
+        pendingPath,
+        `STEWARD_TENANT_ID=${tenantId}\nSTEWARD_API_KEY=${apiKey}\n`,
+      );
+      syncDirectory(dirname(finalPath), parent);
+      return {
+        finalPath,
+        pendingPath,
+        parentDevice: parent.device,
+        parentInode: parent.inode,
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST" || attempt === 3) throw error;
+    }
+  }
+  throw new Error("Could not allocate a unique pending credential file");
+}
+
+/** Atomically make a staged credential canonical after the DB commit. */
+export function promoteDemoCredentials(pending: PendingDemoCredentials): string {
+  const parent = credentialParent(pending.finalPath);
+  if (parent.device !== pending.parentDevice || parent.inode !== pending.parentInode) {
+    throw new Error(`Credential directory changed; recover ${pending.pendingPath}`);
+  }
+  const staged = lstatSync(pending.pendingPath);
+  if (!staged.isFile() || staged.isSymbolicLink() || staged.nlink !== 1) {
+    throw new Error(`Pending credential is unsafe; recover ${pending.pendingPath}`);
+  }
+  if (typeof process.geteuid === "function" && staged.uid !== process.geteuid()) {
+    throw new Error(`Pending credential owner changed; recover ${pending.pendingPath}`);
+  }
+  let promotionPath: string | undefined;
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const candidate = `${pending.finalPath}.promote-${randomBytes(12).toString("hex")}`;
+    try {
+      linkSync(pending.pendingPath, candidate);
+      promotionPath = candidate;
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST" || attempt === 3) throw error;
+    }
+  }
+  if (!promotionPath) {
+    throw new Error(`Could not allocate promotion link; recover ${pending.pendingPath}`);
+  }
+  renameSync(promotionPath, pending.finalPath);
+  syncDirectory(dirname(pending.finalPath), parent);
+  // The canonical name is durable now. Removing the recovery name is cleanup:
+  // if the process crashes first, both names point to the same valid key.
+  unlinkSync(pending.pendingPath);
+  return pending.finalPath;
+}
+
+/** Preserve a recoverable pending key across ambiguous DB or promotion failures. */
+export async function rotateDemoCredentials(
+  tenantId: string,
+  apiKey: string,
+  rotateHash: () => Promise<void>,
+  outputPath?: string,
+  promote: (pending: PendingDemoCredentials) => string = promoteDemoCredentials,
+): Promise<string> {
+  const pending = stageDemoCredentials(tenantId, apiKey, outputPath);
+  try {
+    await rotateHash();
+  } catch {
+    throw new Error(`Credential rotation outcome is uncertain; recover ${pending.pendingPath}`);
+  }
+  try {
+    return promote(pending);
+  } catch {
+    throw new Error(`Credential hash committed; recover ${pending.pendingPath}`);
+  }
 }

--- a/packages/seed/src/index.ts
+++ b/packages/seed/src/index.ts
@@ -11,9 +11,10 @@ import {
   policies,
   tenants,
   transactions,
+  withTenantAuditedTransactionOnDb,
 } from "../../db/src/index.ts";
 import { KeyStore } from "../../vault/src/index.ts";
-import { generateDemoApiKey, writeDemoCredentials } from "./demo-api-key";
+import { generateDemoApiKey, rotateDemoCredentials } from "./demo-api-key";
 
 /* ──────────────────────────────────────────────────────────────────────────── */
 /*  Constants                                                                  */
@@ -136,36 +137,45 @@ async function seed() {
     throw new Error("STEWARD_MASTER_PASSWORD is required");
   }
 
-  // Persist the one-time credential before touching the database. If the
-  // destination is unsafe or unwritable, fail without rotating the tenant's
-  // stored hash to a key the operator can no longer recover.
-  const demoCredentialsPath = writeDemoCredentials(TENANT_ID, DEMO_API_KEY.key);
   const db = getDb();
   const keyStore = new KeyStore(process.env.STEWARD_MASTER_PASSWORD);
   const createdAt = hoursAgo(168); // 7 days ago — agent creation time
   const updatedAt = hoursAgo(1);
 
-  console.log("Cleaning existing waifu.fun data...");
-  await cleanWaifuData();
-
-  /* ── Tenant upsert ─────────────────────────────────────────────────────── */
-  await db
-    .insert(tenants)
-    .values({
-      id: TENANT_ID,
-      name: TENANT_NAME,
-      apiKeyHash: DEMO_API_KEY.hash,
-      createdAt,
-      updatedAt,
-    })
-    .onConflictDoUpdate({
-      target: tenants.id,
-      set: {
-        name: TENANT_NAME,
-        apiKeyHash: DEMO_API_KEY.hash,
-        updatedAt,
-      },
+  /* ── Tenant credential rotation ───────────────────────────────────────── */
+  const demoCredentialsPath = await rotateDemoCredentials(TENANT_ID, DEMO_API_KEY.key, async () => {
+    console.log("Cleaning existing waifu.fun data...");
+    await cleanWaifuData();
+    await withTenantAuditedTransactionOnDb(db, TENANT_ID, async (txRaw, appendAudit) => {
+      const tx = txRaw as typeof db;
+      await tx
+        .insert(tenants)
+        .values({
+          id: TENANT_ID,
+          name: TENANT_NAME,
+          apiKeyHash: DEMO_API_KEY.hash,
+          createdAt,
+          updatedAt,
+        })
+        .onConflictDoUpdate({
+          target: tenants.id,
+          set: {
+            name: TENANT_NAME,
+            apiKeyHash: DEMO_API_KEY.hash,
+            updatedAt,
+          },
+        });
+      await appendAudit({
+        tenantId: TENANT_ID,
+        actorType: "system",
+        actorId: "demo-seed",
+        action: "tenant.api_key.rotate",
+        resourceType: "tenant",
+        resourceId: TENANT_ID,
+        metadata: { source: "demo-seed" },
+      });
     });
+  });
   /* ════════════════════════════════════════════════════════════════════════ */
   /*  AGENT DEFINITIONS                                                      */
   /* ════════════════════════════════════════════════════════════════════════ */


### PR DESCRIPTION
## Summary
- stage each newly generated demo credential in a unique, durably synced owner-only pending file without replacing the currently valid canonical credential
- rotate the tenant hash and record its audit event atomically, then promote through a hard-linked recovery name and an atomic canonical rename
- retain a discoverable pending credential until canonical promotion is durably synced, with redacted recovery diagnostics for ambiguous DB or post-commit failures
- reject redirected credential directories and unsafe pending files

This is a crash-safety corrective follow-up to merged #528.

## Tests
- `bun test --timeout 30000 packages/seed/src/__tests__/demo-api-key.test.ts` (6 pass, 27 assertions)
- `bunx @biomejs/biome check packages/seed/src/index.ts packages/seed/src/demo-api-key.ts packages/seed/src/__tests__/demo-api-key.test.ts`
- `bunx turbo run build --filter=@stwd/api...` (24/24)
- `git diff --check origin/develop...HEAD`