### PR TITLE
fix(worker): validate bindings before yielding

### DIFF
--- a/packages/api/src/__tests__/worker-boot-validation.test.ts
+++ b/packages/api/src/__tests__/worker-boot-validation.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { afterEach, describe, expect, it } from "bun:test";
+import worker from "../worker";
 
 /**
  * Keys this file mutates: bindings hydrateProcessEnv copies onto the global
@@ -43,18 +44,12 @@ describe("workers boot JWT env validation (SEC-134)", () => {
     for (const key of MANAGED_KEYS) saved.set(key, process.env[key]);
   }
 
-  async function freshWorker() {
-    const mod = await import(`../worker?boot-validation=${Date.now()}-${Math.random()}`);
-    return mod.default;
-  }
-
   it("rejects a short JWT secret at cold start in production", async () => {
     snapshotEnv();
-    const worker = await freshWorker();
     await expect(
       worker.fetch(
         new Request("https://workers.test/"),
-        { NODE_ENV: "production", STEWARD_JWT_SECRET: "short" },
+        { NODE_ENV: "production", STEWARD_JWT_SECRET: "short", DATABASE_DRIVER: "bogus" },
         {},
       ),
     ).rejects.toThrow("at least 32 characters in production");
@@ -70,30 +65,55 @@ describe("workers boot JWT env validation (SEC-134)", () => {
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_DB_MODE;
     delete process.env.STEWARD_PGLITE_MEMORY;
-    const worker = await freshWorker();
     await expect(
-      worker.fetch(new Request("https://workers.test/"), { NODE_ENV: "production" }, {}),
+      worker.fetch(
+        new Request("https://workers.test/"),
+        { NODE_ENV: "production", DATABASE_DRIVER: "bogus" },
+        {},
+      ),
     ).rejects.toThrow("STEWARD_JWT_SECRET is required in production");
   });
 
   it("rejects a malformed AGENT_TOKEN_EXPIRY at cold start", async () => {
     snapshotEnv();
-    const worker = await freshWorker();
     await expect(
       worker.fetch(
         new Request("https://workers.test/"),
         {
           STEWARD_JWT_SECRET: "workers-boot-test-secret-32-chars-long!!",
           AGENT_TOKEN_EXPIRY: "not-a-duration",
+          DATABASE_DRIVER: "bogus",
         },
         {},
       ),
     ).rejects.toThrow('AGENT_TOKEN_EXPIRY "not-a-duration" is not a valid positive duration');
   });
 
+  it("validates concurrent request bindings before either database selection", async () => {
+    snapshotEnv();
+    const shortSecret = worker.fetch(
+      new Request("https://workers.test/short-secret"),
+      { NODE_ENV: "production", STEWARD_JWT_SECRET: "short", DATABASE_DRIVER: "bogus" },
+      {},
+    );
+    const malformedExpiry = worker.fetch(
+      new Request("https://workers.test/malformed-expiry"),
+      {
+        STEWARD_JWT_SECRET: "workers-boot-test-secret-32-chars-long!!",
+        AGENT_TOKEN_EXPIRY: "not-a-duration",
+        DATABASE_DRIVER: "bogus",
+      },
+      {},
+    );
+
+    await expect(shortSecret).rejects.toThrow("at least 32 characters in production");
+    await expect(malformedExpiry).rejects.toThrow(
+      'AGENT_TOKEN_EXPIRY "not-a-duration" is not a valid positive duration',
+    );
+  });
+
   it("validates scheduled security bindings before opening any database handle", async () => {
     snapshotEnv();
-    const worker = await freshWorker();
     let waitUntilCalls = 0;
     await expect(
       worker.scheduled(

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -39,6 +39,7 @@
  *                                   configured Redis is unreachable
  */
 
+import { validateJwtSecretEnv } from "@stwd/auth";
 import {
   createDbForRequest,
   createNeonTransactionDbForRequest,
@@ -292,11 +293,11 @@ export function hydrateProcessEnv(env: Env): void {
 
 let workerInit: Promise<void> | null = null;
 
-async function validateWorkerSecurityEnv(): Promise<void> {
+function validateWorkerSecurityEnv(): void {
   // Validate authentication-critical bindings before opening a database
-  // connection. A missing DATABASE_DRIVER must not mask a weak JWT secret or
-  // malformed token lifetime during cold-start validation.
-  const { validateJwtSecretEnv } = await import("@stwd/auth");
+  // connection. This must stay synchronous with hydrateProcessEnv(): yielding
+  // between them would let another request replace the isolate-wide env before
+  // this request's bindings are checked.
   validateJwtSecretEnv();
 }
 
@@ -310,7 +311,7 @@ async function ensureWorkerInit(env: Env): Promise<void> {
     // run the same validation on the Workers boot path so a bad/missing JWT
     // secret or malformed AGENT_TOKEN_EXPIRY fails closed at cold start instead
     // of surfacing at first token sign/verify.
-    await validateWorkerSecurityEnv();
+    validateWorkerSecurityEnv();
     const redisOk = await initRedis(env);
     // Auth stores (passkey challenges, magic-link tokens, SIWE/SIWS nonces)
     // must be initialized too — without this they stay on the lazy memory
@@ -381,7 +382,7 @@ export default {
     // request (not once per isolate) so rotated bindings take effect promptly;
     // the once-per-isolate init below only bootstraps stores/imports.
     hydrateProcessEnv(env);
-    await validateWorkerSecurityEnv();
+    validateWorkerSecurityEnv();
     const executionCtx = ctx as { waitUntil?: (promise: Promise<unknown>) => void };
     const waitUntil =
       typeof executionCtx?.waitUntil === "function"
@@ -403,7 +404,7 @@ export default {
     ctx: { waitUntil(promise: Promise<unknown>): void },
   ) {
     hydrateProcessEnv(env);
-    await validateWorkerSecurityEnv();
+    validateWorkerSecurityEnv();
     ctx.waitUntil(
       Promise.all([
         withWorkerRequestDatabase(env, () => runWorkerUpstreamCredentialLeaseSweep(env)),


### PR DESCRIPTION
## Summary

- keep Worker binding hydration and JWT/token-lifetime validation in one synchronous turn
- prevent a concurrent request from replacing the isolate-wide environment before the first request reaches its security decision
- exercise the deployed singleton handler with hostile concurrent bindings and unsupported database drivers

## Root cause

`validateWorkerSecurityEnv()` yielded at a dynamic auth import after hydrating `process.env`. A second request could hydrate valid bindings while the first was suspended, causing the first to pass security validation and fail later with `WORKER_DATABASE_DRIVER_UNSUPPORTED`.

## Validation

- `bun test --timeout 120000 src/__tests__/worker-boot-validation.test.ts`
- `bun scripts/run-tests-isolated.ts worker-boot-validation worker-runtime-sentinel`
- `bunx turbo run build --filter=@stwd/api...`
- `bunx biome check packages/api/src/worker.ts packages/api/src/__tests__/worker-boot-validation.test.ts`
- `git diff --check origin/develop...HEAD`

Closes #561