### PR TITLE
fix(seed): clarify credential promotion trust boundary

### DIFF
--- a/packages/seed/src/__tests__/demo-api-key.test.ts
+++ b/packages/seed/src/__tests__/demo-api-key.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
   lstatSync,
+  mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
   realpathSync,
-  renameSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -98,7 +98,7 @@ describe("demo API key", () => {
     }
   });
 
-  test("retains the committed credential when atomic promotion fails", async () => {
+  test("retains the committed credential when promotion fails", async () => {
     const root = tempRoot("steward-demo-postcommit-");
     try {
       const path = join(root, "demo.env");
@@ -179,54 +179,18 @@ describe("demo API key", () => {
     }
   });
 
-  test("never promotes a pending pathname swapped after inode validation", () => {
-    const root = tempRoot("steward-demo-race-");
+  test("cleans its generated promotion link when canonical replacement fails", () => {
+    const root = tempRoot("steward-demo-promotion-cleanup-");
     try {
       const path = join(root, "demo.env");
-      const oldKey = generateDemoApiKey().key;
-      promoteDemoCredentials(stageDemoCredentials("waifu.fun", oldKey, path));
-      const nextKey = generateDemoApiKey().key;
-      const pending = stageDemoCredentials("waifu.fun", nextKey, path);
-      const originalPending = `${pending.pendingPath}.original`;
-      expect(() =>
-        promoteDemoCredentials(pending, () => {
-          renameSync(pending.pendingPath, originalPending);
-          writeFileSync(
-            pending.pendingPath,
-            "STEWARD_TENANT_ID=attacker\nSTEWARD_API_KEY=stw_00000000000000000000000000000000\n",
-            { mode: 0o600 },
-          );
-        }),
-      ).toThrow("changed during promotion");
-      expect(readFileSync(path, "utf8")).toContain(`STEWARD_API_KEY=${oldKey}`);
-      expect(readFileSync(path, "utf8")).not.toContain("stw_00000000000000000000000000000000");
-      expect(readFileSync(originalPending, "utf8")).toContain(`STEWARD_API_KEY=${nextKey}`);
-      expect(readdirSync(root).some((name) => name.includes(".promote-"))).toBe(false);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  test("never promotes a promotion pathname swapped after descriptor validation", () => {
-    const root = tempRoot("steward-demo-promotion-race-");
-    try {
-      const path = join(root, "demo.env");
-      const oldKey = generateDemoApiKey().key;
-      promoteDemoCredentials(stageDemoCredentials("waifu.fun", oldKey, path));
       const pending = stageDemoCredentials("waifu.fun", generateDemoApiKey().key, path);
+      mkdirSync(path);
+      writeFileSync(join(path, "occupied"), "keep");
 
-      expect(() =>
-        promoteDemoCredentials(pending, undefined, (promotionPath) => {
-          renameSync(promotionPath, `${promotionPath}.original`);
-          writeFileSync(
-            promotionPath,
-            "STEWARD_TENANT_ID=attacker\nSTEWARD_API_KEY=stw_00000000000000000000000000000000\n",
-            { mode: 0o600 },
-          );
-        }),
-      ).toThrow("changed before canonical rename");
-      expect(readFileSync(path, "utf8")).toContain(`STEWARD_API_KEY=${oldKey}`);
-      expect(readFileSync(path, "utf8")).not.toContain("stw_00000000000000000000000000000000");
+      expect(() => promoteDemoCredentials(pending)).toThrow();
+      expect(lstatSync(pending.pendingPath).isFile()).toBe(true);
+      expect(readFileSync(join(path, "occupied"), "utf8")).toBe("keep");
+      expect(readdirSync(root).some((name) => name.includes(".promote-"))).toBe(false);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/seed/src/demo-api-key.ts
+++ b/packages/seed/src/demo-api-key.ts
@@ -139,12 +139,15 @@ export function stageDemoCredentials(
   throw new Error("Could not allocate a unique pending credential file");
 }
 
-/** Atomically make a staged credential canonical after the DB commit. */
-export function promoteDemoCredentials(
-  pending: PendingDemoCredentials,
-  afterPendingOpen?: () => void,
-  beforePromotionRename?: (promotionPath: string) => void,
-): string {
+/**
+ * Make a staged credential canonical after the DB commit.
+ *
+ * The credential directory and files are restricted to the current user. Every
+ * process that can write to that directory as the same UID is therefore inside
+ * this trust boundary: JavaScript pathname APIs cannot eliminate lstat/link/
+ * rename races against another same-UID writer.
+ */
+export function promoteDemoCredentials(pending: PendingDemoCredentials): string {
   const parent = credentialParent(pending.finalPath);
   if (parent.device !== pending.parentDevice || parent.inode !== pending.parentInode) {
     throw new Error(`Credential directory changed; recover ${pending.pendingPath}`);
@@ -161,8 +164,6 @@ export function promoteDemoCredentials(
     if (typeof process.geteuid === "function" && staged.uid !== process.geteuid()) {
       throw new Error(`Pending credential owner changed; recover ${pending.pendingPath}`);
     }
-
-    afterPendingOpen?.();
 
     let promotionPath: string | undefined;
     try {
@@ -200,7 +201,6 @@ export function promoteDemoCredentials(
           );
         }
 
-        beforePromotionRename?.(promotionPath);
         const beforeRename = lstatSync(promotionPath);
         if (
           !beforeRename.isFile() ||


### PR DESCRIPTION
## Summary

- remove production-only pathname race callbacks from credential promotion
- document same-UID credential-directory writers as trusted while preserving owner-only file handling
- replace misleading race-prevention tests with behavioral cleanup coverage for generated promotion links

## Validation

- `bun test --timeout 120000 packages/seed/src/__tests__/demo-api-key.test.ts`
- `bunx turbo run build --filter=@stwd/seed... --force`
- `bunx biome check packages/seed/src/demo-api-key.ts packages/seed/src/__tests__/demo-api-key.test.ts`
- `git diff --check origin/develop...HEAD`

Closes #551