### PR TITLE
test(api): observe tenant signing KDF construction

### DIFF
--- a/packages/api/src/__tests__/authorization-signature-tenant-keys.test.ts
+++ b/packages/api/src/__tests__/authorization-signature-tenant-keys.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { closeDb, getDb, tenantRequestSigningKeys, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { KeyStore } from "@stwd/vault";
@@ -18,11 +18,21 @@ const BODY = JSON.stringify({ value: "1000" });
 const FRESH_TS = () => String(Math.floor(Date.now() / 1000));
 let authorizationSignature: typeof import("../middleware/authorization-signature")["authorizationSignature"];
 let createAuthorizationSignature: typeof import("../middleware/authorization-signature")["createAuthorizationSignature"];
-let decryptSpy: ReturnType<typeof spyOn>;
+let tenantKeyStoreConstructionCount = 0;
 
 function makeApp() {
   const app = new Hono<{ Variables: AppVariables }>();
-  app.use("*", authorizationSignature({ required: true, secrets: [STATIC_SECRET] }));
+  app.use(
+    "*",
+    authorizationSignature({
+      required: true,
+      secrets: [STATIC_SECRET],
+      tenantKeyStoreFactory(masterPassword, masterSalt, domain) {
+        tenantKeyStoreConstructionCount += 1;
+        return new KeyStore(masterPassword, masterSalt, domain);
+      },
+    }),
+  );
   app.post("/vault/:agentId/sign", (c) =>
     c.json({ ok: true, verified: Boolean(c.get("requestSignatureVerified")) }),
   );
@@ -94,11 +104,7 @@ afterAll(async () => {
 });
 
 beforeEach(() => {
-  decryptSpy = spyOn(KeyStore.prototype, "decrypt");
-});
-
-afterEach(() => {
-  decryptSpy.mockRestore();
+  tenantKeyStoreConstructionCount = 0;
 });
 
 describe("authorizationSignature tenant signing keys", () => {
@@ -113,7 +119,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, verified: true });
-    expect(decryptSpy).toHaveBeenCalledTimes(1);
+    expect(tenantKeyStoreConstructionCount).toBe(1);
   });
 
   it("rejects an unknown (well-formed) signing key id without decrypt work", async () => {
@@ -129,7 +135,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ ok: false, error: "Invalid signing key id" });
-    expect(decryptSpy).not.toHaveBeenCalled();
+    expect(tenantKeyStoreConstructionCount).toBe(0);
   });
 
   it("rejects a malformed signing key id cheaply (no uuid DB error)", async () => {
@@ -145,7 +151,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ ok: false, error: "Invalid signing key id" });
-    expect(decryptSpy).not.toHaveBeenCalled();
+    expect(tenantKeyStoreConstructionCount).toBe(0);
   });
 
   it("does not use tenant signing keys when no key id is named", async () => {
@@ -162,7 +168,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ ok: false, error: "Invalid request signature" });
-    expect(decryptSpy).not.toHaveBeenCalled();
+    expect(tenantKeyStoreConstructionCount).toBe(0);
   });
 
   it("still verifies key-id-less requests signed with a configured static secret", async () => {
@@ -176,6 +182,6 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, verified: true });
-    expect(decryptSpy).not.toHaveBeenCalled();
+    expect(tenantKeyStoreConstructionCount).toBe(0);
   });
 });

--- a/packages/api/src/middleware/authorization-signature.ts
+++ b/packages/api/src/middleware/authorization-signature.ts
@@ -55,6 +55,11 @@ export type AuthorizationSignatureOptions = {
   required?: boolean;
   secrets?: string[];
   appSecretResolver?: (request: Request) => Promise<string[]> | string[];
+  tenantKeyStoreFactory?: (
+    masterPassword: string,
+    masterSalt: string | undefined,
+    domain: "secret-vault",
+  ) => Pick<KeyStore, "decrypt">;
 };
 
 function configuredSecrets(): string[] {
@@ -150,7 +155,10 @@ async function appClientSecretSigningCandidates(request: Request): Promise<strin
 // `randomUUID()`), so a non-UUID header value can be rejected without a query.
 const SIGNING_KEY_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-async function tenantRequestSigningKeyCandidates(request: Request): Promise<string[]> {
+async function tenantRequestSigningKeyCandidates(
+  request: Request,
+  createKeyStore: NonNullable<AuthorizationSignatureOptions["tenantKeyStoreFactory"]>,
+): Promise<string[]> {
   const tenantId = request.headers.get("X-Steward-Tenant");
   if (!isValidTenantId(tenantId)) return [];
 
@@ -176,7 +184,7 @@ async function tenantRequestSigningKeyCandidates(request: Request): Promise<stri
   // Defer KeyStore construction (itself a scrypt KDF) until a row exists, so
   // an unknown key id costs only the cheap lookup above.
   if (rows.length === 0) return [];
-  const keyStore = new KeyStore(masterPassword, undefined, "secret-vault");
+  const keyStore = createKeyStore(masterPassword, undefined, "secret-vault");
   return rows.flatMap((row) => {
     if (row.revokedAt) return [];
     if (row.expiresAt && row.expiresAt <= now) return [];
@@ -799,6 +807,9 @@ export function authorizationSignature(options?: AuthorizationSignatureOptions) 
       process.env.NODE_ENV === "production");
   const secrets = options?.secrets ?? configuredSecrets();
   const appSecretResolver = options?.appSecretResolver ?? appClientSecretSigningCandidates;
+  const tenantKeyStoreFactory =
+    options?.tenantKeyStoreFactory ??
+    ((masterPassword, masterSalt, domain) => new KeyStore(masterPassword, masterSalt, domain));
   const maxClockSkewMs = parsePositiveInt(
     process.env.STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS,
     DEFAULT_MAX_CLOCK_SKEW_MS,
@@ -902,7 +913,9 @@ export function authorizationSignature(options?: AuthorizationSignatureOptions) 
     // requests fall through to the static/app-secret candidates and never
     // trigger tenant-key work — closing the unauthenticated CPU-amplification
     // DoS the global SEC-010 mount exposed.
-    const tenantKeySecrets = signingKeyId ? await tenantRequestSigningKeyCandidates(c.req.raw) : [];
+    const tenantKeySecrets = signingKeyId
+      ? await tenantRequestSigningKeyCandidates(c.req.raw, tenantKeyStoreFactory)
+      : [];
     if (signingKeyId && tenantKeySecrets.length === 0) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid signing key id" }, 401);
     }


### PR DESCRIPTION
Closes #553

Post-merge corrective for #545. The decrypt spy did not observe the expensive root scrypt performed in the `KeyStore` constructor. This adds immutable constructor injection to `authorizationSignature(...)` and counts actual default-equivalent `KeyStore` construction in the behavioral test.

The production default still constructs the real `KeyStore`; there is no mutable module-global test hook or test-named export. Unknown, malformed, and keyless requests prove zero construction; a known key constructs once and verifies.

Exact-head validation:
- focused tenant signing key suite: 5/5
- API dependency build: 24/24
- Biome on both changed files
- `git diff --check`