### PR TITLE
fix(worker): isolate pre-hydration JWT validation import

### DIFF
--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -39,7 +39,10 @@
  *                                   configured Redis is unreachable
  */
 
-import { validateJwtSecretEnv } from "@stwd/auth";
+// Import the JWT leaf, not the @stwd/auth barrel: the barrel loads auth stores
+// that must not snapshot Worker-sensitive environment state before bindings
+// are hydrated by the first request.
+import { validateJwtSecretEnv } from "@stwd/auth/jwt";
 import {
   createDbForRequest,
   createNeonTransactionDbForRequest,

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./jwt": "./src/jwt.ts"
+  },
   "scripts": {
     "build": "tsc --noEmit",
     "dev": "tsc --watch",

--- a/packages/auth/src/__tests__/session-hardening.test.ts
+++ b/packages/auth/src/__tests__/session-hardening.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { jwtVerify } from "jose";
+import { decodeJwt, jwtVerify } from "jose";
 
-import { validateAgentTokenExpiryEnv } from "../jwt";
+import { signAgentToken, validateAgentTokenExpiryEnv } from "../jwt";
 import { SessionManager } from "../session";
 
 describe("validateAgentTokenExpiryEnv (SEC-134)", () => {
@@ -20,6 +20,24 @@ describe("validateAgentTokenExpiryEnv (SEC-134)", () => {
   it("rejects durations beyond the one-year bound", () => {
     for (const value of ["2y", "400d", "53 weeks"]) {
       expect(() => validateAgentTokenExpiryEnv(value)).toThrow(/one-year maximum/);
+    }
+  });
+
+  it("reads the agent expiry after module import so hydrated Worker bindings are current", async () => {
+    const previousSecret = process.env.STEWARD_JWT_SECRET;
+    const previousExpiry = process.env.AGENT_TOKEN_EXPIRY;
+    process.env.STEWARD_JWT_SECRET = "worker-expiry-test-secret-at-least-32-characters";
+    process.env.AGENT_TOKEN_EXPIRY = "2h";
+    try {
+      const payload = decodeJwt(
+        await signAgentToken({ agentId: "agent-a", tenantId: "tenant-a", scope: "agent" }),
+      );
+      expect((payload.exp ?? 0) - (payload.iat ?? 0)).toBe(2 * 60 * 60);
+    } finally {
+      if (previousSecret === undefined) delete process.env.STEWARD_JWT_SECRET;
+      else process.env.STEWARD_JWT_SECRET = previousSecret;
+      if (previousExpiry === undefined) delete process.env.AGENT_TOKEN_EXPIRY;
+      else process.env.AGENT_TOKEN_EXPIRY = previousExpiry;
     }
   });
 });

--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -14,9 +14,14 @@ export const JWT_ISSUER = "steward";
 export const JWT_AUDIENCE = "steward-api";
 export const ACCESS_TOKEN_EXPIRY = "15m";
 export const ACCESS_TOKEN_EXPIRY_SECONDS = 900;
-export const AGENT_TOKEN_EXPIRY = process.env.AGENT_TOKEN_EXPIRY || "30d";
+/** Stable default. Read the environment through getAgentTokenExpiry() at call time. */
+export const AGENT_TOKEN_EXPIRY = "30d";
 export const REFRESH_TOKEN_EXPIRY = "30d";
 export const IDENTITY_TOKEN_EXPIRY = ACCESS_TOKEN_EXPIRY;
+
+export function getAgentTokenExpiry(): string {
+  return process.env.AGENT_TOKEN_EXPIRY || AGENT_TOKEN_EXPIRY;
+}
 
 export type IdentityJwtAlgorithm = "RS256" | "ES256";
 
@@ -494,7 +499,7 @@ export async function signAccessToken(
 
 export async function signAgentToken(
   payload: Omit<AgentTokenPayload, "scope"> & { scope?: "agent"; scopes?: string[] },
-  expiresIn: string = AGENT_TOKEN_EXPIRY,
+  expiresIn: string = getAgentTokenExpiry(),
 ): Promise<string> {
   const merged: Record<string, unknown> = { ...payload, scope: "agent" };
   if (Array.isArray(payload.scopes)) merged.scopes = payload.scopes;


### PR DESCRIPTION
## Security corrective

Post-merge audit of #565 found that its top-level `@stwd/auth` barrel import loads auth stores and JWT module state before the first Worker request hydrates bindings. This preserves #565's synchronous hydration/validation boundary without importing the side-effectful barrel:

- expose a narrow `@stwd/auth/jwt` package entrypoint and import only that leaf from the Worker entry
- remove the JWT module's import-time `AGENT_TOKEN_EXPIRY` capture from token signing; resolve it at call time after Worker hydration
- keep `AGENT_TOKEN_EXPIRY` as the stable documented 30-day default
- add a behavioral token claim regression proving a post-import hydrated expiry controls the signed token

## Exact validation

- Worker boot + auth session hardening: 10 pass, 27 assertions
- isolated Worker boot/runtime sentinel: 2/2 files
- API dependency build: 24/24 packages; direct API TypeScript clean
- Biome exact changed files and `git diff --check`: clean

Closes #561
