### PR TITLE
fix(trading): harden polymarket market grant verification

### DIFF
--- a/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
@@ -275,6 +275,38 @@ describe("POST /v1/trade/polymarket/order", () => {
     }
   });
 
+  it("rejects a caller conditionId mismatch even when the token itself is directly allowlisted", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({
+      allowedAssets: [`pm:${TOKEN_ID}`],
+    });
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          condition_id: OTHER_COND_ID,
+          primary_token_id: TOKEN_ID,
+          secondary_token_id: "8".repeat(72),
+        }),
+        { status: 200 },
+      ),
+    );
+
+    try {
+      const res = await postOrder(app, sessionId, crypto.randomUUID(), {
+        conditionId: COND_ID,
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()) as { code?: string; reason?: string }).toEqual({
+        code: "policy-violation",
+        reason: "condition-id-mismatch",
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(await dailySpendOf(sessionId)).toBe(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("authorizes a market-wide grant only after resolving the token's condition", async () => {
     const { tenantId, agentId, sessionId } = await seedSession({
       allowedAssets: [`pm:cond:0x${"A".repeat(64)}`],

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -1859,7 +1859,10 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
 
     let verifiedConditionId: string | undefined;
     const hasMarketGrant = session.allowedAssets.some((asset) => asset.startsWith("pm:cond:"));
-    if (!check.allowed && check.reason === "market-not-allowed" && hasMarketGrant) {
+    const needsVerifiedConditionId =
+      body.conditionId !== undefined ||
+      (!check.allowed && check.reason === "market-not-allowed" && hasMarketGrant);
+    if (needsVerifiedConditionId) {
       try {
         const clobUrl = configuredPolymarketClobUrl();
         const market = await getMarketByToken(body.tokenId, clobUrl ? { clobUrl } : undefined);
@@ -1905,15 +1908,19 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         await idempotency.store?.(envelope);
         return c.json(envelope.body, envelope.status);
       }
-
-      ({ session, check } = await getSessionManager().checkActiveOrder({
-        tenantId,
-        id: body.sessionId,
-        order: { tokenId: body.tokenId, conditionId: verifiedConditionId, notionalUsd },
-      }));
-      if (session.agentId !== agentId || session.venue !== "polymarket") {
-        await idempotency.release?.();
-        return c.json<ApiResponse>({ ok: false, error: "Active Polymarket session required" }, 403);
+      if (!check.allowed && check.reason === "market-not-allowed" && hasMarketGrant) {
+        ({ session, check } = await getSessionManager().checkActiveOrder({
+          tenantId,
+          id: body.sessionId,
+          order: { tokenId: body.tokenId, conditionId: verifiedConditionId, notionalUsd },
+        }));
+        if (session.agentId !== agentId || session.venue !== "polymarket") {
+          await idempotency.release?.();
+          return c.json<ApiResponse>(
+            { ok: false, error: "Active Polymarket session required" },
+            403,
+          );
+        }
       }
     }
 

--- a/packages/venue-polymarket/src/index.test.ts
+++ b/packages/venue-polymarket/src/index.test.ts
@@ -712,8 +712,10 @@ describe("marketdata batch", () => {
     const sibling = "8".repeat(72);
     const conditionId = `0x${"a".repeat(64)}`;
     let requestedUrl = "";
-    const fetchMock = (async (input: string | URL | Request) => {
+    let requestedRedirect: RequestRedirect | undefined;
+    const fetchMock = (async (input: string | URL | Request, init?: RequestInit) => {
       requestedUrl = String(input);
+      requestedRedirect = init?.redirect;
       return new Response(
         JSON.stringify({
           condition_id: conditionId.toUpperCase().replace("0X", "0x"),
@@ -731,6 +733,7 @@ describe("marketdata batch", () => {
       }),
     ).toEqual({ conditionId, primaryTokenId: tokenId, secondaryTokenId: sibling });
     expect(requestedUrl).toBe(`https://clob.example.test/gateway/markets-by-token/${tokenId}`);
+    expect(requestedRedirect).toBe("error");
   });
 
   test("getMarketByToken rejects a response that does not contain the requested token", async () => {

--- a/packages/venue-polymarket/src/marketdata.ts
+++ b/packages/venue-polymarket/src/marketdata.ts
@@ -99,6 +99,7 @@ export async function getMarketByToken(
   );
   const response = await doFetch(url.toString(), {
     headers: { Accept: "application/json" },
+    redirect: "error",
     signal: timeoutSignal(opts),
   });
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- fail closed on redirected Polymarket market-metadata lookups
- reject caller-supplied conditionId mismatches even when the token itself is directly allowlisted
- keep market-wide grant verification behavior unchanged otherwise
- add focused regressions for redirect-fail-closed transport and exact-token mismatch rejection

## Notes
- Follow-up to merged #537.
- Issue #529 was reopened because #537 auto-closed it before these residual checks landed.

## Validation
- Residual-diff validation in the isolated audit worktree before restack:
  - `bun test --timeout 30000 packages/venue-polymarket/src/index.test.ts` (62 pass)
  - `bun test --timeout 30000 packages/trade-sessions/src/__tests__/trade-sessions.test.ts` (25 pass)
  - `bun test --timeout 30000 packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts` (31 pass)
  - `bunx turbo run build --filter=@stwd/plugin-trading...` (12/12)
- Exact rebased branch validation:
  - `bunx @biomejs/biome check packages/plugin-trading/src/routes/trade.ts packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts packages/venue-polymarket/src/marketdata.ts packages/venue-polymarket/src/index.test.ts`
  - `git diff --check origin/develop...HEAD`

No closing footer yet; #529 should close only when this follow-up merges.