### PR TITLE
fix(eliza): keep API URL normalization linear

### DIFF
--- a/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
+++ b/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
@@ -88,6 +88,34 @@ describe("SUBMIT_TRADE action", () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe(`${nearMiss}/v1/trade/sessions/ses_test`);
   });
 
+  it("strips terminal slash runs while preserving redirect refusal", async () => {
+    process.env.STEWARD_API_URL = `https://steward.example${"/".repeat(200_000)}`;
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, data: { status: "active" } }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      submitTradeAction.validate({} as any, mockMemory("buy 0.01 BTC") as any),
+    ).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://steward.example/v1/trade/sessions/ses_test",
+      expect.objectContaining({ redirect: "error" }),
+    );
+  });
+
+  it("rejects credential-bearing URLs after terminal slash normalization", async () => {
+    process.env.STEWARD_API_URL = "https://user:secret@steward.example////";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      submitTradeAction.validate({} as any, mockMemory("buy 0.01 BTC") as any),
+    ).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("posts parsed order with Bearer JWT and returns confirmation", async () => {
     const fetchMock = vi.fn(
       async () =>

--- a/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
+++ b/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
@@ -73,6 +73,21 @@ describe("SUBMIT_TRADE action", () => {
     );
   });
 
+  it("normalizes adversarial API URL slash runs without regex backtracking", async () => {
+    const nearMiss = `https://steward.example/${"/".repeat(200_000)}x`;
+    process.env.STEWARD_API_URL = nearMiss;
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, data: { status: "active" } }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      submitTradeAction.validate({} as any, mockMemory("buy 0.01 BTC") as any),
+    ).resolves.toBe(true);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(`${nearMiss}/v1/trade/sessions/ses_test`);
+  });
+
   it("posts parsed order with Bearer JWT and returns confirmation", async () => {
     const fetchMock = vi.fn(
       async () =>

--- a/packages/eliza-plugin/src/actions/submit-trade.ts
+++ b/packages/eliza-plugin/src/actions/submit-trade.ts
@@ -77,8 +77,15 @@ function stewardJwt(runtime: IAgentRuntime): string | undefined {
   return envValue(runtime, "STEWARD_JWT");
 }
 
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 0x2f) end -= 1;
+  return end === value.length ? value : value.slice(0, end);
+}
+
 function stewardApiUrl(runtime: IAgentRuntime): string | undefined {
-  const apiUrl = envValue(runtime, "STEWARD_API_URL")?.replace(/\/+$/, "");
+  const configuredUrl = envValue(runtime, "STEWARD_API_URL");
+  const apiUrl = configuredUrl ? stripTrailingSlashes(configuredUrl) : undefined;
   // Reject plaintext non-localhost URLs here too: this action reads the env URL
   // directly and would otherwise send the agent JWT in cleartext.
   if (apiUrl) assertSecureApiUrl(apiUrl);


### PR DESCRIPTION
## Summary
- replace polynomial trailing-slash regex in `SUBMIT_TRADE` URL normalization with a linear scan
- add an adversarial near-miss regression covering a 200,000-slash runtime URL

## Security context
This was found while reconciling open CodeQL alerts #1-17, #30, #32, #33, #35, and #39-41 against current `develop`. The alert-era ReDoS sinks are already stale after #518/#526, but this adjacent runtime URL path had reintroduced the same normalization pattern.

## Validation
- `bunx turbo run build --filter=@stwd/eliza-plugin...` (12/12)
- `bunx vitest run packages/eliza-plugin/src/__tests__/submit-trade.test.ts` (15/15)
- `bunx biome check packages/eliza-plugin/src/actions/submit-trade.ts packages/eliza-plugin/src/__tests__/submit-trade.test.ts`
- `git diff --check HEAD^ HEAD`