### PR TITLE
fix(solana-signer): reject ambiguous bearer credentials

### DIFF
--- a/packages/solana-signer/src/__tests__/bridge.test.ts
+++ b/packages/solana-signer/src/__tests__/bridge.test.ts
@@ -1,7 +1,9 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { connect } from "node:net";
 import { Keypair, Transaction } from "@solana/web3.js";
 import {
   BRIDGE_MAX_BODY_BYTES,
+  BRIDGE_MAX_TOKEN_BYTES,
   BRIDGE_MIN_TOKEN_BYTES,
   BRIDGE_TOKEN_ENV,
   BRIDGE_TOKEN_HEADER,
@@ -52,6 +54,37 @@ function authed(path: string, init: RequestInit = {}): Promise<Response> {
   return fetch(`${bridgeUrl}${path}`, {
     ...init,
     headers: { ...(init.headers ?? {}), [BRIDGE_TOKEN_HEADER]: bridgeToken },
+  });
+}
+
+/** Send exact duplicate fields without Fetch/Headers combining them. */
+async function rawBridgeStatus(headerLines: string[]): Promise<number> {
+  const url = new URL(bridgeUrl);
+  return new Promise<number>((resolve, reject) => {
+    const socket = connect(Number(url.port), url.hostname);
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.on("connect", () => {
+      socket.write(
+        [
+          `GET /pubkey HTTP/1.1`,
+          `Host: ${url.host}`,
+          ...headerLines,
+          "Connection: close",
+          "",
+          "",
+        ].join("\r\n"),
+      );
+    });
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
+    socket.on("end", () => {
+      const match = /^HTTP\/1\.1 (\d{3}) /.exec(response);
+      if (!match) return reject(new Error("bridge returned no HTTP status"));
+      resolve(Number(match[1]));
+    });
+    socket.on("error", reject);
   });
 }
 
@@ -177,11 +210,55 @@ describe("bridge shared-secret auth", () => {
     expect(body.address.length).toBeGreaterThan(30);
   });
 
+  it("treats the bearer scheme case-insensitively", async () => {
+    const res = await fetch(`${bridgeUrl}/pubkey`, {
+      headers: { authorization: `bearer ${bridgeToken}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
   it("refuses a wrong bearer token with 401", async () => {
     const res = await fetch(`${bridgeUrl}/pubkey`, {
       headers: { authorization: `Bearer ${bridgeToken}x` },
     });
     expect(res.status).toBe(401);
+  });
+
+  it("rejects ambiguous bearer whitespace, folded values, and duplicate fields", async () => {
+    for (const authorization of [
+      `Bearer  ${bridgeToken}`,
+      `Bearer\t${bridgeToken}`,
+      `Bearer ${bridgeToken}, Bearer ${bridgeToken}`,
+    ]) {
+      const res = await fetch(`${bridgeUrl}/pubkey`, { headers: { authorization } });
+      expect(res.status).toBe(401);
+    }
+    expect(
+      await rawBridgeStatus([
+        `Authorization: Bearer ${bridgeToken}`,
+        `Authorization: Bearer ${bridgeToken}`,
+      ]),
+    ).toBe(401);
+    expect(
+      await rawBridgeStatus([
+        `${BRIDGE_TOKEN_HEADER}: ${bridgeToken}`,
+        `${BRIDGE_TOKEN_HEADER}: ${bridgeToken}`,
+        `Authorization: Bearer ${bridgeToken}`,
+      ]),
+    ).toBe(401);
+  });
+
+  it("bounds bearer and configured tokens without reflecting them", async () => {
+    const canary = "TOKEN_SECRET_CANARY";
+    const oversized = `${canary}${"a".repeat(BRIDGE_MAX_TOKEN_BYTES)}`;
+    const res = await fetch(`${bridgeUrl}/pubkey`, {
+      headers: { authorization: `Bearer ${oversized}` },
+    });
+    expect(res.status).toBe(401);
+    expect(await res.text()).not.toContain(canary);
+    await expect(startSignerBridge(signer, { token: oversized })).rejects.toThrow(
+      new RegExp(`at most ${BRIDGE_MAX_TOKEN_BYTES} bytes`),
+    );
   });
 
   it("the custom header wins over a bearer header when both are present", async () => {

--- a/packages/solana-signer/src/__tests__/bridge.test.ts
+++ b/packages/solana-signer/src/__tests__/bridge.test.ts
@@ -261,11 +261,34 @@ describe("bridge shared-secret auth", () => {
     );
   });
 
-  it("the custom header wins over a bearer header when both are present", async () => {
-    const res = await fetch(`${bridgeUrl}/pubkey`, {
+  it("accepts the exact maximum token68 boundary on both transports", async () => {
+    const suffix = "-._~+/==";
+    const maxToken = `${"a".repeat(BRIDGE_MAX_TOKEN_BYTES - suffix.length)}${suffix}`;
+    expect(Buffer.byteLength(maxToken, "utf8")).toBe(BRIDGE_MAX_TOKEN_BYTES);
+    const boundaryBridge = await startSignerBridge(signer, { token: maxToken });
+    try {
+      const bearer = await fetch(`${boundaryBridge.url}/pubkey`, {
+        headers: { authorization: `bEaReR ${maxToken}` },
+      });
+      expect(bearer.status).toBe(200);
+      const custom = await fetch(`${boundaryBridge.url}/pubkey`, {
+        headers: { [BRIDGE_TOKEN_HEADER]: maxToken },
+      });
+      expect(custom.status).toBe(200);
+    } finally {
+      await boundaryBridge.close();
+    }
+  });
+
+  it("the custom header wins fail-closed over a bearer header when both are present", async () => {
+    const rejected = await fetch(`${bridgeUrl}/pubkey`, {
       headers: { [BRIDGE_TOKEN_HEADER]: `${bridgeToken}x`, authorization: `Bearer ${bridgeToken}` },
     });
-    expect(res.status).toBe(401);
+    expect(rejected.status).toBe(401);
+    const accepted = await fetch(`${bridgeUrl}/pubkey`, {
+      headers: { [BRIDGE_TOKEN_HEADER]: bridgeToken, authorization: "Basic ignored" },
+    });
+    expect(accepted.status).toBe(200);
   });
 
   it(`honors ${BRIDGE_TOKEN_ENV} from the env, the var both sides read`, async () => {

--- a/packages/solana-signer/src/bridge.ts
+++ b/packages/solana-signer/src/bridge.ts
@@ -38,6 +38,8 @@ export const BRIDGE_TOKEN_ENV = "STEWARD_SIGNER_BRIDGE_TOKEN";
 /** Enough for Solana's transaction limit plus JSON/hints, while bounding RAM. */
 export const BRIDGE_MAX_BODY_BYTES = 16 * 1024;
 export const BRIDGE_MIN_TOKEN_BYTES = 32;
+/** Bounds configured and presented secrets before hashing or comparison. */
+export const BRIDGE_MAX_TOKEN_BYTES = 1024;
 
 export interface SignerBridgeOptions {
   /** Bind host. Loopback by default; never expose this beyond the machine. */
@@ -49,7 +51,8 @@ export interface SignerBridgeOptions {
    *  (for callers that only speak standard bearer auth, e.g. AgentNet's
    *  remote-wallet client). Omitted: STEWARD_SIGNER_BRIDGE_TOKEN from the
    *  env when set, else a fresh random token per session (read it from the
-   *  returned bridge's `token`). Must contain at least 32 UTF-8 bytes. */
+   *  returned bridge's `token`). Must contain 32-1024 UTF-8 bytes. Bearer
+   *  transport additionally requires the standard token68 character set. */
   token?: string;
 }
 
@@ -61,24 +64,46 @@ export interface SignerBridge {
   close(): Promise<void>;
 }
 
-/** Constant-time header check; hashing first keeps lengths equal. */
-function tokenMatches(presented: string | string[] | undefined, expected: string): boolean {
-  if (typeof presented !== "string") return false;
+/** Constant-time check after a fixed public bound; hashing keeps lengths equal. */
+function tokenMatches(presented: string | undefined, expected: string): boolean {
+  if (presented === undefined || Buffer.byteLength(presented, "utf8") > BRIDGE_MAX_TOKEN_BYTES) {
+    return false;
+  }
   return timingSafeEqual(
     createHash("sha256").update(presented).digest(),
     createHash("sha256").update(expected).digest(),
   );
 }
 
-/** The request's presented secret: the bridge header verbatim, else the token
- *  of a standard `Authorization: Bearer <token>` header. Callers that cannot
- *  set custom headers (AgentNet's remote-wallet client sends only bearer
- *  auth) still authenticate; everyone else keeps the existing header. */
-function presentedToken(req: IncomingMessage): string | string[] | undefined {
-  const custom = req.headers[BRIDGE_TOKEN_HEADER];
-  if (custom !== undefined) return custom;
-  const auth = req.headers.authorization;
-  if (typeof auth === "string" && auth.startsWith("Bearer ")) return auth.slice("Bearer ".length);
+const BEARER_AUTHORIZATION = /^Bearer ([A-Za-z0-9\-._~+/]+={0,})$/i;
+
+function rawHeaderValues(req: IncomingMessage, name: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < req.rawHeaders.length; index += 2) {
+    if (req.rawHeaders[index]?.toLowerCase() === name) {
+      values.push(req.rawHeaders[index + 1] ?? "");
+    }
+  }
+  return values;
+}
+
+/** Return one unambiguous secret. `rawHeaders` is intentional: runtimes may
+ *  discard or join duplicate Authorization fields in `headers`, while peers
+ *  and proxies can choose a different occurrence. The custom header retains
+ *  precedence, including when malformed, so it cannot fall through to a
+ *  second credential. */
+function presentedToken(req: IncomingMessage): string | undefined {
+  const custom = rawHeaderValues(req, BRIDGE_TOKEN_HEADER);
+  if (custom.length > 0) return custom.length === 1 ? custom[0] : undefined;
+
+  const authorization = rawHeaderValues(req, "authorization");
+  if (authorization.length !== 1) return undefined;
+  const value = authorization[0];
+  if (Buffer.byteLength(value, "utf8") > BRIDGE_MAX_TOKEN_BYTES + "Bearer ".length) {
+    return undefined;
+  }
+  const match = BEARER_AUTHORIZATION.exec(value);
+  if (match) return match[1];
   return undefined;
 }
 
@@ -156,6 +181,12 @@ export async function startSignerBridge(
     throw new StewardSignerError(
       "api",
       `signer bridge token must contain at least ${BRIDGE_MIN_TOKEN_BYTES} bytes`,
+    );
+  }
+  if (Buffer.byteLength(token, "utf8") > BRIDGE_MAX_TOKEN_BYTES) {
+    throw new StewardSignerError(
+      "api",
+      `signer bridge token must contain at most ${BRIDGE_MAX_TOKEN_BYTES} bytes`,
     );
   }
 


### PR DESCRIPTION
## Security corrective\n\nFollow-up to externally merged #559. Keeps its AgentNet-compatible `Authorization: Bearer` transport while making the credential boundary unambiguous and bounded:\n\n- reject duplicate custom or Authorization fields using raw header occurrences\n- preserve fail-closed custom-header precedence\n- accept the auth scheme case-insensitively but require exact single-space token68 syntax\n- cap configured and presented secrets at 1024 UTF-8 bytes before hashing\n- keep 401 responses generic and prove secret canaries are not reflected\n\nThis branch is based on the merged/restacked #559 bytes and changes only `packages/solana-signer`; it does not revert #558/#560 or unrelated current-develop work. The loopback bridge still emits no CORS allow-origin response, so adding Authorization does not grant browser access.\n\n## Exact validation\n\n- full solana-signer suite: 50 pass, 129 assertions\n- dependency build: 7/7 packages\n- Biome exact changed files: pass\n- `git diff --check`: pass\n\nDraft pending independent exact-head and hosted CI review. No Actions manipulation or merge requested.