### PR TITLE
fix(trading): bound Polymarket market metadata transport

### DIFF
--- a/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
@@ -405,37 +405,47 @@ describe("POST /v1/trade/polymarket/order", () => {
     });
     failingRoutes.onError(() => new Response("audit unavailable", { status: 500 }));
 
-    for (const scenario of ["metadata", "mismatch"] as const) {
-      const { tenantId, agentId, sessionId } = await seedSession({
-        allowedAssets: [`pm:cond:${COND_ID}`],
-      });
-      const app = makeApp(tenantId, agentId, failingRoutes);
-      const key = crypto.randomUUID();
-      const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
-        scenario === "metadata"
-          ? async () => {
-              throw new Error("metadata unavailable");
-            }
-          : async () =>
-              new Response(
-                JSON.stringify({
-                  condition_id: OTHER_COND_ID,
-                  primary_token_id: TOKEN_ID,
-                  secondary_token_id: "8".repeat(72),
-                }),
-                { status: 200 },
-              ),
-      );
+    const originalError = console.error;
+    const logs: string[] = [];
+    console.error = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+    try {
+      for (const scenario of ["metadata", "mismatch"] as const) {
+        const { tenantId, agentId, sessionId } = await seedSession({
+          allowedAssets: [`pm:cond:${COND_ID}`],
+        });
+        const app = makeApp(tenantId, agentId, failingRoutes);
+        const key = crypto.randomUUID();
+        const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+          scenario === "metadata"
+            ? async () => {
+                throw new Error("metadata unavailable");
+              }
+            : async () =>
+                new Response(
+                  JSON.stringify({
+                    condition_id: OTHER_COND_ID,
+                    primary_token_id: TOKEN_ID,
+                    secondary_token_id: "8".repeat(72),
+                  }),
+                  { status: 200 },
+                ),
+        );
 
-      try {
-        const extra = scenario === "mismatch" ? { conditionId: COND_ID } : {};
-        expect((await postOrder(app, sessionId, key, extra)).status).toBe(500);
-        expect((await postOrder(app, sessionId, key, extra)).status).toBe(500);
-        expect(fetchSpy).toHaveBeenCalledTimes(2);
-        expect(await dailySpendOf(sessionId)).toBe(0);
-      } finally {
-        fetchSpy.mockRestore();
+        try {
+          const extra = scenario === "mismatch" ? { conditionId: COND_ID } : {};
+          const expectedStatus = scenario === "metadata" ? 502 : 500;
+          expect((await postOrder(app, sessionId, key, extra)).status).toBe(expectedStatus);
+          expect((await postOrder(app, sessionId, key, extra)).status).toBe(expectedStatus);
+          expect(fetchSpy).toHaveBeenCalledTimes(2);
+          expect(await dailySpendOf(sessionId)).toBe(0);
+        } finally {
+          fetchSpy.mockRestore();
+        }
       }
+      expect(logs.join("\n")).not.toContain("audit unavailable");
+      expect(logs.join("\n")).not.toContain("metadata unavailable");
+    } finally {
+      console.error = originalError;
     }
   });
 

--- a/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
@@ -48,6 +48,7 @@ let submitSpy: ReturnType<typeof spyOn> | undefined;
 let getWalletSpy: ReturnType<typeof spyOn> | undefined;
 let buildSpy: ReturnType<typeof spyOn> | undefined;
 let fenceSpy: ReturnType<typeof spyOn> | undefined;
+let createTradeRoutesForTest: typeof import("../routes/trade").createTradeRoutes;
 
 // Inject a polymarket venue wallet WITH funder metadata so the creds resolver
 // gets past the wallet step. Whether the L2 creds resolve (Phase C) is toggled
@@ -156,6 +157,15 @@ async function auditCount(tenantId: string, action: string): Promise<number> {
   return rows.length;
 }
 
+async function auditMetadata(tenantId: string, action: string): Promise<Record<string, unknown>> {
+  const [row] = await getDb()
+    .select({ metadata: auditEvents.metadata })
+    .from(auditEvents)
+    .where(and(eq(auditEvents.action, action), eq(auditEvents.tenantId, tenantId)))
+    .limit(1);
+  return row?.metadata ?? {};
+}
+
 // Module-level DB + fence setup shared by both describe blocks. The api suite
 // runs all test files in one process; a per-describe closeDb() would tear down
 // PGLite before the second describe's beforeAll re-imports routes.
@@ -185,6 +195,7 @@ beforeAll(async () => {
     }) as never,
   );
   const { createTradeRoutes } = await import("../routes/trade");
+  createTradeRoutesForTest = createTradeRoutes;
   const { testCtx } = await import("./_ctx");
   sharedTestContext = testCtx();
   sharedTradeRoutes = createTradeRoutes(sharedTestContext);
@@ -305,6 +316,39 @@ describe("POST /v1/trade/polymarket/order", () => {
     }
   });
 
+  it("rejects authoritative token metadata for a different, non-allowlisted condition", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({
+      allowedAssets: [`pm:cond:${COND_ID}`],
+    });
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          condition_id: OTHER_COND_ID,
+          primary_token_id: TOKEN_ID,
+          secondary_token_id: "8".repeat(72),
+        }),
+        { status: 200 },
+      ),
+    );
+
+    try {
+      const res = await postOrder(app, sessionId, crypto.randomUUID());
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        code: "policy-violation",
+        reason: "market-not-allowed",
+      });
+      expect(await dailySpendOf(sessionId)).toBe(0);
+      expect(await auditMetadata(tenantId, "trade.order.policy-rejected")).toMatchObject({
+        conditionId: OTHER_COND_ID,
+        reason: "market-not-allowed",
+      });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("keeps metadata outages retryable without authorizing an unverified market grant", async () => {
     const { tenantId, agentId, sessionId } = await seedSession({
       allowedAssets: [`pm:cond:${COND_ID}`],
@@ -340,8 +384,58 @@ describe("POST /v1/trade/polymarket/order", () => {
       );
       expect(fetchSpy).toHaveBeenCalledTimes(2);
       expect(await dailySpendOf(sessionId)).toBe(0);
+      const metadata = await auditMetadata(tenantId, "trade.order.policy-rejected");
+      expect(metadata).toMatchObject({
+        reason: "market-metadata-unavailable",
+        errorClass: "Error",
+        errorCode: null,
+      });
+      expect(JSON.stringify(metadata)).not.toContain("TOKEN_METADATA_SECRET_CANARY");
     } finally {
       fetchSpy.mockRestore();
+    }
+  });
+
+  it("releases metadata and mismatch claims when the audit sink fails", async () => {
+    const failingRoutes = createTradeRoutesForTest({
+      ...sharedTestContext,
+      writeAuditEvent: async () => {
+        throw new Error("audit unavailable");
+      },
+    });
+    failingRoutes.onError(() => new Response("audit unavailable", { status: 500 }));
+
+    for (const scenario of ["metadata", "mismatch"] as const) {
+      const { tenantId, agentId, sessionId } = await seedSession({
+        allowedAssets: [`pm:cond:${COND_ID}`],
+      });
+      const app = makeApp(tenantId, agentId, failingRoutes);
+      const key = crypto.randomUUID();
+      const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+        scenario === "metadata"
+          ? async () => {
+              throw new Error("metadata unavailable");
+            }
+          : async () =>
+              new Response(
+                JSON.stringify({
+                  condition_id: OTHER_COND_ID,
+                  primary_token_id: TOKEN_ID,
+                  secondary_token_id: "8".repeat(72),
+                }),
+                { status: 200 },
+              ),
+      );
+
+      try {
+        const extra = scenario === "mismatch" ? { conditionId: COND_ID } : {};
+        expect((await postOrder(app, sessionId, key, extra)).status).toBe(500);
+        expect((await postOrder(app, sessionId, key, extra)).status).toBe(500);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(await dailySpendOf(sessionId)).toBe(0);
+      } finally {
+        fetchSpy.mockRestore();
+      }
     }
   });
 
@@ -578,6 +672,35 @@ describe("POST /v1/trade/polymarket/order", () => {
       if (prevMemoryAck === undefined) delete process.env.STEWARD_ALLOW_MEMORY_TRADING_IDEMPOTENCY;
       else process.env.STEWARD_ALLOW_MEMORY_TRADING_IDEMPOTENCY = prevMemoryAck;
       delete process.env.POLYMARKET_CLOB_API_URL;
+      delete process.env.STEWARD_PM_TEST_CREDS;
+    }
+  });
+
+  it("rejects credential-bearing or non-canonical CLOB endpoint overrides", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({});
+    stubWallet(true);
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+    const previous = process.env.POLYMARKET_CLOB_API_URL;
+    process.env.STEWARD_PM_TEST_CREDS = "1";
+
+    try {
+      for (const value of [
+        "https://user:secret@clob.e2e.invalid/base",
+        "https://clob.e2e.invalid/base?token=secret",
+        "https://clob.e2e.invalid/base#secret",
+        "https://clob.e2e.invalid/line\nbreak",
+        `https://clob.e2e.invalid/${"a".repeat(2_048)}`,
+      ]) {
+        process.env.POLYMARKET_CLOB_API_URL = value;
+        const res = await postOrder(app, sessionId, crypto.randomUUID());
+        expect(res.status).toBe(409);
+        const responseText = await res.text();
+        expect(responseText).not.toContain("secret");
+        expect(await dailySpendOf(sessionId)).toBe(0);
+      }
+    } finally {
+      if (previous === undefined) delete process.env.POLYMARKET_CLOB_API_URL;
+      else process.env.POLYMARKET_CLOB_API_URL = previous;
       delete process.env.STEWARD_PM_TEST_CREDS;
     }
   });

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -1520,9 +1520,15 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
   function configuredPolymarketClobUrl(): string | undefined {
     const raw = process.env.POLYMARKET_CLOB_API_URL?.trim();
     if (!raw) return undefined;
+    if (raw.length > 2_048 || /[\u0000-\u001f\u007f]/.test(raw)) {
+      throw new Error("POLYMARKET_CLOB_API_URL is invalid");
+    }
     const url = new URL(raw);
     if (url.protocol !== "http:" && url.protocol !== "https:") {
       throw new Error("POLYMARKET_CLOB_API_URL must use http or https");
+    }
+    if (url.username || url.password || url.search || url.hash) {
+      throw new Error("POLYMARKET_CLOB_API_URL must not contain credentials, query, or fragment");
     }
     if (process.env.NODE_ENV === "production" && url.protocol !== "https:") {
       throw new Error("POLYMARKET_CLOB_API_URL must use https in production");
@@ -1865,18 +1871,23 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         const market = await getMarketByToken(body.tokenId, clobUrl ? { clobUrl } : undefined);
         verifiedConditionId = market.conditionId;
       } catch (error) {
-        await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
-          sessionId: session.id,
-          venue: "polymarket",
-          tokenId: body.tokenId,
-          side: body.side,
-          amount,
-          price,
-          notionalUsd,
-          reason: "market-metadata-unavailable",
-          ...redactedThrownDiagnostics(error),
-        });
-        await idempotency.release?.();
+        try {
+          await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
+            sessionId: session.id,
+            venue: "polymarket",
+            tokenId: body.tokenId,
+            side: body.side,
+            amount,
+            price,
+            notionalUsd,
+            reason: "market-metadata-unavailable",
+            ...redactedThrownDiagnostics(error),
+          });
+        } finally {
+          // Metadata reads are pre-execution. Even if the audit sink fails, do
+          // not strand the request's claim and make a safe retry impossible.
+          await idempotency.release?.();
+        }
         return c.json<ApiResponse>(
           { ok: false, error: "Unable to verify Polymarket market binding" },
           502,
@@ -1891,17 +1902,24 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           status: 400,
           body: { code: "policy-violation", reason: "condition-id-mismatch" },
         };
-        await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
-          sessionId: session.id,
-          venue: "polymarket",
-          tokenId: body.tokenId,
-          conditionId: verifiedConditionId,
-          side: body.side,
-          amount,
-          price,
-          notionalUsd,
-          reason: "condition-id-mismatch",
-        });
+        try {
+          await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
+            sessionId: session.id,
+            venue: "polymarket",
+            tokenId: body.tokenId,
+            conditionId: verifiedConditionId,
+            side: body.side,
+            amount,
+            price,
+            notionalUsd,
+            reason: "condition-id-mismatch",
+          });
+        } catch (error) {
+          // The mismatch is definite but still pre-execution. Release rather
+          // than leaving a 24-hour pending claim when its audit write fails.
+          await idempotency.release?.();
+          throw error;
+        }
         await idempotency.store?.(envelope);
         return c.json(envelope.body, envelope.status);
       }

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -1871,6 +1871,9 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         const market = await getMarketByToken(body.tokenId, clobUrl ? { clobUrl } : undefined);
         verifiedConditionId = market.conditionId;
       } catch (error) {
+        // Nothing reached execution. Release before the observational audit so
+        // an audit outage cannot strand this safe retry behind a pending claim.
+        await idempotency.release?.();
         try {
           await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
             sessionId: session.id,
@@ -1883,10 +1886,11 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             reason: "market-metadata-unavailable",
             ...redactedThrownDiagnostics(error),
           });
-        } finally {
-          // Metadata reads are pre-execution. Even if the audit sink fails, do
-          // not strand the request's claim and make a safe retry impossible.
-          await idempotency.release?.();
+        } catch (auditError) {
+          console.error(
+            "[polymarket/order] metadata-failure audit write failed",
+            redactedThrownDiagnostics(auditError),
+          );
         }
         return c.json<ApiResponse>(
           { ok: false, error: "Unable to verify Polymarket market binding" },

--- a/packages/venue-polymarket/src/index.test.ts
+++ b/packages/venue-polymarket/src/index.test.ts
@@ -712,8 +712,10 @@ describe("marketdata batch", () => {
     const sibling = "8".repeat(72);
     const conditionId = `0x${"a".repeat(64)}`;
     let requestedUrl = "";
-    const fetchMock = (async (input: string | URL | Request) => {
+    const fetchMock = (async (input: string | URL | Request, init?: RequestInit) => {
       requestedUrl = String(input);
+      expect(init?.redirect).toBe("error");
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
       return new Response(
         JSON.stringify({
           condition_id: conditionId.toUpperCase().replace("0X", "0x"),
@@ -787,6 +789,72 @@ describe("marketdata batch", () => {
     await expect(getMarketByToken(tokenId, { fetch: duplicateKey })).rejects.toThrow(
       "not valid JSON",
     );
+
+    for (const clobUrl of [
+      "not-a-url-MARKET_URL_SECRET_CANARY",
+      "https://user:MARKET_URL_SECRET_CANARY@clob.example.test",
+      "https://clob.example.test/?token=MARKET_URL_SECRET_CANARY",
+    ]) {
+      const error = await getMarketByToken(tokenId, { clobUrl }).catch((cause) => cause);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("Polymarket market metadata URL is invalid");
+      expect((error as Error).message).not.toContain("MARKET_URL_SECRET_CANARY");
+    }
+  });
+
+  test("getMarketByToken bounds stalled bodies and never awaits hostile cancellation", async () => {
+    const tokenId = "7".repeat(72);
+    const stalled = (async () =>
+      new Response(
+        new ReadableStream({
+          start() {
+            // Intentionally never enqueue or close.
+          },
+        }),
+        { status: 200 },
+      )) as typeof fetch;
+    await expect(
+      getMarketByToken(tokenId, { fetch: stalled, signal: AbortSignal.timeout(20) }),
+    ).rejects.toThrow("request was aborted");
+
+    const hostileDeclaredOverflow = (async () =>
+      new Response(
+        new ReadableStream({
+          cancel() {
+            return new Promise<void>(() => {});
+          },
+        }),
+        { status: 200, headers: { "Content-Length": "20000" } },
+      )) as typeof fetch;
+    await expect(
+      Promise.race([
+        getMarketByToken(tokenId, { fetch: hostileDeclaredOverflow }),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("hostile cancel blocked rejection")), 500),
+        ),
+      ]),
+    ).rejects.toThrow("response is too large");
+
+    const hostileStreamOverflow = (async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(17 * 1024));
+          },
+          cancel() {
+            return new Promise<void>(() => {});
+          },
+        }),
+        { status: 200 },
+      )) as typeof fetch;
+    await expect(
+      Promise.race([
+        getMarketByToken(tokenId, { fetch: hostileStreamOverflow }),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("hostile reader cancel blocked rejection")), 500),
+        ),
+      ]),
+    ).rejects.toThrow("response is too large");
   });
 
   test("getOrderbooks maps by asset_id, keeps empties for misses", async () => {

--- a/packages/venue-polymarket/src/marketdata.ts
+++ b/packages/venue-polymarket/src/marketdata.ts
@@ -29,44 +29,101 @@ function timeoutSignal(opts?: PolymarketFetchOptions): AbortSignal | undefined {
 }
 
 const MAX_MARKET_BY_TOKEN_RESPONSE_BYTES = 16 * 1024;
+const MARKET_BY_TOKEN_TIMEOUT_MS =
+  Number.isSafeInteger(DEFAULT_FETCH_TIMEOUT_MS) && DEFAULT_FETCH_TIMEOUT_MS > 0
+    ? Math.min(DEFAULT_FETCH_TIMEOUT_MS, 60_000)
+    : 15_000;
 
-async function readBoundedMarketJson(response: Response): Promise<unknown> {
+class PolymarketMarketMetadataError extends Error {}
+
+function marketMetadataError(message: string): PolymarketMarketMetadataError {
+  return new PolymarketMarketMetadataError(message);
+}
+
+function cancelBody(body: ReadableStream<Uint8Array> | null): void {
+  try {
+    void Promise.resolve(body?.cancel()).catch(() => undefined);
+  } catch {
+    // Cancellation is best-effort and must never delay or replace a fixed error.
+  }
+}
+
+function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+  try {
+    void Promise.resolve(reader.cancel()).catch(() => undefined);
+  } catch {
+    // Hostile/custom streams cannot delay or replace the bounded transport error.
+  }
+}
+
+function marketByTokenUrl(tokenId: string, rawBase: string): URL {
+  if (rawBase.length > 2_048 || /[\u0000-\u001f\u007f]/.test(rawBase)) {
+    throw marketMetadataError("Polymarket market metadata URL is invalid");
+  }
+  let base: URL;
+  try {
+    base = new URL(rawBase);
+  } catch {
+    throw marketMetadataError("Polymarket market metadata URL is invalid");
+  }
+  if (
+    (base.protocol !== "https:" && base.protocol !== "http:") ||
+    base.username ||
+    base.password ||
+    base.search ||
+    base.hash
+  ) {
+    throw marketMetadataError("Polymarket market metadata URL is invalid");
+  }
+  return new URL(`markets-by-token/${tokenId}`, base.href.endsWith("/") ? base : `${base.href}/`);
+}
+
+async function readBoundedMarketJson(
+  response: Response,
+  signal: AbortSignal,
+  deadline: Promise<never>,
+): Promise<unknown> {
+  if (signal.aborted) {
+    throw marketMetadataError("Polymarket market metadata request was aborted");
+  }
   const declared = response.headers.get("content-length");
   if (declared !== null) {
     if (!/^\d+$/.test(declared)) {
-      throw new Error("Polymarket market metadata returned an invalid Content-Length");
+      throw marketMetadataError("Polymarket market metadata returned an invalid Content-Length");
     }
-    if (Number(declared) > MAX_MARKET_BY_TOKEN_RESPONSE_BYTES) {
-      try {
-        await response.body?.cancel();
-      } catch {
-        throw new Error("Polymarket market metadata overflow could not be canceled");
-      }
-      throw new Error("Polymarket market metadata response is too large");
+    const length = Number(declared);
+    if (!Number.isSafeInteger(length) || length > MAX_MARKET_BY_TOKEN_RESPONSE_BYTES) {
+      cancelBody(response.body);
+      throw marketMetadataError("Polymarket market metadata response is too large");
     }
   }
-  if (!response.body) throw new Error("Polymarket market metadata response has no body");
+  if (!response.body) {
+    throw marketMetadataError("Polymarket market metadata response has no body");
+  }
 
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
+  const cancelOnAbort = () => cancelReader(reader);
+  signal.addEventListener("abort", cancelOnAbort, { once: true });
   try {
     while (true) {
-      const next = await reader.read();
+      const next = await Promise.race([reader.read(), deadline]);
       if (next.done) break;
       total += next.value.byteLength;
       if (total > MAX_MARKET_BY_TOKEN_RESPONSE_BYTES) {
-        try {
-          await reader.cancel();
-        } catch {
-          throw new Error("Polymarket market metadata overflow could not be canceled");
-        }
-        throw new Error("Polymarket market metadata response is too large");
+        cancelReader(reader);
+        throw marketMetadataError("Polymarket market metadata response is too large");
       }
       chunks.push(next.value);
     }
   } finally {
-    reader.releaseLock();
+    signal.removeEventListener("abort", cancelOnAbort);
+    try {
+      reader.releaseLock();
+    } catch {
+      // A hostile or already-cancelled stream must not replace the fixed error.
+    }
   }
 
   const bytes = new Uint8Array(total);
@@ -79,7 +136,7 @@ async function readBoundedMarketJson(response: Response): Promise<unknown> {
   try {
     return strictParseJson(text);
   } catch {
-    throw new Error("Polymarket market metadata response is not valid JSON");
+    throw marketMetadataError("Polymarket market metadata response is not valid JSON");
   }
 }
 
@@ -89,31 +146,72 @@ export async function getMarketByToken(
   opts?: PolymarketFetchOptions,
 ): Promise<PolymarketMarketByToken> {
   if (!/^[0-9]{1,128}$/.test(tokenId)) {
-    throw new Error("Polymarket token id must be a bounded numeric string");
+    throw marketMetadataError("Polymarket token id must be a bounded numeric string");
   }
   const doFetch = opts?.fetch ?? fetch;
   const clobBase = opts?.clobUrl ?? POLYMARKET_CLOB_API_BASE;
-  const url = new URL(
-    `markets-by-token/${tokenId}`,
-    clobBase.endsWith("/") ? clobBase : `${clobBase}/`,
-  );
-  const response = await doFetch(url.toString(), {
-    headers: { Accept: "application/json" },
-    signal: timeoutSignal(opts),
-  });
-  if (!response.ok) {
-    throw new Error(`Polymarket market metadata error: ${response.status}`);
-  }
-  const parsed = marketByTokenSchema.safeParse(await readBoundedMarketJson(response));
-  if (!parsed.success) throw new Error("Polymarket market metadata response is invalid");
-  if (tokenId !== parsed.data.primary_token_id && tokenId !== parsed.data.secondary_token_id) {
-    throw new Error("Polymarket market metadata does not contain the requested token");
-  }
-  return {
-    conditionId: parsed.data.condition_id.toLowerCase(),
-    primaryTokenId: parsed.data.primary_token_id,
-    secondaryTokenId: parsed.data.secondary_token_id,
+  const url = marketByTokenUrl(tokenId, clobBase);
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  let callerAborted = opts?.signal?.aborted ?? false;
+  let rejectDeadline: ((error: Error) => void) | undefined;
+  const abortFromCaller = () => {
+    callerAborted = true;
+    controller.abort();
+    rejectDeadline?.(marketMetadataError("Polymarket market metadata request was aborted"));
   };
+  const deadline = new Promise<never>((_resolve, reject) => {
+    rejectDeadline = reject;
+    timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+      reject(marketMetadataError("Polymarket market metadata request timed out"));
+    }, MARKET_BY_TOKEN_TIMEOUT_MS);
+  });
+  opts?.signal?.addEventListener("abort", abortFromCaller, { once: true });
+
+  try {
+    if (callerAborted) {
+      throw marketMetadataError("Polymarket market metadata request was aborted");
+    }
+    const response = await Promise.race([
+      doFetch(url.toString(), {
+        headers: { Accept: "application/json" },
+        redirect: "error",
+        signal: controller.signal,
+      }),
+      deadline,
+    ]);
+    if (!response.ok) {
+      cancelBody(response.body);
+      throw marketMetadataError(`Polymarket market metadata error: ${response.status}`);
+    }
+    const parsed = marketByTokenSchema.safeParse(
+      await readBoundedMarketJson(response, controller.signal, deadline),
+    );
+    if (!parsed.success) {
+      throw marketMetadataError("Polymarket market metadata response is invalid");
+    }
+    if (tokenId !== parsed.data.primary_token_id && tokenId !== parsed.data.secondary_token_id) {
+      throw marketMetadataError("Polymarket market metadata does not contain the requested token");
+    }
+    return {
+      conditionId: parsed.data.condition_id.toLowerCase(),
+      primaryTokenId: parsed.data.primary_token_id,
+      secondaryTokenId: parsed.data.secondary_token_id,
+    };
+  } catch (error) {
+    if (timedOut) throw marketMetadataError("Polymarket market metadata request timed out");
+    if (callerAborted) {
+      throw marketMetadataError("Polymarket market metadata request was aborted");
+    }
+    if (error instanceof PolymarketMarketMetadataError) throw error;
+    throw marketMetadataError("Polymarket market metadata request failed");
+  } finally {
+    if (timer) clearTimeout(timer);
+    opts?.signal?.removeEventListener("abort", abortFromCaller);
+  }
 }
 
 interface RawOrderbook {


### PR DESCRIPTION
## Summary

Security corrective following the merged #537 audit:

- refuse redirects on authoritative token-to-market metadata reads
- apply one wall-clock deadline across fetch and the entire streamed body
- bound decoded response bytes and make body/reader cancellation non-blocking and best-effort
- sanitize provider, malformed URL, stream, abort, and cancellation failures
- reject CLOB endpoint overrides containing credentials, query strings, fragments, controls, or oversized input while retaining the documented HTTPS compatible-gateway deployment boundary
- release pre-execution idempotency claims even when metadata-error or condition-mismatch audit writes fail
- add behavioral regressions for redirects, stalled streams, hostile cancellation, URL-secret canaries, authoritative-condition confusion, persisted diagnostic redaction, unsafe endpoint overrides, and audit-failure retries

Arbitrary HTTPS gateway hosts remain allowed intentionally: this is trusted deployment configuration used for compatible CLOB gateways, not tenant/request input. The corrective removes URL-carried secret material and cross-URL ambiguity without breaking that documented integration surface.

## Validation

Exact production patch validation, then guarded restack onto `2f14d881108b914ecaa09fdeb406aea1d8d9b0f8`:

- 12-package dependency build: passed
- venue-polymarket: 63 passed, 0 failed, 135 assertions
- Polymarket order/session route: 33 passed, 0 failed, 160 assertions
- Biome: passed
- `git diff --check`: passed

No Actions were manipulated.
