### PR TITLE
fix(seed): bind credential promotion to validated inode

### DIFF
--- a/packages/seed/src/__tests__/demo-api-key.test.ts
+++ b/packages/seed/src/__tests__/demo-api-key.test.ts
@@ -5,8 +5,10 @@ import {
   readdirSync,
   readFileSync,
   realpathSync,
+  renameSync,
   rmSync,
   symlinkSync,
+  writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -47,6 +49,23 @@ describe("demo API key", () => {
       expect(readFileSync(pending.pendingPath, "utf8")).toBe(
         `STEWARD_TENANT_ID=waifu.fun\nSTEWARD_API_KEY=${nextKey}\n`,
       );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects dotenv injection through the exported staging API", () => {
+    const root = tempRoot("steward-demo-validation-");
+    try {
+      const path = join(root, "demo.env");
+      const key = generateDemoApiKey().key;
+      expect(() => stageDemoCredentials("waifu.fun\nOTHER=x", key, path)).toThrow(
+        "tenant id is invalid",
+      );
+      expect(() => stageDemoCredentials("waifu.fun", `${key}\nOTHER=x`, path)).toThrow(
+        "API key is invalid",
+      );
+      expect(readdirSync(root)).toEqual([]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -155,6 +174,33 @@ describe("demo API key", () => {
       promoteDemoCredentials(pending);
       expect(lstatSync(linkedFile).isSymbolicLink()).toBe(false);
       expect(readFileSync(canonical, "utf8")).not.toBe(readFileSync(linkedFile, "utf8"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("never promotes a pending pathname swapped after inode validation", () => {
+    const root = tempRoot("steward-demo-race-");
+    try {
+      const path = join(root, "demo.env");
+      const oldKey = generateDemoApiKey().key;
+      promoteDemoCredentials(stageDemoCredentials("waifu.fun", oldKey, path));
+      const nextKey = generateDemoApiKey().key;
+      const pending = stageDemoCredentials("waifu.fun", nextKey, path);
+      const originalPending = `${pending.pendingPath}.original`;
+      expect(() =>
+        promoteDemoCredentials(pending, () => {
+          renameSync(pending.pendingPath, originalPending);
+          writeFileSync(
+            pending.pendingPath,
+            "STEWARD_TENANT_ID=attacker\nSTEWARD_API_KEY=stw_00000000000000000000000000000000\n",
+            { mode: 0o600 },
+          );
+        }),
+      ).toThrow("changed during promotion");
+      expect(readFileSync(path, "utf8")).toContain(`STEWARD_API_KEY=${oldKey}`);
+      expect(readFileSync(path, "utf8")).not.toContain("stw_00000000000000000000000000000000");
+      expect(readFileSync(originalPending, "utf8")).toContain(`STEWARD_API_KEY=${nextKey}`);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/seed/src/demo-api-key.ts
+++ b/packages/seed/src/demo-api-key.ts
@@ -34,6 +34,12 @@ function assertTenantId(tenantId: string): void {
   }
 }
 
+function assertApiKey(apiKey: string): void {
+  if (!/^stw_[0-9a-f]{32}$/.test(apiKey)) {
+    throw new Error("Demo credential API key is invalid");
+  }
+}
+
 function credentialParent(path: string): { device: number; inode: number } {
   const parentPath = dirname(path);
   mkdirSync(parentPath, { recursive: true, mode: 0o700 });
@@ -109,6 +115,7 @@ export function stageDemoCredentials(
   outputPath = process.env.STEWARD_DEMO_CREDENTIALS_FILE ?? ".steward/demo-credentials.env",
 ): PendingDemoCredentials {
   assertTenantId(tenantId);
+  assertApiKey(apiKey);
   const finalPath = resolve(outputPath);
   const parent = credentialParent(finalPath);
   for (let attempt = 0; attempt < 4; attempt++) {
@@ -133,38 +140,76 @@ export function stageDemoCredentials(
 }
 
 /** Atomically make a staged credential canonical after the DB commit. */
-export function promoteDemoCredentials(pending: PendingDemoCredentials): string {
+export function promoteDemoCredentials(
+  pending: PendingDemoCredentials,
+  afterPendingOpen?: () => void,
+): string {
   const parent = credentialParent(pending.finalPath);
   if (parent.device !== pending.parentDevice || parent.inode !== pending.parentInode) {
     throw new Error(`Credential directory changed; recover ${pending.pendingPath}`);
   }
-  const staged = lstatSync(pending.pendingPath);
-  if (!staged.isFile() || staged.isSymbolicLink() || staged.nlink !== 1) {
-    throw new Error(`Pending credential is unsafe; recover ${pending.pendingPath}`);
-  }
-  if (typeof process.geteuid === "function" && staged.uid !== process.geteuid()) {
-    throw new Error(`Pending credential owner changed; recover ${pending.pendingPath}`);
-  }
-  let promotionPath: string | undefined;
-  for (let attempt = 0; attempt < 4; attempt++) {
-    const candidate = `${pending.finalPath}.promote-${randomBytes(12).toString("hex")}`;
-    try {
-      linkSync(pending.pendingPath, candidate);
-      promotionPath = candidate;
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST" || attempt === 3) throw error;
+  const pendingFd = openSync(
+    pending.pendingPath,
+    fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK,
+  );
+  try {
+    const staged = fstatSync(pendingFd);
+    if (!staged.isFile() || staged.nlink !== 1 || (staged.mode & 0o777) !== 0o600) {
+      throw new Error(`Pending credential is unsafe; recover ${pending.pendingPath}`);
     }
+    if (typeof process.geteuid === "function" && staged.uid !== process.geteuid()) {
+      throw new Error(`Pending credential owner changed; recover ${pending.pendingPath}`);
+    }
+
+    afterPendingOpen?.();
+
+    let promotionPath: string | undefined;
+    for (let attempt = 0; attempt < 4; attempt++) {
+      const candidate = `${pending.finalPath}.promote-${randomBytes(12).toString("hex")}`;
+      try {
+        linkSync(pending.pendingPath, candidate);
+        promotionPath = candidate;
+        break;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST" || attempt === 3) throw error;
+      }
+    }
+    if (!promotionPath) {
+      throw new Error(`Could not allocate promotion link; recover ${pending.pendingPath}`);
+    }
+
+    const linkedPath = lstatSync(promotionPath);
+    const promotionFd = openSync(
+      promotionPath,
+      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK,
+    );
+    try {
+      const linkedFd = fstatSync(promotionFd);
+      if (
+        !linkedPath.isFile() ||
+        !linkedFd.isFile() ||
+        linkedPath.dev !== staged.dev ||
+        linkedPath.ino !== staged.ino ||
+        linkedFd.dev !== staged.dev ||
+        linkedFd.ino !== staged.ino
+      ) {
+        throw new Error(
+          `Pending credential changed during promotion; recover ${pending.pendingPath}`,
+        );
+      }
+    } finally {
+      closeSync(promotionFd);
+    }
+
+    renameSync(promotionPath, pending.finalPath);
+    syncDirectory(dirname(pending.finalPath), parent);
+    // The canonical name is durable now. Removing the recovery name is cleanup:
+    // if the process crashes first, both names point to the same valid key.
+    unlinkSync(pending.pendingPath);
+    return pending.finalPath;
+  } finally {
+    closeSync(pendingFd);
   }
-  if (!promotionPath) {
-    throw new Error(`Could not allocate promotion link; recover ${pending.pendingPath}`);
-  }
-  renameSync(promotionPath, pending.finalPath);
-  syncDirectory(dirname(pending.finalPath), parent);
-  // The canonical name is durable now. Removing the recovery name is cleanup:
-  // if the process crashes first, both names point to the same valid key.
-  unlinkSync(pending.pendingPath);
-  return pending.finalPath;
 }
 
 /** Preserve a recoverable pending key across ambiguous DB or promotion failures. */


### PR DESCRIPTION
## Summary
- open each pending credential once with `O_NOFOLLOW`, validate its inode, ownership, link count, and mode through the descriptor, and keep it open through promotion validation
- verify both the promotion pathname and its opened descriptor identify that same validated inode before atomic rename
- reject non-canonical Steward API keys before the exported staging API writes dotenv content
- add deterministic pathname-swap and dotenv-injection regressions

Minimal race-hardening follow-up to merged #533.

## Tests
- `bun test --timeout 30000 packages/seed/src/__tests__/demo-api-key.test.ts` (8 pass, 34 assertions)
- `bunx @biomejs/biome check packages/seed/src/demo-api-key.ts packages/seed/src/__tests__/demo-api-key.test.ts`
- `bunx turbo run build --filter=@stwd/api...` (24/24)
- `git diff --check origin/develop...HEAD`