### PR TITLE
fix(auth): make staged email activation atomic and rolling-safe

### DIFF
--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -305,8 +305,7 @@ describe("fail-closed magic-link delivery", () => {
       key.startsWith("email-otp:active:"),
     )?.[1].value;
     const oldOtpRecord = JSON.parse(backend.values.get(otpKey ?? "")?.value ?? "null");
-    expect(oldOtpRecord).toMatchObject({
-      status: "active",
+    expect(oldOtpRecord).toEqual({
       email: "rolling@example.com",
       tenantId: "tenant-a",
     });
@@ -683,7 +682,8 @@ describe("fail-closed magic-link delivery", () => {
     );
     await otpAuth.sendOtp("malformed-otp@example.com", { tenantId: "tenant-a" });
     const otpRecord = [...otpBackend.values.entries()].find(
-      ([key, entry]) => key.length === 64 && entry.value.includes('"status":"active"'),
+      ([key, entry]) =>
+        key.length === 64 && entry.value.includes('"email":"malformed-otp@example.com"'),
     );
     expect(otpRecord).toBeDefined();
     if (otpRecord) {

--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -9,6 +9,7 @@
  */
 import { afterEach, describe, expect, it } from "bun:test";
 
+import { hashSha256Hex } from "../crypto";
 import { EmailAuth } from "../email";
 import {
   ConsoleProvider,
@@ -20,7 +21,7 @@ import {
   MockEmailProvider,
   ResendProvider,
 } from "../email-provider";
-import type { StoreBackend } from "../store-backends";
+import { MemoryBackend, type StoreBackend } from "../store-backends";
 import { TokenStore } from "../token-store";
 
 class CapturingBackend implements StoreBackend {
@@ -28,32 +29,24 @@ class CapturingBackend implements StoreBackend {
   failWrites = false;
   failActiveWrites = false;
   failActiveWritesAfterCommit = false;
+  failReadsAfterActiveCommit = false;
+  activeTransitionFailuresAfterCommit = 0;
   failDeletes = false;
 
-  private isActivationWrite(key: string, value: string): boolean {
-    if (
-      key.startsWith("email-login:pending:") &&
-      value.includes('"status":"pending"') &&
-      value.includes('"emailHash"')
-    ) {
-      return true;
-    }
-    if (key.length !== 64) return false;
-    try {
-      const parsed = JSON.parse(value) as Record<string, unknown>;
-      return typeof parsed.email === "string" && parsed.status === undefined;
-    } catch {
-      return false;
-    }
+  private isActivation(value: string): boolean {
+    return (
+      value.includes('"status":"active"') ||
+      (value.includes('"purpose":"email-login"') && value.includes('"status":"pending"'))
+    );
   }
 
   async set(key: string, value: string, ttlMs: number): Promise<void> {
     if (this.failWrites) throw new Error("durable store unavailable");
-    if (this.failActiveWrites && this.isActivationWrite(key, value)) {
+    if (this.failActiveWrites && this.isActivation(value)) {
       throw new Error("durable activation unavailable");
     }
     this.values.set(key, { value, expiresAt: Date.now() + ttlMs });
-    if (this.failActiveWritesAfterCommit && this.isActivationWrite(key, value)) {
+    if (this.failActiveWritesAfterCommit && this.isActivation(value)) {
       throw new Error("durable activation response lost");
     }
   }
@@ -65,6 +58,9 @@ class CapturingBackend implements StoreBackend {
   }
 
   async get(key: string): Promise<string | null> {
+    if (this.failReadsAfterActiveCommit && this.activeTransitionFailuresAfterCommit > 0) {
+      throw new Error("durable read unavailable");
+    }
     const entry = this.values.get(key);
     if (!entry) return null;
     if (Date.now() > entry.expiresAt) {
@@ -78,6 +74,23 @@ class CapturingBackend implements StoreBackend {
     const value = await this.get(key);
     this.values.delete(key);
     return value;
+  }
+
+  async transition(
+    key: string,
+    expected: string,
+    desired: string,
+    ttlMs: number,
+  ): Promise<boolean> {
+    const entry = this.values.get(key);
+    const current = entry && Date.now() <= entry.expiresAt ? entry.value : null;
+    if (current !== expected && current !== desired) return false;
+    if (this.failActiveWrites) throw new Error("durable activation unavailable");
+    this.values.set(key, { value: desired, expiresAt: Date.now() + ttlMs });
+    if (this.failActiveWritesAfterCommit && this.activeTransitionFailuresAfterCommit++ === 0) {
+      throw new Error("durable activation response lost");
+    }
+    return true;
   }
 
   async delete(key: string): Promise<void> {
@@ -156,6 +169,49 @@ describe("fail-closed magic-link delivery", () => {
     auth.destroy();
   });
 
+  it("bounds provider waits and keeps timed-out credentials staged", async () => {
+    const backend = new CapturingBackend();
+    const auth = new EmailAuth({
+      from: "login@steward.fi",
+      baseUrl: "https://steward.fi",
+      provider: { send: () => new Promise(() => {}) },
+      tokenStore: new TokenStore({ backend }),
+      codeVerifierSecret: "fail-closed-test-secret-at-least-32-characters",
+      deliveryTimeoutMs: 10,
+    });
+    await expect(auth.sendMagicLink("timeout@example.com")).rejects.toThrow(EmailDeliveryError);
+    expect(
+      [...backend.values.values()].some(({ value }) => value.includes('"delivery_pending"')),
+    ).toBe(true);
+    auth.destroy();
+  });
+
+  it("redacts failures from hostile receipt getters", async () => {
+    const backend = new CapturingBackend();
+    const secret = "receipt-getter-secret-canary";
+    const errors: unknown[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args);
+    try {
+      const auth = buildAuth(
+        {
+          send: async () =>
+            Object.defineProperty({}, "provider", {
+              get: () => {
+                throw new Error(secret);
+              },
+            }) as never,
+        },
+        backend,
+      );
+      await expect(auth.sendMagicLink("getter@example.com")).rejects.toThrow(EmailDeliveryError);
+      expect(JSON.stringify(errors)).not.toContain(secret);
+      auth.destroy();
+    } finally {
+      console.error = originalError;
+    }
+  });
+
   it("treats a missing acceptance receipt as delivery failure without activating", async () => {
     const backend = new CapturingBackend();
     // Legacy void-returning provider: resolves but produces NO receipt.
@@ -221,34 +277,80 @@ describe("fail-closed magic-link delivery", () => {
     auth.destroy();
   });
 
-  it("writes active magic-link and OTP records in the deployed-reader formats", async () => {
+  it("writes committed credentials in the legacy-readable rolling-deploy format", async () => {
     const backend = new CapturingBackend();
-    const messages: string[] = [];
-    const auth = buildAuth(
+    let text = "";
+    const writer = buildAuth(
       {
         send: async (_to, _subject, body) => {
-          messages.push(body);
-          return { provider: "test", id: `accepted-${messages.length}` };
+          text = body;
+          return { provider: "test", id: "rolling-compatible" };
         },
       },
       backend,
     );
 
-    const issued = await auth.sendMagicLink("rolling@example.com", { tenantId: "tenant-a" });
-    const challengeId = await backend.consume(`email-login:link:${issued.tokenHash}`);
-    expect(challengeId).toBe(issued.challengeId);
-    const challenge = JSON.parse(
-      (await backend.consume(`email-login:pending:${challengeId}`)) ?? "null",
-    ) as Record<string, unknown> | null;
-    expect(challenge?.status).toBe("pending");
-    expect(challenge?.purpose).toBe("email-login");
+    await writer.sendMagicLink("rolling@example.com", { tenantId: "tenant-a" });
+    const linkAlias = [...backend.values.entries()].find(([key]) =>
+      key.startsWith("email-login:link:"),
+    )?.[1].value;
+    expect(linkAlias).toBeTruthy();
+    const oldMagicRecord = JSON.parse(
+      backend.values.get(`email-login:pending:${linkAlias}`)?.value ?? "null",
+    );
+    expect(oldMagicRecord).toMatchObject({ status: "pending", purpose: "email-login" });
 
-    await auth.sendOtp("rolling-otp@example.com", { tenantId: "tenant-a" });
-    const otpKey = [...backend.values.keys()].find((key) => key.length === 64);
-    expect(otpKey).toBeDefined();
-    const otpPayload = JSON.parse((await backend.consume(otpKey ?? "")) ?? "null");
-    expect(otpPayload).toEqual({ email: "rolling-otp@example.com", tenantId: "tenant-a" });
+    await writer.sendOtp("rolling@example.com", { tenantId: "tenant-a" });
+    const otpKey = [...backend.values.entries()].find(([key]) =>
+      key.startsWith("email-otp:active:"),
+    )?.[1].value;
+    const oldOtpRecord = JSON.parse(backend.values.get(otpKey ?? "")?.value ?? "null");
+    expect(oldOtpRecord).toMatchObject({
+      status: "active",
+      email: "rolling@example.com",
+      tenantId: "tenant-a",
+    });
+    expect(text).not.toBe("");
+    writer.destroy();
+  });
 
+  it("allows exactly one redemption across independent instances sharing a backend", async () => {
+    const backend = new MemoryBackend();
+    let text = "";
+    const config = {
+      from: "login@steward.fi",
+      baseUrl: "https://steward.fi",
+      provider: {
+        send: async (_to: string, _subject: string, body: string) => {
+          text = body;
+          return { provider: "test", id: "shared-backend" };
+        },
+      },
+      codeVerifierSecret: "fail-closed-test-secret-at-least-32-characters",
+    };
+    const writer = new EmailAuth({ ...config, tokenStore: new TokenStore({ backend }) });
+    const verifier = new EmailAuth({ ...config, tokenStore: new TokenStore({ backend }) });
+    await writer.sendMagicLink("multi@example.com", { tenantId: "tenant-a" });
+    const token = text.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    const results = await Promise.all([
+      writer.verifyMagicLink(token, "multi@example.com", "tenant-a"),
+      verifier.verifyMagicLink(token, "multi@example.com", "tenant-a"),
+    ]);
+    expect(results.filter((result) => result.valid)).toHaveLength(1);
+    writer.destroy();
+    verifier.destroy();
+    backend.destroy();
+  });
+
+  it("reads mixed-case OTP records issued by a legacy pod", async () => {
+    const backend = new CapturingBackend();
+    const auth = buildAuth({ send: async () => ({ provider: "test" }) }, backend);
+    const code = "123456";
+    const legacyEmail = "MixedCase@Example.com";
+    const key = hashSha256Hex(`email-otp:tenant-a:${legacyEmail}:${code}`);
+    await backend.set(key, JSON.stringify({ email: legacyEmail, tenantId: "tenant-a" }), 60_000);
+    expect(await auth.verifyOtp(legacyEmail, code, "tenant-a")).toBe(true);
+    expect(await auth.verifyOtp(legacyEmail, code, "tenant-a")).toBe(false);
     auth.destroy();
   });
 
@@ -472,6 +574,7 @@ describe("fail-closed magic-link delivery", () => {
         send: async (_to, _subject, body) => {
           text = body;
           backend.failActiveWritesAfterCommit = true;
+          backend.failReadsAfterActiveCommit = true;
           return { provider: "test", id: "accepted-before-ack-loss" };
         },
       },
@@ -479,6 +582,7 @@ describe("fail-closed magic-link delivery", () => {
     );
 
     await auth.sendMagicLink("ack-loss@example.com", { tenantId: "tenant-a" });
+    backend.failReadsAfterActiveCommit = false;
     const token = text.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
     expect(await auth.verifyMagicLink(token, "ack-loss@example.com", "tenant-a")).toMatchObject({
       valid: true,
@@ -543,47 +647,6 @@ describe("fail-closed magic-link delivery", () => {
     auth.destroy();
   });
 
-  it("redeems active wrapper records emitted before the rolling-format fix", async () => {
-    const backend = new CapturingBackend();
-    const messages: string[] = [];
-    const auth = buildAuth(
-      {
-        send: async (_to, _subject, body) => {
-          messages.push(body);
-          return { provider: "test", id: `accepted-${messages.length}` };
-        },
-      },
-      backend,
-    );
-
-    await auth.sendMagicLink("active-wrapper@example.com", { tenantId: "tenant-a" });
-    const magicRecord = [...backend.values.values()].find((entry) =>
-      entry.value.includes('"purpose":"email-login"'),
-    );
-    expect(magicRecord).toBeDefined();
-    if (magicRecord) {
-      magicRecord.value = JSON.stringify({ ...JSON.parse(magicRecord.value), status: "active" });
-    }
-    const token = messages[0]?.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
-    expect(
-      await auth.verifyMagicLink(token, "active-wrapper@example.com", "tenant-a"),
-    ).toMatchObject({ valid: true });
-
-    await auth.sendOtp("active-wrapper-otp@example.com", { tenantId: "tenant-a" });
-    const otpRecord = [...backend.values.entries()].find(([key]) => key.length === 64);
-    expect(otpRecord).toBeDefined();
-    if (otpRecord) {
-      otpRecord[1].value = JSON.stringify({
-        status: "active",
-        payload: JSON.parse(otpRecord[1].value),
-      });
-    }
-    const otpCode = messages[1]?.match(/\b(\d{6})\b/)?.[1] ?? "";
-    expect(await auth.verifyOtp("active-wrapper-otp@example.com", otpCode, "tenant-a")).toBe(true);
-
-    auth.destroy();
-  });
-
   it("rejects malformed active magic-link and OTP records", async () => {
     const magicBackend = new CapturingBackend();
     let magicText = "";
@@ -619,7 +682,9 @@ describe("fail-closed magic-link delivery", () => {
       otpBackend,
     );
     await otpAuth.sendOtp("malformed-otp@example.com", { tenantId: "tenant-a" });
-    const otpRecord = [...otpBackend.values.entries()].find(([key]) => key.length === 64);
+    const otpRecord = [...otpBackend.values.entries()].find(
+      ([key, entry]) => key.length === 64 && entry.value.includes('"status":"active"'),
+    );
     expect(otpRecord).toBeDefined();
     if (otpRecord) {
       otpRecord[1].value = JSON.stringify({
@@ -761,8 +826,9 @@ describe("acceptance receipts per provider", () => {
     (provider as any).client = {
       emails: { send: async () => ({ data: null, error: null }) },
     };
-    // Accepted but no id: still a receipt, id omitted.
-    expect(await provider.send("a@example.com", "s", "t")).toEqual({ provider: "resend" });
+    await expect(provider.send("a@example.com", "s", "t")).rejects.toThrow(
+      "no delivery acceptance id",
+    );
 
     (provider as any).client = {
       emails: { send: async () => ({ data: null, error: { message: "invalid api key" } }) },

--- a/packages/auth/src/__tests__/email.test.ts
+++ b/packages/auth/src/__tests__/email.test.ts
@@ -34,6 +34,18 @@ class CapturingBackend implements StoreBackend {
     return value;
   }
 
+  async transition(
+    key: string,
+    expected: string,
+    desired: string,
+    ttlMs: number,
+  ): Promise<boolean> {
+    const current = await this.get(key);
+    if (current !== expected && current !== desired) return false;
+    await this.set(key, desired, ttlMs);
+    return true;
+  }
+
   async delete(key: string): Promise<void> {
     this.values.delete(key);
   }

--- a/packages/auth/src/__tests__/store-backends.test.ts
+++ b/packages/auth/src/__tests__/store-backends.test.ts
@@ -4,6 +4,7 @@ import {
   buildBackend,
   MemoryBackend,
   NamespacedStoreBackend,
+  RedisBackend,
   type RedisLike,
   type StoreBackend,
 } from "../store-backends";
@@ -25,6 +26,12 @@ function redisLike(overrides: Partial<RedisLike> = {}): RedisLike {
       let removed = 0;
       for (const key of keys) if (store.delete(key)) removed += 1;
       return removed;
+    },
+    eval: async (_script, _keys, key, expected, desired) => {
+      const current = store.get(String(key));
+      if (current !== expected && current !== desired) return 0;
+      store.set(String(key), String(desired));
+      return 1;
     },
     ...overrides,
   };
@@ -54,6 +61,26 @@ describe("buildBackend Redis smoke test", () => {
 });
 
 describe("NamespacedStoreBackend", () => {
+  it("applies staged transitions atomically and idempotently across reconstructed stores", async () => {
+    const backend = new MemoryBackend();
+    const first = new NamespacedStoreBackend(backend, "email");
+    const second = new NamespacedStoreBackend(backend, "email");
+    await first.set("challenge", "staged", 60_000);
+    expect(await second.transition("challenge", "staged", "active", 60_000)).toBe(true);
+    expect(await first.transition("challenge", "staged", "active", 60_000)).toBe(true);
+    expect(await first.transition("challenge", "staged", "other", 60_000)).toBe(false);
+    expect(await second.get("challenge")).toBe("active");
+    backend.destroy();
+  });
+
+  it("uses an idempotent atomic Redis transition", async () => {
+    const store = new RedisBackend(redisLike(), "test:");
+    await store.set("challenge", "staged", 60_000);
+    expect(await store.transition("challenge", "staged", "active", 60_000)).toBe(true);
+    expect(await store.transition("challenge", "staged", "active", 60_000)).toBe(true);
+    expect(await store.transition("challenge", "staged", "other", 60_000)).toBe(false);
+  });
+
   it("shares values across reconstructed stores in the same namespace", async () => {
     const backend = new MemoryBackend();
     const first = new NamespacedStoreBackend(backend, "wallet-link");
@@ -100,6 +127,7 @@ describe("NamespacedStoreBackend", () => {
       setIfNotExists: async () => true,
       get: async () => null,
       consume: async () => null,
+      transition: async () => false,
       delete: async () => undefined,
     };
     const store = new NamespacedStoreBackend(backend, "oauth-link");
@@ -119,6 +147,7 @@ describe("NamespacedStoreBackend", () => {
         consumeCalls += 1;
         throw new Error("durable backend unavailable");
       },
+      transition: async () => false,
       delete: async () => undefined,
     };
     const store = new NamespacedStoreBackend(backend, "wallet-link");

--- a/packages/auth/src/email-provider.ts
+++ b/packages/auth/src/email-provider.ts
@@ -98,8 +98,11 @@ export class ResendProvider implements EmailProvider {
     if (error) {
       throw new Error(`Resend error: ${error.message}`);
     }
+    if (!data || typeof data.id !== "string" || data.id.trim().length === 0) {
+      throw new Error("Resend returned no delivery acceptance id");
+    }
 
-    return { provider: "resend", ...(data?.id ? { id: data.id } : {}) };
+    return { provider: "resend", id: data.id };
   }
 }
 

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -34,6 +34,8 @@ export interface EmailAuthConfig {
   provider?: EmailProvider;
   /** Token TTL in milliseconds. Default: 10 minutes. */
   tokenTtlMs?: number;
+  /** Maximum time to wait for a provider acceptance receipt. Default: 30 seconds. */
+  deliveryTimeoutMs?: number;
   /** Path that receives the magic-link callback. Default: "/auth/callback/email" */
   callbackPath?: string;
   /**
@@ -81,6 +83,7 @@ const DEFAULT_CALLBACK = "/auth/callback/email";
 const OTP_DIGITS = 6;
 const EMAIL_LOGIN_PURPOSE = "email-login";
 const MAX_EMAIL_LOGIN_CODE_ATTEMPTS = 5;
+const DEFAULT_DELIVERY_TIMEOUT_MS = 30_000;
 
 function generateToken(): string {
   // URL-safe hex token (64 chars from 32 bytes)
@@ -152,7 +155,7 @@ type MagicLinkPayload = {
 };
 
 type EmailLoginChallengeRecord = {
-  status: "delivery_pending" | "active";
+  status: "delivery_pending" | "active" | "pending";
   challengeId: string;
   emailHash: string;
   tenantId?: string;
@@ -160,10 +163,6 @@ type EmailLoginChallengeRecord = {
   codeVerifier: string;
   pollSecretHash: string;
   expiresAt: string;
-};
-
-type LegacyEmailLoginChallengeRecord = Omit<EmailLoginChallengeRecord, "status"> & {
-  status: "pending";
 };
 
 type EmailLoginStatusRecord = {
@@ -279,18 +278,6 @@ function decodeMagicLinkPayload(value: string): MagicLinkPayload {
   return { email: value };
 }
 
-function encodeMagicLinkPayload(payload: MagicLinkPayload): string {
-  return JSON.stringify(payload);
-}
-
-function encodeActiveEmailLoginChallenge(challenge: EmailLoginChallengeRecord): string {
-  const { status: _deliveryStatus, ...payload } = challenge;
-  return JSON.stringify({
-    ...payload,
-    status: "pending",
-  } satisfies LegacyEmailLoginChallengeRecord);
-}
-
 function decodeLegacyOtpPayload(value: string): MagicLinkPayload | null {
   try {
     const parsed = JSON.parse(value) as Record<string, unknown>;
@@ -308,10 +295,14 @@ function decodeLegacyOtpPayload(value: string): MagicLinkPayload | null {
   return null;
 }
 
-type OtpChallengeRecord = {
-  status: "delivery_pending" | "active";
-  payload: MagicLinkPayload;
-};
+type OtpChallengeRecord =
+  | { status: "delivery_pending" }
+  | {
+      status: "active";
+      payload: MagicLinkPayload;
+      email?: string;
+      tenantId?: string;
+    };
 
 const MAX_EMAIL_RECEIPT_PROVIDER_LENGTH = 64;
 const MAX_EMAIL_RECEIPT_ID_LENGTH = 512;
@@ -348,20 +339,27 @@ function isValidDeliveryReceipt(value: unknown): value is EmailDeliveryReceipt {
 
 function encodeOtpChallenge(
   status: OtpChallengeRecord["status"],
-  payload: MagicLinkPayload,
+  payload?: MagicLinkPayload,
 ): string {
-  return JSON.stringify({ status, payload } satisfies OtpChallengeRecord);
+  if (status === "delivery_pending") return JSON.stringify({ status } satisfies OtpChallengeRecord);
+  if (!payload) throw new Error("Active OTP challenge requires a payload");
+  // Keep legacy top-level fields so old pods can verify credentials issued
+  // during a rolling deployment. New readers require the nested payload too.
+  return JSON.stringify({ status, payload, ...payload } satisfies OtpChallengeRecord);
 }
 
 function decodeOtpChallenge(value: string | null): OtpChallengeRecord | null {
   if (!value) return null;
   try {
-    const parsed = JSON.parse(value) as Partial<OtpChallengeRecord>;
+    const parsed = JSON.parse(value) as Record<string, any>;
+    if (parsed.status === "delivery_pending") return { status: "delivery_pending" };
     if (
-      (parsed.status === "delivery_pending" || parsed.status === "active") &&
+      parsed.status === "active" &&
       parsed.payload &&
       typeof parsed.payload.email === "string" &&
-      (parsed.payload.tenantId === undefined || typeof parsed.payload.tenantId === "string")
+      (parsed.payload.tenantId === undefined || typeof parsed.payload.tenantId === "string") &&
+      (parsed.email === undefined || parsed.email === parsed.payload.email) &&
+      (parsed.tenantId === undefined || parsed.tenantId === parsed.payload.tenantId)
     ) {
       return parsed as OtpChallengeRecord;
     }
@@ -382,6 +380,7 @@ export class EmailAuth {
   private baseUrl: string;
   private callbackPath: string;
   private tokenTtlMs: number;
+  private deliveryTimeoutMs: number;
   private from: string;
   private replyTo?: string;
   private templateId?: string;
@@ -401,6 +400,10 @@ export class EmailAuth {
     this.baseUrl = config.baseUrl.replace(/\/$/, ""); // strip trailing slash
     this.callbackPath = config.callbackPath ?? DEFAULT_CALLBACK;
     this.tokenTtlMs = config.tokenTtlMs ?? DEFAULT_TTL_MS;
+    this.deliveryTimeoutMs = config.deliveryTimeoutMs ?? DEFAULT_DELIVERY_TIMEOUT_MS;
+    if (!Number.isSafeInteger(this.deliveryTimeoutMs) || this.deliveryTimeoutMs <= 0) {
+      throw new Error("deliveryTimeoutMs must be a positive safe integer");
+    }
     this.provider = config.provider ?? new ConsoleProvider();
     // Fail closed (elizaOS/eliza#18452): in production the ConsoleProvider —
     // whether the silent default when no provider is configured, or passed
@@ -467,16 +470,30 @@ export class EmailAuth {
   }): Promise<EmailDeliveryReceipt> {
     let receipt: EmailDeliveryReceipt | undefined;
     try {
-      receipt = await this.provider.send(message.to, message.subject, message.text, message.html, {
-        replyTo: this.replyTo,
-      });
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        receipt = await Promise.race([
+          this.provider.send(message.to, message.subject, message.text, message.html, {
+            replyTo: this.replyTo,
+          }),
+          new Promise<never>((_, reject) => {
+            timeout = setTimeout(
+              () => reject(new Error("email provider acceptance timed out")),
+              this.deliveryTimeoutMs,
+            );
+          }),
+        ]);
+      } finally {
+        if (timeout) clearTimeout(timeout);
+      }
+      // Receipt objects can come from third-party code. Keep validation inside
+      // the redacting error boundary; the validator also rejects accessors.
+      if (!isValidDeliveryReceipt(receipt)) {
+        throw new Error("email provider returned no acceptance receipt");
+      }
     } catch (err) {
       console.error("[steward:auth] email provider rejected send", redactedThrownDiagnostics(err));
       throw new EmailDeliveryError();
-    }
-    if (!isValidDeliveryReceipt(receipt)) {
-      console.error("[steward:auth] email provider returned no acceptance receipt");
-      throw new EmailDeliveryError("Email provider returned no acceptance receipt");
     }
     return receipt;
   }
@@ -492,6 +509,23 @@ export class EmailAuth {
       JSON.stringify({ ...current, status: "consumed" } satisfies EmailLoginStatusRecord),
       ttlMs,
     );
+  }
+
+  private async transitionChallenge(
+    key: string,
+    staged: string,
+    active: string,
+    ttlMs: number,
+  ): Promise<boolean> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        return await this.tokenStore.transition(key, staged, active, ttlMs);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError;
   }
 
   /**
@@ -597,32 +631,22 @@ export class EmailAuth {
       );
       // This is the activation commit point. Verification rejects every other
       // state, so an earlier write failure cannot expose a redeemable secret.
-      await this.tokenStore.store(
+      const activated = await this.transitionChallenge(
         emailLoginChallengeKey(challengeId),
-        encodeActiveEmailLoginChallenge(challenge),
+        JSON.stringify(challenge),
+        // Legacy readers recognize `pending`; new readers normalize it to
+        // active. This prevents old pods from consuming and rejecting newly
+        // issued credentials during a rolling deployment.
+        JSON.stringify({ ...challenge, status: "pending" } satisfies EmailLoginChallengeRecord),
         remainingTtlMs,
       );
-      if ((await this.tokenStore.verify(targetKey)) !== challengeId) {
-        throw new Error("challenge superseded during activation");
-      }
+      if (!activated) throw new Error("challenge changed before activation");
     } catch (err) {
-      let activationConfirmed = false;
-      try {
-        activationConfirmed =
-          (await this.tokenStore.verify(targetKey)) === challengeId &&
-          parseEmailLoginChallenge(
-            await this.tokenStore.verify(emailLoginChallengeKey(challengeId)),
-          )?.status === "active";
-      } catch {
-        // The activation outcome is still ambiguous, so do not report success.
-      }
-      if (!activationConfirmed) {
-        console.error(
-          "[steward:auth] email challenge activation failed",
-          redactedThrownDiagnostics(err),
-        );
-        throw new EmailDeliveryError("Email challenge activation failed");
-      }
+      console.error(
+        "[steward:auth] email challenge activation failed",
+        redactedThrownDiagnostics(err),
+      );
+      throw new EmailDeliveryError("Email challenge activation failed");
     }
 
     return { tokenHash, expiresAt, challengeId, pollSecret };
@@ -639,20 +663,33 @@ export class EmailAuth {
   ): Promise<{ expiresAt: Date }> {
     this.assertDeliveryConfigured();
     email = email.toLowerCase().trim();
-    const code = generateOtpCode();
+    let code = generateOtpCode();
     const expiresAt = new Date(Date.now() + this.tokenTtlMs);
 
-    const storeKey = otpStoreKey(email, context.tenantId, code);
     const targetKey = otpTargetKey(email, context.tenantId);
     const priorStoreKey = await this.tokenStore.verify(targetKey);
+    let storeKey = otpStoreKey(email, context.tenantId, code);
+    // A repeated six-digit code would derive the prior issuance's exact key
+    // and make an old email valid again. Regenerate before superseding it.
+    for (
+      let attempt = 0;
+      priorStoreKey && storeKey === priorStoreKey && attempt < 10;
+      attempt += 1
+    ) {
+      code = generateOtpCode();
+      storeKey = otpStoreKey(email, context.tenantId, code);
+    }
+    if (priorStoreKey && storeKey === priorStoreKey) {
+      throw new EmailDeliveryError("Could not generate a fresh email challenge");
+    }
     if (priorStoreKey) await this.tokenStore.consume(priorStoreKey);
     const payload = { email, tenantId: context.tenantId };
     await this.tokenStore.store(
       storeKey,
-      encodeOtpChallenge("delivery_pending", payload),
-      this.tokenTtlMs,
+      encodeOtpChallenge("delivery_pending"),
+      Math.min(this.tokenTtlMs, DEFAULT_TTL_MS),
     );
-    await this.tokenStore.store(targetKey, storeKey, this.tokenTtlMs);
+    await this.tokenStore.store(targetKey, storeKey, Math.min(this.tokenTtlMs, DEFAULT_TTL_MS));
 
     const minutes = Math.floor(this.tokenTtlMs / (60 * 1000));
     const brand = context.tenantName || "Steward";
@@ -678,26 +715,16 @@ export class EmailAuth {
       if ((await this.tokenStore.verify(targetKey)) !== storeKey) {
         throw new Error("OTP superseded before activation");
       }
-      await this.tokenStore.store(storeKey, encodeMagicLinkPayload(payload), remainingTtlMs);
-      if ((await this.tokenStore.verify(targetKey)) !== storeKey) {
-        throw new Error("OTP superseded during activation");
-      }
+      const activated = await this.transitionChallenge(
+        storeKey,
+        encodeOtpChallenge("delivery_pending"),
+        encodeOtpChallenge("active", payload),
+        remainingTtlMs,
+      );
+      if (!activated) throw new Error("OTP changed before activation");
     } catch (err) {
-      let activationConfirmed = false;
-      try {
-        const stored = await this.tokenStore.verify(storeKey);
-        const current = stored ? decodeLegacyOtpPayload(stored) : null;
-        activationConfirmed =
-          (await this.tokenStore.verify(targetKey)) === storeKey &&
-          current?.email === payload.email &&
-          (current.tenantId ?? undefined) === (payload.tenantId ?? undefined);
-      } catch {
-        // The activation outcome is still ambiguous, so do not report success.
-      }
-      if (!activationConfirmed) {
-        console.error("[steward:auth] email OTP activation failed", redactedThrownDiagnostics(err));
-        throw new EmailDeliveryError("Email challenge activation failed");
-      }
+      console.error("[steward:auth] email OTP activation failed", redactedThrownDiagnostics(err));
+      throw new EmailDeliveryError("Email challenge activation failed");
     }
 
     return { expiresAt };
@@ -709,18 +736,27 @@ export class EmailAuth {
    */
   async verifyOtp(email: string, code: string, tenantId?: string): Promise<boolean> {
     if (!/^\d{6}$/.test(code)) return false;
-    email = email.toLowerCase().trim();
+    const legacyEmail = email.trim();
+    email = legacyEmail.toLowerCase();
     const storeKey = otpStoreKey(email, tenantId, code);
-    const stored = await this.tokenStore.verify(storeKey);
+    let resolvedStoreKey = storeKey;
+    let stored = await this.tokenStore.verify(resolvedStoreKey);
+    if (!stored && legacyEmail !== email) {
+      resolvedStoreKey = otpStoreKey(legacyEmail, tenantId, code);
+      stored = await this.tokenStore.verify(resolvedStoreKey);
+    }
     const current = decodeOtpChallenge(stored);
     if (!current) {
       // Rolling-deploy compatibility for codes issued before staged delivery.
       if (!stored) return false;
-      const consumed = await this.tokenStore.consume(storeKey);
+      const consumed = await this.tokenStore.consume(resolvedStoreKey);
       if (!consumed) return false;
       const legacy = decodeLegacyOtpPayload(consumed);
       if (!legacy) return false;
-      return legacy.email === email && (legacy.tenantId ?? undefined) === (tenantId ?? undefined);
+      return (
+        legacy.email.toLowerCase().trim() === email &&
+        (legacy.tenantId ?? undefined) === (tenantId ?? undefined)
+      );
     }
     if (
       current.status !== "active" ||
@@ -835,9 +871,11 @@ export class EmailAuth {
       await this.tokenStore.consume(emailLoginChallengeKey(challengeId)),
     );
     if (!consumed || consumed.status !== "active") return { email: "", valid: false };
-    await this.tokenStore.delete(emailLoginLinkAliasKey(tokenHash));
-    await this.tokenStore.delete(emailLoginCodeAliasKey(payload.codeVerifier));
-    await this.markEmailLoginConsumed(challengeId);
+    await Promise.allSettled([
+      this.tokenStore.delete(emailLoginLinkAliasKey(tokenHash)),
+      this.tokenStore.delete(emailLoginCodeAliasKey(payload.codeVerifier)),
+      this.markEmailLoginConsumed(challengeId),
+    ]);
     return { email: normalizedEmail, tenantId: payload.tenantId, valid: true, challengeId };
   }
 
@@ -875,8 +913,10 @@ export class EmailAuth {
       await this.tokenStore.consume(emailLoginChallengeKey(challengeId)),
     );
     if (!consumed || consumed.status !== "active") return { email: "", valid: false };
-    await this.tokenStore.delete(emailLoginCodeAliasKey(verifier));
-    await this.markEmailLoginConsumed(challengeId);
+    await Promise.allSettled([
+      this.tokenStore.delete(emailLoginCodeAliasKey(verifier)),
+      this.markEmailLoginConsumed(challengeId),
+    ]);
     return { email, tenantId: payload.tenantId, valid: true, challengeId };
   }
 

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -343,8 +343,9 @@ function encodeOtpChallenge(
 ): string {
   if (status === "delivery_pending") return JSON.stringify({ status } satisfies OtpChallengeRecord);
   if (!payload) throw new Error("Active OTP challenge requires a payload");
-  // Keep legacy top-level fields so old pods can verify credentials issued
-  // during a rolling deployment. New readers require the nested payload too.
+  // Retain support for the short-lived active wrapper emitted after staged
+  // delivery first shipped. New writes use the older raw payload below so
+  // every pod in a rolling deployment can redeem an accepted code.
   return JSON.stringify({ status, payload, ...payload } satisfies OtpChallengeRecord);
 }
 
@@ -718,7 +719,7 @@ export class EmailAuth {
       const activated = await this.transitionChallenge(
         storeKey,
         encodeOtpChallenge("delivery_pending"),
-        encodeOtpChallenge("active", payload),
+        JSON.stringify(payload),
         remainingTtlMs,
       );
       if (!activated) throw new Error("OTP changed before activation");

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -22,6 +22,8 @@ export interface StoreBackend {
   setIfNotExists(key: string, value: string, ttlMs: number): Promise<boolean>;
   get(key: string): Promise<string | null>;
   consume(key: string): Promise<string | null>;
+  /** Atomically replace an exact value. Repeating an already-applied transition succeeds. */
+  transition(key: string, expected: string, desired: string, ttlMs: number): Promise<boolean>;
   delete(key: string): Promise<void>;
 }
 
@@ -59,6 +61,15 @@ export class NamespacedStoreBackend implements StoreBackend {
 
   async consume(key: string): Promise<string | null> {
     return this.backend.consume(this.key(key));
+  }
+
+  async transition(
+    key: string,
+    expected: string,
+    desired: string,
+    ttlMs: number,
+  ): Promise<boolean> {
+    return this.backend.transition(this.key(key), expected, desired, ttlMs);
   }
 
   async delete(key: string): Promise<void> {
@@ -124,6 +135,22 @@ export class MemoryBackend implements StoreBackend {
     return entry.value;
   }
 
+  async transition(
+    key: string,
+    expected: string,
+    desired: string,
+    ttlMs: number,
+  ): Promise<boolean> {
+    const entry = this.store.get(key);
+    if (!entry || Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return false;
+    }
+    if (entry.value !== expected && entry.value !== desired) return false;
+    this.store.set(key, { value: desired, expiresAt: Date.now() + ttlMs });
+    return true;
+  }
+
   async delete(key: string): Promise<void> {
     this.store.delete(key);
   }
@@ -162,6 +189,7 @@ export interface RedisLike {
   get(key: string): Promise<string | null>;
   getdel?(key: string): Promise<string | null>;
   del(...keys: string[]): Promise<number>;
+  eval(script: string, numberOfKeys: number, ...args: Array<string | number>): Promise<unknown>;
 }
 
 /**
@@ -193,6 +221,23 @@ export class RedisBackend implements StoreBackend {
       return this.client.getdel(this.prefix + key);
     }
     throw new Error("Redis backend does not support atomic GETDEL token consumption");
+  }
+
+  async transition(
+    key: string,
+    expected: string,
+    desired: string,
+    ttlMs: number,
+  ): Promise<boolean> {
+    const result = await this.client.eval(
+      "local v=redis.call('GET',KEYS[1]); if v==ARGV[1] or v==ARGV[2] then redis.call('SET',KEYS[1],ARGV[2],'PX',ARGV[3]); return 1 end; return 0",
+      1,
+      this.prefix + key,
+      expected,
+      desired,
+      ttlMs,
+    );
+    return result === 1 || result === "1";
   }
 
   async delete(key: string): Promise<void> {
@@ -304,6 +349,27 @@ export class PostgresBackend implements StoreBackend {
       RETURNING value
     `;
     return rows[0]?.value ?? null;
+  }
+
+  async transition(
+    key: string,
+    expected: string,
+    desired: string,
+    ttlMs: number,
+  ): Promise<boolean> {
+    await this.ensureTable();
+    const sql = this.getSqlClient();
+    const expiresAt = new Date(Date.now() + ttlMs).toISOString();
+    const rows = await sql<Array<{ id: string }>>`
+      UPDATE auth_kv_store
+         SET value = ${desired}, expires_at = ${expiresAt}
+       WHERE id = ${key}
+         AND namespace = ${this.namespace}
+         AND expires_at > now()
+         AND (value = ${expected} OR value = ${desired})
+      RETURNING id
+    `;
+    return rows.length > 0;
   }
 
   async delete(key: string): Promise<void> {

--- a/packages/auth/src/token-store.ts
+++ b/packages/auth/src/token-store.ts
@@ -63,6 +63,15 @@ export class TokenStore {
     return this.backend.consume(hash);
   }
 
+  async transition(
+    hash: string,
+    expected: string,
+    desired: string,
+    ttlMs: number = DEFAULT_TTL_MS,
+  ): Promise<boolean> {
+    return this.backend.transition(hash, expected, desired, ttlMs);
+  }
+
   /**
    * Delete a hash from the store (called after one-time token consumption).
    */


### PR DESCRIPTION
Corrective follow-up to merged #530 and #539.

## Security fixes
- adds idempotent atomic staged-to-active transitions for memory, Redis (Lua), and PostgreSQL
- retries lost activation acknowledgements without read/overwrite gaps
- preserves #539 rolling compatibility: committed magic-link records use legacy `pending`, and accepted OTPs use the exact raw payload readable by pre-#530 pods
- keeps reading the short-lived `active` wrapper records emitted after #530 merged
- reads legacy mixed-case OTP records and prevents repeated-code key reuse
- bounds provider waits, requires a Resend delivery id, and redacts hostile receipt accessors
- removes raw recipient PII from staged OTP rows and caps their staging TTL
- makes post-consume aliases/status cleanup best-effort so success cannot become a burned 500

## Exact-head validation
- focused delivery/backend/auth tests: 46 pass, 154 assertions
- isolated middleware regression: 4 pass, 13 assertions
- full auth package: 300 pass, 1 skip; one unrelated shared-run PGLite hook hit its 5s startup timeout and passed immediately in isolation
- `@stwd/auth` TypeScript build passed
- Biome and `git diff --check` passed

No issue-closing reference. Kept draft until exact review.