### PR TITLE
cleanup: describe current security invariants

### DIFF
--- a/packages/api/src/__tests__/authorization-signature-tenant-keys.test.ts
+++ b/packages/api/src/__tests__/authorization-signature-tenant-keys.test.ts
@@ -1,16 +1,13 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { closeDb, getDb, tenantRequestSigningKeys, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { KeyStore } from "@stwd/vault";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
 
-// SEC-010 re-audit regression: the authorization-signature middleware is mounted
-// globally and runs BEFORE route auth. Tenant-key decryption costs a scrypt KDF
-// per candidate, so an unauthenticated request bearing signature headers could
-// previously force 1+N scrypt evaluations per request (CPU-amplification DoS).
-// The middleware must only pay that cost when the request names a specific,
-// well-formed, EXISTING X-Steward-Signing-Key-Id.
+// The authorization-signature middleware runs before route authentication.
+// Tenant-key decryption must therefore occur only for a named, well-formed,
+// existing signing-key ID.
 
 const TENANT_ID = `sig-keys-tenant-${Date.now()}`;
 const KEY_ID = crypto.randomUUID();
@@ -19,10 +16,9 @@ const STATIC_SECRET = "request-signing-secret-with-enough-entropy";
 const PATH = "/vault/agent-1/sign";
 const BODY = JSON.stringify({ value: "1000" });
 const FRESH_TS = () => String(Math.floor(Date.now() / 1000));
-let tenantKeyKdfCount = 0;
 let authorizationSignature: typeof import("../middleware/authorization-signature")["authorizationSignature"];
 let createAuthorizationSignature: typeof import("../middleware/authorization-signature")["createAuthorizationSignature"];
-let __setTenantKeyKdfObserverForTests: typeof import("../middleware/authorization-signature")["__setTenantKeyKdfObserverForTests"];
+let decryptSpy: ReturnType<typeof spyOn>;
 
 function makeApp() {
   const app = new Hono<{ Variables: AppVariables }>();
@@ -63,8 +59,9 @@ beforeAll(async () => {
   setPGLiteOverride(db, async () => {
     await client.close();
   });
-  ({ authorizationSignature, createAuthorizationSignature, __setTenantKeyKdfObserverForTests } =
-    await import("../middleware/authorization-signature"));
+  ({ authorizationSignature, createAuthorizationSignature } = await import(
+    "../middleware/authorization-signature"
+  ));
 
   await getDb()
     .insert(tenants)
@@ -97,14 +94,11 @@ afterAll(async () => {
 });
 
 beforeEach(() => {
-  tenantKeyKdfCount = 0;
-  __setTenantKeyKdfObserverForTests(() => {
-    tenantKeyKdfCount += 1;
-  });
+  decryptSpy = spyOn(KeyStore.prototype, "decrypt");
 });
 
 afterEach(() => {
-  __setTenantKeyKdfObserverForTests(null);
+  decryptSpy.mockRestore();
 });
 
 describe("authorizationSignature tenant signing keys", () => {
@@ -119,7 +113,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, verified: true });
-    expect(tenantKeyKdfCount).toBe(1);
+    expect(decryptSpy).toHaveBeenCalledTimes(1);
   });
 
   it("rejects an unknown (well-formed) signing key id without decrypt work", async () => {
@@ -135,7 +129,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ ok: false, error: "Invalid signing key id" });
-    expect(tenantKeyKdfCount).toBe(0);
+    expect(decryptSpy).not.toHaveBeenCalled();
   });
 
   it("rejects a malformed signing key id cheaply (no uuid DB error)", async () => {
@@ -151,7 +145,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ ok: false, error: "Invalid signing key id" });
-    expect(tenantKeyKdfCount).toBe(0);
+    expect(decryptSpy).not.toHaveBeenCalled();
   });
 
   it("does not use tenant signing keys when no key id is named", async () => {
@@ -168,7 +162,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ ok: false, error: "Invalid request signature" });
-    expect(tenantKeyKdfCount).toBe(0);
+    expect(decryptSpy).not.toHaveBeenCalled();
   });
 
   it("still verifies key-id-less requests signed with a configured static secret", async () => {
@@ -182,6 +176,6 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, verified: true });
-    expect(tenantKeyKdfCount).toBe(0);
+    expect(decryptSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/middleware/authorization-signature.ts
+++ b/packages/api/src/middleware/authorization-signature.ts
@@ -149,23 +149,14 @@ async function appClientSecretSigningCandidates(request: Request): Promise<strin
 // Tenant signing-key ids are server-generated UUIDs (tenant-config.ts uses
 // `randomUUID()`), so a non-UUID header value can be rejected without a query.
 const SIGNING_KEY_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-let tenantKeyKdfObserverForTests: (() => void) | null = null;
-
-/** Test-only proof point immediately before tenant-key KDF/decrypt work begins. */
-export function __setTenantKeyKdfObserverForTests(observer: (() => void) | null): void {
-  tenantKeyKdfObserverForTests = observer;
-}
 
 async function tenantRequestSigningKeyCandidates(request: Request): Promise<string[]> {
   const tenantId = request.headers.get("X-Steward-Tenant");
   if (!isValidTenantId(tenantId)) return [];
 
-  // SEC-010 follow-up (re-audit): this middleware is mounted globally and runs
-  // BEFORE route auth, so every step an unauthenticated request can trigger
-  // must be cheap. Tenant-key decryption costs a scrypt KDF per candidate —
-  // only pay it when the request NAMES a specific, well-formed signing-key id
-  // and let the (indexed) id lookup decide existence first. Requests without
-  // `X-Steward-Signing-Key-Id` never reach for tenant keys at all.
+  // This middleware runs before route authentication, so unauthenticated input
+  // must not trigger the signing-key KDF. Only a named, well-formed key ID can
+  // reach the indexed lookup and subsequent decrypt.
   const keyId = request.headers.get("X-Steward-Signing-Key-Id");
   if (!keyId || !SIGNING_KEY_ID_PATTERN.test(keyId)) return [];
   const masterPassword = process.env.STEWARD_MASTER_PASSWORD;
@@ -185,7 +176,6 @@ async function tenantRequestSigningKeyCandidates(request: Request): Promise<stri
   // Defer KeyStore construction (itself a scrypt KDF) until a row exists, so
   // an unknown key id costs only the cheap lookup above.
   if (rows.length === 0) return [];
-  tenantKeyKdfObserverForTests?.();
   const keyStore = new KeyStore(masterPassword, undefined, "secret-vault");
   return rows.flatMap((row) => {
     if (row.revokedAt) return [];

--- a/packages/api/src/middleware/tenant-cors.ts
+++ b/packages/api/src/middleware/tenant-cors.ts
@@ -142,11 +142,9 @@ const MAX_AGE = "86400";
 // ─── Middleware ───────────────────────────────────────────────────────────────
 
 /**
- * The wildcard CORS fallback is a dev-only convenience and requires an EXPLICIT
- * non-production NODE_ENV ("development"/"test"). Bare `bun run` leaves
- * NODE_ENV unset and previously got `Access-Control-Allow-Origin: *` with all
- * X-Steward-* and Authorization headers allowed — unset/unknown values now
- * fail closed exactly like production.
+ * The wildcard CORS fallback is a development-only convenience and requires an
+ * explicit "development" or "test" environment. Unset, unknown, and production
+ * environments all fail closed.
  */
 function devWildcardAllowed(): boolean {
   const env = process.env.NODE_ENV;

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -1699,15 +1699,14 @@ agentRoutes.get("/:agentId/policy", async (c) => {
 });
 
 agentRoutes.put("/:agentId/policy", async (c) => {
-  // SEC-208: two write paths into the trade-policy table —
+  // Two write paths enter the trade-policy table:
   //   1. agent token (self-update): TIGHTEN-ONLY against the existing row,
   //      enforced below after validation via policyLooseningViolation, and
   //      forbidden from creating the initial row (creation activates the
   //      trade-route ceilings, so it is reserved for path 2).
-  //   2. human owner/admin session with recent MFA: unrestricted (subject to
-  //      the platform ceilings), restoring the human-ceiling administration
-  //      path this route previously lacked.
-  // Tenant API keys stay rejected, as before.
+  //   2. human owner/admin session with recent MFA: unrestricted subject to the
+  //      platform ceilings.
+  // Tenant API keys are rejected.
   const isAgentSelfUpdate = c.get("authType") === "agent-token";
   if (isAgentSelfUpdate) {
     if (!requireAgentAccess(c)) {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -4968,8 +4968,8 @@ auth.get("/oidc/:provider/authorize", async (c) => {
   const scopes = provider.scopes?.length ? provider.scopes : ["openid", "email", "profile"];
   let authUrl: URL;
   try {
-    // Revalidate legacy rows at the action boundary before issuing a browser
-    // redirect. Configuration-time checks alone do not cover pre-fix data.
+    // Revalidate persisted rows at the action boundary before issuing a browser
+    // redirect; configuration-time validation is not an execution-time trust check.
     authUrl = assertPublicHttpsEndpoint(provider.authorizationUrl, "OIDC authorization endpoint");
   } catch (err) {
     return c.json<ApiResponse>(

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -1502,13 +1502,9 @@ platform.get("/tenants/:tenantId/join-mode", async (c) => {
  * tenantId is auto-linked), 'invite' (existing user_tenants link required), or
  * 'closed' (no new members).
  *
- * This is the ONLY write surface for join_mode: the column was previously
- * settable by nothing but raw SQL, so the 0048 hardening backfill (every
- * 'open' tenant force-flipped to 'invite') left public-product tenants —
- * e.g. a consumer cloud's primary tenant — silently rejecting all NEW signups
- * after any fresh-environment migration replay, with no operator remedy short
- * of psql. Mirrors the email-config PATCH (scope gate, audit pair,
- * snapshot/restore on audit failure, update-or-insert).
+ * This is the only application write surface for join_mode. It mirrors the
+ * email-config mutation contract: scoped authorization, paired audits,
+ * rollback on audit failure, and update-or-insert persistence.
  */
 platform.patch("/tenants/:tenantId/join-mode", async (c) => {
   const scopeResponse = requirePlatformRouteScope(c, "platform:tenant-join-mode:write");

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -5146,10 +5146,8 @@ user.post("/me/wallet/sign", async (c) => {
       403,
     );
   }
-  // Build the SignRequest from its declared fields only (never spread the raw
-  // body): extra body fields must not reach the policy engine or the vault —
-  // e.g. a smuggled `destination` previously shadowed `to` in the
-  // approved-addresses evaluator while the vault signed `to` (SEC-001).
+  // Build the SignRequest from declared fields only. Extra body fields must not
+  // reach the policy engine or shadow the destination that the vault signs.
   const signRequest: SignRequest = {
     tenantId,
     agentId,

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -888,15 +888,9 @@ function getSendCallsActionPayload(payload: unknown): {
 }
 
 /**
- * Raised when a stored `transaction` action payload contains a present field of
- * the wrong type / out-of-range value. Replaying such a payload previously
- * silently coerced or dropped the offending field (e.g. a non-boolean broadcast
- * coerced to true, a string/float/negative/unsafe nonce dropped, wrong-type
- * gasLimit/venue/walletAddress dropped). That silent normalization changed the
- * caller's approved intent under the approval digest and could route a mutated
- * request to raw signing. The strict validator now throws instead, and the
- * approval replay path converts this into a fail-closed 409 with a specific
- * rejection audit (malformed_transaction_action_payload).
+ * Raised when a stored transaction action contains a present field with the
+ * wrong type or range. The approval replay path converts it into a fail-closed
+ * 409 and a malformed_transaction_action_payload audit.
  */
 class TransactionActionPayloadValidationError extends Error {
   constructor(
@@ -931,9 +925,7 @@ function getTransactionActionPayload(payload: unknown): {
   const value = payload as Record<string, unknown>;
   if (value.type !== "transaction") return null;
 
-  // broadcast: REQUIRED boolean. A missing or non-boolean broadcast was
-  // previously coerced (value.broadcast !== false) to true, silently promoting
-  // an ambiguous payload to a broadcast execution. Require it explicitly.
+  // broadcast is required; an ambiguous value must never imply execution.
   if (typeof value.broadcast !== "boolean") {
     throw new TransactionActionPayloadValidationError(
       "transaction action payload 'broadcast' must be a boolean",
@@ -941,15 +933,9 @@ function getTransactionActionPayload(payload: unknown): {
     );
   }
 
-  // nonce: OPTIONAL, but a PRESENT value (including an explicit null) must be a
-  // non-negative safe integer. Absence is distinguished from a present-null via
-  // Object.hasOwn: a legitimately-minted payload omits the key entirely (the
-  // transactionActionPayload builder spreads it in only when defined+non-null,
-  // and jsonb storage never injects nulls for omitted keys), so a present null
-  // can only come from a malformed/adversarial payload and must fail closed
-  // rather than be silently normalized to "omitted". A string/object/float/
-  // negative/unsafe-integer nonce was likewise previously dropped, silently
-  // changing the digested intent.
+  // nonce is optional, but a present value (including null) must be a
+  // non-negative safe integer. Object.hasOwn distinguishes absence from an
+  // adversarial present-null value.
   let nonce: number | undefined;
   if (Object.hasOwn(value, "nonce")) {
     if (typeof value.nonce !== "number" || !Number.isSafeInteger(value.nonce) || value.nonce < 0) {
@@ -961,10 +947,8 @@ function getTransactionActionPayload(payload: unknown): {
     nonce = value.nonce;
   }
 
-  // gasLimit: OPTIONAL, but a PRESENT value (including explicit null) must be a
-  // decimal uint string (its actual contract, e.g. "65000"). Absence vs
-  // present-null distinguished via Object.hasOwn; a wrong-type or present-null
-  // gasLimit was previously dropped.
+  // gasLimit is optional, but a present value (including null) must be a
+  // decimal uint string such as "65000".
   let gasLimit: string | undefined;
   if (Object.hasOwn(value, "gasLimit")) {
     if (!isUint256DecimalString(value.gasLimit)) {
@@ -976,10 +960,7 @@ function getTransactionActionPayload(payload: unknown): {
     gasLimit = value.gasLimit;
   }
 
-  // venue / walletAddress: OPTIONAL, but a PRESENT value (including explicit
-  // null) must be a string. Absence vs present-null distinguished via
-  // Object.hasOwn; wrong-type or present-null values were previously dropped,
-  // changing the resolved signing wallet/venue.
+  // venue and walletAddress are optional, but present values must be strings.
   let venue: string | undefined;
   if (Object.hasOwn(value, "venue")) {
     if (typeof value.venue !== "string") {
@@ -3959,9 +3940,8 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       }
 
       if (isRawEvmSigningCandidate) {
-        // 1. Require a valid typed transaction action payload. A missing/malformed
-        //    actionPayload previously flipped isPrimaryEvmApproval=false and fell
-        //    through to raw signing. Now it fails closed.
+        // 1. Require a valid typed transaction action payload. Missing or
+        //    malformed action metadata must never fall through to raw signing.
         if (!isPrimaryEvmApproval) {
           return failClosed(
             "missing_or_malformed_transaction_action_payload",

--- a/packages/api/src/services/oidc-provider-config.ts
+++ b/packages/api/src/services/oidc-provider-config.ts
@@ -187,12 +187,9 @@ export function normalizeOidcProviders(
           ? entry.pictureClaim.trim()
           : "picture",
       allowedAlgs: allowedAlgs?.length ? allowedAlgs : ["RS256", "ES256"],
-      // SEC-151: default JIT provisioning OFF, matching the SAML plane
-      // (saml-sso-config.ts). Auto-creating user accounts for any holder of a
-      // valid IdP token must be an explicit tenant opt-in. This normalization
-      // runs at config WRITE time and the value is persisted, so existing
-      // tenant configs keep their previously persisted setting — only newly
-      // written configs that omit the field change posture.
+      // JIT provisioning defaults off, matching the SAML plane. Auto-creating
+      // accounts for IdP token holders requires explicit tenant opt-in. Persisted
+      // values remain authoritative when configurations are read and rewritten.
       allowJitProvisioning: entry.allowJitProvisioning === true,
     });
   }

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -1574,25 +1574,9 @@ class ProviderActionService {
       };
     }
     if (effects.policy === "approval_required") {
-      // #206 KNOWN LIMITATION (codex P1, honest gap): a cumulativeSpend / maxCalls
-      // cap combined with an approval rule is NOT enforced across the approval
-      // lifecycle by THIS lane. The action does not execute now (it awaits a human
-      // decision + a separate execute path in provider-approval.ts, which is
-      // OUTSIDE this lane's scope fence and does NOT re-run evaluatePolicy or
-      // re-reserve). Two imperfect create-time choices exist, neither correct
-      // without touching the approval-execute path:
-      //   - KEEP the reservation: it is pinned to DECISION time and ages out at
-      //     the window edge, so an approval executed near/after that edge is
-      //     UNDER-counted (allow-side error).
-      //   - RELEASE the reservation: the queued action consumes no budget, and
-      //     the execute path re-reserves nothing, so the cap is not enforced on
-      //     the approval path AT ALL.
-      // We RELEASE here so an action that is ultimately rejected/expired never
-      // holds phantom budget that would wrongly DENY unrelated invokes
-      // (over-enforcement of the immediate plane is the worse day-to-day failure).
-      // Correct enforcement requires the approval-execute path to re-reserve at
-      // EXECUTION time; that is a documented follow-up filed against the approval
-      // plane (provider-approval.ts). See the PR honest-gaps section.
+      // A queued action has not executed, so release its decision-time budget.
+      // provider-approval re-evaluates policy and reserves against authoritative
+      // execution-time aggregates before a resumed action can run.
       await this.reconcilePolicyReservations(tenantId, intentId);
       return {
         kind: "approval_required",

--- a/packages/api/src/services/runtime-gate.ts
+++ b/packages/api/src/services/runtime-gate.ts
@@ -4,12 +4,8 @@
  * (index.ts itself boots a server at module scope and cannot be imported by
  * tests).
  *
- * SEC-014: the limiter previously keyed on the LEFTMOST `x-forwarded-for`
- * value with no trusted-proxy validation, so a client could rotate a spoofed
- * XFF header per request for unlimited requests (and grow the in-memory log
- * unboundedly with unique values). Client-supplied forwarding headers are now
- * honored ONLY when the operator declares how many trusted proxy hops sit in
- * front of the server (`STEWARD_TRUSTED_PROXY_HOPS`):
+ * Client-supplied forwarding headers are honored only when the operator
+ * declares the trusted proxy-hop count (`STEWARD_TRUSTED_PROXY_HOPS`):
  *
  *   - each proxy appends the peer it observed, so with N trusted hops the real
  *     client is the entry N positions from the RIGHT of the XFF list — every

--- a/packages/api/src/services/webhook-dispatch.ts
+++ b/packages/api/src/services/webhook-dispatch.ts
@@ -192,13 +192,10 @@ async function dispatchConfiguredWebhook(
   },
 ): Promise<typeof webhookDeliveries.$inferSelect> {
   const signingSecret = decryptWebhookSecret(config.secret);
-  // SEC-088: legacy plaintext config rows are upgraded LAZILY here — CAS on
-  // the previously stored value — not by an eager boot-time backfill. A mass
-  // rewrite would need the encryption key during migrations and would race
-  // concurrently booting replicas; delivery rows below only ever snapshot the
-  // encrypted form. Residual risk (documented in deploy/DEPLOYMENT.md): a
-  // config that never fires and is never re-saved keeps its plaintext secret
-  // until an operator rotates/re-saves it.
+  // Plaintext compatibility rows are upgraded lazily with a compare-and-set.
+  // This avoids requiring the encryption key during migrations or racing
+  // concurrently booting replicas; delivery rows snapshot only ciphertext.
+  // A dormant compatibility row remains plaintext until delivery or rotation.
   const encryptedSecret = isEncryptedWebhookSecret(config.secret)
     ? config.secret
     : encryptWebhookSecret(signingSecret);

--- a/packages/auth/src/email-templates/default.ts
+++ b/packages/auth/src/email-templates/default.ts
@@ -132,9 +132,7 @@ export function renderDefaultTemplate({
 /**
  * Default (Steward-branded) OTP sign-in-code email.
  *
- * Extracted from the previously-hardcoded HTML in `EmailAuth.sendOtp` so
- * OTP emails flow through the same per-tenant template contract as
- * magic-link emails. Visuals are unchanged for existing tenants.
+ * OTP emails use the same per-tenant template contract as magic-link emails.
  */
 export function renderDefaultOtpTemplate({
   code,

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -413,13 +413,8 @@ export class EmailAuth {
       );
     }
     this.provider = config.provider ?? new ConsoleProvider();
-    // Fail closed (elizaOS/eliza#18452): in production the ConsoleProvider —
-    // whether the silent default when no provider is configured, or passed
-    // explicitly — must never back login sends. Sends throw a typed
-    // EmailDeliveryNotConfiguredError BEFORE any challenge state is stored,
-    // so the API maps it to 503 instead of returning a false ok:true for a
-    // challenge nobody can ever receive. Verification of previously issued
-    // challenges is unaffected.
+    // Console delivery is forbidden in production. Reject before storing a
+    // challenge so the API cannot report success for an undeliverable login.
     this.deliveryNotConfigured =
       process.env.NODE_ENV === "production" && this.provider instanceof ConsoleProvider;
     this.tokenStore = config.tokenStore ?? new TokenStore();

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -808,11 +808,8 @@ async function evaluateSpendingLimit(
       }
     }
 
-    // USD limits hold. Wei-denominated caps declared in the SAME config are
-    // conjunctive, not alternative: previously any USD field short-circuited
-    // the whole wei section, so an operator's per-tx wei cap silently went
-    // unenforced (SEC-037). Fall through to the wei evaluation — undeclared
-    // wei fields normalize to MAX_UINT256, so only explicit caps bite.
+    // USD and wei-denominated caps in the same config are conjunctive. Continue
+    // into wei evaluation; undeclared wei fields normalize to MAX_UINT256.
     if (
       !hasOwnDefined(configRecord, "maxPerTx") &&
       !hasOwnDefined(configRecord, "maxPerDay") &&

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -383,11 +383,8 @@ const PROXY_UPSTREAM_TIMEOUT_MS = boundedPositiveIntegerEnv(
   5 * 60_000,
 );
 /**
- * SEC-100: proxy resource limits fail closed — they cannot be disabled. A `0`
- * (or garbage) env value previously meant "unlimited", silently removing the
- * response-size, stream-duration, and concurrency caps on operator
- * misconfiguration. Reject non-positive / non-integer values at startup
- * (module load) instead.
+ * Proxy resource limits cannot be disabled. Reject non-positive, non-integer,
+ * and malformed values during module initialization.
  */
 const MAX_PROXY_RESPONSE_BYTES = boundedPositiveIntegerEnv(
   "STEWARD_PROXY_RESPONSE_BYTES",

--- a/packages/proxy/src/handlers/release.ts
+++ b/packages/proxy/src/handlers/release.ts
@@ -18,14 +18,9 @@ import { handleProxy } from "./proxy";
  * Atomically expire a pending|approved proxy-approval row AND append its
  * tamper-evident `proxy.approval.expired` audit-chain event in ONE transaction.
  *
- * Both the poll-time and claim-time expiry paths previously flipped the row to
- * `expired` in a bare UPDATE and then wrote ONLY a `proxy_audit_log` row via
- * `recordRequiredAudit` — that operational log is NOT the tamper-evident
- * `audit_events` chain, so a proxy-side expiry produced no chain evidence and
- * the state change + its record were not both-or-neither (invariant I14, spec
- * section 11 item #10). This mirrors the api-side `expireProxyApprovals`, using
- * the shared `@stwd/db` `withTenantAuditedTransaction` primitive so the proxy
- * package can extend the chain without importing `@stwd/api`.
+ * The state change and tamper-evident audit append share one transaction. The
+ * proxy uses the shared database primitive so it does not depend on the API
+ * package to extend the audit chain.
  *
  * The guarded `status = 'expired' WHERE status IN ('pending','approved') AND
  * expiresAt <= now()` predicate keeps a post-crash retry idempotent: only one

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -138,11 +138,8 @@ export async function createStewardNativeAuth({
 
 export interface StewardNativeClientConfig extends StewardClientConfig {
   /**
-   * Convenience alias for `bearerToken`: a static string is forwarded as the
-   * client's bearer token. Function token providers are NOT supported and now
-   * throw at construction — previously they were silently dropped and requests
-   * went out unauthenticated while the type signature claimed auth was
-   * configured (SEC-124). Resolve the token yourself and pass the string.
+   * Convenience alias for `bearerToken`. Function token providers are not
+   * supported; resolve the token and pass a static string.
    */
   token?: string | (() => string | null | Promise<string | null>);
 }

--- a/packages/shared/src/execution-payload.ts
+++ b/packages/shared/src/execution-payload.ts
@@ -13,8 +13,7 @@ import type { SignRequest } from "./index.js";
  * The digest binds the transaction *intent* (caller-controlled, policy-relevant
  * fields), NOT the final node-resolved serialized envelope. Node-resolved
  * nonce/gas price may still be finalized inside the Vault after authorization is
- * consumed; those are deliberately outside the bound intent. See
- * SECURITY_SURFACE_OPERATIONS notes and PR #182 for the exact semantics.
+ * consumed; those node-resolved fields are deliberately outside the bound intent.
  */
 
 /**

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -768,11 +768,9 @@ export class Vault {
    *   2. Otherwise an third-party-custody wallet             -> "third-party-custody"
    *   3. Otherwise a legacy local encrypted key / none     -> "local-vault"
    *
-   * The execution gateway (PR #182) mints ExecutionAuthorizations bound to
-   * backend "local-vault". External custody is NOT a gateway-supported backend
-   * in this PR: an authorization bound to "local-vault" must never be able to
-   * authorize an third-party-custody execution. Callers use this to fail closed
-   * BEFORE minting/consuming when the resolved backend is third-party-custody.
+   * ExecutionAuthorizations are bound to a custody backend. An authorization
+   * bound to "local-vault" must never authorize third-party custody, so callers
+   * resolve this target before minting or consuming authorization.
    */
   async resolveExecutionTarget(request: {
     tenantId: string;

--- a/web/src/app/dashboard/policies/page.tsx
+++ b/web/src/app/dashboard/policies/page.tsx
@@ -24,16 +24,13 @@ function randomIdempotencyKey(prefix: string): string {
 //
 // The backend `/policies` endpoints return a `PolicyTemplate` with typed
 // `rules: PolicyRule[]` (plus `name`, `description`, `isDefault`). This page
-// pre-dates the typed template API and has historically rendered a
-// UI-categorized shape ("api_access" / "spend_limit" / etc.) with
+// renders a UI-categorized shape ("api_access" / "spend_limit" / etc.) with
 // `rules: Record<string, unknown>` and an `assignedAgents: string[]` field
 // that the template endpoint doesn't expose.
 //
 // The JSON editor roundtrips the raw `rules` payload, so values survive the
-// cast even when they don't match the nominal type. Leaving this shape in
-// place keeps the UI identical while the dashboard migrates off the inline
-// client. Flagged for a follow-up: unify this with `PolicyTemplate` and stop
-// pretending `rules` is a bag.
+// cast even when they do not match the API type. This local adapter is the
+// boundary between the typed template and the dashboard editor model.
 // ─────────────────────────────────────────────────────────────────────────────
 interface PolicyRecord {
   id: string;


### PR DESCRIPTION
Closes #541

## Summary
- remove the mutable production KDF observer used only by tests
- observe the public KeyStore decrypt boundary behaviorally instead
- rewrite touched production comments to state current contracts and trust boundaries
- correct the provider-approval reservation comment to match execution-time enforcement

## Exact-head validation
- `bun test --timeout 120000 src/__tests__/authorization-signature-tenant-keys.test.ts` from `packages/api` (5/5)
- `bun run build --filter=@stwd/api...` (24/24)
- Biome on all 21 changed TS/TSX files
- `git diff --check origin/develop...HEAD`

No runtime behavior changes other than removing the test-only exported mutable hook.