### PR TITLE
fix(vault): report pre-broadcast nonce release failures

### DIFF
--- a/packages/vault/src/__tests__/local-evm-broadcast.test.ts
+++ b/packages/vault/src/__tests__/local-evm-broadcast.test.ts
@@ -72,6 +72,54 @@ describe("local EVM deterministic broadcast lifecycle", () => {
     expect(subject.events).toEqual(["prepare", "checkpoint", "release"]);
   });
 
+  test("preserves pre-broadcast failures and reports release failures with redacted diagnostics", async () => {
+    const originalConsoleError = console.error;
+    const diagnostics: unknown[][] = [];
+    console.error = (...args: unknown[]) => diagnostics.push(args);
+
+    try {
+      for (const stage of ["prepare", "checkpoint"] as const) {
+        const operationError = new Error(`${stage} failed`);
+        const subject = lifecycle({
+          prepare: async () => {
+            subject.events.push("prepare");
+            if (stage === "prepare") throw operationError;
+            return SERIALIZED;
+          },
+          checkpoint: async () => {
+            subject.events.push("checkpoint");
+            if (stage === "checkpoint") throw operationError;
+          },
+          releaseBeforeBroadcast: async () => {
+            subject.events.push("release");
+            throw new Error("DATABASE_URL=postgres://nonce-release-secret");
+          },
+        });
+
+        expect(await executeLocalEvmBroadcast(subject).catch((error) => error)).toBe(
+          operationError,
+        );
+        expect(subject.events).toEqual(
+          stage === "prepare" ? ["prepare", "release"] : ["prepare", "checkpoint", "release"],
+        );
+      }
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    expect(diagnostics).toEqual([
+      [
+        "[vault] Failed to release EVM nonce after pre-broadcast failure",
+        { errorClass: "Error", errorCode: null },
+      ],
+      [
+        "[vault] Failed to release EVM nonce after pre-broadcast failure",
+        { errorClass: "Error", errorCode: null },
+      ],
+    ]);
+    expect(JSON.stringify(diagnostics)).not.toContain("nonce-release-secret");
+  });
+
   test("reconciles a lost RPC response by deterministic hash without rebroadcasting", async () => {
     let broadcasts = 0;
     const subject = lifecycle({

--- a/packages/vault/src/__tests__/local-evm-broadcast.test.ts
+++ b/packages/vault/src/__tests__/local-evm-broadcast.test.ts
@@ -120,6 +120,29 @@ describe("local EVM deterministic broadcast lifecycle", () => {
     expect(JSON.stringify(diagnostics)).not.toContain("nonce-release-secret");
   });
 
+  test("preserves the operation failure when the diagnostic sink throws", async () => {
+    const originalConsoleError = console.error;
+    const operationError = new Error("checkpoint failed");
+    console.error = () => {
+      throw new Error("diagnostic sink failed");
+    };
+
+    try {
+      const subject = lifecycle({
+        checkpoint: async () => {
+          throw operationError;
+        },
+        releaseBeforeBroadcast: async () => {
+          throw new Error("release failed");
+        },
+      });
+
+      expect(await executeLocalEvmBroadcast(subject).catch((error) => error)).toBe(operationError);
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
   test("reconciles a lost RPC response by deterministic hash without rebroadcasting", async () => {
     let broadcasts = 0;
     const subject = lifecycle({

--- a/packages/vault/src/local-evm-broadcast.ts
+++ b/packages/vault/src/local-evm-broadcast.ts
@@ -1,3 +1,4 @@
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { type Hex, keccak256 } from "viem";
 import { ExternalBroadcastOutcomeUnknownError } from "./external-key-custody";
 
@@ -14,6 +15,19 @@ export interface LocalEvmBroadcastLifecycle {
   releaseBeforeBroadcast: () => Promise<void>;
   /** Persist accepted state and confirm allocator bookkeeping. */
   finalizeAccepted: (transactionHash: Hex) => Promise<void>;
+}
+
+async function releaseBeforeBroadcast(lifecycle: LocalEvmBroadcastLifecycle): Promise<void> {
+  try {
+    await lifecycle.releaseBeforeBroadcast();
+  } catch (error) {
+    // Preserve the operation failure for callers while making allocator cleanup
+    // failures visible without exposing database or provider diagnostics.
+    console.error(
+      "[vault] Failed to release EVM nonce after pre-broadcast failure",
+      redactedThrownDiagnostics(error),
+    );
+  }
 }
 
 /**
@@ -33,7 +47,7 @@ export async function executeLocalEvmBroadcast(
   try {
     serializedTransaction = await lifecycle.prepare();
   } catch (error) {
-    await lifecycle.releaseBeforeBroadcast().catch(() => {});
+    await releaseBeforeBroadcast(lifecycle);
     throw error;
   }
 
@@ -42,7 +56,7 @@ export async function executeLocalEvmBroadcast(
     await lifecycle.checkpoint(transactionHash);
   } catch (error) {
     // No mutating RPC has happened, so this is the final safe release point.
-    await lifecycle.releaseBeforeBroadcast().catch(() => {});
+    await releaseBeforeBroadcast(lifecycle);
     throw error;
   }
 

--- a/packages/vault/src/local-evm-broadcast.ts
+++ b/packages/vault/src/local-evm-broadcast.ts
@@ -23,10 +23,14 @@ async function releaseBeforeBroadcast(lifecycle: LocalEvmBroadcastLifecycle): Pr
   } catch (error) {
     // Preserve the operation failure for callers while making allocator cleanup
     // failures visible without exposing database or provider diagnostics.
-    console.error(
-      "[vault] Failed to release EVM nonce after pre-broadcast failure",
-      redactedThrownDiagnostics(error),
-    );
+    try {
+      console.error(
+        "[vault] Failed to release EVM nonce after pre-broadcast failure",
+        redactedThrownDiagnostics(error),
+      );
+    } catch {
+      // Diagnostics are best-effort and must never replace the operation error.
+    }
   }
 }
 


### PR DESCRIPTION
Addresses #525.

## Summary
- report failed pre-broadcast EVM nonce releases with a fixed, bounded diagnostic
- preserve the original preparation/checkpoint failure so caller behavior remains stable
- behaviorally inject cleanup failures at both safe-release boundaries and prove secret-bearing diagnostics are redacted

## Audit conclusion
- the two best-effort transitions in `upstream-leases.ts` leave `acknowledging` or `revoking` claims that the stale recovery sweep can reclaim; callers still fail closed
- accepted EVM nonce confirmation remains intentionally non-fatal: the deterministic broadcast is already accepted, `nextNonce` remains monotonic, and only explicitly `dropped` rows can be reclaimed

## Validation
Exact head checks after the final rebase:
- `bun run --cwd packages/shared build`
- `bun test packages/vault/src/__tests__/local-evm-broadcast.test.ts` (7 pass)
- `bunx biome check packages/vault/src/local-evm-broadcast.ts packages/vault/src/__tests__/local-evm-broadcast.test.ts`
- `bun run --cwd packages/vault build`
- `git diff --check origin/develop...HEAD`

Broader package validation before the final base refresh:
- `bun run --cwd packages/vault test` (448 pass, 9 skip, 0 fail)