### PR TITLE
solana-signer: accept Authorization Bearer alongside the bridge header

### DIFF
--- a/packages/solana-signer/src/__tests__/bridge.test.ts
+++ b/packages/solana-signer/src/__tests__/bridge.test.ts
@@ -168,6 +168,29 @@ describe("bridge shared-secret auth", () => {
     expect(res.status).toBe(401);
   });
 
+  it("accepts the same secret as Authorization: Bearer (AgentNet's remote-wallet client)", async () => {
+    const res = await fetch(`${bridgeUrl}/pubkey`, {
+      headers: { authorization: `Bearer ${bridgeToken}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { address: string };
+    expect(body.address.length).toBeGreaterThan(30);
+  });
+
+  it("refuses a wrong bearer token with 401", async () => {
+    const res = await fetch(`${bridgeUrl}/pubkey`, {
+      headers: { authorization: `Bearer ${bridgeToken}x` },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("the custom header wins over a bearer header when both are present", async () => {
+    const res = await fetch(`${bridgeUrl}/pubkey`, {
+      headers: { [BRIDGE_TOKEN_HEADER]: `${bridgeToken}x`, authorization: `Bearer ${bridgeToken}` },
+    });
+    expect(res.status).toBe(401);
+  });
+
   it(`honors ${BRIDGE_TOKEN_ENV} from the env, the var both sides read`, async () => {
     const envToken = "e".repeat(BRIDGE_MIN_TOKEN_BYTES);
     process.env[BRIDGE_TOKEN_ENV] = envToken;

--- a/packages/solana-signer/src/bridge.ts
+++ b/packages/solana-signer/src/bridge.ts
@@ -12,14 +12,15 @@
 //                              closed and message-derived features stay off.
 //
 // Loopback is a machine-wide surface: ANY local process can connect to a
-// 127.0.0.1 port, so by default every request must present a shared secret in
-// the x-steward-bridge-token header. The token comes from the
-// STEWARD_SIGNER_BRIDGE_TOKEN env var when set (the same var the consumer
-// process reads to send the header), otherwise a fresh random token is
-// generated per session and exposed as `token` on the returned bridge. A
-// missing or wrong header is 401 before the signer is touched. There is no
-// unauthenticated mode: browser CSRF and unrelated local processes can reach
-// loopback ports too.
+// 127.0.0.1 port, so every request must present a shared secret, either in
+// the x-steward-bridge-token header or as standard `Authorization: Bearer`
+// (for consumers whose HTTP clients only speak bearer auth, e.g. AgentNet's
+// remote-wallet client). The token comes from the STEWARD_SIGNER_BRIDGE_TOKEN
+// env var when set (the same var the consumer process reads to send the
+// header), otherwise a fresh random token is generated per session and
+// exposed as `token` on the returned bridge. A missing or wrong secret is 401
+// before the signer is touched. There is no unauthenticated mode: browser
+// CSRF and unrelated local processes can reach loopback ports too.
 //
 // Policy refusals map to JSON errors with the refusal text and kind, so the
 // remote side can print WHY the vault said no instead of a bare status code.
@@ -43,10 +44,12 @@ export interface SignerBridgeOptions {
   host?: string;
   /** 0 (default) picks an ephemeral port; read the final one from `url`. */
   port?: number;
-  /** Shared secret required in the x-steward-bridge-token header of every
-   *  request. Omitted: STEWARD_SIGNER_BRIDGE_TOKEN from the env when set,
-   *  else a fresh random token per session (read it from the returned
-   *  bridge's `token`). Must contain at least 32 UTF-8 bytes. */
+  /** Shared secret required on every request, presented either in the
+   *  x-steward-bridge-token header or as `Authorization: Bearer <token>`
+   *  (for callers that only speak standard bearer auth, e.g. AgentNet's
+   *  remote-wallet client). Omitted: STEWARD_SIGNER_BRIDGE_TOKEN from the
+   *  env when set, else a fresh random token per session (read it from the
+   *  returned bridge's `token`). Must contain at least 32 UTF-8 bytes. */
   token?: string;
 }
 
@@ -65,6 +68,18 @@ function tokenMatches(presented: string | string[] | undefined, expected: string
     createHash("sha256").update(presented).digest(),
     createHash("sha256").update(expected).digest(),
   );
+}
+
+/** The request's presented secret: the bridge header verbatim, else the token
+ *  of a standard `Authorization: Bearer <token>` header. Callers that cannot
+ *  set custom headers (AgentNet's remote-wallet client sends only bearer
+ *  auth) still authenticate; everyone else keeps the existing header. */
+function presentedToken(req: IncomingMessage): string | string[] | undefined {
+  const custom = req.headers[BRIDGE_TOKEN_HEADER];
+  if (custom !== undefined) return custom;
+  const auth = req.headers.authorization;
+  if (typeof auth === "string" && auth.startsWith("Bearer ")) return auth.slice("Bearer ".length);
+  return undefined;
 }
 
 function statusFor(kind: StewardSignerError["kind"]): number {
@@ -153,11 +168,11 @@ export async function startSignerBridge(
   async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
     // Auth before routing: an unauthenticated caller learns nothing and the
     // signer is never touched.
-    if (!tokenMatches(req.headers[BRIDGE_TOKEN_HEADER], token)) {
+    if (!tokenMatches(presentedToken(req), token)) {
       respond(res, 401, {
         error:
-          `missing or wrong ${BRIDGE_TOKEN_HEADER} header; this bridge only answers ` +
-          "callers holding its session's shared secret",
+          `missing or wrong ${BRIDGE_TOKEN_HEADER} or Authorization: Bearer header; ` +
+          "this bridge only answers callers holding its session's shared secret",
       });
       return;
     }


### PR DESCRIPTION
Found running the first full AgentNet remote-signer chain end to end against the bridge: AgentNet's merged remote-wallet client (IQCoreTeam/AgentNet#191) speaks the documented three-endpoint protocol but sends no custom headers, so every call 401s despite both sides being individually green. Proven live: direct GET /pubkey returns 401, the identical call with the shared secret succeeds.

This accepts the same shared secret presented as standard `Authorization: Bearer <token>`, in addition to the existing `x-steward-bridge-token` header.

- Custom header takes precedence when both are present (a wrong custom header still 401s even with a correct bearer).
- Wrong bearer is 401. No unauthenticated mode is introduced.
- Constant-time comparison unchanged for both paths.
- Three new tests (accept, reject wrong bearer, precedence); solana-signer suite 47 pass, typecheck clean.

Companion PR on the AgentNet side teaches its client to send the bearer secret.