### PR TITLE
fix(auth): close publication concurrency gaps

### DIFF
--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -31,6 +31,7 @@ class CapturingBackend implements StoreBackend {
   failActiveWritesAfterCommit = false;
   failReadsAfterActiveCommit = false;
   activeTransitionFailuresAfterCommit = 0;
+  afterActivationCommitBeforeLostAck?: () => Promise<void>;
   failDeletes = false;
   replaceGuardBeforeTransition = false;
 
@@ -152,6 +153,7 @@ class CapturingBackend implements StoreBackend {
       entries.some((entry) => this.isActivation(entry.key, entry.value)) &&
       this.activeTransitionFailuresAfterCommit++ === 0
     ) {
+      await this.afterActivationCommitBeforeLostAck?.();
       throw new Error("durable activation response lost");
     }
     return true;
@@ -825,6 +827,104 @@ describe("fail-closed magic-link delivery", () => {
     const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
     expect(await auth.verifyOtp("otp-ack-loss@example.com", code, "tenant-a")).toBe(true);
     auth.destroy();
+  });
+
+  it("confirms a magic-link commit after lost acknowledgement and a newer failed reservation", async () => {
+    const backend = new CapturingBackend();
+    let firstText = "";
+    let secondProviderStarted!: () => void;
+    const secondProviderEntered = new Promise<void>((resolve) => {
+      secondProviderStarted = resolve;
+    });
+    let rejectSecond!: (reason: unknown) => void;
+    const secondProviderResult = new Promise<never>((_resolve, reject) => {
+      rejectSecond = reject;
+    });
+    const first = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          firstText = body;
+          backend.failActiveWritesAfterCommit = true;
+          return { provider: "test", id: "first-committed-before-ack-loss" };
+        },
+      },
+      backend,
+    );
+    const second = buildAuth(
+      {
+        send: async () => {
+          secondProviderStarted();
+          return secondProviderResult;
+        },
+      },
+      backend,
+    );
+    let secondSend: Promise<unknown> | undefined;
+    backend.afterActivationCommitBeforeLostAck = async () => {
+      secondSend = second.sendMagicLink("ack-reservation@example.com", {
+        tenantId: "tenant-a",
+      });
+      await secondProviderEntered;
+    };
+
+    await first.sendMagicLink("ack-reservation@example.com", { tenantId: "tenant-a" });
+    rejectSecond(new Error("SECOND_PROVIDER_SECRET_CANARY"));
+    if (!secondSend) throw new Error("newer issuance did not start");
+    await expect(secondSend).rejects.toThrow(EmailDeliveryError);
+
+    const token = firstText.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    expect(
+      await first.verifyMagicLink(token, "ack-reservation@example.com", "tenant-a"),
+    ).toMatchObject({ valid: true });
+    first.destroy();
+    second.destroy();
+  });
+
+  it("confirms an OTP commit after lost acknowledgement and a newer failed reservation", async () => {
+    const backend = new CapturingBackend();
+    let firstText = "";
+    let secondProviderStarted!: () => void;
+    const secondProviderEntered = new Promise<void>((resolve) => {
+      secondProviderStarted = resolve;
+    });
+    let rejectSecond!: (reason: unknown) => void;
+    const secondProviderResult = new Promise<never>((_resolve, reject) => {
+      rejectSecond = reject;
+    });
+    const first = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          firstText = body;
+          backend.failActiveWritesAfterCommit = true;
+          return { provider: "test", id: "first-otp-committed-before-ack-loss" };
+        },
+      },
+      backend,
+    );
+    const second = buildAuth(
+      {
+        send: async () => {
+          secondProviderStarted();
+          return secondProviderResult;
+        },
+      },
+      backend,
+    );
+    let secondSend: Promise<unknown> | undefined;
+    backend.afterActivationCommitBeforeLostAck = async () => {
+      secondSend = second.sendOtp("otp-ack-reservation@example.com", { tenantId: "tenant-a" });
+      await secondProviderEntered;
+    };
+
+    await first.sendOtp("otp-ack-reservation@example.com", { tenantId: "tenant-a" });
+    rejectSecond(new Error("SECOND_PROVIDER_SECRET_CANARY"));
+    if (!secondSend) throw new Error("newer OTP issuance did not start");
+    await expect(secondSend).rejects.toThrow(EmailDeliveryError);
+
+    const code = firstText.match(/\b(\d{6})\b/)?.[1] ?? "";
+    expect(await first.verifyOtp("otp-ack-reservation@example.com", code, "tenant-a")).toBe(true);
+    first.destroy();
+    second.destroy();
   });
 
   it("keeps only the newest concurrently published challenge across independent instances", async () => {

--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -191,6 +191,25 @@ function buildAuth(provider: EmailProvider | undefined, backend: CapturingBacken
   });
 }
 
+function expectOpaqueBoundedPublicationReceipt(
+  backend: CapturingBackend,
+  canaries: readonly string[],
+): void {
+  const receipts = [...backend.values.entries()].filter(([key]) =>
+    key.startsWith("email-issuance:published:"),
+  );
+  expect(receipts).toHaveLength(1);
+  const [key, receipt] = receipts[0]!;
+  expect(key).toMatch(/^email-issuance:published:[0-9a-f]{64}$/);
+  expect(receipt.value).toMatch(/^published:[0-9a-f]{64}$/);
+  expect(key.slice("email-issuance:published:".length)).toBe(
+    receipt.value.slice("published:".length),
+  );
+  expect(receipt.expiresAt).toBeGreaterThan(Date.now());
+  expect(receipt.expiresAt).toBeLessThanOrEqual(Date.now() + 10 * 60_000);
+  for (const canary of canaries) expect(`${key}:${receipt.value}`).not.toContain(canary);
+}
+
 async function legacyVerifyMagicLink(backend: StoreBackend, token: string): Promise<boolean> {
   const challengeId = await backend.consume(`email-login:link:${hashSha256Hex(token)}`);
   if (!challengeId) return false;
@@ -873,6 +892,11 @@ describe("fail-closed magic-link delivery", () => {
     await expect(secondSend).rejects.toThrow(EmailDeliveryError);
 
     const token = firstText.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    expectOpaqueBoundedPublicationReceipt(backend, [
+      "ack-reservation@example.com",
+      "tenant-a",
+      token,
+    ]);
     expect(
       await first.verifyMagicLink(token, "ack-reservation@example.com", "tenant-a"),
     ).toMatchObject({ valid: true });
@@ -922,6 +946,11 @@ describe("fail-closed magic-link delivery", () => {
     await expect(secondSend).rejects.toThrow(EmailDeliveryError);
 
     const code = firstText.match(/\b(\d{6})\b/)?.[1] ?? "";
+    expectOpaqueBoundedPublicationReceipt(backend, [
+      "otp-ack-reservation@example.com",
+      "tenant-a",
+      code,
+    ]);
     expect(await first.verifyOtp("otp-ack-reservation@example.com", code, "tenant-a")).toBe(true);
     first.destroy();
     second.destroy();

--- a/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
@@ -9,9 +9,7 @@ const sql = databaseUrl ? postgres(databaseUrl, { max: 3 }) : null;
 
 setDefaultTimeout(30_000);
 
-type ObservedOutcome<T> =
-  | { ok: true; value: T }
-  | { ok: false; error: unknown };
+type ObservedOutcome<T> = { ok: true; value: T } | { ok: false; error: unknown };
 
 function observePromise<T>(promise: Promise<T>): Promise<ObservedOutcome<T>> {
   return promise.then(

--- a/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
@@ -9,6 +9,17 @@ const sql = databaseUrl ? postgres(databaseUrl, { max: 3 }) : null;
 
 setDefaultTimeout(30_000);
 
+type ObservedOutcome<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: unknown };
+
+function observePromise<T>(promise: Promise<T>): Promise<ObservedOutcome<T>> {
+  return promise.then(
+    (value) => ({ ok: true, value }),
+    (error) => ({ ok: false, error }),
+  );
+}
+
 async function waitForBlockedPublisher(lockKey: string, lockerPid: number): Promise<number> {
   if (!sql) throw new Error("DATABASE_URL required");
   for (let attempt = 0; attempt < 500; attempt += 1) {
@@ -81,6 +92,7 @@ integration("Postgres email challenge publication", () => {
     >`SELECT pg_backend_pid() AS pid`;
     let locked = false;
     let stale: Promise<boolean> | undefined;
+    let staleOutcome: Promise<ObservedOutcome<boolean>> | undefined;
     try {
       await locker`SELECT pg_advisory_lock(hashtextextended(${lockKey}, 0))`;
       locked = true;
@@ -93,6 +105,7 @@ integration("Postgres email challenge publication", () => {
           expected: "generation-old",
         },
       ]);
+      staleOutcome = observePromise(stale);
 
       const publisherPid = await waitForBlockedPublisher(lockKey, lockerPid);
       expect(publisherPid).not.toBe(lockerPid);
@@ -106,10 +119,13 @@ integration("Postgres email challenge publication", () => {
         await locker`SELECT pg_advisory_unlock(hashtextextended(${lockKey}, 0))`;
       }
       locker.release();
+      if (staleOutcome) await staleOutcome;
     }
 
-    if (!stale) throw new Error("stale publication did not start");
-    expect(await stale).toBe(false);
+    if (!staleOutcome || !stale) throw new Error("stale publication did not start");
+    const staleResult = await staleOutcome;
+    if (!staleResult.ok) throw staleResult.error;
+    expect(staleResult.value).toBe(false);
     expect(await backend.get("challenge-old")).toBeNull();
     const current = [
       { key: "challenge-new", value: "active-new", ttlMs: 60_000 },
@@ -144,6 +160,7 @@ integration("Postgres email challenge publication", () => {
     >`SELECT pg_backend_pid() AS pid`;
     let transactionOpen = false;
     let publication: Promise<boolean> | undefined;
+    let publicationOutcome: Promise<ObservedOutcome<boolean>> | undefined;
     try {
       await locker`BEGIN`;
       transactionOpen = true;
@@ -162,6 +179,7 @@ integration("Postgres email challenge publication", () => {
           expected: "generation-old",
         },
       ]);
+      publicationOutcome = observePromise(publication);
 
       const publisherPid = await waitForPublisherBlockedAfterGuard(
         `${namespace}:${targetKey}`,
@@ -182,10 +200,13 @@ integration("Postgres email challenge publication", () => {
     } finally {
       if (transactionOpen) await locker`ROLLBACK`;
       locker.release();
+      if (publicationOutcome) await publicationOutcome;
     }
 
-    if (!publication) throw new Error("publication did not start");
-    expect(await publication).toBe(false);
+    if (!publicationOutcome || !publication) throw new Error("publication did not start");
+    const publicationResult = await publicationOutcome;
+    if (!publicationResult.ok) throw publicationResult.error;
+    expect(publicationResult.value).toBe(false);
     expect(await backend.get(targetKey)).toBe("generation-ordinary");
     expect(await backend.get(blockerKey)).toBe("blocker-original");
     expect(await backend.get("challenge")).toBeNull();
@@ -212,6 +233,7 @@ integration("Postgres email challenge publication", () => {
       >`SELECT pg_backend_pid() AS pid`;
       let transactionOpen = false;
       let publication: Promise<boolean> | undefined;
+      let publicationOutcome: Promise<ObservedOutcome<boolean>> | undefined;
       try {
         await locker`BEGIN`;
         transactionOpen = true;
@@ -225,6 +247,7 @@ integration("Postgres email challenge publication", () => {
           { key: "challenge", value: "active", ttlMs: 60_000 },
           { key: targetKey, value: "generation-published", ttlMs: 60_000, expected: null },
         ]);
+        publicationOutcome = observePromise(publication);
 
         await waitForPublisherBlockedAfterGuard(`${namespace}:${targetKey}`, lockerPid);
         await sql`
@@ -238,10 +261,13 @@ integration("Postgres email challenge publication", () => {
       } finally {
         if (transactionOpen) await locker`ROLLBACK`;
         locker.release();
+        if (publicationOutcome) await publicationOutcome;
       }
 
-      if (!publication) throw new Error("publication did not start");
-      expect(await publication).toBe(false);
+      if (!publicationOutcome || !publication) throw new Error("publication did not start");
+      const publicationResult = await publicationOutcome;
+      if (!publicationResult.ok) throw publicationResult.error;
+      expect(publicationResult.value).toBe(false);
       expect(await backend.get(targetKey)).toBe("generation-ordinary");
       expect(await backend.get(blockerKey)).toBe("blocker-original");
       expect(await backend.get("challenge")).toBeNull();

--- a/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
@@ -5,7 +5,7 @@ import { PostgresBackend } from "../store-backends";
 
 const databaseUrl = process.env.DATABASE_URL;
 const integration = describe.skipIf(!databaseUrl);
-const sql = databaseUrl ? postgres(databaseUrl, { max: 2 }) : null;
+const sql = databaseUrl ? postgres(databaseUrl, { max: 3 }) : null;
 
 setDefaultTimeout(30_000);
 
@@ -31,6 +31,35 @@ async function waitForBlockedPublisher(lockKey: string, lockerPid: number): Prom
     await Bun.sleep(10);
   }
   throw new Error("timed out waiting for the stale publisher to block on the guarded key");
+}
+
+async function waitForPublisherBlockedAfterGuard(
+  guardedLockKey: string,
+  lockerPid: number,
+): Promise<number> {
+  if (!sql) throw new Error("DATABASE_URL required");
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    const rows = await sql<Array<{ pid: number }>>`
+      WITH target AS (
+        SELECT hashtextextended(${guardedLockKey}, 0)::bigint AS key
+      )
+      SELECT DISTINCT locks.pid
+        FROM pg_locks AS locks
+        JOIN pg_stat_activity AS activity ON activity.pid = locks.pid
+        CROSS JOIN target
+       WHERE locks.locktype = 'advisory'
+         AND locks.granted = true
+         AND locks.pid <> ${lockerPid}
+         AND locks.database = (SELECT oid FROM pg_database WHERE datname = current_database())
+         AND locks.classid::bigint = ((target.key >> 32) & 4294967295)
+         AND locks.objid::bigint = (target.key & 4294967295)
+         AND locks.objsubid = 1
+         AND activity.wait_event_type = 'Lock'
+    `;
+    if (rows[0]) return rows[0].pid;
+    await Bun.sleep(10);
+  }
+  throw new Error("timed out waiting for publication after its guard read");
 }
 
 integration("Postgres email challenge publication", () => {
@@ -98,5 +127,67 @@ integration("Postgres email challenge publication", () => {
       ]),
     ).rejects.toThrow("Store publication contains duplicate keys");
     expect(await backend.get("duplicate")).toBeNull();
+  });
+
+  it("never overwrites an ordinary writer that commits after the guard read", async () => {
+    if (!sql) throw new Error("DATABASE_URL required");
+    const namespace = `email-publish-post-guard-${crypto.randomUUID()}`;
+    const backend = new PostgresBackend(namespace);
+    const blockerKey = "00-blocker";
+    const targetKey = "target";
+    await backend.set(blockerKey, "blocker-original", 60_000);
+    await backend.set(targetKey, "generation-old", 60_000);
+
+    const locker = await sql.reserve();
+    const [{ pid: lockerPid }] = await locker<
+      Array<{ pid: number }>
+    >`SELECT pg_backend_pid() AS pid`;
+    let transactionOpen = false;
+    let publication: Promise<boolean> | undefined;
+    try {
+      await locker`BEGIN`;
+      transactionOpen = true;
+      await locker`
+        SELECT value FROM auth_kv_store
+         WHERE id = ${blockerKey} AND namespace = ${namespace}
+         FOR UPDATE
+      `;
+      publication = backend.publish([
+        { key: blockerKey, value: "blocker-published", ttlMs: 60_000 },
+        { key: "challenge", value: "active", ttlMs: 60_000 },
+        {
+          key: targetKey,
+          value: "generation-published",
+          ttlMs: 60_000,
+          expected: "generation-old",
+        },
+      ]);
+
+      const publisherPid = await waitForPublisherBlockedAfterGuard(
+        `${namespace}:${targetKey}`,
+        lockerPid,
+      );
+      expect(publisherPid).not.toBe(lockerPid);
+
+      // This is the write used by a pre-#550 pod: it deliberately does not
+      // participate in the new publisher's advisory-lock protocol.
+      await sql`
+        INSERT INTO auth_kv_store (id, namespace, value, expires_at)
+        VALUES (${targetKey}, ${namespace}, 'generation-ordinary', now() + interval '1 minute')
+        ON CONFLICT (id, namespace) DO UPDATE
+          SET value = EXCLUDED.value, expires_at = EXCLUDED.expires_at
+      `;
+      await locker`COMMIT`;
+      transactionOpen = false;
+    } finally {
+      if (transactionOpen) await locker`ROLLBACK`;
+      locker.release();
+    }
+
+    if (!publication) throw new Error("publication did not start");
+    expect(await publication).toBe(false);
+    expect(await backend.get(targetKey)).toBe("generation-ordinary");
+    expect(await backend.get(blockerKey)).toBe("blocker-original");
+    expect(await backend.get("challenge")).toBeNull();
   });
 });

--- a/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
@@ -190,4 +190,61 @@ integration("Postgres email challenge publication", () => {
     expect(await backend.get(blockerKey)).toBe("blocker-original");
     expect(await backend.get("challenge")).toBeNull();
   });
+
+  it("protects absent and expired guards from an ordinary post-read insert", async () => {
+    if (!sql) throw new Error("DATABASE_URL required");
+    for (const initialState of ["absent", "expired"] as const) {
+      const namespace = `email-publish-null-guard-${initialState}-${crypto.randomUUID()}`;
+      const backend = new PostgresBackend(namespace);
+      const blockerKey = "00-blocker";
+      const targetKey = "target";
+      await backend.set(blockerKey, "blocker-original", 60_000);
+      if (initialState === "expired") {
+        await sql`
+          INSERT INTO auth_kv_store (id, namespace, value, expires_at)
+          VALUES (${targetKey}, ${namespace}, 'generation-expired', now() - interval '1 minute')
+        `;
+      }
+
+      const locker = await sql.reserve();
+      const [{ pid: lockerPid }] = await locker<
+        Array<{ pid: number }>
+      >`SELECT pg_backend_pid() AS pid`;
+      let transactionOpen = false;
+      let publication: Promise<boolean> | undefined;
+      try {
+        await locker`BEGIN`;
+        transactionOpen = true;
+        await locker`
+          SELECT value FROM auth_kv_store
+           WHERE id = ${blockerKey} AND namespace = ${namespace}
+           FOR UPDATE
+        `;
+        publication = backend.publish([
+          { key: blockerKey, value: "blocker-published", ttlMs: 60_000 },
+          { key: "challenge", value: "active", ttlMs: 60_000 },
+          { key: targetKey, value: "generation-published", ttlMs: 60_000, expected: null },
+        ]);
+
+        await waitForPublisherBlockedAfterGuard(`${namespace}:${targetKey}`, lockerPid);
+        await sql`
+          INSERT INTO auth_kv_store (id, namespace, value, expires_at)
+          VALUES (${targetKey}, ${namespace}, 'generation-ordinary', now() + interval '1 minute')
+          ON CONFLICT (id, namespace) DO UPDATE
+            SET value = EXCLUDED.value, expires_at = EXCLUDED.expires_at
+        `;
+        await locker`COMMIT`;
+        transactionOpen = false;
+      } finally {
+        if (transactionOpen) await locker`ROLLBACK`;
+        locker.release();
+      }
+
+      if (!publication) throw new Error("publication did not start");
+      expect(await publication).toBe(false);
+      expect(await backend.get(targetKey)).toBe("generation-ordinary");
+      expect(await backend.get(blockerKey)).toBe("blocker-original");
+      expect(await backend.get("challenge")).toBeNull();
+    }
+  });
 });

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -251,6 +251,10 @@ function issuancePublicationMarker(reservation: string): string {
   return `published:${hashSha256Hex(reservation)}`;
 }
 
+function issuancePublicationReceiptKey(reservation: string): string {
+  return `email-issuance:published:${hashSha256Hex(reservation)}`;
+}
+
 function parseIssuanceReservation(value: string | null): IssuanceReservation | null {
   if (!value?.startsWith("{")) return null;
   try {
@@ -562,13 +566,25 @@ export class EmailAuth {
     );
   }
 
-  private async publishChallenge(entries: readonly StorePublishEntry[]): Promise<boolean> {
+  private async publishChallenge(
+    entries: readonly StorePublishEntry[],
+    confirmOwnPublication?: () => Promise<boolean>,
+  ): Promise<boolean> {
     let lastError: unknown;
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
-        return await this.tokenStore.publish(entries);
+        const published = await this.tokenStore.publish(entries);
+        if (published || !lastError || !confirmOwnPublication) return published;
+        return await confirmOwnPublication();
       } catch (error) {
         lastError = error;
+        if (confirmOwnPublication) {
+          try {
+            if (await confirmOwnPublication()) return true;
+          } catch {
+            // The durable outcome remains ambiguous; retry the atomic publish.
+          }
+        }
       }
     }
     throw lastError;
@@ -641,6 +657,8 @@ export class EmailAuth {
       reservation,
       prior: priorChallengeId,
     } = await this.reserveIssuance(targetKey, challengeId, ttlMs);
+    const publicationReceiptKey = issuancePublicationReceiptKey(reservation);
+    const publicationReceipt = issuancePublicationMarker(reservation);
 
     const codeVerifier = this.codeVerifier(email, context.tenantId, code);
     const challenge: EmailLoginChallengeRecord = {
@@ -714,53 +732,64 @@ export class EmailAuth {
     try {
       // Publish only legacy-readable records. Until this atomic operation
       // commits, neither old nor new pods can discover the staged credential.
-      const published = await this.publishChallenge([
-        { key: stagingKey, value: null, ttlMs: remainingTtlMs },
-        ...(priorChallengeId
-          ? [
-              {
-                key: emailLoginChallengeKey(priorChallengeId),
-                value: null,
-                ttlMs: remainingTtlMs,
-              },
-              {
-                key: emailLoginStatusKey(priorChallengeId),
-                value: null,
-                ttlMs: remainingTtlMs,
-              },
-            ]
-          : []),
-        {
-          key: emailLoginChallengeKey(challengeId),
-          value: JSON.stringify({
-            ...challenge,
-            status: "pending",
-          } satisfies EmailLoginChallengeRecord),
-          ttlMs: remainingTtlMs,
-        },
-        {
-          key: emailLoginStatusKey(challengeId),
-          value: JSON.stringify({
-            ...stagedStatus,
-            status: "pending",
-          } satisfies EmailLoginStatusRecord),
-          ttlMs: remainingTtlMs,
-        },
-        { key: emailLoginLinkAliasKey(tokenHash), value: challengeId, ttlMs: remainingTtlMs },
-        { key: emailLoginCodeAliasKey(codeVerifier), value: challengeId, ttlMs: remainingTtlMs },
-        {
-          key: targetKey,
-          value: challengeId,
-          ttlMs: remainingTtlMs,
-          expected: priorChallengeId,
-        },
-        {
-          key: reservationKey,
-          value: issuancePublicationMarker(reservation),
-          ttlMs: remainingTtlMs,
-          expected: reservation,
-        },
-      ]);
+      const published = await this.publishChallenge(
+        [
+          { key: stagingKey, value: null, ttlMs: remainingTtlMs },
+          ...(priorChallengeId
+            ? [
+                {
+                  key: emailLoginChallengeKey(priorChallengeId),
+                  value: null,
+                  ttlMs: remainingTtlMs,
+                },
+                {
+                  key: emailLoginStatusKey(priorChallengeId),
+                  value: null,
+                  ttlMs: remainingTtlMs,
+                },
+              ]
+            : []),
+          {
+            key: emailLoginChallengeKey(challengeId),
+            value: JSON.stringify({
+              ...challenge,
+              status: "pending",
+            } satisfies EmailLoginChallengeRecord),
+            ttlMs: remainingTtlMs,
+          },
+          {
+            key: emailLoginStatusKey(challengeId),
+            value: JSON.stringify({
+              ...stagedStatus,
+              status: "pending",
+            } satisfies EmailLoginStatusRecord),
+            ttlMs: remainingTtlMs,
+          },
+          { key: emailLoginLinkAliasKey(tokenHash), value: challengeId, ttlMs: remainingTtlMs },
+          { key: emailLoginCodeAliasKey(codeVerifier), value: challengeId, ttlMs: remainingTtlMs },
+          {
+            key: targetKey,
+            value: challengeId,
+            ttlMs: remainingTtlMs,
+            expected: priorChallengeId,
+          },
+          {
+            key: reservationKey,
+            value: publicationReceipt,
+            ttlMs: remainingTtlMs,
+            expected: reservation,
+          },
+          {
+            key: publicationReceiptKey,
+            value: publicationReceipt,
+            ttlMs: remainingTtlMs,
+            expected: null,
+          },
+        ],
+        async () =>
+          (await this.tokenStore.verify(publicationReceiptKey)) === publicationReceipt &&
+          (await this.tokenStore.verify(targetKey)) === challengeId,
+      );
       if (!published) throw new Error("email issuance was superseded");
     } catch (err) {
       await Promise.all([
@@ -798,6 +827,8 @@ export class EmailAuth {
       reservation,
       prior: priorStoreKey,
     } = await this.reserveIssuance(targetKey, stagingId, this.tokenTtlMs);
+    const publicationReceiptKey = issuancePublicationReceiptKey(reservation);
+    const publicationReceipt = issuancePublicationMarker(reservation);
     let storeKey = otpStoreKey(email, context.tenantId, code);
     // A repeated six-digit code would derive the prior issuance's exact key
     // and make an old email valid again. Regenerate before superseding it.
@@ -862,28 +893,39 @@ export class EmailAuth {
       throw new EmailDeliveryError("Email challenge activation failed");
     }
     try {
-      const published = await this.publishChallenge([
-        { key: stagingKey, value: null, ttlMs: remainingTtlMs },
-        ...(priorStoreKey ? [{ key: priorStoreKey, value: null, ttlMs: remainingTtlMs }] : []),
-        {
-          key: storeKey,
-          // Deployed pre-staging readers accept only the raw two-field payload.
-          value: JSON.stringify(payload),
-          ttlMs: remainingTtlMs,
-        },
-        {
-          key: targetKey,
-          value: storeKey,
-          ttlMs: remainingTtlMs,
-          expected: priorStoreKey,
-        },
-        {
-          key: reservationKey,
-          value: issuancePublicationMarker(reservation),
-          ttlMs: remainingTtlMs,
-          expected: reservation,
-        },
-      ]);
+      const published = await this.publishChallenge(
+        [
+          { key: stagingKey, value: null, ttlMs: remainingTtlMs },
+          ...(priorStoreKey ? [{ key: priorStoreKey, value: null, ttlMs: remainingTtlMs }] : []),
+          {
+            key: storeKey,
+            // Deployed pre-staging readers accept only the raw two-field payload.
+            value: JSON.stringify(payload),
+            ttlMs: remainingTtlMs,
+          },
+          {
+            key: targetKey,
+            value: storeKey,
+            ttlMs: remainingTtlMs,
+            expected: priorStoreKey,
+          },
+          {
+            key: reservationKey,
+            value: publicationReceipt,
+            ttlMs: remainingTtlMs,
+            expected: reservation,
+          },
+          {
+            key: publicationReceiptKey,
+            value: publicationReceipt,
+            ttlMs: remainingTtlMs,
+            expected: null,
+          },
+        ],
+        async () =>
+          (await this.tokenStore.verify(publicationReceiptKey)) === publicationReceipt &&
+          (await this.tokenStore.verify(targetKey)) === storeKey,
+      );
       if (!published) throw new Error("email issuance was superseded");
     } catch (err) {
       await Promise.all([

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -272,6 +272,14 @@ type TransactionSql = <T extends readonly unknown[] = readonly unknown[]>(
   ...values: readonly unknown[]
 ) => Promise<T>;
 
+function postgresErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const descriptor = Object.getOwnPropertyDescriptor(error, "code");
+  return descriptor && "value" in descriptor && typeof descriptor.value === "string"
+    ? descriptor.value
+    : undefined;
+}
+
 /**
  * Redis-backed store backend.
  * Uses atomic SET key value PX ttlMs for writes; native TTL handles expiry.
@@ -521,58 +529,68 @@ export class PostgresBackend implements StoreBackend {
       ...entry,
       expiresAt: new Date(Date.now() + entry.ttlMs).toISOString(),
     }));
-    let published = true;
-    await sql.begin(async (transaction: TransactionSql) => {
-      const ordered = [...prepared].sort((left, right) => left.key.localeCompare(right.key));
-      const guarded = ordered.filter((entry) => entry.expected !== undefined);
-      for (const entry of ordered) {
-        // An advisory transaction lock also serializes the absent-row case,
-        // which SELECT ... FOR UPDATE alone cannot protect at READ COMMITTED.
-        await transaction`
-          SELECT pg_advisory_xact_lock(
-            hashtextextended(${`${this.namespace}:${entry.key}`}, 0)
-          )
-        `;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      let published = true;
+      try {
+        await sql.begin("isolation level serializable", async (transaction: TransactionSql) => {
+          const ordered = [...prepared].sort((left, right) =>
+            left.key < right.key ? -1 : left.key > right.key ? 1 : 0,
+          );
+          const guarded = ordered.filter((entry) => entry.expected !== undefined);
+          for (const entry of ordered) {
+            // Cooperative publishers serialize absent rows here. SERIALIZABLE
+            // additionally detects older binaries and ordinary writers that do
+            // not participate in this advisory-lock protocol.
+            await transaction`
+              SELECT pg_advisory_xact_lock(
+                hashtextextended(${`${this.namespace}:${entry.key}`}, 0)
+              )
+            `;
+          }
+          let allExpected = true;
+          let allDesired = guarded.length > 0;
+          for (const entry of guarded) {
+            const rows = await transaction<Array<{ value: string }>>`
+              SELECT value
+                FROM auth_kv_store
+               WHERE id = ${entry.key}
+                 AND namespace = ${this.namespace}
+                 AND expires_at > now()
+               LIMIT 1
+            `;
+            const current = rows[0]?.value ?? null;
+            if (current !== entry.expected) allExpected = false;
+            if (current !== entry.value) allDesired = false;
+          }
+          if (allDesired) return;
+          if (!allExpected) {
+            published = false;
+            return;
+          }
+          for (const entry of prepared) {
+            if (entry.value === null) {
+              await transaction`
+                DELETE FROM auth_kv_store
+                 WHERE id = ${entry.key}
+                   AND namespace = ${this.namespace}
+              `;
+            } else {
+              await transaction`
+                INSERT INTO auth_kv_store (id, namespace, value, expires_at)
+                VALUES (${entry.key}, ${this.namespace}, ${entry.value}, ${entry.expiresAt})
+                ON CONFLICT (id, namespace) DO UPDATE
+                  SET value      = EXCLUDED.value,
+                      expires_at = EXCLUDED.expires_at
+              `;
+            }
+          }
+        });
+        return published;
+      } catch (error) {
+        if (postgresErrorCode(error) !== "40001" || attempt === 2) throw error;
       }
-      let allExpected = true;
-      let allDesired = guarded.length > 0;
-      for (const entry of guarded) {
-        const rows = await transaction<Array<{ value: string }>>`
-          SELECT value
-            FROM auth_kv_store
-           WHERE id = ${entry.key}
-             AND namespace = ${this.namespace}
-             AND expires_at > now()
-           LIMIT 1
-        `;
-        const current = rows[0]?.value ?? null;
-        if (current !== entry.expected) allExpected = false;
-        if (current !== entry.value) allDesired = false;
-      }
-      if (allDesired) return;
-      if (!allExpected) {
-        published = false;
-        return;
-      }
-      for (const entry of prepared) {
-        if (entry.value === null) {
-          await transaction`
-            DELETE FROM auth_kv_store
-             WHERE id = ${entry.key}
-               AND namespace = ${this.namespace}
-          `;
-        } else {
-          await transaction`
-            INSERT INTO auth_kv_store (id, namespace, value, expires_at)
-            VALUES (${entry.key}, ${this.namespace}, ${entry.value}, ${entry.expiresAt})
-            ON CONFLICT (id, namespace) DO UPDATE
-              SET value      = EXCLUDED.value,
-                  expires_at = EXCLUDED.expires_at
-          `;
-        }
-      }
-    });
-    return published;
+    }
+    return false;
   }
 
   async delete(key: string): Promise<void> {


### PR DESCRIPTION
Closes #564

## Summary
- run PostgreSQL batch publication at `SERIALIZABLE` and retry serialization failures so an ordinary or rolling old-pod write after the guard read cannot be overwritten
- add an immutable, TTL-bounded per-issuance commit receipt so magic-link and OTP sends can confirm their own publication after a lost storage acknowledgement, even when a newer issuance has reserved the target
- keep confirmation bound to both the exact receipt and the still-active target, preserving consumption safety and newer-writer ownership
- add behavioral magic-link/OTP overlap tests and deterministic real-PostgreSQL interleaving tests using an uncooperative legacy-style writer
- cover existing, absent, and expired publication guards plus receipt opacity, ownership, and TTL bounds

## Validation (exact head `3cf3d40cde19028903254864af94a7c2b3dda099`)
- `bun test --timeout 60000 packages/auth/src/__tests__/email-delivery-failclosed.test.ts packages/auth/src/__tests__/email.test.ts packages/auth/src/__tests__/store-backends.test.ts packages/auth/src/__tests__/challenge-store.test.ts` (60 pass, 229 assertions)
- `DATABASE_URL=... bun test --timeout 60000 packages/auth/src/__tests__/email-postgres-publish.integration.test.ts` against isolated PostgreSQL 16 (3 pass, 22 assertions)
- `bun run --cwd packages/auth build`
- `bunx turbo run build --filter=@stwd/auth...` (7/7 packages)
- Biome on all four changed files
- `git diff --check`

A clean `bun install --frozen-lockfile` reached the existing native `pkcs11js` postinstall and failed because the host Python environment lacks the `gyp.generator.xcode` module. `bun install --frozen-lockfile --ignore-scripts` completed without changing the lockfile; hosted CI remains the clean-install authority.