### PR TITLE
feat(db): add all-or-nothing RLS catalog gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,8 +494,8 @@ jobs:
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
-      - name: RLS pool isolation proof (real Postgres)
-        run: bun test ./packages/db/src/__tests__/tenant-rls-postgres.test.ts
+      - name: RLS pool and catalog isolation proof (real Postgres)
+        run: bun test ./packages/db/src/__tests__/tenant-rls-postgres.test.ts ./packages/db/src/__tests__/rls-catalog-gate-postgres.test.ts
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,6 +448,41 @@ jobs:
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
 
+  rls-catalog-postgres15:
+    name: RLS Catalog Gate (Postgres 15)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: steward
+          POSTGRES_PASSWORD: steward_ci
+          POSTGRES_DB: steward_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U steward"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: RLS catalog compatibility proof
+        run: bun test ./packages/db/src/__tests__/rls-catalog-gate-postgres.test.ts
+        env:
+          DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
+
   integration:
     name: Integration Tests (Postgres)
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -584,8 +584,8 @@ jobs:
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
-      - name: RLS pool isolation proof (real Postgres)
-        run: bun test ./packages/db/src/__tests__/tenant-rls-postgres.test.ts
+      - name: RLS pool and catalog isolation proof (real Postgres)
+        run: bun test ./packages/db/src/__tests__/tenant-rls-postgres.test.ts ./packages/db/src/__tests__/rls-catalog-gate-postgres.test.ts
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -535,6 +535,41 @@ jobs:
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
 
+  rls-catalog-postgres15:
+    name: RLS Catalog Gate (Postgres 15)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: steward
+          POSTGRES_PASSWORD: steward_ci
+          POSTGRES_DB: steward_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U steward"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: RLS catalog compatibility proof
+        run: bun test ./packages/db/src/__tests__/rls-catalog-gate-postgres.test.ts
+        env:
+          DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
+
   integration:
     name: Integration Tests (Postgres)
     runs-on: ubuntu-latest

--- a/docs/security/database-rls-rollout.mdx
+++ b/docs/security/database-rls-rollout.mdx
@@ -105,6 +105,17 @@ Partitioned tables require policies on the parent plus an activation assertion
 over `pg_partition_tree`. The catalog gate must also reject every non-inventory
 table in future migrations.
 
+`inspectRlsCatalog` is the read-only structural gate for that maintenance
+window. It accepts a fully inactive catalog (including policies staged while
+all RLS flags remain off), but once any protected table or partition has an RLS
+flag it requires the complete inventoried set to be `ENABLE` + `FORCE`. It also
+rejects inventory drift, RLS on intentionally global tables, orphan
+partitions, table ownership by the runtime role, `SUPERUSER`, and
+`BYPASSRLS`. The gate counts policy coverage; it does not prove policy
+expressions correct and is not wired to production startup yet. Activation
+still requires the policy generator, restricted bootstrap roles/functions,
+transaction propagation, and the full cross-tenant suite.
+
 ## Roles and activation order
 
 1. Create a NOLOGIN migration owner and a distinct LOGIN application role with

--- a/docs/security/database-rls-rollout.mdx
+++ b/docs/security/database-rls-rollout.mdx
@@ -112,12 +112,16 @@ roles whose privileges the runtime can inherit or assume, plus any assumable
 `SUPERUSER` or `BYPASSRLS` role. It traverses partition trees by relation OID,
 including partitions stored outside the root table's schema.
 
-The mandatory inventory includes every core Drizzle table. A deployment using
-the PostgreSQL auth compatibility store must add the exported auth inventory
-contribution for `auth_kv_store`; deployments with plugin-owned relations must
-likewise pass an explicit protected or RLS-excluded contribution for every
-plugin. Contributions can extend but cannot replace the mandatory inventory.
-Unknown, missing, duplicate, or ambiguously classified relations fail closed.
+On PostgreSQL 16 and newer, assumability follows the membership grant's `SET`
+option while inherited owner privileges follow `USAGE`. PostgreSQL 15 has no
+per-membership `SET` option, so every `MEMBER` role is conservatively treated
+as assumable; inherited owner privileges still use `USAGE`.
+
+The mandatory inventory includes every core Drizzle table plus the
+always-migrated `auth_kv_store`. Deployments with plugin-owned relations must
+pass an explicit protected or RLS-excluded contribution for every plugin.
+Contributions can extend but cannot replace the mandatory inventory. Unknown,
+missing, duplicate, or ambiguously classified relations fail closed.
 The gate accepts a fully inactive catalog (including policies staged while all
 RLS flags remain off), but once any protected table or partition has an RLS
 flag it requires the complete inventoried set to be `ENABLE` + `FORCE`.

--- a/docs/security/database-rls-rollout.mdx
+++ b/docs/security/database-rls-rollout.mdx
@@ -106,15 +106,26 @@ over `pg_partition_tree`. The catalog gate must also reject every non-inventory
 table in future migrations.
 
 `inspectRlsCatalog` is the read-only structural gate for that maintenance
-window. It accepts a fully inactive catalog (including policies staged while
-all RLS flags remain off), but once any protected table or partition has an RLS
-flag it requires the complete inventoried set to be `ENABLE` + `FORCE`. It also
-rejects inventory drift, RLS on intentionally global tables, orphan
-partitions, table ownership by the runtime role, `SUPERUSER`, and
-`BYPASSRLS`. The gate counts policy coverage; it does not prove policy
-expressions correct and is not wired to production startup yet. Activation
-still requires the policy generator, restricted bootstrap roles/functions,
-transaction propagation, and the full cross-tenant suite.
+window. The caller must name the runtime role being assessed; the inspection
+connection is not assumed to be the runtime identity. The gate rejects owner
+roles whose privileges the runtime can inherit or assume, plus any assumable
+`SUPERUSER` or `BYPASSRLS` role. It traverses partition trees by relation OID,
+including partitions stored outside the root table's schema.
+
+The mandatory inventory includes every core Drizzle table. A deployment using
+the PostgreSQL auth compatibility store must add the exported auth inventory
+contribution for `auth_kv_store`; deployments with plugin-owned relations must
+likewise pass an explicit protected or RLS-excluded contribution for every
+plugin. Contributions can extend but cannot replace the mandatory inventory.
+Unknown, missing, duplicate, or ambiguously classified relations fail closed.
+The gate accepts a fully inactive catalog (including policies staged while all
+RLS flags remain off), but once any protected table or partition has an RLS
+flag it requires the complete inventoried set to be `ENABLE` + `FORCE`.
+
+The gate counts policy coverage; it does not prove policy expressions correct
+and is not wired to production startup yet. Activation still requires the
+policy generator, restricted bootstrap roles/functions, transaction
+propagation, and the full cross-tenant suite.
 
 ## Roles and activation order
 

--- a/packages/db/src/__tests__/rls-catalog-gate-postgres.test.ts
+++ b/packages/db/src/__tests__/rls-catalog-gate-postgres.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import postgres from "postgres";
+import {
+  inspectRlsCatalog,
+  RLS_ACTIVATION_TABLES,
+  type RlsCatalogClient,
+} from "../rls-catalog-gate";
+import { INTENTIONALLY_GLOBAL_TABLES } from "../rls-inventory";
+
+const describeWithPostgres = process.env.DATABASE_URL ? describe : describe.skip;
+const schemaName = `rls_catalog_${randomUUID().replaceAll("-", "")}`;
+setDefaultTimeout(30_000);
+
+function identifier(value: string): string {
+  if (!/^[a-z_][a-z0-9_]{0,62}$/.test(value)) throw new Error("unsafe test identifier");
+  return `"${value}"`;
+}
+
+describeWithPostgres("SEC-169 catalog activation gate on real Postgres", () => {
+  const client = postgres(process.env.DATABASE_URL as string, { max: 1, prepare: false });
+
+  beforeAll(async () => {
+    await client.unsafe(`CREATE SCHEMA ${identifier(schemaName)}`);
+    for (const table of [...RLS_ACTIVATION_TABLES, ...Object.keys(INTENTIONALLY_GLOBAL_TABLES)]) {
+      await client.unsafe(
+        `CREATE TABLE ${identifier(schemaName)}.${identifier(table)} (id text PRIMARY KEY, tenant_id text)`,
+      );
+    }
+  });
+
+  afterAll(async () => {
+    await client.unsafe(`DROP SCHEMA IF EXISTS ${identifier(schemaName)} CASCADE`);
+    await client.end();
+  });
+
+  test("observes an inactive complete inventory and rejects one-table activation", async () => {
+    await expect(
+      inspectRlsCatalog(client as unknown as RlsCatalogClient, schemaName),
+    ).resolves.toMatchObject({
+      state: "inactive",
+      policyCoverageComplete: false,
+      protectedTableCount: RLS_ACTIVATION_TABLES.length,
+    });
+
+    const first = identifier(RLS_ACTIVATION_TABLES[0]);
+    await client.unsafe(`
+      CREATE POLICY tenant_isolation ON ${identifier(schemaName)}.${first}
+        USING (tenant_id = NULLIF(current_setting('steward.tenant_id', true), ''))
+        WITH CHECK (tenant_id = NULLIF(current_setting('steward.tenant_id', true), ''));
+      ALTER TABLE ${identifier(schemaName)}.${first} ENABLE ROW LEVEL SECURITY;
+      ALTER TABLE ${identifier(schemaName)}.${first} FORCE ROW LEVEL SECURITY;
+    `);
+    await expect(
+      inspectRlsCatalog(client as unknown as RlsCatalogClient, schemaName),
+    ).rejects.toThrow("RLS_CATALOG_PARTIAL_ACTIVATION");
+  });
+});

--- a/packages/db/src/__tests__/rls-catalog-gate-postgres.test.ts
+++ b/packages/db/src/__tests__/rls-catalog-gate-postgres.test.ts
@@ -2,14 +2,27 @@ import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "
 import { randomUUID } from "node:crypto";
 import postgres from "postgres";
 import {
+  AUTH_RLS_CATALOG_INVENTORY_CONTRIBUTION,
   inspectRlsCatalog,
   RLS_ACTIVATION_TABLES,
   type RlsCatalogClient,
+  type RlsCatalogInventoryContribution,
 } from "../rls-catalog-gate";
 import { INTENTIONALLY_GLOBAL_TABLES } from "../rls-inventory";
 
 const describeWithPostgres = process.env.DATABASE_URL ? describe : describe.skip;
-const schemaName = `rls_catalog_${randomUUID().replaceAll("-", "")}`;
+const suffix = randomUUID().replaceAll("-", "").slice(0, 20);
+const schemaName = `rls_catalog_${suffix}`;
+const partitionSchemaName = `rls_partition_${suffix}`;
+const ownerRole = `rls_owner_${suffix}`;
+const applicationRole = `rls_app_${suffix}`;
+const ownerMemberRole = `rls_member_${suffix}`;
+const bypassRole = `rls_bypass_${suffix}`;
+const pluginContribution: RlsCatalogInventoryContribution = {
+  owner: "test-plugin",
+  protectedTables: ["capabilities", "capability_grants"],
+  rlsExcludedTables: ["example_log"],
+};
 setDefaultTimeout(30_000);
 
 function identifier(value: string): string {
@@ -19,40 +32,122 @@ function identifier(value: string): string {
 
 describeWithPostgres("SEC-169 catalog activation gate on real Postgres", () => {
   const client = postgres(process.env.DATABASE_URL as string, { max: 1, prepare: false });
+  let administratorRole = "";
+  const rootTable = RLS_ACTIVATION_TABLES[0];
+  const protectedTables = [...RLS_ACTIVATION_TABLES, ...(pluginContribution.protectedTables ?? [])];
+  const excludedTables = [
+    ...Object.keys(INTENTIONALLY_GLOBAL_TABLES),
+    "auth_kv_store",
+    ...(pluginContribution.rlsExcludedTables ?? []),
+  ];
+
+  function inspectAs(runtimeRole: string, withPlugin = true) {
+    return inspectRlsCatalog(client as unknown as RlsCatalogClient, {
+      schema: schemaName,
+      runtimeRole,
+      inventoryContributions: withPlugin
+        ? [AUTH_RLS_CATALOG_INVENTORY_CONTRIBUTION, pluginContribution]
+        : [AUTH_RLS_CATALOG_INVENTORY_CONTRIBUTION],
+    });
+  }
 
   beforeAll(async () => {
-    await client.unsafe(`CREATE SCHEMA ${identifier(schemaName)}`);
-    for (const table of [...RLS_ACTIVATION_TABLES, ...Object.keys(INTENTIONALLY_GLOBAL_TABLES)]) {
-      await client.unsafe(
-        `CREATE TABLE ${identifier(schemaName)}.${identifier(table)} (id text PRIMARY KEY, tenant_id text)`,
-      );
+    const [identity] = await client<Array<{ current_user: string }>>`
+      SELECT current_user
+    `;
+    administratorRole = identity?.current_user ?? "";
+    await client.unsafe(`
+      CREATE ROLE ${identifier(ownerRole)} NOLOGIN NOSUPERUSER NOBYPASSRLS;
+      CREATE ROLE ${identifier(applicationRole)} NOLOGIN NOSUPERUSER NOBYPASSRLS;
+      CREATE ROLE ${identifier(ownerMemberRole)} NOLOGIN NOSUPERUSER NOBYPASSRLS;
+      CREATE ROLE ${identifier(bypassRole)} NOLOGIN NOSUPERUSER BYPASSRLS;
+      GRANT ${identifier(ownerRole)} TO ${identifier(ownerMemberRole)}
+        WITH INHERIT TRUE, SET TRUE;
+      CREATE SCHEMA ${identifier(schemaName)};
+      CREATE SCHEMA ${identifier(partitionSchemaName)};
+    `);
+    for (const table of [...protectedTables, ...excludedTables]) {
+      const qualified = `${identifier(schemaName)}.${identifier(table)}`;
+      if (table === rootTable) {
+        await client.unsafe(
+          `CREATE TABLE ${qualified} (id integer, tenant_id text) PARTITION BY RANGE (id)`,
+        );
+      } else {
+        await client.unsafe(`CREATE TABLE ${qualified} (id integer PRIMARY KEY, tenant_id text)`);
+      }
+      await client.unsafe(`ALTER TABLE ${qualified} OWNER TO ${identifier(ownerRole)}`);
     }
+    const externalPartition = `${identifier(partitionSchemaName)}.${identifier(`${rootTable}_2026`)}`;
+    await client.unsafe(
+      `CREATE TABLE ${externalPartition} ` +
+        `PARTITION OF ${identifier(schemaName)}.${identifier(rootTable)} ` +
+        "FOR VALUES FROM (0) TO (100)",
+    );
+    await client.unsafe(`ALTER TABLE ${externalPartition} OWNER TO ${identifier(ownerRole)}`);
   });
 
   afterAll(async () => {
-    await client.unsafe(`DROP SCHEMA IF EXISTS ${identifier(schemaName)} CASCADE`);
+    await client.unsafe(`
+      DROP SCHEMA IF EXISTS ${identifier(schemaName)} CASCADE;
+      DROP SCHEMA IF EXISTS ${identifier(partitionSchemaName)} CASCADE;
+      REVOKE ${identifier(ownerRole)} FROM ${identifier(ownerMemberRole)};
+      DROP ROLE IF EXISTS ${identifier(applicationRole)};
+      DROP ROLE IF EXISTS ${identifier(ownerMemberRole)};
+      DROP ROLE IF EXISTS ${identifier(bypassRole)};
+      DROP ROLE IF EXISTS ${identifier(ownerRole)};
+    `);
     await client.end();
   });
 
-  test("observes an inactive complete inventory and rejects one-table activation", async () => {
-    await expect(
-      inspectRlsCatalog(client as unknown as RlsCatalogClient, schemaName),
-    ).resolves.toMatchObject({
+  test("enforces complete dynamic inventory, partitions, and runtime-role safety", async () => {
+    await expect(inspectAs(applicationRole, false)).rejects.toThrow(
+      "RLS_CATALOG_INVENTORY_MISMATCH",
+    );
+    await expect(inspectAs(applicationRole)).resolves.toMatchObject({
       state: "inactive",
       policyCoverageComplete: false,
-      protectedTableCount: RLS_ACTIVATION_TABLES.length,
+      protectedTableCount: protectedTables.length,
+      partitionCount: 1,
     });
 
-    const first = identifier(RLS_ACTIVATION_TABLES[0]);
+    const externalPartition = `${identifier(partitionSchemaName)}.${identifier(`${rootTable}_2026`)}`;
     await client.unsafe(`
-      CREATE POLICY tenant_isolation ON ${identifier(schemaName)}.${first}
-        USING (tenant_id = NULLIF(current_setting('steward.tenant_id', true), ''))
-        WITH CHECK (tenant_id = NULLIF(current_setting('steward.tenant_id', true), ''));
-      ALTER TABLE ${identifier(schemaName)}.${first} ENABLE ROW LEVEL SECURITY;
-      ALTER TABLE ${identifier(schemaName)}.${first} FORCE ROW LEVEL SECURITY;
+      ALTER TABLE ${externalPartition} ENABLE ROW LEVEL SECURITY;
+      ALTER TABLE ${externalPartition} FORCE ROW LEVEL SECURITY;
     `);
-    await expect(
-      inspectRlsCatalog(client as unknown as RlsCatalogClient, schemaName),
-    ).rejects.toThrow("RLS_CATALOG_PARTIAL_ACTIVATION");
+    await expect(inspectAs(applicationRole)).rejects.toThrow("RLS_CATALOG_PARTIAL_ACTIVATION");
+    await client.unsafe(`
+      ALTER TABLE ${externalPartition} NO FORCE ROW LEVEL SECURITY;
+      ALTER TABLE ${externalPartition} DISABLE ROW LEVEL SECURITY;
+    `);
+
+    for (const table of protectedTables) {
+      const qualified = `${identifier(schemaName)}.${identifier(table)}`;
+      await client.unsafe(`
+        CREATE POLICY tenant_isolation ON ${qualified} USING (true) WITH CHECK (true);
+        ALTER TABLE ${qualified} ENABLE ROW LEVEL SECURITY;
+        ALTER TABLE ${qualified} FORCE ROW LEVEL SECURITY;
+      `);
+    }
+    await client.unsafe(`
+      ALTER TABLE ${externalPartition} ENABLE ROW LEVEL SECURITY;
+      ALTER TABLE ${externalPartition} FORCE ROW LEVEL SECURITY;
+    `);
+
+    await expect(inspectAs(applicationRole)).resolves.toMatchObject({
+      state: "active",
+      policyCoverageComplete: true,
+      protectedTableCount: protectedTables.length,
+      partitionCount: 1,
+    });
+    await expect(inspectAs(ownerMemberRole)).rejects.toThrow("RLS_CATALOG_UNSAFE_APPLICATION_ROLE");
+    await client.unsafe(
+      `GRANT ${identifier(bypassRole)} TO ${identifier(applicationRole)} WITH SET TRUE`,
+    );
+    await expect(inspectAs(applicationRole)).rejects.toThrow(
+      "RLS_CATALOG_UNSAFE_APPLICATION_ROLE: bypassrls",
+    );
+    await client.unsafe(`REVOKE ${identifier(bypassRole)} FROM ${identifier(applicationRole)}`);
+    await expect(inspectAs(administratorRole)).rejects.toThrow("superuser");
   });
 });

--- a/packages/db/src/__tests__/rls-catalog-gate-postgres.test.ts
+++ b/packages/db/src/__tests__/rls-catalog-gate-postgres.test.ts
@@ -2,7 +2,6 @@ import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "
 import { randomUUID } from "node:crypto";
 import postgres from "postgres";
 import {
-  AUTH_RLS_CATALOG_INVENTORY_CONTRIBUTION,
   inspectRlsCatalog,
   RLS_ACTIVATION_TABLES,
   type RlsCatalogClient,
@@ -33,6 +32,7 @@ function identifier(value: string): string {
 describeWithPostgres("SEC-169 catalog activation gate on real Postgres", () => {
   const client = postgres(process.env.DATABASE_URL as string, { max: 1, prepare: false });
   let administratorRole = "";
+  let serverVersionNumber = 0;
   const rootTable = RLS_ACTIVATION_TABLES[0];
   const protectedTables = [...RLS_ACTIVATION_TABLES, ...(pluginContribution.protectedTables ?? [])];
   const excludedTables = [
@@ -45,27 +45,30 @@ describeWithPostgres("SEC-169 catalog activation gate on real Postgres", () => {
     return inspectRlsCatalog(client as unknown as RlsCatalogClient, {
       schema: schemaName,
       runtimeRole,
-      inventoryContributions: withPlugin
-        ? [AUTH_RLS_CATALOG_INVENTORY_CONTRIBUTION, pluginContribution]
-        : [AUTH_RLS_CATALOG_INVENTORY_CONTRIBUTION],
+      inventoryContributions: withPlugin ? [pluginContribution] : [],
     });
   }
 
   beforeAll(async () => {
-    const [identity] = await client<Array<{ current_user: string }>>`
-      SELECT current_user
+    const [identity] = await client<Array<{ current_user: string; server_version_num: number }>>`
+      SELECT current_user, current_setting('server_version_num')::integer AS server_version_num
     `;
     administratorRole = identity?.current_user ?? "";
+    serverVersionNumber = identity?.server_version_num ?? 0;
     await client.unsafe(`
       CREATE ROLE ${identifier(ownerRole)} NOLOGIN NOSUPERUSER NOBYPASSRLS;
       CREATE ROLE ${identifier(applicationRole)} NOLOGIN NOSUPERUSER NOBYPASSRLS;
       CREATE ROLE ${identifier(ownerMemberRole)} NOLOGIN NOSUPERUSER NOBYPASSRLS;
       CREATE ROLE ${identifier(bypassRole)} NOLOGIN NOSUPERUSER BYPASSRLS;
-      GRANT ${identifier(ownerRole)} TO ${identifier(ownerMemberRole)}
-        WITH INHERIT TRUE, SET TRUE;
       CREATE SCHEMA ${identifier(schemaName)};
       CREATE SCHEMA ${identifier(partitionSchemaName)};
     `);
+    await client.unsafe(
+      serverVersionNumber >= 160000
+        ? `GRANT ${identifier(ownerRole)} TO ${identifier(ownerMemberRole)} ` +
+            "WITH INHERIT TRUE, SET FALSE"
+        : `GRANT ${identifier(ownerRole)} TO ${identifier(ownerMemberRole)}`,
+    );
     for (const table of [...protectedTables, ...excludedTables]) {
       const qualified = `${identifier(schemaName)}.${identifier(table)}`;
       if (table === rootTable) {
@@ -142,8 +145,33 @@ describeWithPostgres("SEC-169 catalog activation gate on real Postgres", () => {
     });
     await expect(inspectAs(ownerMemberRole)).rejects.toThrow("RLS_CATALOG_UNSAFE_APPLICATION_ROLE");
     await client.unsafe(
-      `GRANT ${identifier(bypassRole)} TO ${identifier(applicationRole)} WITH SET TRUE`,
+      serverVersionNumber >= 160000
+        ? `GRANT ${identifier(bypassRole)} TO ${identifier(applicationRole)} ` +
+            "WITH INHERIT FALSE, SET TRUE"
+        : `GRANT ${identifier(bypassRole)} TO ${identifier(applicationRole)}`,
     );
+    if (serverVersionNumber >= 160000) {
+      const [membership] = await client<
+        Array<{
+          owner_set: boolean;
+          owner_usage: boolean;
+          bypass_set: boolean;
+          bypass_usage: boolean;
+        }>
+      >`
+        SELECT
+          pg_has_role(${ownerMemberRole}, ${ownerRole}, 'SET') AS owner_set,
+          pg_has_role(${ownerMemberRole}, ${ownerRole}, 'USAGE') AS owner_usage,
+          pg_has_role(${applicationRole}, ${bypassRole}, 'SET') AS bypass_set,
+          pg_has_role(${applicationRole}, ${bypassRole}, 'USAGE') AS bypass_usage
+      `;
+      expect(membership).toEqual({
+        owner_set: false,
+        owner_usage: true,
+        bypass_set: true,
+        bypass_usage: false,
+      });
+    }
     await expect(inspectAs(applicationRole)).rejects.toThrow(
       "RLS_CATALOG_UNSAFE_APPLICATION_ROLE: bypassrls",
     );

--- a/packages/db/src/__tests__/rls-catalog-gate.test.ts
+++ b/packages/db/src/__tests__/rls-catalog-gate.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { assessRlsCatalogSnapshot, type RlsCatalogRow } from "../rls-catalog-gate";
+import {
+  assessRlsCatalogSnapshot,
+  inspectRlsCatalog,
+  type RlsCatalogRow,
+} from "../rls-catalog-gate";
 
 function row(table_name: string, overrides: Partial<RlsCatalogRow> = {}): RlsCatalogRow {
   return {
@@ -54,6 +58,30 @@ describe("SEC-169 catalog activation gate", () => {
         [],
       ),
     ).toThrow("RLS_CATALOG_UNSAFE_APPLICATION_ROLE");
+  });
+
+  test("rejects active SUPERUSER and table-owner application roles", () => {
+    const active = { rls_enabled: true, rls_forced: true, policy_count: 1 };
+    expect(() =>
+      assessRlsCatalogSnapshot([row("a", { ...active, role_super: true })], ["a"], []),
+    ).toThrow("RLS_CATALOG_UNSAFE_APPLICATION_ROLE: superuser");
+    expect(() =>
+      assessRlsCatalogSnapshot([row("a", { ...active, owned_by_current_role: true })], ["a"], []),
+    ).toThrow("RLS_CATALOG_UNSAFE_APPLICATION_ROLE: owner:a");
+  });
+
+  test("rejects an invalid schema before querying the catalog", async () => {
+    let queried = false;
+    const client = {
+      async unsafe() {
+        queried = true;
+        return [];
+      },
+    };
+    await expect(inspectRlsCatalog(client, "public; SET ROLE owner")).rejects.toThrow(
+      "RLS_CATALOG_SCHEMA_INVALID",
+    );
+    expect(queried).toBe(false);
   });
 
   test("rejects inventory drift, protected global tables, and orphan partitions", () => {

--- a/packages/db/src/__tests__/rls-catalog-gate.test.ts
+++ b/packages/db/src/__tests__/rls-catalog-gate.test.ts
@@ -89,5 +89,15 @@ describe("SEC-169 catalog activation gate", () => {
         [],
       ),
     ).toThrow("RLS_CATALOG_PARTIAL_ACTIVATION");
+    expect(() =>
+      assessRlsCatalogSnapshot(
+        [
+          row("a", active),
+          row("a_2026", { ...active, partition_root: "a", owned_by_current_role: true }),
+        ],
+        ["a"],
+        [],
+      ),
+    ).toThrow("RLS_CATALOG_UNSAFE_APPLICATION_ROLE");
   });
 });

--- a/packages/db/src/__tests__/rls-catalog-gate.test.ts
+++ b/packages/db/src/__tests__/rls-catalog-gate.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { assessRlsCatalogSnapshot, type RlsCatalogRow } from "../rls-catalog-gate";
+
+function row(table_name: string, overrides: Partial<RlsCatalogRow> = {}): RlsCatalogRow {
+  return {
+    table_name,
+    partition_root: null,
+    rls_enabled: false,
+    rls_forced: false,
+    policy_count: 0,
+    owned_by_current_role: false,
+    role_super: false,
+    role_bypass_rls: false,
+    ...overrides,
+  };
+}
+
+describe("SEC-169 catalog activation gate", () => {
+  test("permits inactive and fully staged catalogs without enabling partial RLS", () => {
+    expect(
+      assessRlsCatalogSnapshot([row("a"), row("b"), row("global")], ["a", "b"], ["global"]),
+    ).toMatchObject({ state: "inactive", policyCoverageComplete: false });
+    expect(
+      assessRlsCatalogSnapshot(
+        [row("a", { policy_count: 1 }), row("b", { policy_count: 1 }), row("global")],
+        ["a", "b"],
+        ["global"],
+      ),
+    ).toMatchObject({ state: "policies-staged", policyCoverageComplete: true });
+  });
+
+  test("rejects partial flags, missing policies, and unsafe active roles", () => {
+    expect(() =>
+      assessRlsCatalogSnapshot(
+        [row("a", { rls_enabled: true, rls_forced: true, policy_count: 1 }), row("b")],
+        ["a", "b"],
+        [],
+      ),
+    ).toThrow("RLS_CATALOG_PARTIAL_ACTIVATION");
+    expect(() =>
+      assessRlsCatalogSnapshot(
+        [
+          row("a", { rls_enabled: true, rls_forced: true, policy_count: 1 }),
+          row("b", { rls_enabled: true, rls_forced: true }),
+        ],
+        ["a", "b"],
+        [],
+      ),
+    ).toThrow("RLS_CATALOG_PARTIAL_ACTIVATION");
+    expect(() =>
+      assessRlsCatalogSnapshot(
+        [row("a", { rls_enabled: true, rls_forced: true, policy_count: 1, role_bypass_rls: true })],
+        ["a"],
+        [],
+      ),
+    ).toThrow("RLS_CATALOG_UNSAFE_APPLICATION_ROLE");
+  });
+
+  test("rejects inventory drift, protected global tables, and orphan partitions", () => {
+    expect(() => assessRlsCatalogSnapshot([row("a"), row("unexpected")], ["a"], [])).toThrow(
+      "RLS_CATALOG_INVENTORY_MISMATCH",
+    );
+    expect(() =>
+      assessRlsCatalogSnapshot([row("a"), row("global", { rls_enabled: true })], ["a"], ["global"]),
+    ).toThrow("RLS_CATALOG_GLOBAL_TABLE_PROTECTED");
+    expect(() =>
+      assessRlsCatalogSnapshot([row("a"), row("a_2026", { partition_root: "missing" })], ["a"], []),
+    ).toThrow("RLS_CATALOG_INVENTORY_MISMATCH");
+  });
+
+  test("accepts only complete active catalogs and requires partition flags", () => {
+    const active = { rls_enabled: true, rls_forced: true, policy_count: 1 };
+    expect(
+      assessRlsCatalogSnapshot(
+        [row("a", active), row("b", active), row("a_2026", { ...active, partition_root: "a" })],
+        ["a", "b"],
+        [],
+      ),
+    ).toEqual({
+      state: "active",
+      policyCoverageComplete: true,
+      protectedTableCount: 2,
+      partitionCount: 1,
+    });
+    expect(() =>
+      assessRlsCatalogSnapshot(
+        [row("a", active), row("a_2026", { partition_root: "a" })],
+        ["a"],
+        [],
+      ),
+    ).toThrow("RLS_CATALOG_PARTIAL_ACTIVATION");
+  });
+});

--- a/packages/db/src/__tests__/rls-catalog-gate.test.ts
+++ b/packages/db/src/__tests__/rls-catalog-gate.test.ts
@@ -226,6 +226,7 @@ describe("SEC-169 catalog activation gate", () => {
       },
     ]);
     expect(composed.protectedTables).toContain("plugin_tenant_table");
+    expect(composed.rlsExcludedTables).toContain("auth_kv_store");
     expect(composed.rlsExcludedTables).toContain("plugin_global_table");
     expect(() =>
       composeRlsCatalogInventory([{ owner: "invalid-plugin", rlsExcludedTables: ["agents"] }]),

--- a/packages/db/src/__tests__/rls-catalog-gate.test.ts
+++ b/packages/db/src/__tests__/rls-catalog-gate.test.ts
@@ -1,20 +1,34 @@
 import { describe, expect, test } from "bun:test";
 import {
   assessRlsCatalogSnapshot,
+  composeRlsCatalogInventory,
   inspectRlsCatalog,
+  type RlsCatalogInventory,
   type RlsCatalogRow,
 } from "../rls-catalog-gate";
 
+function inventory(
+  protectedTables: readonly string[],
+  rlsExcludedTables: readonly string[] = [],
+): RlsCatalogInventory {
+  return { protectedTables, rlsExcludedTables };
+}
+
 function row(table_name: string, overrides: Partial<RlsCatalogRow> = {}): RlsCatalogRow {
   return {
+    relation_oid: table_name,
     table_name,
+    table_schema: "public",
+    partition_root_oid: null,
     partition_root: null,
+    partition_root_schema: null,
     rls_enabled: false,
     rls_forced: false,
     policy_count: 0,
-    owned_by_current_role: false,
-    role_super: false,
-    role_bypass_rls: false,
+    owned_by_runtime_role: false,
+    owner_privileges_available_to_runtime: false,
+    runtime_can_assume_superuser: false,
+    runtime_can_assume_bypassrls: false,
     ...overrides,
   };
 }
@@ -22,13 +36,15 @@ function row(table_name: string, overrides: Partial<RlsCatalogRow> = {}): RlsCat
 describe("SEC-169 catalog activation gate", () => {
   test("permits inactive and fully staged catalogs without enabling partial RLS", () => {
     expect(
-      assessRlsCatalogSnapshot([row("a"), row("b"), row("global")], ["a", "b"], ["global"]),
+      assessRlsCatalogSnapshot(
+        [row("a"), row("b"), row("global")],
+        inventory(["a", "b"], ["global"]),
+      ),
     ).toMatchObject({ state: "inactive", policyCoverageComplete: false });
     expect(
       assessRlsCatalogSnapshot(
         [row("a", { policy_count: 1 }), row("b", { policy_count: 1 }), row("global")],
-        ["a", "b"],
-        ["global"],
+        inventory(["a", "b"], ["global"]),
       ),
     ).toMatchObject({ state: "policies-staged", policyCoverageComplete: true });
   });
@@ -37,8 +53,7 @@ describe("SEC-169 catalog activation gate", () => {
     expect(() =>
       assessRlsCatalogSnapshot(
         [row("a", { rls_enabled: true, rls_forced: true, policy_count: 1 }), row("b")],
-        ["a", "b"],
-        [],
+        inventory(["a", "b"]),
       ),
     ).toThrow("RLS_CATALOG_PARTIAL_ACTIVATION");
     expect(() =>
@@ -47,15 +62,20 @@ describe("SEC-169 catalog activation gate", () => {
           row("a", { rls_enabled: true, rls_forced: true, policy_count: 1 }),
           row("b", { rls_enabled: true, rls_forced: true }),
         ],
-        ["a", "b"],
-        [],
+        inventory(["a", "b"]),
       ),
     ).toThrow("RLS_CATALOG_PARTIAL_ACTIVATION");
     expect(() =>
       assessRlsCatalogSnapshot(
-        [row("a", { rls_enabled: true, rls_forced: true, policy_count: 1, role_bypass_rls: true })],
-        ["a"],
-        [],
+        [
+          row("a", {
+            rls_enabled: true,
+            rls_forced: true,
+            policy_count: 1,
+            runtime_can_assume_bypassrls: true,
+          }),
+        ],
+        inventory(["a"]),
       ),
     ).toThrow("RLS_CATALOG_UNSAFE_APPLICATION_ROLE");
   });
@@ -63,10 +83,22 @@ describe("SEC-169 catalog activation gate", () => {
   test("rejects active SUPERUSER and table-owner application roles", () => {
     const active = { rls_enabled: true, rls_forced: true, policy_count: 1 };
     expect(() =>
-      assessRlsCatalogSnapshot([row("a", { ...active, role_super: true })], ["a"], []),
+      assessRlsCatalogSnapshot(
+        [row("a", { ...active, runtime_can_assume_superuser: true })],
+        inventory(["a"]),
+      ),
     ).toThrow("RLS_CATALOG_UNSAFE_APPLICATION_ROLE: superuser");
     expect(() =>
-      assessRlsCatalogSnapshot([row("a", { ...active, owned_by_current_role: true })], ["a"], []),
+      assessRlsCatalogSnapshot(
+        [
+          row("a", {
+            ...active,
+            owned_by_runtime_role: true,
+            owner_privileges_available_to_runtime: true,
+          }),
+        ],
+        inventory(["a"]),
+      ),
     ).toThrow("RLS_CATALOG_UNSAFE_APPLICATION_ROLE: owner:a");
   });
 
@@ -78,21 +110,50 @@ describe("SEC-169 catalog activation gate", () => {
         return [];
       },
     };
-    await expect(inspectRlsCatalog(client, "public; SET ROLE owner")).rejects.toThrow(
-      "RLS_CATALOG_SCHEMA_INVALID",
-    );
+    await expect(
+      inspectRlsCatalog(client, {
+        schema: "public; SET ROLE owner",
+        runtimeRole: "app_role",
+      }),
+    ).rejects.toThrow("RLS_CATALOG_SCHEMA_INVALID");
     expect(queried).toBe(false);
   });
 
   test("rejects inventory drift, protected global tables, and orphan partitions", () => {
-    expect(() => assessRlsCatalogSnapshot([row("a"), row("unexpected")], ["a"], [])).toThrow(
+    expect(() => assessRlsCatalogSnapshot([row("a"), row("unexpected")], inventory(["a"]))).toThrow(
       "RLS_CATALOG_INVENTORY_MISMATCH",
     );
     expect(() =>
-      assessRlsCatalogSnapshot([row("a"), row("global", { rls_enabled: true })], ["a"], ["global"]),
-    ).toThrow("RLS_CATALOG_GLOBAL_TABLE_PROTECTED");
+      assessRlsCatalogSnapshot(
+        [row("a"), row("global", { rls_enabled: true })],
+        inventory(["a"], ["global"]),
+      ),
+    ).toThrow("RLS_CATALOG_EXCLUDED_TABLE_PROTECTED");
     expect(() =>
-      assessRlsCatalogSnapshot([row("a"), row("a_2026", { partition_root: "missing" })], ["a"], []),
+      assessRlsCatalogSnapshot(
+        [
+          row("a"),
+          row("a_2026", {
+            partition_root: "missing",
+            partition_root_oid: "missing",
+            partition_root_schema: "public",
+          }),
+        ],
+        inventory(["a"]),
+      ),
+    ).toThrow("RLS_CATALOG_INVENTORY_MISMATCH");
+    expect(() =>
+      assessRlsCatalogSnapshot(
+        [
+          row("a"),
+          row("same_named_external_child", {
+            partition_root: "a",
+            partition_root_oid: "external-a",
+            partition_root_schema: "public",
+          }),
+        ],
+        inventory(["a"]),
+      ),
     ).toThrow("RLS_CATALOG_INVENTORY_MISMATCH");
   });
 
@@ -100,9 +161,17 @@ describe("SEC-169 catalog activation gate", () => {
     const active = { rls_enabled: true, rls_forced: true, policy_count: 1 };
     expect(
       assessRlsCatalogSnapshot(
-        [row("a", active), row("b", active), row("a_2026", { ...active, partition_root: "a" })],
-        ["a", "b"],
-        [],
+        [
+          row("a", active),
+          row("b", active),
+          row("a_2026", {
+            ...active,
+            partition_root: "a",
+            partition_root_oid: "a",
+            partition_root_schema: "public",
+          }),
+        ],
+        inventory(["a", "b"]),
       ),
     ).toEqual({
       state: "active",
@@ -112,20 +181,54 @@ describe("SEC-169 catalog activation gate", () => {
     });
     expect(() =>
       assessRlsCatalogSnapshot(
-        [row("a", active), row("a_2026", { partition_root: "a" })],
-        ["a"],
-        [],
+        [
+          row("a", active),
+          row("a_2026", {
+            partition_root: "a",
+            partition_root_oid: "a",
+            partition_root_schema: "public",
+          }),
+        ],
+        inventory(["a"]),
       ),
     ).toThrow("RLS_CATALOG_PARTIAL_ACTIVATION");
     expect(() =>
       assessRlsCatalogSnapshot(
         [
           row("a", active),
-          row("a_2026", { ...active, partition_root: "a", owned_by_current_role: true }),
+          row("a_2026", {
+            ...active,
+            partition_root: "a",
+            partition_root_oid: "a",
+            partition_root_schema: "public",
+            owned_by_runtime_role: true,
+            owner_privileges_available_to_runtime: true,
+          }),
         ],
-        ["a"],
-        [],
+        inventory(["a"]),
       ),
     ).toThrow("RLS_CATALOG_UNSAFE_APPLICATION_ROLE");
+  });
+
+  test("rejects owner-role membership before activation and composes plugin inventory", () => {
+    expect(() =>
+      assessRlsCatalogSnapshot(
+        [row("a", { owner_privileges_available_to_runtime: true })],
+        inventory(["a"]),
+      ),
+    ).toThrow("RLS_CATALOG_UNSAFE_APPLICATION_ROLE: owner-role:a");
+
+    const composed = composeRlsCatalogInventory([
+      {
+        owner: "plugin-example",
+        protectedTables: ["plugin_tenant_table"],
+        rlsExcludedTables: ["plugin_global_table"],
+      },
+    ]);
+    expect(composed.protectedTables).toContain("plugin_tenant_table");
+    expect(composed.rlsExcludedTables).toContain("plugin_global_table");
+    expect(() =>
+      composeRlsCatalogInventory([{ owner: "invalid-plugin", rlsExcludedTables: ["agents"] }]),
+    ).toThrow("RLS_CATALOG_INVENTORY_INVALID: duplicate:agents");
   });
 });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -51,7 +51,6 @@ export {
   sanitizePluginMigrationId,
 } from "./plugin-migrate";
 export {
-  AUTH_RLS_CATALOG_INVENTORY_CONTRIBUTION,
   assessRlsCatalogSnapshot,
   CORE_RLS_CATALOG_INVENTORY,
   CORE_RLS_EXCLUDED_TABLES,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -51,11 +51,18 @@ export {
   sanitizePluginMigrationId,
 } from "./plugin-migrate";
 export {
+  AUTH_RLS_CATALOG_INVENTORY_CONTRIBUTION,
   assessRlsCatalogSnapshot,
+  CORE_RLS_CATALOG_INVENTORY,
+  CORE_RLS_EXCLUDED_TABLES,
+  composeRlsCatalogInventory,
+  type InspectRlsCatalogOptions,
   inspectRlsCatalog,
   RLS_ACTIVATION_TABLES,
   type RlsCatalogAssessment,
   type RlsCatalogClient,
+  type RlsCatalogInventory,
+  type RlsCatalogInventoryContribution,
   type RlsCatalogRow,
 } from "./rls-catalog-gate";
 export {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -51,6 +51,14 @@ export {
   sanitizePluginMigrationId,
 } from "./plugin-migrate";
 export {
+  assessRlsCatalogSnapshot,
+  inspectRlsCatalog,
+  RLS_ACTIVATION_TABLES,
+  type RlsCatalogAssessment,
+  type RlsCatalogClient,
+  type RlsCatalogRow,
+} from "./rls-catalog-gate";
+export {
   ALL_INVENTORIED_TABLES,
   BOOTSTRAP_ROOT_TABLES,
   DIRECT_TENANT_TABLES,

--- a/packages/db/src/rls-catalog-gate.ts
+++ b/packages/db/src/rls-catalog-gate.ts
@@ -16,15 +16,103 @@ export const RLS_ACTIVATION_TABLES = [
   ...Object.keys(BOOTSTRAP_ROOT_TABLES),
 ].sort();
 
+export const CORE_RLS_EXCLUDED_TABLES = [...Object.keys(INTENTIONALLY_GLOBAL_TABLES)].sort();
+
+export interface RlsCatalogInventory {
+  protectedTables: readonly string[];
+  rlsExcludedTables: readonly string[];
+}
+
+export interface RlsCatalogInventoryContribution {
+  owner: string;
+  protectedTables?: readonly string[];
+  rlsExcludedTables?: readonly string[];
+}
+
+export const AUTH_RLS_CATALOG_INVENTORY_CONTRIBUTION: RlsCatalogInventoryContribution = {
+  owner: "@stwd/auth",
+  // This compatibility store exists only when auth uses PostgreSQL. It has no
+  // tenant column; tenant binding lives in opaque, namespaced keys.
+  rlsExcludedTables: ["auth_kv_store"],
+};
+
+export const CORE_RLS_CATALOG_INVENTORY: RlsCatalogInventory = {
+  protectedTables: RLS_ACTIVATION_TABLES,
+  rlsExcludedTables: CORE_RLS_EXCLUDED_TABLES,
+};
+
+const POSTGRES_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]{0,62}$/;
+const INVENTORY_OWNER = /^[@A-Za-z0-9_./-]{1,128}$/;
+
+function normalizeRlsCatalogInventory(
+  ...inventories: readonly RlsCatalogInventory[]
+): RlsCatalogInventory {
+  const protectedTables = inventories.flatMap((inventory) => [...inventory.protectedTables]);
+  const rlsExcludedTables = inventories.flatMap((inventory) => [...inventory.rlsExcludedTables]);
+  const all = [...protectedTables, ...rlsExcludedTables];
+  const invalid = all.filter((table) => !POSTGRES_IDENTIFIER.test(table));
+  const duplicates = all.filter((table, index) => all.indexOf(table) !== index);
+  if (invalid.length || duplicates.length) {
+    fail("RLS_CATALOG_INVENTORY_INVALID", [
+      ...invalid.map((table) => `invalid:${table}`),
+      ...duplicates.map((table) => `duplicate:${table}`),
+    ]);
+  }
+  return {
+    protectedTables: [...protectedTables].sort(),
+    rlsExcludedTables: [...rlsExcludedTables].sort(),
+  };
+}
+
+export function composeRlsCatalogInventory(
+  contributions: readonly RlsCatalogInventoryContribution[] = [],
+): RlsCatalogInventory {
+  const invalidOwners = contributions
+    .filter((contribution) => !INVENTORY_OWNER.test(contribution.owner))
+    .map(() => "owner:invalid");
+  if (invalidOwners.length) fail("RLS_CATALOG_INVENTORY_INVALID", invalidOwners);
+  const claims = new Map<string, string>(
+    [
+      ...CORE_RLS_CATALOG_INVENTORY.protectedTables,
+      ...CORE_RLS_CATALOG_INVENTORY.rlsExcludedTables,
+    ].map((table) => [table, "steward-core"] as const),
+  );
+  const duplicateClaims: string[] = [];
+  for (const contribution of contributions) {
+    for (const table of [
+      ...(contribution.protectedTables ?? []),
+      ...(contribution.rlsExcludedTables ?? []),
+    ]) {
+      const priorOwner = claims.get(table);
+      if (priorOwner)
+        duplicateClaims.push(`duplicate:${table}:${priorOwner}/${contribution.owner}`);
+      else claims.set(table, contribution.owner);
+    }
+  }
+  if (duplicateClaims.length) fail("RLS_CATALOG_INVENTORY_INVALID", duplicateClaims);
+  return normalizeRlsCatalogInventory(
+    CORE_RLS_CATALOG_INVENTORY,
+    ...contributions.map((contribution) => ({
+      protectedTables: contribution.protectedTables ?? [],
+      rlsExcludedTables: contribution.rlsExcludedTables ?? [],
+    })),
+  );
+}
+
 export interface RlsCatalogRow {
+  relation_oid: string;
   table_name: string;
+  table_schema: string;
+  partition_root_oid: string | null;
   partition_root: string | null;
+  partition_root_schema: string | null;
   rls_enabled: boolean;
   rls_forced: boolean;
   policy_count: number;
-  owned_by_current_role: boolean;
-  role_super: boolean;
-  role_bypass_rls: boolean;
+  owned_by_runtime_role: boolean;
+  owner_privileges_available_to_runtime: boolean;
+  runtime_can_assume_superuser: boolean;
+  runtime_can_assume_bypassrls: boolean;
 }
 
 export interface RlsCatalogAssessment {
@@ -38,23 +126,79 @@ export interface RlsCatalogClient {
   unsafe(query: string, parameters: unknown[]): Promise<RlsCatalogRow[]>;
 }
 
+export interface InspectRlsCatalogOptions {
+  schema?: string;
+  runtimeRole: string;
+  inventoryContributions?: readonly RlsCatalogInventoryContribution[];
+}
+
 const CATALOG_QUERY = `
+WITH runtime_role AS (
+  SELECT oid
+    FROM pg_catalog.pg_roles
+   WHERE rolname = $2
+), assumable_roles AS (
+  SELECT candidate.oid, candidate.rolsuper, candidate.rolbypassrls
+    FROM pg_catalog.pg_roles candidate
+    CROSS JOIN runtime_role runtime
+   WHERE candidate.oid = runtime.oid
+      OR pg_catalog.pg_has_role(runtime.oid, candidate.oid, 'SET')
+), usable_roles AS (
+  SELECT candidate.oid
+    FROM pg_catalog.pg_roles candidate
+    CROSS JOIN runtime_role runtime
+   WHERE candidate.oid = runtime.oid
+      OR pg_catalog.pg_has_role(runtime.oid, candidate.oid, 'USAGE')
+), target_roots AS (
+  SELECT relation.oid, relation.relkind
+    FROM pg_catalog.pg_class relation
+    JOIN pg_catalog.pg_namespace namespace ON namespace.oid = relation.relnamespace
+   WHERE namespace.nspname = $1
+     AND relation.relkind IN ('r', 'p')
+     AND NOT relation.relispartition
+), catalog_relations AS (
+  SELECT root.oid AS root_oid, root.oid AS child_oid
+    FROM target_roots root
+  UNION
+  SELECT root.oid AS root_oid, tree.relid AS child_oid
+    FROM target_roots root
+    CROSS JOIN LATERAL pg_catalog.pg_partition_tree(root.oid) tree
+   WHERE root.relkind = 'p'
+  UNION
+  SELECT pg_catalog.pg_partition_root(child.oid) AS root_oid, child.oid AS child_oid
+    FROM pg_catalog.pg_class child
+    JOIN pg_catalog.pg_namespace namespace ON namespace.oid = child.relnamespace
+   WHERE namespace.nspname = $1
+     AND child.relispartition
+)
 SELECT
+  child.oid::text AS relation_oid,
   child.relname AS table_name,
+  child_namespace.nspname AS table_schema,
+  CASE WHEN child.relispartition THEN root.oid::text ELSE NULL END AS partition_root_oid,
   CASE WHEN child.relispartition THEN root.relname ELSE NULL END AS partition_root,
+  CASE WHEN child.relispartition THEN root_namespace.nspname ELSE NULL END
+    AS partition_root_schema,
   child.relrowsecurity AS rls_enabled,
   child.relforcerowsecurity AS rls_forced,
   (SELECT count(*)::int FROM pg_catalog.pg_policy p WHERE p.polrelid = child.oid) AS policy_count,
-  child.relowner = current_role_row.oid AS owned_by_current_role,
-  current_role_row.rolsuper AS role_super,
-  current_role_row.rolbypassrls AS role_bypass_rls
-FROM pg_catalog.pg_class child
-JOIN pg_catalog.pg_namespace namespace ON namespace.oid = child.relnamespace
-JOIN pg_catalog.pg_roles current_role_row ON current_role_row.rolname = current_user
-LEFT JOIN pg_catalog.pg_class root ON root.oid = pg_catalog.pg_partition_root(child.oid)
-WHERE namespace.nspname = $1
-  AND child.relkind IN ('r', 'p')
-ORDER BY child.relname`;
+  child.relowner = runtime.oid AS owned_by_runtime_role,
+  EXISTS (
+    SELECT 1 FROM usable_roles usable WHERE usable.oid = child.relowner
+    UNION ALL
+    SELECT 1 FROM assumable_roles assumable WHERE assumable.oid = child.relowner
+  ) AS owner_privileges_available_to_runtime,
+  COALESCE((SELECT bool_or(role.rolsuper) FROM assumable_roles role), false)
+    AS runtime_can_assume_superuser,
+  COALESCE((SELECT bool_or(role.rolbypassrls) FROM assumable_roles role), false)
+    AS runtime_can_assume_bypassrls
+FROM catalog_relations relation
+JOIN pg_catalog.pg_class child ON child.oid = relation.child_oid
+JOIN pg_catalog.pg_namespace child_namespace ON child_namespace.oid = child.relnamespace
+CROSS JOIN runtime_role runtime
+JOIN pg_catalog.pg_class root ON root.oid = relation.root_oid
+JOIN pg_catalog.pg_namespace root_namespace ON root_namespace.oid = root.relnamespace
+ORDER BY child_namespace.nspname, child.relname`;
 
 function fail(code: string, details: string[]): never {
   throw new Error(`${code}: ${details.sort().join(",")}`);
@@ -70,21 +214,30 @@ function fail(code: string, details: string[]): never {
  */
 export function assessRlsCatalogSnapshot(
   rows: RlsCatalogRow[],
-  expectedProtected: readonly string[] = RLS_ACTIVATION_TABLES,
-  expectedGlobal: readonly string[] = Object.keys(INTENTIONALLY_GLOBAL_TABLES),
+  inventory: RlsCatalogInventory = CORE_RLS_CATALOG_INVENTORY,
+  schema = "public",
 ): RlsCatalogAssessment {
-  const protectedSet = new Set(expectedProtected);
-  const globalSet = new Set(expectedGlobal);
-  const inventorySet = new Set([...protectedSet, ...globalSet]);
+  const normalizedInventory = normalizeRlsCatalogInventory(inventory);
+  const protectedSet = new Set(normalizedInventory.protectedTables);
+  const excludedSet = new Set(normalizedInventory.rlsExcludedTables);
+  const inventorySet = new Set([...protectedSet, ...excludedSet]);
   const ordinaryRows = rows.filter((row) => row.partition_root === null);
   const partitions = rows.filter((row) => row.partition_root !== null);
+  const protectedRootOids = new Set(
+    ordinaryRows.filter((row) => protectedSet.has(row.table_name)).map((row) => row.relation_oid),
+  );
   const actual = new Set(ordinaryRows.map((row) => row.table_name));
   const missing = [...inventorySet].filter((table) => !actual.has(table));
   const unknown = [...actual].filter(
     (table) => !inventorySet.has(table) && table !== "__steward_migrations",
   );
   const orphanPartitions = partitions
-    .filter((row) => !row.partition_root || !protectedSet.has(row.partition_root))
+    .filter(
+      (row) =>
+        !row.partition_root_oid ||
+        !protectedRootOids.has(row.partition_root_oid) ||
+        row.partition_root_schema !== schema,
+    )
     .map((row) => row.table_name);
   if (missing.length || unknown.length || orphanPartitions.length) {
     fail("RLS_CATALOG_INVENTORY_MISMATCH", [
@@ -94,16 +247,36 @@ export function assessRlsCatalogSnapshot(
     ]);
   }
 
-  const globalRls = ordinaryRows
-    .filter((row) => globalSet.has(row.table_name) && (row.rls_enabled || row.rls_forced))
+  const excludedRls = ordinaryRows
+    .filter((row) => excludedSet.has(row.table_name) && (row.rls_enabled || row.rls_forced))
     .map((row) => row.table_name);
-  if (globalRls.length) fail("RLS_CATALOG_GLOBAL_TABLE_PROTECTED", globalRls);
+  if (excludedRls.length) fail("RLS_CATALOG_EXCLUDED_TABLE_PROTECTED", excludedRls);
 
   const protectedRows = ordinaryRows.filter((row) => protectedSet.has(row.table_name));
   const activationRows = [...protectedRows, ...partitions];
   const anyEnabled = activationRows.some((row) => row.rls_enabled || row.rls_forced);
   const staged = protectedRows.some((row) => row.policy_count > 0);
   const policiesComplete = protectedRows.every((row) => row.policy_count > 0);
+
+  const unsafeRole = activationRows[0];
+  if (
+    unsafeRole?.runtime_can_assume_superuser ||
+    unsafeRole?.runtime_can_assume_bypassrls ||
+    activationRows.some((row) => row.owner_privileges_available_to_runtime)
+  ) {
+    fail(
+      "RLS_CATALOG_UNSAFE_APPLICATION_ROLE",
+      [
+        unsafeRole?.runtime_can_assume_superuser ? "superuser" : "",
+        unsafeRole?.runtime_can_assume_bypassrls ? "bypassrls" : "",
+        ...activationRows
+          .filter((row) => row.owner_privileges_available_to_runtime)
+          .map((row) =>
+            row.owned_by_runtime_role ? `owner:${row.table_name}` : `owner-role:${row.table_name}`,
+          ),
+      ].filter(Boolean),
+    );
+  }
 
   if (!anyEnabled) {
     return {
@@ -127,24 +300,6 @@ export function assessRlsCatalogSnapshot(
     ]);
   }
 
-  const unsafeRole = activationRows[0];
-  if (
-    unsafeRole?.role_super ||
-    unsafeRole?.role_bypass_rls ||
-    activationRows.some((row) => row.owned_by_current_role)
-  ) {
-    fail(
-      "RLS_CATALOG_UNSAFE_APPLICATION_ROLE",
-      [
-        unsafeRole?.role_super ? "superuser" : "",
-        unsafeRole?.role_bypass_rls ? "bypassrls" : "",
-        ...activationRows
-          .filter((row) => row.owned_by_current_role)
-          .map((row) => `owner:${row.table_name}`),
-      ].filter(Boolean),
-    );
-  }
-
   return {
     state: "active",
     policyCoverageComplete: true,
@@ -155,13 +310,22 @@ export function assessRlsCatalogSnapshot(
 
 export async function inspectRlsCatalog(
   client: RlsCatalogClient,
-  schema = "public",
+  options: InspectRlsCatalogOptions,
 ): Promise<RlsCatalogAssessment> {
-  if (!/^[A-Za-z_][A-Za-z0-9_]{0,62}$/.test(schema)) {
+  const schema = options.schema ?? "public";
+  if (!POSTGRES_IDENTIFIER.test(schema)) {
     throw new Error("RLS_CATALOG_SCHEMA_INVALID");
   }
-  const rows = await client.unsafe(CATALOG_QUERY, [schema]);
-  return assessRlsCatalogSnapshot(rows);
+  if (!POSTGRES_IDENTIFIER.test(options.runtimeRole)) {
+    throw new Error("RLS_CATALOG_RUNTIME_ROLE_INVALID");
+  }
+  const rows = await client.unsafe(CATALOG_QUERY, [schema, options.runtimeRole]);
+  if (rows.length === 0) throw new Error("RLS_CATALOG_RUNTIME_ROLE_OR_SCHEMA_MISSING");
+  return assessRlsCatalogSnapshot(
+    rows,
+    composeRlsCatalogInventory(options.inventoryContributions),
+    schema,
+  );
 }
 
 // Compile-time/runtime evidence that the activation and global sets still

--- a/packages/db/src/rls-catalog-gate.ts
+++ b/packages/db/src/rls-catalog-gate.ts
@@ -127,18 +127,18 @@ export function assessRlsCatalogSnapshot(
     ]);
   }
 
-  const unsafeRole = protectedRows[0];
+  const unsafeRole = activationRows[0];
   if (
     unsafeRole?.role_super ||
     unsafeRole?.role_bypass_rls ||
-    protectedRows.some((row) => row.owned_by_current_role)
+    activationRows.some((row) => row.owned_by_current_role)
   ) {
     fail(
       "RLS_CATALOG_UNSAFE_APPLICATION_ROLE",
       [
         unsafeRole?.role_super ? "superuser" : "",
         unsafeRole?.role_bypass_rls ? "bypassrls" : "",
-        ...protectedRows
+        ...activationRows
           .filter((row) => row.owned_by_current_role)
           .map((row) => `owner:${row.table_name}`),
       ].filter(Boolean),

--- a/packages/db/src/rls-catalog-gate.ts
+++ b/packages/db/src/rls-catalog-gate.ts
@@ -1,0 +1,174 @@
+import {
+  ALL_INVENTORIED_TABLES,
+  BOOTSTRAP_ROOT_TABLES,
+  DIRECT_TENANT_TABLES,
+  HYBRID_SCOPE_TABLES,
+  INDIRECT_TENANT_TABLES,
+  INTENTIONALLY_GLOBAL_TABLES,
+  TENANT_COLUMN_BACKFILL_TABLES,
+} from "./rls-inventory";
+
+export const RLS_ACTIVATION_TABLES = [
+  ...DIRECT_TENANT_TABLES,
+  ...Object.keys(INDIRECT_TENANT_TABLES),
+  ...Object.keys(TENANT_COLUMN_BACKFILL_TABLES),
+  ...Object.keys(HYBRID_SCOPE_TABLES),
+  ...Object.keys(BOOTSTRAP_ROOT_TABLES),
+].sort();
+
+export interface RlsCatalogRow {
+  table_name: string;
+  partition_root: string | null;
+  rls_enabled: boolean;
+  rls_forced: boolean;
+  policy_count: number;
+  owned_by_current_role: boolean;
+  role_super: boolean;
+  role_bypass_rls: boolean;
+}
+
+export interface RlsCatalogAssessment {
+  state: "inactive" | "policies-staged" | "active";
+  policyCoverageComplete: boolean;
+  protectedTableCount: number;
+  partitionCount: number;
+}
+
+export interface RlsCatalogClient {
+  unsafe(query: string, parameters: unknown[]): Promise<RlsCatalogRow[]>;
+}
+
+const CATALOG_QUERY = `
+SELECT
+  child.relname AS table_name,
+  CASE WHEN child.relispartition THEN root.relname ELSE NULL END AS partition_root,
+  child.relrowsecurity AS rls_enabled,
+  child.relforcerowsecurity AS rls_forced,
+  (SELECT count(*)::int FROM pg_catalog.pg_policy p WHERE p.polrelid = child.oid) AS policy_count,
+  child.relowner = current_role_row.oid AS owned_by_current_role,
+  current_role_row.rolsuper AS role_super,
+  current_role_row.rolbypassrls AS role_bypass_rls
+FROM pg_catalog.pg_class child
+JOIN pg_catalog.pg_namespace namespace ON namespace.oid = child.relnamespace
+JOIN pg_catalog.pg_roles current_role_row ON current_role_row.rolname = current_user
+LEFT JOIN pg_catalog.pg_class root ON root.oid = pg_catalog.pg_partition_root(child.oid)
+WHERE namespace.nspname = $1
+  AND child.relkind IN ('r', 'p')
+ORDER BY child.relname`;
+
+function fail(code: string, details: string[]): never {
+  throw new Error(`${code}: ${details.sort().join(",")}`);
+}
+
+/**
+ * Assess a catalog snapshot without changing it. The activation invariant is
+ * all-or-nothing: policies may be staged while every table remains disabled,
+ * but once any table is enabled, every protected table and partition must be
+ * ENABLE+FORCE in the same snapshot. This structural gate deliberately does
+ * not claim that staged policy expressions are semantically correct; the
+ * policy generator and cross-tenant proofs remain separate activation gates.
+ */
+export function assessRlsCatalogSnapshot(
+  rows: RlsCatalogRow[],
+  expectedProtected: readonly string[] = RLS_ACTIVATION_TABLES,
+  expectedGlobal: readonly string[] = Object.keys(INTENTIONALLY_GLOBAL_TABLES),
+): RlsCatalogAssessment {
+  const protectedSet = new Set(expectedProtected);
+  const globalSet = new Set(expectedGlobal);
+  const inventorySet = new Set([...protectedSet, ...globalSet]);
+  const ordinaryRows = rows.filter((row) => row.partition_root === null);
+  const partitions = rows.filter((row) => row.partition_root !== null);
+  const actual = new Set(ordinaryRows.map((row) => row.table_name));
+  const missing = [...inventorySet].filter((table) => !actual.has(table));
+  const unknown = [...actual].filter(
+    (table) => !inventorySet.has(table) && table !== "__steward_migrations",
+  );
+  const orphanPartitions = partitions
+    .filter((row) => !row.partition_root || !protectedSet.has(row.partition_root))
+    .map((row) => row.table_name);
+  if (missing.length || unknown.length || orphanPartitions.length) {
+    fail("RLS_CATALOG_INVENTORY_MISMATCH", [
+      ...missing.map((name) => `missing:${name}`),
+      ...unknown.map((name) => `unknown:${name}`),
+      ...orphanPartitions.map((name) => `partition:${name}`),
+    ]);
+  }
+
+  const globalRls = ordinaryRows
+    .filter((row) => globalSet.has(row.table_name) && (row.rls_enabled || row.rls_forced))
+    .map((row) => row.table_name);
+  if (globalRls.length) fail("RLS_CATALOG_GLOBAL_TABLE_PROTECTED", globalRls);
+
+  const protectedRows = ordinaryRows.filter((row) => protectedSet.has(row.table_name));
+  const activationRows = [...protectedRows, ...partitions];
+  const anyEnabled = activationRows.some((row) => row.rls_enabled || row.rls_forced);
+  const staged = protectedRows.some((row) => row.policy_count > 0);
+  const policiesComplete = protectedRows.every((row) => row.policy_count > 0);
+
+  if (!anyEnabled) {
+    return {
+      state: staged ? "policies-staged" : "inactive",
+      policyCoverageComplete: policiesComplete,
+      protectedTableCount: protectedRows.length,
+      partitionCount: partitions.length,
+    };
+  }
+
+  const incomplete = activationRows
+    .filter((row) => !row.rls_enabled || !row.rls_forced)
+    .map((row) => row.table_name);
+  const missingPolicies = protectedRows
+    .filter((row) => row.policy_count === 0)
+    .map((row) => row.table_name);
+  if (incomplete.length || missingPolicies.length) {
+    fail("RLS_CATALOG_PARTIAL_ACTIVATION", [
+      ...incomplete.map((name) => `flags:${name}`),
+      ...missingPolicies.map((name) => `policy:${name}`),
+    ]);
+  }
+
+  const unsafeRole = protectedRows[0];
+  if (
+    unsafeRole?.role_super ||
+    unsafeRole?.role_bypass_rls ||
+    protectedRows.some((row) => row.owned_by_current_role)
+  ) {
+    fail(
+      "RLS_CATALOG_UNSAFE_APPLICATION_ROLE",
+      [
+        unsafeRole?.role_super ? "superuser" : "",
+        unsafeRole?.role_bypass_rls ? "bypassrls" : "",
+        ...protectedRows
+          .filter((row) => row.owned_by_current_role)
+          .map((row) => `owner:${row.table_name}`),
+      ].filter(Boolean),
+    );
+  }
+
+  return {
+    state: "active",
+    policyCoverageComplete: true,
+    protectedTableCount: protectedRows.length,
+    partitionCount: partitions.length,
+  };
+}
+
+export async function inspectRlsCatalog(
+  client: RlsCatalogClient,
+  schema = "public",
+): Promise<RlsCatalogAssessment> {
+  if (!/^[A-Za-z_][A-Za-z0-9_]{0,62}$/.test(schema)) {
+    throw new Error("RLS_CATALOG_SCHEMA_INVALID");
+  }
+  const rows = await client.unsafe(CATALOG_QUERY, [schema]);
+  return assessRlsCatalogSnapshot(rows);
+}
+
+// Compile-time/runtime evidence that the activation and global sets still
+// cover the inventory; the inventory test provides the schema-table proof.
+if (
+  new Set([...RLS_ACTIVATION_TABLES, ...Object.keys(INTENTIONALLY_GLOBAL_TABLES)]).size !==
+  ALL_INVENTORIED_TABLES.length
+) {
+  throw new Error("RLS_CATALOG_STATIC_INVENTORY_MISMATCH");
+}

--- a/packages/db/src/rls-catalog-gate.ts
+++ b/packages/db/src/rls-catalog-gate.ts
@@ -16,7 +16,12 @@ export const RLS_ACTIVATION_TABLES = [
   ...Object.keys(BOOTSTRAP_ROOT_TABLES),
 ].sort();
 
-export const CORE_RLS_EXCLUDED_TABLES = [...Object.keys(INTENTIONALLY_GLOBAL_TABLES)].sort();
+export const CORE_RLS_EXCLUDED_TABLES = [
+  ...Object.keys(INTENTIONALLY_GLOBAL_TABLES),
+  // Migration 0009 always creates this auth compatibility store. It has no
+  // tenant column; tenant binding lives in opaque, namespaced keys.
+  "auth_kv_store",
+].sort();
 
 export interface RlsCatalogInventory {
   protectedTables: readonly string[];
@@ -28,13 +33,6 @@ export interface RlsCatalogInventoryContribution {
   protectedTables?: readonly string[];
   rlsExcludedTables?: readonly string[];
 }
-
-export const AUTH_RLS_CATALOG_INVENTORY_CONTRIBUTION: RlsCatalogInventoryContribution = {
-  owner: "@stwd/auth",
-  // This compatibility store exists only when auth uses PostgreSQL. It has no
-  // tenant column; tenant binding lives in opaque, namespaced keys.
-  rlsExcludedTables: ["auth_kv_store"],
-};
 
 export const CORE_RLS_CATALOG_INVENTORY: RlsCatalogInventory = {
   protectedTables: RLS_ACTIVATION_TABLES,
@@ -137,12 +135,19 @@ WITH runtime_role AS (
   SELECT oid
     FROM pg_catalog.pg_roles
    WHERE rolname = $2
+), server_capabilities AS (
+  SELECT current_setting('server_version_num')::integer >= 160000 AS role_membership_options
 ), assumable_roles AS (
   SELECT candidate.oid, candidate.rolsuper, candidate.rolbypassrls
     FROM pg_catalog.pg_roles candidate
     CROSS JOIN runtime_role runtime
+    CROSS JOIN server_capabilities capabilities
    WHERE candidate.oid = runtime.oid
-      OR pg_catalog.pg_has_role(runtime.oid, candidate.oid, 'SET')
+      OR pg_catalog.pg_has_role(
+           runtime.oid,
+           candidate.oid,
+           CASE WHEN capabilities.role_membership_options THEN 'SET' ELSE 'MEMBER' END
+         )
 ), usable_roles AS (
   SELECT candidate.oid
     FROM pg_catalog.pg_roles candidate


### PR DESCRIPTION
## SEC-169 bounded checkpoint

Adds a read-only structural catalog gate without creating policies, enabling RLS, or wiring startup activation. The gate permits an entirely inactive catalog and structurally staged policies while every RLS flag remains off. Once any protected table or partition is enabled, it requires the complete composed inventory to be `ENABLE` + `FORCE` in the same catalog snapshot.

The catalog traversal is relation-OID based and includes descendants stored outside the root schema. The caller must explicitly name the runtime role; the gate rejects owner privileges available through `USAGE` or assumption, and `SUPERUSER`/`BYPASSRLS` attributes on the runtime or an assumable role. PostgreSQL 16+ uses per-membership `SET`; PostgreSQL 15 conservatively treats every `MEMBER` role as assumable.

The mandatory inventory covers core Drizzle tables plus always-migrated `auth_kv_store`. Plugins add explicit owned contributions; contributions extend but cannot replace core, and unknown, missing, invalid, or duplicate classifications fail closed. Policy counts remain structural evidence only and do not claim semantic correctness.

## Exact local evidence (`44f059d9381461661888bb3bcfb03e893cb8a4cf`)

- catalog + inventory unit: 9 pass, 102 assertions
- real PostgreSQL 16: 1 pass, 8 assertions; covers external-schema partition discovery, partial activation, full active restricted-role success, inherited-only owner rejection (`USAGE=true`, `SET=false`), assumable-only BYPASSRLS rejection (`SET=true`, `USAGE=false`), SUPERUSER rejection, mandatory auth inventory, and plugin inventory
- PostgreSQL 15 compatibility is a dedicated lightweight job in both PR and develop CI; hosted exact-head result pending
- DB dependency build: 5/5 packages, uncached
- DB direct TypeScript build: pass
- Biome exact TypeScript files: pass
- actionlint and CI test inventory: pass
- diff check: pass

## Still blocked / not included

SEC-169 remains open. This does not enable RLS and is not wired to startup. Restricted bootstrap functions, full request/background transaction propagation, generated direct/derived/hybrid policy expressions, all-table activation, and cross-tenant CRUD/join/upsert proofs remain required.

Draft pending independent exact-head and hosted PostgreSQL 15/16 review. Do not merge until those checks complete.