### PR TITLE
fix(trading): verify exact-token condition binding

### DIFF
--- a/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
@@ -286,6 +286,38 @@ describe("POST /v1/trade/polymarket/order", () => {
     }
   });
 
+  it("rejects a caller conditionId mismatch even when the token itself is directly allowlisted", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({
+      allowedAssets: [`pm:${TOKEN_ID}`],
+    });
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          condition_id: OTHER_COND_ID,
+          primary_token_id: TOKEN_ID,
+          secondary_token_id: "8".repeat(72),
+        }),
+        { status: 200 },
+      ),
+    );
+
+    try {
+      const res = await postOrder(app, sessionId, crypto.randomUUID(), {
+        conditionId: COND_ID,
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()) as { code?: string; reason?: string }).toEqual({
+        code: "policy-violation",
+        reason: "condition-id-mismatch",
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(await dailySpendOf(sessionId)).toBe(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("authorizes a market-wide grant only after resolving the token's condition", async () => {
     const { tenantId, agentId, sessionId } = await seedSession({
       allowedAssets: [`pm:cond:0x${"A".repeat(64)}`],

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -1843,9 +1843,10 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       notionalUsd = polymarketNotionalUsd(body.side, amount, price);
     }
 
-    // Exact token grants are evaluated without a network dependency. If only a
-    // market-wide grant could authorize the order, resolve the token's parent
-    // condition from the CLOB and evaluate again using that verified binding.
+    // Exact token grants without a caller-asserted condition remain network
+    // independent. If a condition is asserted, or only a market-wide grant
+    // could authorize the order, resolve the token's authoritative parent
+    // condition from the CLOB before trusting that binding.
     let { session, check } = await getSessionManager().checkActiveOrder({
       tenantId,
       id: body.sessionId,
@@ -1865,7 +1866,10 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
 
     let verifiedConditionId: string | undefined;
     const hasMarketGrant = session.allowedAssets.some((asset) => asset.startsWith("pm:cond:"));
-    if (!check.allowed && check.reason === "market-not-allowed" && hasMarketGrant) {
+    const needsVerifiedConditionId =
+      body.conditionId !== undefined ||
+      (!check.allowed && check.reason === "market-not-allowed" && hasMarketGrant);
+    if (needsVerifiedConditionId) {
       try {
         const clobUrl = configuredPolymarketClobUrl();
         const market = await getMarketByToken(body.tokenId, clobUrl ? { clobUrl } : undefined);
@@ -1928,14 +1932,19 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         return c.json(envelope.body, envelope.status);
       }
 
-      ({ session, check } = await getSessionManager().checkActiveOrder({
-        tenantId,
-        id: body.sessionId,
-        order: { tokenId: body.tokenId, conditionId: verifiedConditionId, notionalUsd },
-      }));
-      if (session.agentId !== agentId || session.venue !== "polymarket") {
-        await idempotency.release?.();
-        return c.json<ApiResponse>({ ok: false, error: "Active Polymarket session required" }, 403);
+      if (!check.allowed && check.reason === "market-not-allowed" && hasMarketGrant) {
+        ({ session, check } = await getSessionManager().checkActiveOrder({
+          tenantId,
+          id: body.sessionId,
+          order: { tokenId: body.tokenId, conditionId: verifiedConditionId, notionalUsd },
+        }));
+        if (session.agentId !== agentId || session.venue !== "polymarket") {
+          await idempotency.release?.();
+          return c.json<ApiResponse>(
+            { ok: false, error: "Active Polymarket session required" },
+            403,
+          );
+        }
       }
     }
 


### PR DESCRIPTION
## Security corrective

Builds on merged #547 (including the #548 release-before-audit semantics) and preserves its bounded/redacted market metadata transport. Adds the remaining invariant from closed #552: when a caller supplies `conditionId`, authoritative token metadata must match it even if `pm:<tokenId>` is directly allowlisted. Exact-token requests that omit `conditionId` remain network-independent.

## Exact validation

- `bun test --timeout 60000 packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts packages/venue-polymarket/src/index.test.ts packages/trade-sessions/src/__tests__/trade-sessions.test.ts` — 122 pass, 360 assertions
- `bunx turbo run build --filter=@stwd/plugin-trading...` — 12/12 packages
- Biome exact changed files — pass
- `git diff --check` — pass

Closes #529
