### PR TITLE
test(api): preserve tenant KDF proof point

### DIFF
--- a/packages/api/src/__tests__/authorization-signature-tenant-keys.test.ts
+++ b/packages/api/src/__tests__/authorization-signature-tenant-keys.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { closeDb, getDb, tenantRequestSigningKeys, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { KeyStore } from "@stwd/vault";
@@ -18,7 +18,8 @@ const BODY = JSON.stringify({ value: "1000" });
 const FRESH_TS = () => String(Math.floor(Date.now() / 1000));
 let authorizationSignature: typeof import("../middleware/authorization-signature")["authorizationSignature"];
 let createAuthorizationSignature: typeof import("../middleware/authorization-signature")["createAuthorizationSignature"];
-let decryptSpy: ReturnType<typeof spyOn>;
+let __setTenantKeyKdfObserverForTests: typeof import("../middleware/authorization-signature")["__setTenantKeyKdfObserverForTests"];
+let tenantKeyKdfCount = 0;
 
 function makeApp() {
   const app = new Hono<{ Variables: AppVariables }>();
@@ -59,9 +60,8 @@ beforeAll(async () => {
   setPGLiteOverride(db, async () => {
     await client.close();
   });
-  ({ authorizationSignature, createAuthorizationSignature } = await import(
-    "../middleware/authorization-signature"
-  ));
+  ({ authorizationSignature, createAuthorizationSignature, __setTenantKeyKdfObserverForTests } =
+    await import("../middleware/authorization-signature"));
 
   await getDb()
     .insert(tenants)
@@ -94,11 +94,14 @@ afterAll(async () => {
 });
 
 beforeEach(() => {
-  decryptSpy = spyOn(KeyStore.prototype, "decrypt");
+  tenantKeyKdfCount = 0;
+  __setTenantKeyKdfObserverForTests(() => {
+    tenantKeyKdfCount += 1;
+  });
 });
 
 afterEach(() => {
-  decryptSpy.mockRestore();
+  __setTenantKeyKdfObserverForTests(null);
 });
 
 describe("authorizationSignature tenant signing keys", () => {
@@ -113,7 +116,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, verified: true });
-    expect(decryptSpy).toHaveBeenCalledTimes(1);
+    expect(tenantKeyKdfCount).toBe(1);
   });
 
   it("rejects an unknown (well-formed) signing key id without decrypt work", async () => {
@@ -129,7 +132,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ ok: false, error: "Invalid signing key id" });
-    expect(decryptSpy).not.toHaveBeenCalled();
+    expect(tenantKeyKdfCount).toBe(0);
   });
 
   it("rejects a malformed signing key id cheaply (no uuid DB error)", async () => {
@@ -145,7 +148,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ ok: false, error: "Invalid signing key id" });
-    expect(decryptSpy).not.toHaveBeenCalled();
+    expect(tenantKeyKdfCount).toBe(0);
   });
 
   it("does not use tenant signing keys when no key id is named", async () => {
@@ -162,7 +165,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ ok: false, error: "Invalid request signature" });
-    expect(decryptSpy).not.toHaveBeenCalled();
+    expect(tenantKeyKdfCount).toBe(0);
   });
 
   it("still verifies key-id-less requests signed with a configured static secret", async () => {
@@ -176,6 +179,6 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, verified: true });
-    expect(decryptSpy).not.toHaveBeenCalled();
+    expect(tenantKeyKdfCount).toBe(0);
   });
 });

--- a/packages/api/src/middleware/authorization-signature.ts
+++ b/packages/api/src/middleware/authorization-signature.ts
@@ -149,6 +149,12 @@ async function appClientSecretSigningCandidates(request: Request): Promise<strin
 // Tenant signing-key ids are server-generated UUIDs (tenant-config.ts uses
 // `randomUUID()`), so a non-UUID header value can be rejected without a query.
 const SIGNING_KEY_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+let tenantKeyKdfObserverForTests: (() => void) | null = null;
+
+/** Test-only proof point immediately before tenant-key KDF/decrypt work begins. */
+export function __setTenantKeyKdfObserverForTests(observer: (() => void) | null): void {
+  tenantKeyKdfObserverForTests = observer;
+}
 
 async function tenantRequestSigningKeyCandidates(request: Request): Promise<string[]> {
   const tenantId = request.headers.get("X-Steward-Tenant");
@@ -176,6 +182,7 @@ async function tenantRequestSigningKeyCandidates(request: Request): Promise<stri
   // Defer KeyStore construction (itself a scrypt KDF) until a row exists, so
   // an unknown key id costs only the cheap lookup above.
   if (rows.length === 0) return [];
+  tenantKeyKdfObserverForTests?.();
   const keyStore = new KeyStore(masterPassword, undefined, "secret-vault");
   return rows.flatMap((row) => {
     if (row.revokedAt) return [];


### PR DESCRIPTION
## Summary
- restore the pre-KeyStore observer used by tenant request-signature regressions
- assert unknown, malformed, and key-id-less unauthenticated requests never reach constructor-side scrypt work
- preserve the existing deep-imported test-only export and reset the observer after every test

The merged #545 replacement spy only observed `decrypt()`, but `KeyStore` performs an expensive scrypt in its constructor before decrypt is called. This restores the stronger CPU-amplification regression without reverting the comment cleanups.

## Tests
- `bun test --timeout 30000 packages/api/src/__tests__/authorization-signature-tenant-keys.test.ts` (5 pass, 15 assertions)
- `bunx @biomejs/biome check packages/api/src/middleware/authorization-signature.ts packages/api/src/__tests__/authorization-signature-tenant-keys.test.ts`
- `bunx turbo run build --filter=@stwd/api...` (24/24)
- `git diff --check origin/develop...HEAD`