### PR TITLE
fix(seed): verify canonical credential inode

### DIFF
--- a/packages/seed/src/__tests__/demo-api-key.test.ts
+++ b/packages/seed/src/__tests__/demo-api-key.test.ts
@@ -205,4 +205,29 @@ describe("demo API key", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  test("never promotes a promotion pathname swapped after descriptor validation", () => {
+    const root = tempRoot("steward-demo-promotion-race-");
+    try {
+      const path = join(root, "demo.env");
+      const oldKey = generateDemoApiKey().key;
+      promoteDemoCredentials(stageDemoCredentials("waifu.fun", oldKey, path));
+      const pending = stageDemoCredentials("waifu.fun", generateDemoApiKey().key, path);
+
+      expect(() =>
+        promoteDemoCredentials(pending, undefined, (promotionPath) => {
+          renameSync(promotionPath, `${promotionPath}.original`);
+          writeFileSync(
+            promotionPath,
+            "STEWARD_TENANT_ID=attacker\nSTEWARD_API_KEY=stw_00000000000000000000000000000000\n",
+            { mode: 0o600 },
+          );
+        }),
+      ).toThrow("changed before canonical rename");
+      expect(readFileSync(path, "utf8")).toContain(`STEWARD_API_KEY=${oldKey}`);
+      expect(readFileSync(path, "utf8")).not.toContain("stw_00000000000000000000000000000000");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/seed/src/demo-api-key.ts
+++ b/packages/seed/src/demo-api-key.ts
@@ -143,6 +143,7 @@ export function stageDemoCredentials(
 export function promoteDemoCredentials(
   pending: PendingDemoCredentials,
   afterPendingOpen?: () => void,
+  beforePromotionRename?: (promotionPath: string) => void,
 ): string {
   const parent = credentialParent(pending.finalPath);
   if (parent.device !== pending.parentDevice || parent.inode !== pending.parentInode) {
@@ -197,16 +198,34 @@ export function promoteDemoCredentials(
           `Pending credential changed during promotion; recover ${pending.pendingPath}`,
         );
       }
+
+      beforePromotionRename?.(promotionPath);
+      const beforeRename = lstatSync(promotionPath);
+      if (
+        !beforeRename.isFile() ||
+        beforeRename.dev !== linkedFd.dev ||
+        beforeRename.ino !== linkedFd.ino
+      ) {
+        throw new Error(
+          `Pending credential changed before canonical rename; recover ${pending.pendingPath}`,
+        );
+      }
+
+      renameSync(promotionPath, pending.finalPath);
+      const canonical = lstatSync(pending.finalPath);
+      if (!canonical.isFile() || canonical.dev !== linkedFd.dev || canonical.ino !== linkedFd.ino) {
+        throw new Error(
+          `Canonical credential changed during promotion; recover ${pending.pendingPath}`,
+        );
+      }
+      syncDirectory(dirname(pending.finalPath), parent);
+      // The canonical name is durable now. Removing the recovery name is cleanup:
+      // if the process crashes first, both names point to the same valid key.
+      unlinkSync(pending.pendingPath);
+      return pending.finalPath;
     } finally {
       closeSync(promotionFd);
     }
-
-    renameSync(promotionPath, pending.finalPath);
-    syncDirectory(dirname(pending.finalPath), parent);
-    // The canonical name is durable now. Removing the recovery name is cleanup:
-    // if the process crashes first, both names point to the same valid key.
-    unlinkSync(pending.pendingPath);
-    return pending.finalPath;
   } finally {
     closeSync(pendingFd);
   }


### PR DESCRIPTION
## Summary
- keep the validated promotion descriptor open through the atomic rename
- reject a swapped promotion pathname immediately before rename
- verify the canonical path is the same validated inode before reporting success
- add a deterministic promotion-path swap regression

Follow-up to #536, which merged while this bounded repair was under exact validation.

## Exact-head evidence
- seed credential suite: 9/9, 37 assertions
- affected API dependency build: 24/24
- Biome and git diff check: clean