### PR TITLE
fix(ci): honor trade-session test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,10 @@ jobs:
             # context from their package-local bunfig.toml. Running them from
             # the repository root skips that preload and fails at module init.
             (cd "${{ matrix.package }}" && bun run test)
+          elif [ "${{ matrix.package }}" = "packages/trade-sessions" ]; then
+            # PGLite migrations can exceed Bun's 5s default on hosted runners.
+            # Keep file isolation while honoring the package's 30s test budget.
+            bun test --isolate --timeout 30000 packages/trade-sessions
           else
             bun test --isolate ${{ matrix.package }}
           fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -254,6 +254,10 @@ jobs:
             # context from their package-local bunfig.toml. Running them from
             # the repository root skips that preload and fails at module init.
             (cd "${{ matrix.package }}" && bun run test)
+          elif [ "${{ matrix.package }}" = "packages/trade-sessions" ]; then
+            # PGLite migrations can exceed Bun's 5s default on hosted runners.
+            # Keep file isolation while honoring the package's 30s test budget.
+            bun test --isolate --timeout 30000 packages/trade-sessions
           else
             bun test --isolate ${{ matrix.package }}
           fi

--- a/scripts/__tests__/check-ci-test-inventory.test.ts
+++ b/scripts/__tests__/check-ci-test-inventory.test.ts
@@ -25,6 +25,13 @@ describe("CI test inventory", () => {
     }
   });
 
+  test("trade-session CI preserves the package's PGLite timeout", () => {
+    for (const workflow of [".github/workflows/ci.yml", ".github/workflows/pr.yml"]) {
+      const source = readFileSync(workflow, "utf8");
+      expect(source).toContain("bun test --isolate --timeout 30000 packages/trade-sessions");
+    }
+  });
+
   test("a future unlisted test package fails closed", () => {
     expect(() =>
       assertCompleteCoverage(["packages/a", "packages/new"], ["packages/a"], []),


### PR DESCRIPTION
## Security/CI finding

The generic unit matrix invoked `bun test --isolate packages/trade-sessions` from the repository root, bypassing the package's explicit 30-second PGLite timeout. Hosted CI therefore used Bun's 5-second default and reported two false failures in the SEC-044 submission-fence regressions after slow migrations.

## Fix

- preserve file isolation but pass `--timeout 30000` for `packages/trade-sessions` in both PR and develop workflows
- add a static inventory regression pinning the bounded timeout in both workflows

## Exact-head evidence

Base: `1aa2e325d14e8ffc1bd2fb693ba34cb023e5ac3f`
Head: `f283f058fe1cf7d08a49204a07af4993a635db93`

- trade-sessions: 25/25, including both previously timed-out SEC-044 cases
- CI inventory: 13/13, 48 assertions
- dependency build: 7/7
- Biome and `git diff --check`: clean

Keep draft until fresh exact-head hosted CI is green.
