### PR TITLE
fix(trading): short-circuit denied condition checks

### DIFF
--- a/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
@@ -256,6 +256,36 @@ describe("POST /v1/trade/polymarket/order", () => {
     expect(await dailySpendOf(sessionId)).toBe(0);
   });
 
+  it("does not let a caller conditionId turn an unrelated policy denial into a metadata dependency", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({
+      allowedAssets: [`pm:${TOKEN_ID}`],
+      perOrderCapUsd: "5",
+    });
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+    const key = crypto.randomUUID();
+    const fetchSpy = spyOn(globalThis, "fetch").mockRejectedValue(
+      new Error("policy denials must not perform market metadata IO"),
+    );
+
+    try {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const res = await postOrder(app, sessionId, key, {
+          amount: 10,
+          conditionId: COND_ID,
+        });
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({
+          code: "policy-violation",
+          reason: "per-order-cap-exceeded",
+        });
+      }
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(await dailySpendOf(sessionId)).toBe(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("rejects a caller conditionId that disagrees with authoritative token metadata", async () => {
     const { tenantId, agentId, sessionId } = await seedSession({
       allowedAssets: [`pm:cond:${COND_ID}`],

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -1867,7 +1867,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     let verifiedConditionId: string | undefined;
     const hasMarketGrant = session.allowedAssets.some((asset) => asset.startsWith("pm:cond:"));
     const needsVerifiedConditionId =
-      body.conditionId !== undefined ||
+      (check.allowed && body.conditionId !== undefined) ||
       (!check.allowed && check.reason === "market-not-allowed" && hasMarketGrant);
     if (needsVerifiedConditionId) {
       try {


### PR DESCRIPTION
## Security corrective\n\nFollow-up to externally merged #558. A caller-supplied `conditionId` previously forced authoritative metadata I/O even when the initial session policy result was an unrelated deterministic denial (for example per-order or daily cap, or inactive session). A CLOB outage could therefore replace the stable denial with a retryable 502 and denied traffic could cause unnecessary outbound work.\n\nOnly verify a caller condition after the direct-token policy gate succeeds, while retaining the verified market-grant fallback. Direct-token requests without a condition remain network-independent.\n\n## Exact validation\n\n- plugin-trading Polymarket route: 35 pass, 172 assertions\n- dependency build: 12/12 packages\n- Biome exact changed files: pass\n- `git diff --check`: pass\n\nDraft for independent review. No Actions manipulation or merge requested.