### PR TITLE
fix(auth): bind staged activation to current challenge

### DIFF
--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -32,6 +32,7 @@ class CapturingBackend implements StoreBackend {
   failReadsAfterActiveCommit = false;
   activeTransitionFailuresAfterCommit = 0;
   failDeletes = false;
+  replaceGuardBeforeTransition = false;
 
   private isActivation(value: string): boolean {
     return (
@@ -81,7 +82,14 @@ class CapturingBackend implements StoreBackend {
     expected: string,
     desired: string,
     ttlMs: number,
+    guard?: { key: string; expected: string },
   ): Promise<boolean> {
+    if (guard && this.replaceGuardBeforeTransition) {
+      const current = this.values.get(guard.key);
+      if (current) current.value = "newer-challenge";
+      this.replaceGuardBeforeTransition = false;
+    }
+    if (guard && this.values.get(guard.key)?.value !== guard.expected) return false;
     const entry = this.values.get(key);
     const current = entry && Date.now() <= entry.expiresAt ? entry.value : null;
     if (current !== expected && current !== desired) return false;
@@ -170,6 +178,18 @@ describe("fail-closed magic-link delivery", () => {
   });
 
   it("bounds provider waits and keeps timed-out credentials staged", async () => {
+    expect(
+      () =>
+        new EmailAuth({
+          from: "login@steward.fi",
+          baseUrl: "https://steward.fi",
+          provider: new MockEmailProvider(),
+          tokenStore: new TokenStore({ backend: new CapturingBackend() }),
+          codeVerifierSecret: "fail-closed-test-secret-at-least-32-characters",
+          deliveryTimeoutMs: Number.MAX_SAFE_INTEGER,
+        }),
+    ).toThrow("deliveryTimeoutMs must be an integer between");
+
     const backend = new CapturingBackend();
     const auth = new EmailAuth({
       from: "login@steward.fi",
@@ -624,6 +644,30 @@ describe("fail-closed magic-link delivery", () => {
     auth.destroy();
   });
 
+  it("does not activate after the target is superseded at the commit boundary", async () => {
+    const backend = new CapturingBackend();
+    let text = "";
+    const auth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          text = body;
+          backend.replaceGuardBeforeTransition = true;
+          return { provider: "test", id: "accepted-before-supersede" };
+        },
+      },
+      backend,
+    );
+
+    await expect(
+      auth.sendMagicLink("commit-race@example.com", { tenantId: "tenant-a" }),
+    ).rejects.toThrow(EmailDeliveryError);
+    const token = text.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    expect(await auth.verifyMagicLink(token, "commit-race@example.com", "tenant-a")).toMatchObject({
+      valid: false,
+    });
+    auth.destroy();
+  });
+
   it("supersedes an accepted OTP when the same target retries", async () => {
     const backend = new CapturingBackend();
     const messages: string[] = [];
@@ -643,6 +687,47 @@ describe("fail-closed magic-link delivery", () => {
     const secondCode = messages[1]?.match(/\b(\d{6})\b/)?.[1] ?? "";
     expect(await auth.verifyOtp("otp-retry@example.com", firstCode, "tenant-a")).toBe(false);
     expect(await auth.verifyOtp("otp-retry@example.com", secondCode, "tenant-a")).toBe(true);
+    auth.destroy();
+  });
+
+  it("redeems active wrapper records emitted before the rolling-format fix", async () => {
+    const backend = new CapturingBackend();
+    const messages: string[] = [];
+    const auth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          messages.push(body);
+          return { provider: "test", id: `accepted-${messages.length}` };
+        },
+      },
+      backend,
+    );
+
+    await auth.sendMagicLink("active-wrapper@example.com", { tenantId: "tenant-a" });
+    const magicRecord = [...backend.values.values()].find((entry) =>
+      entry.value.includes('"purpose":"email-login"'),
+    );
+    expect(magicRecord).toBeDefined();
+    if (magicRecord) {
+      magicRecord.value = JSON.stringify({ ...JSON.parse(magicRecord.value), status: "active" });
+    }
+    const token = messages[0]?.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    expect(
+      await auth.verifyMagicLink(token, "active-wrapper@example.com", "tenant-a"),
+    ).toMatchObject({ valid: true });
+
+    await auth.sendOtp("active-wrapper-otp@example.com", { tenantId: "tenant-a" });
+    const otpRecord = [...backend.values.entries()].find(([key]) => key.length === 64);
+    expect(otpRecord).toBeDefined();
+    if (otpRecord) {
+      otpRecord[1].value = JSON.stringify({
+        status: "active",
+        payload: { email: "active-wrapper-otp@example.com", tenantId: "tenant-a" },
+      });
+    }
+    const otpCode = messages[1]?.match(/\b(\d{6})\b/)?.[1] ?? "";
+    expect(await auth.verifyOtp("active-wrapper-otp@example.com", otpCode, "tenant-a")).toBe(true);
+
     auth.destroy();
   });
 

--- a/packages/auth/src/__tests__/store-backends.test.ts
+++ b/packages/auth/src/__tests__/store-backends.test.ts
@@ -27,7 +27,10 @@ function redisLike(overrides: Partial<RedisLike> = {}): RedisLike {
       for (const key of keys) if (store.delete(key)) removed += 1;
       return removed;
     },
-    eval: async (_script, _keys, key, expected, desired) => {
+    eval: async (_script, keys, key, ...args) => {
+      const [guardKey, expected, desired, _ttl, guardExpected] =
+        keys === 2 ? args : [undefined, ...args];
+      if (guardKey !== undefined && store.get(String(guardKey)) !== guardExpected) return 0;
       const current = store.get(String(key));
       if (current !== expected && current !== desired) return 0;
       store.set(String(key), String(desired));
@@ -79,6 +82,28 @@ describe("NamespacedStoreBackend", () => {
     expect(await store.transition("challenge", "staged", "active", 60_000)).toBe(true);
     expect(await store.transition("challenge", "staged", "active", 60_000)).toBe(true);
     expect(await store.transition("challenge", "staged", "other", 60_000)).toBe(false);
+  });
+
+  it("binds transitions to an exact live guard in memory and Redis", async () => {
+    for (const store of [new MemoryBackend(), new RedisBackend(redisLike(), "test:")]) {
+      await store.set("challenge", "staged", 60_000);
+      await store.set("target", "newest", 60_000);
+      expect(
+        await store.transition("challenge", "staged", "active", 60_000, {
+          key: "target",
+          expected: "superseded",
+        }),
+      ).toBe(false);
+      expect(await store.get("challenge")).toBe("staged");
+      expect(
+        await store.transition("challenge", "staged", "active", 60_000, {
+          key: "target",
+          expected: "newest",
+        }),
+      ).toBe(true);
+      expect(await store.get("challenge")).toBe("active");
+      if (store instanceof MemoryBackend) store.destroy();
+    }
   });
 
   it("shares values across reconstructed stores in the same namespace", async () => {

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -84,6 +84,7 @@ const OTP_DIGITS = 6;
 const EMAIL_LOGIN_PURPOSE = "email-login";
 const MAX_EMAIL_LOGIN_CODE_ATTEMPTS = 5;
 const DEFAULT_DELIVERY_TIMEOUT_MS = 30_000;
+const MAX_DELIVERY_TIMEOUT_MS = 5 * 60_000;
 
 function generateToken(): string {
   // URL-safe hex token (64 chars from 32 bytes)
@@ -402,8 +403,14 @@ export class EmailAuth {
     this.callbackPath = config.callbackPath ?? DEFAULT_CALLBACK;
     this.tokenTtlMs = config.tokenTtlMs ?? DEFAULT_TTL_MS;
     this.deliveryTimeoutMs = config.deliveryTimeoutMs ?? DEFAULT_DELIVERY_TIMEOUT_MS;
-    if (!Number.isSafeInteger(this.deliveryTimeoutMs) || this.deliveryTimeoutMs <= 0) {
-      throw new Error("deliveryTimeoutMs must be a positive safe integer");
+    if (
+      !Number.isSafeInteger(this.deliveryTimeoutMs) ||
+      this.deliveryTimeoutMs <= 0 ||
+      this.deliveryTimeoutMs > MAX_DELIVERY_TIMEOUT_MS
+    ) {
+      throw new Error(
+        `deliveryTimeoutMs must be an integer between 1 and ${MAX_DELIVERY_TIMEOUT_MS}`,
+      );
     }
     this.provider = config.provider ?? new ConsoleProvider();
     // Fail closed (elizaOS/eliza#18452): in production the ConsoleProvider —
@@ -517,11 +524,12 @@ export class EmailAuth {
     staged: string,
     active: string,
     ttlMs: number,
+    guard: { key: string; expected: string },
   ): Promise<boolean> {
     let lastError: unknown;
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
-        return await this.tokenStore.transition(key, staged, active, ttlMs);
+        return await this.tokenStore.transition(key, staged, active, ttlMs, guard);
       } catch (error) {
         lastError = error;
       }
@@ -640,6 +648,7 @@ export class EmailAuth {
         // issued credentials during a rolling deployment.
         JSON.stringify({ ...challenge, status: "pending" } satisfies EmailLoginChallengeRecord),
         remainingTtlMs,
+        { key: targetKey, expected: challengeId },
       );
       if (!activated) throw new Error("challenge changed before activation");
     } catch (err) {
@@ -721,6 +730,7 @@ export class EmailAuth {
         encodeOtpChallenge("delivery_pending"),
         JSON.stringify(payload),
         remainingTtlMs,
+        { key: targetKey, expected: storeKey },
       );
       if (!activated) throw new Error("OTP changed before activation");
     } catch (err) {

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -23,7 +23,13 @@ export interface StoreBackend {
   get(key: string): Promise<string | null>;
   consume(key: string): Promise<string | null>;
   /** Atomically replace an exact value. Repeating an already-applied transition succeeds. */
-  transition(key: string, expected: string, desired: string, ttlMs: number): Promise<boolean>;
+  transition(
+    key: string,
+    expected: string,
+    desired: string,
+    ttlMs: number,
+    guard?: { key: string; expected: string },
+  ): Promise<boolean>;
   delete(key: string): Promise<void>;
 }
 
@@ -68,8 +74,15 @@ export class NamespacedStoreBackend implements StoreBackend {
     expected: string,
     desired: string,
     ttlMs: number,
+    guard?: { key: string; expected: string },
   ): Promise<boolean> {
-    return this.backend.transition(this.key(key), expected, desired, ttlMs);
+    return this.backend.transition(
+      this.key(key),
+      expected,
+      desired,
+      ttlMs,
+      guard ? { key: this.key(guard.key), expected: guard.expected } : undefined,
+    );
   }
 
   async delete(key: string): Promise<void> {
@@ -140,7 +153,15 @@ export class MemoryBackend implements StoreBackend {
     expected: string,
     desired: string,
     ttlMs: number,
+    guard?: { key: string; expected: string },
   ): Promise<boolean> {
+    if (guard) {
+      const guarded = this.store.get(guard.key);
+      if (!guarded || Date.now() > guarded.expiresAt || guarded.value !== guard.expected) {
+        if (guarded && Date.now() > guarded.expiresAt) this.store.delete(guard.key);
+        return false;
+      }
+    }
     const entry = this.store.get(key);
     if (!entry || Date.now() > entry.expiresAt) {
       this.store.delete(key);
@@ -228,7 +249,21 @@ export class RedisBackend implements StoreBackend {
     expected: string,
     desired: string,
     ttlMs: number,
+    guard?: { key: string; expected: string },
   ): Promise<boolean> {
+    if (guard) {
+      const result = await this.client.eval(
+        "if redis.call('GET',KEYS[2])~=ARGV[4] then return 0 end; local v=redis.call('GET',KEYS[1]); if v==ARGV[1] or v==ARGV[2] then redis.call('SET',KEYS[1],ARGV[2],'PX',ARGV[3]); return 1 end; return 0",
+        2,
+        this.prefix + key,
+        this.prefix + guard.key,
+        expected,
+        desired,
+        ttlMs,
+        guard.expected,
+      );
+      return result === 1 || result === "1";
+    }
     const result = await this.client.eval(
       "local v=redis.call('GET',KEYS[1]); if v==ARGV[1] or v==ARGV[2] then redis.call('SET',KEYS[1],ARGV[2],'PX',ARGV[3]); return 1 end; return 0",
       1,
@@ -356,11 +391,29 @@ export class PostgresBackend implements StoreBackend {
     expected: string,
     desired: string,
     ttlMs: number,
+    guard?: { key: string; expected: string },
   ): Promise<boolean> {
     await this.ensureTable();
     const sql = this.getSqlClient();
     const expiresAt = new Date(Date.now() + ttlMs).toISOString();
-    const rows = await sql<Array<{ id: string }>>`
+    const rows = guard
+      ? await sql<Array<{ id: string }>>`
+      UPDATE auth_kv_store
+         SET value = ${desired}, expires_at = ${expiresAt}
+       WHERE id = ${key}
+         AND namespace = ${this.namespace}
+         AND expires_at > now()
+         AND (value = ${expected} OR value = ${desired})
+         AND EXISTS (
+           SELECT 1 FROM auth_kv_store AS guard_row
+            WHERE guard_row.id = ${guard.key}
+              AND guard_row.namespace = ${this.namespace}
+              AND guard_row.expires_at > now()
+              AND guard_row.value = ${guard.expected}
+         )
+      RETURNING id
+    `
+      : await sql<Array<{ id: string }>>`
       UPDATE auth_kv_store
          SET value = ${desired}, expires_at = ${expiresAt}
        WHERE id = ${key}

--- a/packages/auth/src/token-store.ts
+++ b/packages/auth/src/token-store.ts
@@ -68,8 +68,9 @@ export class TokenStore {
     expected: string,
     desired: string,
     ttlMs: number = DEFAULT_TTL_MS,
+    guard?: { key: string; expected: string },
   ): Promise<boolean> {
-    return this.backend.transition(hash, expected, desired, ttlMs);
+    return this.backend.transition(hash, expected, desired, ttlMs, guard);
   }
 
   /**


### PR DESCRIPTION
## Summary
- atomically bind staged email activation to the exact current target alias
- prevent a superseded challenge from becoming redeemable during a commit-boundary race
- preserve lost-ack/idempotent transition behavior across memory, Redis, namespaced, and Postgres stores

## Validation
- full @stwd/auth test suite passed
- API dependency build 24/24
- Biome and git diff check clean
- real PostgreSQL guard transition proof passed for mismatched and exact guards