### PR TITLE
test(auth): prove blocked email publication race

### DIFF
--- a/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import postgres from "postgres";
 
 import { PostgresBackend } from "../store-backends";
@@ -6,6 +6,32 @@ import { PostgresBackend } from "../store-backends";
 const databaseUrl = process.env.DATABASE_URL;
 const integration = describe.skipIf(!databaseUrl);
 const sql = databaseUrl ? postgres(databaseUrl, { max: 2 }) : null;
+
+setDefaultTimeout(30_000);
+
+async function waitForBlockedPublisher(lockKey: string, lockerPid: number): Promise<number> {
+  if (!sql) throw new Error("DATABASE_URL required");
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    const rows = await sql<Array<{ pid: number }>>`
+      WITH target AS (
+        SELECT hashtextextended(${lockKey}, 0)::bigint AS key
+      )
+      SELECT DISTINCT locks.pid
+        FROM pg_locks AS locks
+        CROSS JOIN target
+       WHERE locks.locktype = 'advisory'
+         AND locks.granted = false
+         AND locks.pid <> ${lockerPid}
+         AND locks.database = (SELECT oid FROM pg_database WHERE datname = current_database())
+         AND locks.classid::bigint = ((target.key >> 32) & 4294967295)
+         AND locks.objid::bigint = (target.key & 4294967295)
+         AND locks.objsubid = 1
+    `;
+    if (rows[0]) return rows[0].pid;
+    await Bun.sleep(10);
+  }
+  throw new Error("timed out waiting for the stale publisher to block on the guarded key");
+}
 
 integration("Postgres email challenge publication", () => {
   afterAll(async () => {
@@ -20,20 +46,40 @@ integration("Postgres email challenge publication", () => {
     await backend.set(reservationKey, "generation-old", 60_000);
 
     const locker = await sql.reserve();
-    await locker`SELECT pg_advisory_lock(hashtextextended(${`${namespace}:${reservationKey}`}, 0))`;
-    const stale = backend.publish([
-      { key: "challenge-old", value: "active-old", ttlMs: 60_000 },
-      { key: reservationKey, value: "published-old", ttlMs: 60_000, expected: "generation-old" },
-    ]);
-    await Bun.sleep(50);
+    const lockKey = `${namespace}:${reservationKey}`;
+    const [{ pid: lockerPid }] = await locker<
+      Array<{ pid: number }>
+    >`SELECT pg_backend_pid() AS pid`;
+    let locked = false;
+    let stale: Promise<boolean> | undefined;
+    try {
+      await locker`SELECT pg_advisory_lock(hashtextextended(${lockKey}, 0))`;
+      locked = true;
+      stale = backend.publish([
+        { key: "challenge-old", value: "active-old", ttlMs: 60_000 },
+        {
+          key: reservationKey,
+          value: "published-old",
+          ttlMs: 60_000,
+          expected: "generation-old",
+        },
+      ]);
 
-    await sql`
-      UPDATE auth_kv_store SET value = 'generation-new'
-       WHERE id = ${reservationKey} AND namespace = ${namespace}
-    `;
-    await locker`SELECT pg_advisory_unlock(hashtextextended(${`${namespace}:${reservationKey}`}, 0))`;
-    locker.release();
+      const publisherPid = await waitForBlockedPublisher(lockKey, lockerPid);
+      expect(publisherPid).not.toBe(lockerPid);
 
+      await sql`
+        UPDATE auth_kv_store SET value = 'generation-new'
+         WHERE id = ${reservationKey} AND namespace = ${namespace}
+      `;
+    } finally {
+      if (locked) {
+        await locker`SELECT pg_advisory_unlock(hashtextextended(${lockKey}, 0))`;
+      }
+      locker.release();
+    }
+
+    if (!stale) throw new Error("stale publication did not start");
     expect(await stale).toBe(false);
     expect(await backend.get("challenge-old")).toBeNull();
     const current = [
@@ -44,5 +90,13 @@ integration("Postgres email challenge publication", () => {
     expect(await backend.consume("challenge-new")).toBe("active-new");
     expect(await backend.publish(current)).toBe(true);
     expect(await backend.get("challenge-new")).toBeNull();
+
+    await expect(
+      backend.publish([
+        { key: "duplicate", value: "first", ttlMs: 60_000 },
+        { key: "duplicate", value: "second", ttlMs: 60_000 },
+      ]),
+    ).rejects.toThrow("Store publication contains duplicate keys");
+    expect(await backend.get("duplicate")).toBeNull();
   });
 });

--- a/packages/auth/src/__tests__/store-backends.test.ts
+++ b/packages/auth/src/__tests__/store-backends.test.ts
@@ -92,6 +92,19 @@ describe("buildBackend Redis smoke test", () => {
 });
 
 describe("NamespacedStoreBackend", () => {
+  it("rejects duplicate publish keys without applying either value", async () => {
+    for (const backend of [new MemoryBackend(), new RedisBackend(redisLike(), "test:")]) {
+      await expect(
+        backend.publish([
+          { key: "credential", value: "first", ttlMs: 60_000 },
+          { key: "credential", value: "second", ttlMs: 60_000 },
+        ]),
+      ).rejects.toThrow("Store publication contains duplicate keys");
+      expect(await backend.get("credential")).toBeNull();
+      if (backend instanceof MemoryBackend) backend.destroy();
+    }
+  });
+
   it("conditionally publishes all keys or none and makes retries no-ops", async () => {
     for (const backend of [new MemoryBackend(), new RedisBackend(redisLike(), "test:")]) {
       await backend.set("generation", "reservation-a", 60_000);

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -31,6 +31,18 @@ export interface StorePublishEntry {
   expected?: string | null;
 }
 
+function assertUniquePublishKeys(entries: readonly StorePublishEntry[]): void {
+  const keys = new Set<string>();
+  for (const entry of entries) {
+    if (keys.has(entry.key)) {
+      // Duplicate operations have backend-dependent last-write-wins semantics
+      // and can make a guard describe a different write than the one applied.
+      throw new Error("Store publication contains duplicate keys");
+    }
+    keys.add(entry.key);
+  }
+}
+
 export interface StoreBackend {
   set(key: string, value: string, ttlMs: number): Promise<void>;
   setIfNotExists(key: string, value: string, ttlMs: number): Promise<boolean>;
@@ -193,6 +205,7 @@ export class MemoryBackend implements StoreBackend {
   }
 
   async publish(entries: readonly StorePublishEntry[]): Promise<boolean> {
+    assertUniquePublishKeys(entries);
     const now = Date.now();
     const currentValue = (key: string): string | null => {
       const current = this.store.get(key);
@@ -322,6 +335,7 @@ export class RedisBackend implements StoreBackend {
   }
 
   async publish(entries: readonly StorePublishEntry[]): Promise<boolean> {
+    assertUniquePublishKeys(entries);
     if (entries.length === 0) return true;
     const keys = entries.map((entry) => this.prefix + entry.key);
     const args = entries.flatMap((entry) => [
@@ -499,6 +513,7 @@ export class PostgresBackend implements StoreBackend {
   }
 
   async publish(entries: readonly StorePublishEntry[]): Promise<boolean> {
+    assertUniquePublishKeys(entries);
     if (entries.length === 0) return true;
     await this.ensureTable();
     const sql = this.getSqlClient();


### PR DESCRIPTION
## Summary
- replace the timing-based PostgreSQL publication race test with synchronization on the exact blocked advisory lock and distinct backend PID
- reject duplicate atomic-publication keys consistently across memory, Redis, and PostgreSQL before mutation
- cover duplicate-key fail-closed behavior in unit and PostgreSQL integration tests

## Validation
- `bun test packages/auth/src/__tests__` (314 pass, 3 environment-gated skips)
- `bun test packages/auth/src/__tests__/store-backends.test.ts packages/auth/src/__tests__/email-postgres-publish.integration.test.ts packages/auth/src/__tests__/email-delivery-failclosed.test.ts packages/auth/src/__tests__/email.test.ts` (56 pass, 2 PostgreSQL skips without DATABASE_URL)
- `bun run --cwd packages/auth build`
- `bunx biome check packages/auth/src/store-backends.ts packages/auth/src/__tests__/store-backends.test.ts packages/auth/src/__tests__/email-postgres-publish.integration.test.ts`
- `git diff --check origin/develop...HEAD`

The real PostgreSQL test remains wired to the DATABASE_URL-gated CI job. Local Docker/PostgreSQL was unavailable for an additional live run.