### PR TITLE
fix(trading): verify Polymarket market grants

### DIFF
--- a/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
@@ -1,20 +1,10 @@
 /**
  * Behavioral coverage for POST /v1/trade/polymarket/order.
  *
- * Mirrors the Hyperliquid venue-submit fence harness: real in-memory PGLite,
- * TradeSessionManager, policy/session routes, vault provisioning, credential
- * derivation, and execution adapter. Focused fault-path cases retain narrow
- * wallet/adapter spies. The deterministic E2E case uses the real vault signer
- * and Polymarket SDK, intercepting only the SDK's HTTP methods at the network
- * edge.
- *
- * Coverage:
- *   (a) policy-reject: market-not-allowed -> 400 policy-violation + audit, no spend.
- *   (b) policy-reject: per-order-cap-exceeded -> 400 policy-violation + audit.
- *   (c) idempotency: conflict (same key, different body) -> 409; replay -> same envelope.
- *   (d) session-not-active (revoked) -> 403.
- *   (e) creds-not-provisioned -> 409 fail-closed, no spend reserved.
- *   (f) happy path (mocked adapter returns filled) -> 200 + spend reserved + submitted audit.
+ * The harness uses PGLite, TradeSessionManager, the public route, vault
+ * provisioning, credential derivation, and the execution adapter. Focused
+ * fault cases retain narrow wallet/adapter spies; the deterministic end-to-end
+ * case uses the real vault signer and SDK while intercepting only network I/O.
  */
 import {
   afterAll,
@@ -49,7 +39,8 @@ import type { AppVariables } from "../services/context";
 setDefaultTimeout(30000);
 
 const TOKEN_ID = "71321045679252212594626385532706912750332728571942532289631379312455583992563";
-const COND_ID = "0xabc123";
+const COND_ID = `0x${"a".repeat(64)}`;
+const OTHER_COND_ID = `0x${"b".repeat(64)}`;
 const FUNDER = "0x0985cCC0fD7C568d493874D845471D5F4B1D9c3c";
 const WALLET = "0x1111111111111111111111111111111111111111";
 
@@ -254,25 +245,104 @@ describe("POST /v1/trade/polymarket/order", () => {
     expect(await dailySpendOf(sessionId)).toBe(0);
   });
 
-  it("SECURITY: a caller-supplied conditionId does NOT grant a non-allowlisted token", async () => {
-    // Session allowlists ONLY the market (pm:cond:<id>), not the specific token.
-    // The order route must NOT trust the caller's conditionId (the order is
-    // submitted for tokenId only), so pairing the real token with the allowlisted
-    // condition id must STILL be rejected as market-not-allowed — no bypass.
+  it("rejects a caller conditionId that disagrees with authoritative token metadata", async () => {
     const { tenantId, agentId, sessionId } = await seedSession({
       allowedAssets: [`pm:cond:${COND_ID}`],
     });
     stubWallet(true);
     const app = makeApp(tenantId, agentId, tradeRoutes);
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          condition_id: OTHER_COND_ID,
+          primary_token_id: TOKEN_ID,
+          secondary_token_id: "8".repeat(72),
+        }),
+        { status: 200 },
+      ),
+    );
 
-    const res = await postOrder(app, sessionId, crypto.randomUUID(), {
-      conditionId: COND_ID,
+    try {
+      const res = await postOrder(app, sessionId, crypto.randomUUID(), {
+        conditionId: COND_ID,
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code?: string; reason?: string };
+      expect(body).toEqual({ code: "policy-violation", reason: "condition-id-mismatch" });
+      expect(await dailySpendOf(sessionId)).toBe(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("authorizes a market-wide grant only after resolving the token's condition", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({
+      allowedAssets: [`pm:cond:0x${"A".repeat(64)}`],
     });
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { code?: string; reason?: string };
-    expect(body.code).toBe("policy-violation");
-    expect(body.reason).toBe("market-not-allowed");
-    expect(await dailySpendOf(sessionId)).toBe(0);
+    stubWallet(true);
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          condition_id: COND_ID,
+          primary_token_id: TOKEN_ID,
+          secondary_token_id: "8".repeat(72),
+        }),
+        { status: 200 },
+      ),
+    );
+
+    try {
+      const res = await postOrder(app, sessionId, crypto.randomUUID());
+      expect(res.status).toBe(409);
+      expect(((await res.json()) as { error?: string }).error).toContain(
+        "credentials are not provisioned",
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(await dailySpendOf(sessionId)).toBe(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("keeps metadata outages retryable without authorizing an unverified market grant", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({
+      allowedAssets: [`pm:cond:${COND_ID}`],
+    });
+    stubWallet(true);
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+    const key = crypto.randomUUID();
+    const fetchSpy = spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("TOKEN_METADATA_SECRET_CANARY"))
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            condition_id: COND_ID,
+            primary_token_id: TOKEN_ID,
+            secondary_token_id: "8".repeat(72),
+          }),
+          { status: 200 },
+        ),
+      );
+
+    try {
+      const first = await postOrder(app, sessionId, key);
+      expect(first.status).toBe(502);
+      expect(await first.json()).toEqual({
+        ok: false,
+        error: "Unable to verify Polymarket market binding",
+      });
+
+      const retry = await postOrder(app, sessionId, key);
+      expect(retry.status).toBe(409);
+      expect(((await retry.json()) as { error?: string }).error).toContain(
+        "credentials are not provisioned",
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(await dailySpendOf(sessionId)).toBe(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("SEC-041: SELL notional is floored at the CLOB best bid (low-limit cap bypass fails)", async () => {
@@ -358,16 +428,22 @@ describe("POST /v1/trade/polymarket/order", () => {
   });
 
   it("honors an exact pm:<tokenId> allowlist entry (passes the policy gate)", async () => {
-    // The per-token entry IS the executable unit — it grants exactly this token.
     const { tenantId, agentId, sessionId } = await seedSession({
       allowedAssets: [`pm:${TOKEN_ID}`],
     });
     stubWallet(true); // funder present, L2 creds unprovisioned -> 409 past the gate
     const app = makeApp(tenantId, agentId, tradeRoutes);
+    const fetchSpy = spyOn(globalThis, "fetch").mockRejectedValue(
+      new Error("exact token grants must not require market metadata"),
+    );
 
-    const res = await postOrder(app, sessionId, crypto.randomUUID());
-    // Policy gate PASSED (token allowed) -> reaches the creds gate -> 409.
-    expect(res.status).toBe(409);
+    try {
+      const res = await postOrder(app, sessionId, crypto.randomUUID());
+      expect(res.status).toBe(409);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("returns 409 on idempotency-key reuse with a different body; replays the same envelope", async () => {

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -38,6 +38,7 @@ import {
   clobApiCredentialsSchema,
   deriveApiCredentials,
   type EthersSignerLike,
+  getMarketByToken,
   getPrices,
   isPolymarketPostNotAttempted,
   isPolymarketUnauthorized,
@@ -60,7 +61,7 @@ import { DurableIdempotencyStore } from "./idempotency";
 // public route (not just seeded out of band).
 const sessionPredictionMarketAssetSchema = z
   .string()
-  .regex(/^pm:(cond:0x[0-9a-fA-F]{1,64}|[0-9]{1,128})$/);
+  .regex(/^pm:(cond:0x[0-9a-fA-F]{64}|[0-9]{1,128})$/);
 
 const createSessionSchema = z
   .object({
@@ -141,7 +142,7 @@ const pmSubmitOrderSchema = z.object({
   // market (both YES/NO outcomes) without a per-token entry.
   conditionId: z
     .string()
-    .regex(/^0x[0-9a-fA-F]{1,64}$/, "conditionId must be a 0x-hex string")
+    .regex(/^0x[0-9a-fA-F]{64}$/, "conditionId must be a bytes32 hex string")
     .optional(),
   side: z.enum(["buy", "sell"]),
   // BUY: amount is USD notional to spend. SELL: amount is shares.
@@ -1836,24 +1837,14 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       notionalUsd = polymarketNotionalUsd(body.side, amount, price);
     }
 
-    // Session fetch + ownership + venue check + the prediction-market policy gate,
-    // all in one pass. checkActiveOrder loads the session and runs checkOrderAllowed
-    // against the allowlist + per-order/daily caps.
-    //
-    // We deliberately do not forward the caller-supplied `conditionId` to
-    // the allowlist check. The order is submitted for `tokenId` only, so trusting an
-    // UNVERIFIED conditionId would let an agent pair any non-allowlisted token with
-    // an allowlisted `pm:cond:<id>` and bypass the market allowlist. Until the
-    // token->condition mapping is resolved from VERIFIED Polymarket metadata, the
-    // order route honors ONLY exact `pm:<tokenId>` entries. A `pm:cond:<id>`
-    // session grant therefore does not authorize this route by itself; an exact
-    // per-token grant is required.
-    const { session, check } = await getSessionManager().checkActiveOrder({
+    // Exact token grants are evaluated without a network dependency. If only a
+    // market-wide grant could authorize the order, resolve the token's parent
+    // condition from the CLOB and evaluate again using that verified binding.
+    let { session, check } = await getSessionManager().checkActiveOrder({
       tenantId,
       id: body.sessionId,
       order: {
         tokenId: body.tokenId,
-        // conditionId intentionally omitted — see SECURITY note above.
         notionalUsd,
       },
     });
@@ -1866,13 +1857,73 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       return c.json<ApiResponse>({ ok: false, error: "Active Polymarket session required" }, 403);
     }
 
+    let verifiedConditionId: string | undefined;
+    const hasMarketGrant = session.allowedAssets.some((asset) => asset.startsWith("pm:cond:"));
+    if (!check.allowed && check.reason === "market-not-allowed" && hasMarketGrant) {
+      try {
+        const clobUrl = configuredPolymarketClobUrl();
+        const market = await getMarketByToken(body.tokenId, clobUrl ? { clobUrl } : undefined);
+        verifiedConditionId = market.conditionId;
+      } catch (error) {
+        await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
+          sessionId: session.id,
+          venue: "polymarket",
+          tokenId: body.tokenId,
+          side: body.side,
+          amount,
+          price,
+          notionalUsd,
+          reason: "market-metadata-unavailable",
+          ...redactedThrownDiagnostics(error),
+        });
+        await idempotency.release?.();
+        return c.json<ApiResponse>(
+          { ok: false, error: "Unable to verify Polymarket market binding" },
+          502,
+        );
+      }
+
+      if (
+        body.conditionId !== undefined &&
+        body.conditionId.toLowerCase() !== verifiedConditionId
+      ) {
+        const envelope: TradeIdempotencyResponse = {
+          status: 400,
+          body: { code: "policy-violation", reason: "condition-id-mismatch" },
+        };
+        await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
+          sessionId: session.id,
+          venue: "polymarket",
+          tokenId: body.tokenId,
+          conditionId: verifiedConditionId,
+          side: body.side,
+          amount,
+          price,
+          notionalUsd,
+          reason: "condition-id-mismatch",
+        });
+        await idempotency.store?.(envelope);
+        return c.json(envelope.body, envelope.status);
+      }
+
+      ({ session, check } = await getSessionManager().checkActiveOrder({
+        tenantId,
+        id: body.sessionId,
+        order: { tokenId: body.tokenId, conditionId: verifiedConditionId, notionalUsd },
+      }));
+      if (session.agentId !== agentId || session.venue !== "polymarket") {
+        await idempotency.release?.();
+        return c.json<ApiResponse>({ ok: false, error: "Active Polymarket session required" }, 403);
+      }
+    }
+
     if (!check.allowed) {
       const status = pmPolicyRejectStatus(check.reason);
       await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
         sessionId: session.id,
         venue: "polymarket",
         tokenId: body.tokenId,
-        conditionId: body.conditionId ?? null,
+        conditionId: verifiedConditionId ?? null,
         side: body.side,
         amount,
         price,
@@ -1905,7 +1956,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         sessionId: session.id,
         venue: "polymarket",
         tokenId: body.tokenId,
-        conditionId: body.conditionId ?? null,
+        conditionId: verifiedConditionId ?? null,
         reason: creds.reason,
       });
       await idempotency.release?.();
@@ -1921,7 +1972,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         sessionId: session.id,
         venue: "polymarket",
         tokenId: body.tokenId,
-        conditionId: body.conditionId ?? null,
+        conditionId: verifiedConditionId ?? null,
         reason: "wallet-binding-mismatch",
         sessionWallet: session.walletId,
         resolvedWallet: creds.walletAddress,
@@ -1992,7 +2043,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           sessionId: session.id,
           venue: "polymarket",
           tokenId: body.tokenId,
-          conditionId: body.conditionId ?? null,
+          conditionId: verifiedConditionId ?? null,
           side: body.side,
           amount,
           price,
@@ -2025,7 +2076,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             sessionId: session.id,
             venue: "polymarket",
             tokenId: body.tokenId,
-            conditionId: body.conditionId ?? null,
+            conditionId: verifiedConditionId ?? null,
             notionalUsd,
             reason: "pre-submit-build-failed",
             ...redactedThrownDiagnostics(err),
@@ -2091,7 +2142,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
               sessionId: session.id,
               venue: "polymarket",
               tokenId: body.tokenId,
-              conditionId: body.conditionId ?? null,
+              conditionId: verifiedConditionId ?? null,
               notionalUsd,
               reason: "pre-submit-build-failed",
               ...redactedThrownDiagnostics(err),
@@ -2109,7 +2160,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             sessionId: session.id,
             venue: "polymarket",
             tokenId: body.tokenId,
-            conditionId: body.conditionId ?? null,
+            conditionId: verifiedConditionId ?? null,
             notionalUsd,
             reason: "submit-status-unknown",
             ...redactedThrownDiagnostics(err),
@@ -2151,7 +2202,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             sessionId: session.id,
             venue: "polymarket",
             tokenId: body.tokenId,
-            conditionId: body.conditionId ?? null,
+            conditionId: verifiedConditionId ?? null,
             side: body.side,
             amount,
             price,
@@ -2181,7 +2232,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             sessionId: session.id,
             venue: "polymarket",
             tokenId: body.tokenId,
-            conditionId: body.conditionId ?? null,
+            conditionId: verifiedConditionId ?? null,
             side: body.side,
             amount,
             price,
@@ -2213,7 +2264,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             sessionId: session.id,
             venue: "polymarket",
             tokenId: body.tokenId,
-            conditionId: body.conditionId ?? null,
+            conditionId: verifiedConditionId ?? null,
             side: body.side,
             amount,
             price,

--- a/packages/trade-sessions/src/__tests__/trade-sessions.test.ts
+++ b/packages/trade-sessions/src/__tests__/trade-sessions.test.ts
@@ -16,6 +16,7 @@ import {
 
 const TENANT_ID = "test-tenant";
 const AGENT_ID = "sol";
+const CONDITION_ID = `0x${"a".repeat(64)}`;
 
 const openClients: Array<{ close: () => Promise<void> }> = [];
 
@@ -292,15 +293,16 @@ describe("prediction-market allowlist (pure)", () => {
         "pm:71321045679252212594626385532706912750332728571942532289631379312455583992563",
       ).success,
     ).toBe(true);
-    expect(allowedAssetSchema.safeParse("pm:cond:0xabc123").success).toBe(true);
+    expect(allowedAssetSchema.safeParse(`pm:cond:${CONDITION_ID}`).success).toBe(true);
+    expect(allowedAssetSchema.safeParse("pm:cond:0xabc123").success).toBe(false);
     expect(allowedAssetSchema.safeParse("pm:not-a-token!").success).toBe(false);
   });
 
   test("pm asset helpers", () => {
     expect(predictionMarketTokenAsset("123")).toBe("pm:123");
-    expect(predictionMarketConditionAsset("0xabc")).toBe("pm:cond:0xabc");
+    expect(predictionMarketConditionAsset(CONDITION_ID)).toBe(`pm:cond:${CONDITION_ID}`);
     expect(isPredictionMarketAsset("pm:123")).toBe(true);
-    expect(isPredictionMarketAsset("pm:cond:0xabc")).toBe(true);
+    expect(isPredictionMarketAsset(`pm:cond:${CONDITION_ID}`)).toBe(true);
     expect(isPredictionMarketAsset("NEAR")).toBe(false);
   });
 
@@ -309,8 +311,11 @@ describe("prediction-market allowlist (pure)", () => {
     expect(isPredictionMarketAllowed(byToken, "123")).toBe(true);
     expect(isPredictionMarketAllowed(byToken, "999")).toBe(false);
 
-    const byCond = ["pm:cond:0xabc"];
-    expect(isPredictionMarketAllowed(byCond, "123", "0xabc")).toBe(true); // token via condition grant
+    const byCond = [`pm:cond:${CONDITION_ID}`];
+    expect(isPredictionMarketAllowed(byCond, "123", CONDITION_ID)).toBe(true);
+    expect(isPredictionMarketAllowed([`pm:cond:0x${"A".repeat(64)}`], "123", CONDITION_ID)).toBe(
+      true,
+    );
     expect(isPredictionMarketAllowed(byCond, "123", "0xdef")).toBe(false);
     expect(isPredictionMarketAllowed(byCond, "123")).toBe(false); // no condition passed
   });
@@ -322,7 +327,7 @@ describe("checkOrderAllowed (pure pre-venue gate)", () => {
     "status" | "allowedAssets" | "perOrderCapUsd" | "dailyCapUsd" | "dailySpendUsd"
   > = {
     status: "active",
-    allowedAssets: ["NEAR", "pm:123", "pm:cond:0xabc"],
+    allowedAssets: ["NEAR", "pm:123", `pm:cond:${CONDITION_ID}`],
     perOrderCapUsd: 1000,
     dailyCapUsd: 5000,
     dailySpendUsd: 0,
@@ -340,7 +345,7 @@ describe("checkOrderAllowed (pure pre-venue gate)", () => {
 
   test("allows a pm token via condition grant", () => {
     expect(
-      checkOrderAllowed(base, { tokenId: "777", conditionId: "0xabc", notionalUsd: 500 }),
+      checkOrderAllowed(base, { tokenId: "777", conditionId: CONDITION_ID, notionalUsd: 500 }),
     ).toEqual({
       allowed: true,
     });

--- a/packages/trade-sessions/src/index.ts
+++ b/packages/trade-sessions/src/index.ts
@@ -27,9 +27,7 @@ const namespacedAssetSchema = z.string().regex(/^[a-z0-9]+:[A-Z0-9]+$/);
 //   `pm:cond:<conditionId>` — a whole market (both outcomes) by condition id
 // Stored alongside crypto assets in the same `allowedAssets` text[] so no schema
 // migration is needed; the venue layer interprets the `pm:` namespace.
-const predictionMarketAssetSchema = z
-  .string()
-  .regex(/^pm:(cond:0x[0-9a-fA-F]{1,64}|[0-9]{1,128})$/);
+const predictionMarketAssetSchema = z.string().regex(/^pm:(cond:0x[0-9a-fA-F]{64}|[0-9]{1,128})$/);
 export const allowedAssetSchema = z.union([
   coreAllowedAssetSchema,
   predictionMarketAssetSchema,
@@ -46,7 +44,7 @@ export function predictionMarketTokenAsset(tokenId: string): string {
 }
 
 export function predictionMarketConditionAsset(conditionId: string): string {
-  return `pm:cond:${conditionId}`;
+  return `pm:cond:${conditionId.toLowerCase()}`;
 }
 
 export function isPredictionMarketAsset(asset: string): boolean {
@@ -66,7 +64,14 @@ export function isPredictionMarketAllowed(
 ): boolean {
   const set = new Set(allowedAssets);
   if (set.has(predictionMarketTokenAsset(tokenId))) return true;
-  if (conditionId && set.has(predictionMarketConditionAsset(conditionId))) return true;
+  if (
+    conditionId &&
+    allowedAssets.some(
+      (asset) => asset.toLowerCase() === predictionMarketConditionAsset(conditionId),
+    )
+  ) {
+    return true;
+  }
   return false;
 }
 

--- a/packages/venue-polymarket/src/constants.ts
+++ b/packages/venue-polymarket/src/constants.ts
@@ -1,6 +1,5 @@
 // Polymarket runs on Polygon (chain id 137), settled in USDC (6 decimals).
 // Three hosts, three jobs: Gamma=discover, CLOB=quote+trade, Data=positions.
-// See POLYMARKET-KNOWLEDGE-DUMP.md §2.
 
 export const POLYMARKET_GAMMA_API_BASE = "https://gamma-api.polymarket.com";
 export const POLYMARKET_CLOB_API_BASE = "https://clob.polymarket.com";

--- a/packages/venue-polymarket/src/data.ts
+++ b/packages/venue-polymarket/src/data.ts
@@ -5,10 +5,8 @@ import { type PolymarketPosition } from "./types";
 // ---------------------------------------------------------------------------
 // Data API — positions / trades / activity (public reads).
 //
-// matchr read positions via a Goldsky subgraph + Supabase market enrichment.
-// In steward we DON'T have those; use the public Data API /positions endpoint
-// keyed by the funder Safe address. Pure read, no DB enrichment here — leave
-// market-metadata joins to the tenant layer (Phase B/C).
+// Positions are read from the public /positions endpoint keyed by the funder
+// Safe address. This adapter does not join tenant-owned market metadata.
 // ---------------------------------------------------------------------------
 
 function timeoutSignal(opts?: PolymarketFetchOptions): AbortSignal | undefined {

--- a/packages/venue-polymarket/src/discovery.ts
+++ b/packages/venue-polymarket/src/discovery.ts
@@ -5,7 +5,7 @@ import { type PolymarketEvent, type PolymarketMarket } from "./types";
 // ---------------------------------------------------------------------------
 // Discovery — Gamma. Keyset/cursor pagination is the stable path for backfills.
 // `offset` is REJECTED on keyset endpoints; keyset events expose `closed` but
-// NOT `active` (filter active client-side). See KNOWLEDGE-DUMP §3.
+// not `active`, so active state is filtered client-side.
 // ---------------------------------------------------------------------------
 
 export interface PolymarketFetchOptions {

--- a/packages/venue-polymarket/src/execution.ts
+++ b/packages/venue-polymarket/src/execution.ts
@@ -171,8 +171,8 @@ export function deriveActualFill(
 
 // ---------------------------------------------------------------------------
 // clob-client construction — sigType 2 + funder Safe + builder attribution.
-// The clob-client is typed against ethers v5 Wallet; we cast the injected
-// (v6-shaped) signer. Known wart — see KNOWLEDGE-DUMP §5/§8.
+// The clob-client expects the ethers v5 signer surface; the adapter below
+// exposes that surface over the injected signer without exporting custody.
 // ---------------------------------------------------------------------------
 
 /**

--- a/packages/venue-polymarket/src/index.test.ts
+++ b/packages/venue-polymarket/src/index.test.ts
@@ -18,7 +18,13 @@ import {
   signEndpointUrl,
   toClobCompatibleSigner,
 } from "./index";
-import { getBatchPriceHistory, getOrderbooks, getPriceHistory, getPrices } from "./marketdata";
+import {
+  getBatchPriceHistory,
+  getMarketByToken,
+  getOrderbooks,
+  getPriceHistory,
+  getPrices,
+} from "./marketdata";
 
 // ---------------------------------------------------------------------------
 // Test fixtures — a fake signer + account. NO network.
@@ -701,6 +707,88 @@ describe("credential helpers", () => {
 // ---------------------------------------------------------------------------
 
 describe("marketdata batch", () => {
+  test("getMarketByToken returns only an authoritative response containing the requested token", async () => {
+    const tokenId = "7".repeat(72);
+    const sibling = "8".repeat(72);
+    const conditionId = `0x${"a".repeat(64)}`;
+    let requestedUrl = "";
+    const fetchMock = (async (input: string | URL | Request) => {
+      requestedUrl = String(input);
+      return new Response(
+        JSON.stringify({
+          condition_id: conditionId.toUpperCase().replace("0X", "0x"),
+          primary_token_id: tokenId,
+          secondary_token_id: sibling,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    expect(
+      await getMarketByToken(tokenId, {
+        fetch: fetchMock,
+        clobUrl: "https://clob.example.test/gateway",
+      }),
+    ).toEqual({ conditionId, primaryTokenId: tokenId, secondaryTokenId: sibling });
+    expect(requestedUrl).toBe(`https://clob.example.test/gateway/markets-by-token/${tokenId}`);
+  });
+
+  test("getMarketByToken rejects a response that does not contain the requested token", async () => {
+    const tokenId = "7".repeat(72);
+    const fetchMock = (async () =>
+      new Response(
+        JSON.stringify({
+          condition_id: `0x${"a".repeat(64)}`,
+          primary_token_id: "8".repeat(72),
+          secondary_token_id: "9".repeat(72),
+        }),
+        { status: 200 },
+      )) as typeof fetch;
+    await expect(getMarketByToken(tokenId, { fetch: fetchMock })).rejects.toThrow(
+      "does not contain the requested token",
+    );
+  });
+
+  test("getMarketByToken rejects malformed and oversized responses", async () => {
+    const tokenId = "7".repeat(72);
+    const malformed = (async () =>
+      new Response(
+        JSON.stringify({
+          condition_id: "0xabc",
+          primary_token_id: tokenId,
+          secondary_token_id: "8".repeat(72),
+        }),
+        { status: 200 },
+      )) as typeof fetch;
+    await expect(getMarketByToken(tokenId, { fetch: malformed })).rejects.toThrow(
+      "response is invalid",
+    );
+
+    let canceled = false;
+    const oversized = (async () =>
+      new Response(
+        new ReadableStream({
+          cancel() {
+            canceled = true;
+          },
+        }),
+        { status: 200, headers: { "Content-Length": "20000" } },
+      )) as typeof fetch;
+    await expect(getMarketByToken(tokenId, { fetch: oversized })).rejects.toThrow(
+      "response is too large",
+    );
+    expect(canceled).toBe(true);
+
+    const duplicateKey = (async () =>
+      new Response(
+        `{"condition_id":"0x${"a".repeat(64)}","condition_id":"0x${"b".repeat(64)}","primary_token_id":"${tokenId}","secondary_token_id":"${"8".repeat(72)}"}`,
+        { status: 200 },
+      )) as typeof fetch;
+    await expect(getMarketByToken(tokenId, { fetch: duplicateKey })).rejects.toThrow(
+      "not valid JSON",
+    );
+  });
+
   test("getOrderbooks maps by asset_id, keeps empties for misses", async () => {
     const t1 = "1".repeat(72);
     const t2 = "2".repeat(72);

--- a/packages/venue-polymarket/src/index.ts
+++ b/packages/venue-polymarket/src/index.ts
@@ -1,10 +1,10 @@
 // @stwd/venue-polymarket
 //
-// Polymarket venue adapter for Steward. Pure adapter logic + types — NO routes,
-// NO DB, NO tenant wiring (that's Phase B/C). Mirrors @stwd/venue-hyperliquid's
-// shape: injected signer/credentials, zod schemas, config-driven builder fee.
+// Polymarket venue adapter for Steward. It owns venue-specific types, parsing,
+// signing, and public market-data access. Route, tenant, and persistence policy
+// remain in the API and trading packages.
 //
-// Layout (per POLYMARKET-KNOWLEDGE-DUMP §6):
+// Layout:
 //   constants    — hosts, chain id, sig types, limits
 //   types        — zod schemas (order, signed order, market, position)
 //   parsing      — Gamma JSON-string parsing (clobTokenIds/outcomes/outcomePrices)

--- a/packages/venue-polymarket/src/marketdata.ts
+++ b/packages/venue-polymarket/src/marketdata.ts
@@ -1,3 +1,4 @@
+import { strictParseJson } from "@stwd/shared";
 import {
   DEFAULT_FETCH_TIMEOUT_MS,
   POLYMARKET_BATCH_PRICE_HISTORY_LIMIT,
@@ -6,8 +7,10 @@ import {
 import type { PolymarketFetchOptions } from "./discovery";
 import { isPricePoint } from "./parsing";
 import {
+  marketByTokenSchema,
   type OrderSide,
   type PolymarketBestPrice,
+  type PolymarketMarketByToken,
   type PolymarketOrderbook,
   type PolymarketPricePoint,
   type PolymarketTickSize,
@@ -23,6 +26,94 @@ function timeoutSignal(opts?: PolymarketFetchOptions): AbortSignal | undefined {
   if (opts?.signal) return opts.signal;
   if (DEFAULT_FETCH_TIMEOUT_MS <= 0) return undefined;
   return AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS);
+}
+
+const MAX_MARKET_BY_TOKEN_RESPONSE_BYTES = 16 * 1024;
+
+async function readBoundedMarketJson(response: Response): Promise<unknown> {
+  const declared = response.headers.get("content-length");
+  if (declared !== null) {
+    if (!/^\d+$/.test(declared)) {
+      throw new Error("Polymarket market metadata returned an invalid Content-Length");
+    }
+    if (Number(declared) > MAX_MARKET_BY_TOKEN_RESPONSE_BYTES) {
+      try {
+        await response.body?.cancel();
+      } catch {
+        throw new Error("Polymarket market metadata overflow could not be canceled");
+      }
+      throw new Error("Polymarket market metadata response is too large");
+    }
+  }
+  if (!response.body) throw new Error("Polymarket market metadata response has no body");
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      total += next.value.byteLength;
+      if (total > MAX_MARKET_BY_TOKEN_RESPONSE_BYTES) {
+        try {
+          await reader.cancel();
+        } catch {
+          throw new Error("Polymarket market metadata overflow could not be canceled");
+        }
+        throw new Error("Polymarket market metadata response is too large");
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  try {
+    return strictParseJson(text);
+  } catch {
+    throw new Error("Polymarket market metadata response is not valid JSON");
+  }
+}
+
+/** Resolve the authoritative condition and sibling token for a CLOB token ID. */
+export async function getMarketByToken(
+  tokenId: string,
+  opts?: PolymarketFetchOptions,
+): Promise<PolymarketMarketByToken> {
+  if (!/^[0-9]{1,128}$/.test(tokenId)) {
+    throw new Error("Polymarket token id must be a bounded numeric string");
+  }
+  const doFetch = opts?.fetch ?? fetch;
+  const clobBase = opts?.clobUrl ?? POLYMARKET_CLOB_API_BASE;
+  const url = new URL(
+    `markets-by-token/${tokenId}`,
+    clobBase.endsWith("/") ? clobBase : `${clobBase}/`,
+  );
+  const response = await doFetch(url.toString(), {
+    headers: { Accept: "application/json" },
+    signal: timeoutSignal(opts),
+  });
+  if (!response.ok) {
+    throw new Error(`Polymarket market metadata error: ${response.status}`);
+  }
+  const parsed = marketByTokenSchema.safeParse(await readBoundedMarketJson(response));
+  if (!parsed.success) throw new Error("Polymarket market metadata response is invalid");
+  if (tokenId !== parsed.data.primary_token_id && tokenId !== parsed.data.secondary_token_id) {
+    throw new Error("Polymarket market metadata does not contain the requested token");
+  }
+  return {
+    conditionId: parsed.data.condition_id.toLowerCase(),
+    primaryTokenId: parsed.data.primary_token_id,
+    secondaryTokenId: parsed.data.secondary_token_id,
+  };
 }
 
 interface RawOrderbook {

--- a/packages/venue-polymarket/src/types.ts
+++ b/packages/venue-polymarket/src/types.ts
@@ -18,6 +18,21 @@ export type OrderType = z.infer<typeof orderTypeSchema>;
 // token_id is the unit of everything on the order side (NOT the slug). Big numeric string.
 export const tokenIdSchema = z.string().regex(/^[0-9]+$/, "token_id must be a numeric string");
 
+export const marketByTokenSchema = z
+  .object({
+    condition_id: z.string().regex(/^0x[0-9a-fA-F]{64}$/, "condition_id must be bytes32 hex"),
+    primary_token_id: z.string().regex(/^[0-9]{1,128}$/, "primary token id must be numeric"),
+    secondary_token_id: z.string().regex(/^[0-9]{1,128}$/, "secondary token id must be numeric"),
+  })
+  .refine((value) => value.primary_token_id !== value.secondary_token_id, {
+    message: "market token ids must be distinct",
+  });
+export type PolymarketMarketByToken = {
+  conditionId: string;
+  primaryTokenId: string;
+  secondaryTokenId: string;
+};
+
 // ---------------------------------------------------------------------------
 // createOrder options (tickSize + negRisk) — MUST be passed to createOrder
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #529.

## Summary
- resolve market-wide Polymarket session grants through the documented markets-by-token endpoint
- require exact bytes32 condition IDs and verify the requested token belongs to the returned market
- bound, strictly parse, and cancel oversized metadata responses; keep exact-token grants network-independent
- make metadata outages retryable without retaining the idempotency claim or reserving spend
- remove obsolete phase and knowledge-dump commentary from the touched venue surface

Official contract: https://docs.polymarket.com/api-reference/markets/get-market-by-token

## Exact-head validation
- 12-package dependency build passed
- venue-polymarket: 62 passed
- trade-sessions: 25 passed
- Polymarket route: 30 passed
- Biome and git diff checks passed

The broad plugin package runner was also exercised. A root invocation missed the package preload and failed two unrelated audit-key fixture cases; the same cases pass under the package-owned command. That package-owned broad run later stalled in unrelated concurrent PGLite suites, so the exact owning route and dependency suites above are the acceptance evidence.