### PR TITLE
fix(auth): preserve rolling email challenge redemption

### DIFF
--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -8816,7 +8816,7 @@ auth.post("/email/otp/send", async (c) => {
     ({ expiresAt } = await emailAuth.sendOtp(email, { tenantId: resolvedTenantId }));
   } catch (err) {
     // Fail closed: mirror /email/send — no ok:true without an acceptance
-    // receipt, and the stored code is deleted by EmailAuth on failure.
+    // receipt, and EmailAuth keeps an unaccepted code non-redeemable.
     const deliveryFailure = emailDeliveryFailureResponse(c, err);
     if (deliveryFailure) return deliveryFailure;
     throw err;

--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -30,13 +30,30 @@ class CapturingBackend implements StoreBackend {
   failActiveWritesAfterCommit = false;
   failDeletes = false;
 
+  private isActivationWrite(key: string, value: string): boolean {
+    if (
+      key.startsWith("email-login:pending:") &&
+      value.includes('"status":"pending"') &&
+      value.includes('"emailHash"')
+    ) {
+      return true;
+    }
+    if (key.length !== 64) return false;
+    try {
+      const parsed = JSON.parse(value) as Record<string, unknown>;
+      return typeof parsed.email === "string" && parsed.status === undefined;
+    } catch {
+      return false;
+    }
+  }
+
   async set(key: string, value: string, ttlMs: number): Promise<void> {
     if (this.failWrites) throw new Error("durable store unavailable");
-    if (this.failActiveWrites && value.includes('"status":"active"')) {
+    if (this.failActiveWrites && this.isActivationWrite(key, value)) {
       throw new Error("durable activation unavailable");
     }
     this.values.set(key, { value, expiresAt: Date.now() + ttlMs });
-    if (this.failActiveWritesAfterCommit && value.includes('"status":"active"')) {
+    if (this.failActiveWritesAfterCommit && this.isActivationWrite(key, value)) {
       throw new Error("durable activation response lost");
     }
   }
@@ -200,6 +217,37 @@ describe("fail-closed magic-link delivery", () => {
     const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
     const result = await auth.verifyEmailLoginCode("ok@example.com", code, "tenant-a");
     expect(result.valid).toBe(true);
+
+    auth.destroy();
+  });
+
+  it("writes active magic-link and OTP records in the deployed-reader formats", async () => {
+    const backend = new CapturingBackend();
+    const messages: string[] = [];
+    const auth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          messages.push(body);
+          return { provider: "test", id: `accepted-${messages.length}` };
+        },
+      },
+      backend,
+    );
+
+    const issued = await auth.sendMagicLink("rolling@example.com", { tenantId: "tenant-a" });
+    const challengeId = await backend.consume(`email-login:link:${issued.tokenHash}`);
+    expect(challengeId).toBe(issued.challengeId);
+    const challenge = JSON.parse(
+      (await backend.consume(`email-login:pending:${challengeId}`)) ?? "null",
+    ) as Record<string, unknown> | null;
+    expect(challenge?.status).toBe("pending");
+    expect(challenge?.purpose).toBe("email-login");
+
+    await auth.sendOtp("rolling-otp@example.com", { tenantId: "tenant-a" });
+    const otpKey = [...backend.values.keys()].find((key) => key.length === 64);
+    expect(otpKey).toBeDefined();
+    const otpPayload = JSON.parse((await backend.consume(otpKey ?? "")) ?? "null");
+    expect(otpPayload).toEqual({ email: "rolling-otp@example.com", tenantId: "tenant-a" });
 
     auth.destroy();
   });
@@ -495,6 +543,47 @@ describe("fail-closed magic-link delivery", () => {
     auth.destroy();
   });
 
+  it("redeems active wrapper records emitted before the rolling-format fix", async () => {
+    const backend = new CapturingBackend();
+    const messages: string[] = [];
+    const auth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          messages.push(body);
+          return { provider: "test", id: `accepted-${messages.length}` };
+        },
+      },
+      backend,
+    );
+
+    await auth.sendMagicLink("active-wrapper@example.com", { tenantId: "tenant-a" });
+    const magicRecord = [...backend.values.values()].find((entry) =>
+      entry.value.includes('"purpose":"email-login"'),
+    );
+    expect(magicRecord).toBeDefined();
+    if (magicRecord) {
+      magicRecord.value = JSON.stringify({ ...JSON.parse(magicRecord.value), status: "active" });
+    }
+    const token = messages[0]?.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    expect(
+      await auth.verifyMagicLink(token, "active-wrapper@example.com", "tenant-a"),
+    ).toMatchObject({ valid: true });
+
+    await auth.sendOtp("active-wrapper-otp@example.com", { tenantId: "tenant-a" });
+    const otpRecord = [...backend.values.entries()].find(([key]) => key.length === 64);
+    expect(otpRecord).toBeDefined();
+    if (otpRecord) {
+      otpRecord[1].value = JSON.stringify({
+        status: "active",
+        payload: JSON.parse(otpRecord[1].value),
+      });
+    }
+    const otpCode = messages[1]?.match(/\b(\d{6})\b/)?.[1] ?? "";
+    expect(await auth.verifyOtp("active-wrapper-otp@example.com", otpCode, "tenant-a")).toBe(true);
+
+    auth.destroy();
+  });
+
   it("rejects malformed active magic-link and OTP records", async () => {
     const magicBackend = new CapturingBackend();
     let magicText = "";
@@ -530,9 +619,7 @@ describe("fail-closed magic-link delivery", () => {
       otpBackend,
     );
     await otpAuth.sendOtp("malformed-otp@example.com", { tenantId: "tenant-a" });
-    const otpRecord = [...otpBackend.values.entries()].find(
-      ([key, entry]) => key.length === 64 && entry.value.includes('"status":"active"'),
-    );
+    const otpRecord = [...otpBackend.values.entries()].find(([key]) => key.length === 64);
     expect(otpRecord).toBeDefined();
     if (otpRecord) {
       otpRecord[1].value = JSON.stringify({

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -162,6 +162,10 @@ type EmailLoginChallengeRecord = {
   expiresAt: string;
 };
 
+type LegacyEmailLoginChallengeRecord = Omit<EmailLoginChallengeRecord, "status"> & {
+  status: "pending";
+};
+
 type EmailLoginStatusRecord = {
   status: "delivery_pending" | "pending" | "consumed" | "locked";
   challengeId: string;
@@ -273,6 +277,18 @@ function decodeMagicLinkPayload(value: string): MagicLinkPayload {
     // Backward-compatible legacy tokens stored the email as the raw value.
   }
   return { email: value };
+}
+
+function encodeMagicLinkPayload(payload: MagicLinkPayload): string {
+  return JSON.stringify(payload);
+}
+
+function encodeActiveEmailLoginChallenge(challenge: EmailLoginChallengeRecord): string {
+  const { status: _deliveryStatus, ...payload } = challenge;
+  return JSON.stringify({
+    ...payload,
+    status: "pending",
+  } satisfies LegacyEmailLoginChallengeRecord);
 }
 
 function decodeLegacyOtpPayload(value: string): MagicLinkPayload | null {
@@ -583,7 +599,7 @@ export class EmailAuth {
       // state, so an earlier write failure cannot expose a redeemable secret.
       await this.tokenStore.store(
         emailLoginChallengeKey(challengeId),
-        JSON.stringify({ ...challenge, status: "active" } satisfies EmailLoginChallengeRecord),
+        encodeActiveEmailLoginChallenge(challenge),
         remainingTtlMs,
       );
       if ((await this.tokenStore.verify(targetKey)) !== challengeId) {
@@ -662,16 +678,19 @@ export class EmailAuth {
       if ((await this.tokenStore.verify(targetKey)) !== storeKey) {
         throw new Error("OTP superseded before activation");
       }
-      await this.tokenStore.store(storeKey, encodeOtpChallenge("active", payload), remainingTtlMs);
+      await this.tokenStore.store(storeKey, encodeMagicLinkPayload(payload), remainingTtlMs);
       if ((await this.tokenStore.verify(targetKey)) !== storeKey) {
         throw new Error("OTP superseded during activation");
       }
     } catch (err) {
       let activationConfirmed = false;
       try {
+        const stored = await this.tokenStore.verify(storeKey);
+        const current = stored ? decodeLegacyOtpPayload(stored) : null;
         activationConfirmed =
           (await this.tokenStore.verify(targetKey)) === storeKey &&
-          decodeOtpChallenge(await this.tokenStore.verify(storeKey))?.status === "active";
+          current?.email === payload.email &&
+          (current.tenantId ?? undefined) === (payload.tenantId ?? undefined);
       } catch {
         // The activation outcome is still ambiguous, so do not report success.
       }


### PR DESCRIPTION
Follow-up to #530.

## Summary
- keep pre-acceptance magic-link and OTP records in the non-redeemable `delivery_pending` format
- write activated credentials in the exact formats understood by already-deployed readers
- continue accepting the short-lived `active` wrapper records emitted after #530 merged
- test old-reader/new-writer and new-reader/intermediate-writer compatibility behaviorally
- correct the route comment to describe retained non-redeemable staging

## Validation
- focused auth/API delivery tests: 28 passed, 112 assertions
- full auth package plus API delivery suite: 304 passed, 1 skipped, 940 assertions
- forced affected API dependency build: 24/24 packages
- Biome and `git diff --check` passed

The original staged delivery remains fail closed: no provider rejection or pre-acceptance record becomes redeemable.