### PR TITLE
fix(trading): release metadata outage claims before audit

### DIFF
--- a/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
@@ -345,6 +345,51 @@ describe("POST /v1/trade/polymarket/order", () => {
     }
   });
 
+  it("releases the metadata-failure claim when the audit backend is unavailable", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({
+      allowedAssets: [`pm:cond:${COND_ID}`],
+    });
+    stubWallet(true);
+    const { createTradeRoutes } = await import("../routes/trade");
+    const auditOutageRoutes = createTradeRoutes({
+      ...sharedTestContext,
+      writeAuditEvent: async () => {
+        throw new Error("AUDIT_BACKEND_SECRET_CANARY");
+      },
+    });
+    const app = makeApp(tenantId, agentId, auditOutageRoutes);
+    const key = crypto.randomUUID();
+    const fetchSpy = spyOn(globalThis, "fetch").mockRejectedValue(
+      new Error("TOKEN_METADATA_SECRET_CANARY"),
+    );
+    const originalError = console.error;
+    const logs: string[] = [];
+    console.error = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+
+    try {
+      const first = await postOrder(app, sessionId, key);
+      expect(first.status).toBe(502);
+      expect(await first.json()).toEqual({
+        ok: false,
+        error: "Unable to verify Polymarket market binding",
+      });
+
+      const retry = await postOrder(app, sessionId, key);
+      expect(retry.status).toBe(502);
+      expect(await retry.json()).toEqual({
+        ok: false,
+        error: "Unable to verify Polymarket market binding",
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(logs.join("\n")).not.toContain("AUDIT_BACKEND_SECRET_CANARY");
+      expect(logs.join("\n")).not.toContain("TOKEN_METADATA_SECRET_CANARY");
+      expect(await dailySpendOf(sessionId)).toBe(0);
+    } finally {
+      console.error = originalError;
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("SEC-041: SELL notional is floored at the CLOB best bid (low-limit cap bypass fails)", async () => {
     // perOrderCap 50. A FOK sell of 100 shares at limit 0.01 would fill at the
     // best bid (0.90): real notional ~$90 must be capped, not the caller-stated

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -1865,18 +1865,28 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         const market = await getMarketByToken(body.tokenId, clobUrl ? { clobUrl } : undefined);
         verifiedConditionId = market.conditionId;
       } catch (error) {
-        await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
-          sessionId: session.id,
-          venue: "polymarket",
-          tokenId: body.tokenId,
-          side: body.side,
-          amount,
-          price,
-          notionalUsd,
-          reason: "market-metadata-unavailable",
-          ...redactedThrownDiagnostics(error),
-        });
+        // No submission was attempted, so release the claim before the
+        // observational audit write. An audit outage must not turn a safe
+        // metadata retry into a long-lived in-progress conflict.
         await idempotency.release?.();
+        try {
+          await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
+            sessionId: session.id,
+            venue: "polymarket",
+            tokenId: body.tokenId,
+            side: body.side,
+            amount,
+            price,
+            notionalUsd,
+            reason: "market-metadata-unavailable",
+            ...redactedThrownDiagnostics(error),
+          });
+        } catch (auditError) {
+          console.error(
+            "[polymarket/order] metadata-failure audit write failed",
+            redactedThrownDiagnostics(auditError),
+          );
+        }
         return c.json<ApiResponse>(
           { ok: false, error: "Unable to verify Polymarket market binding" },
           502,


### PR DESCRIPTION
Closes #544.

## Summary
- release the Polymarket trade idempotency claim before recording a metadata-lookup rejection
- contain audit persistence failures with bounded redacted diagnostics so they cannot replace the intended sanitized metadata response
- prove two hostile metadata attempts with the same key both reach the upstream lookup even while audit persistence fails
- preserve strict token-to-condition verification and all existing execution/idempotency behavior

## Validation
- `bun test --timeout 120000 packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts` — 31 passed, 139 assertions
- affected `@stwd/plugin-trading` dependency build — 12/12 packages
- Biome and `git diff --check` passed

No production-global test hook was added; the regression uses the existing route context dependency injection.