### PR TITLE
fix(worker): defer auth config capture until hydration

### DIFF
--- a/packages/api/src/__tests__/worker-boot-validation.test.ts
+++ b/packages/api/src/__tests__/worker-boot-validation.test.ts
@@ -6,7 +6,9 @@
  */
 
 import { afterEach, describe, expect, it } from "bun:test";
-import worker from "../worker";
+import { signAgentToken } from "@stwd/auth/jwt";
+import { decodeJwt } from "jose";
+import worker, { hydrateProcessEnv } from "../worker";
 
 /**
  * Keys this file mutates: bindings hydrateProcessEnv copies onto the global
@@ -110,6 +112,30 @@ describe("workers boot JWT env validation (SEC-134)", () => {
     await expect(malformedExpiry).rejects.toThrow(
       'AGENT_TOKEN_EXPIRY "not-a-duration" is not a valid positive duration',
     );
+  });
+
+  it("uses the current Worker expiry binding when minting after module initialization", async () => {
+    snapshotEnv();
+    const secret = "workers-rotated-expiry-secret-at-least-32-chars";
+    hydrateProcessEnv({
+      STEWARD_JWT_SECRET: secret,
+      AGENT_TOKEN_EXPIRY: "1h",
+      DATABASE_URL: "unused",
+    });
+    const first = decodeJwt(
+      await signAgentToken({ agentId: "worker-agent", tenantId: "worker-tenant" }),
+    );
+    hydrateProcessEnv({
+      STEWARD_JWT_SECRET: secret,
+      AGENT_TOKEN_EXPIRY: "5m",
+      DATABASE_URL: "unused",
+    });
+    const rotated = decodeJwt(
+      await signAgentToken({ agentId: "worker-agent", tenantId: "worker-tenant" }),
+    );
+
+    expect((first.exp ?? 0) - (first.iat ?? 0)).toBe(3600);
+    expect((rotated.exp ?? 0) - (rotated.iat ?? 0)).toBe(300);
   });
 
   it("validates scheduled security bindings before opening any database handle", async () => {

--- a/packages/api/src/__tests__/worker-boot-validation.test.ts
+++ b/packages/api/src/__tests__/worker-boot-validation.test.ts
@@ -7,7 +7,7 @@
 
 import { afterEach, describe, expect, it } from "bun:test";
 import { signAgentToken } from "@stwd/auth/jwt";
-import { decodeJwt } from "jose";
+import { decodeJwt, jwtVerify } from "jose";
 import worker, { hydrateProcessEnv } from "../worker";
 
 /**
@@ -116,26 +116,35 @@ describe("workers boot JWT env validation (SEC-134)", () => {
 
   it("uses the current Worker expiry binding when minting after module initialization", async () => {
     snapshotEnv();
-    const secret = "workers-rotated-expiry-secret-at-least-32-chars";
+    const firstSecret = "workers-first-rotated-secret-at-least-32-chars";
+    const rotatedSecret = "workers-second-rotated-secret-at-least-32-chars";
     hydrateProcessEnv({
-      STEWARD_JWT_SECRET: secret,
+      STEWARD_JWT_SECRET: firstSecret,
       AGENT_TOKEN_EXPIRY: "1h",
       DATABASE_URL: "unused",
     });
-    const first = decodeJwt(
-      await signAgentToken({ agentId: "worker-agent", tenantId: "worker-tenant" }),
-    );
+    const firstToken = await signAgentToken({ agentId: "worker-agent", tenantId: "worker-tenant" });
+    const first = decodeJwt(firstToken);
     hydrateProcessEnv({
-      STEWARD_JWT_SECRET: secret,
+      STEWARD_JWT_SECRET: rotatedSecret,
       AGENT_TOKEN_EXPIRY: "5m",
       DATABASE_URL: "unused",
     });
-    const rotated = decodeJwt(
-      await signAgentToken({ agentId: "worker-agent", tenantId: "worker-tenant" }),
-    );
+    const rotatedToken = await signAgentToken({
+      agentId: "worker-agent",
+      tenantId: "worker-tenant",
+    });
+    const rotated = decodeJwt(rotatedToken);
 
     expect((first.exp ?? 0) - (first.iat ?? 0)).toBe(3600);
     expect((rotated.exp ?? 0) - (rotated.iat ?? 0)).toBe(300);
+    await expect(
+      jwtVerify(firstToken, new TextEncoder().encode(firstSecret)),
+    ).resolves.toBeDefined();
+    await expect(
+      jwtVerify(rotatedToken, new TextEncoder().encode(rotatedSecret)),
+    ).resolves.toBeDefined();
+    await expect(jwtVerify(rotatedToken, new TextEncoder().encode(firstSecret))).rejects.toThrow();
   });
 
   it("validates scheduled security bindings before opening any database handle", async () => {

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -4,7 +4,12 @@
  * Mount: app.route("/agents", agentRoutes)
  */
 
-import { hashSha256Hex, importP256PublicKey, revocationStore } from "@stwd/auth";
+import {
+  getAgentTokenExpiry,
+  hashSha256Hex,
+  importP256PublicKey,
+  revocationStore,
+} from "@stwd/auth";
 import { agentPolicies, toPersistedPolicyRule } from "@stwd/db";
 import { getSpend, getSpendByHost, invalidateCache, type SpendPeriod } from "@stwd/redis";
 import { redactedThrownDiagnostics } from "@stwd/shared";
@@ -13,7 +18,6 @@ import { type Context, Hono } from "hono";
 import { isRedisAvailable } from "../middleware/redis";
 import { withTenantAuditedTransaction, writeAuditEvent } from "../services/audit";
 import {
-  AGENT_TOKEN_EXPIRY,
   type AgentIdentity,
   type ApiResponse,
   type AppVariables,
@@ -251,7 +255,8 @@ function parseDurationSeconds(value: string): number | null {
 }
 
 function normalizeAgentTokenExpiry(value: unknown): string | null {
-  const requested = typeof value === "string" && value.trim() ? value.trim() : AGENT_TOKEN_EXPIRY;
+  const requested =
+    typeof value === "string" && value.trim() ? value.trim() : getAgentTokenExpiry();
   const seconds = parseDurationSeconds(requested);
   if (!seconds || seconds > MAX_AGENT_TOKEN_SECONDS) return null;
   return requested;

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -9,6 +9,7 @@
 import {
   ACCESS_TOKEN_EXPIRY,
   assertTokenNotRevoked,
+  getAgentTokenExpiry,
   signAccessToken,
   signAgentToken,
   validateApiKey,
@@ -83,7 +84,6 @@ function positiveIntEnv(name: string, fallback: number): number {
 // falls back to that default, so this can never weaken the guard unintentionally.
 export const RATE_LIMIT_WINDOW_MS = positiveIntEnv("STEWARD_RATE_LIMIT_WINDOW_MS", 60_000);
 export const RATE_LIMIT_MAX_REQUESTS = positiveIntEnv("STEWARD_RATE_LIMIT_MAX_REQUESTS", 100);
-export const AGENT_TOKEN_EXPIRY = process.env.AGENT_TOKEN_EXPIRY || "30d";
 export const isWorkersRuntime =
   process.env.STEWARD_RUNTIME === "workers" ||
   (typeof navigator !== "undefined" && navigator.userAgent === "Cloudflare-Workers");
@@ -157,7 +157,7 @@ export async function createAgentToken(
   const tokenScopes = normalizeAgentTokenScopes(scopes);
   return signAgentToken(
     { agentId, tenantId, scopes: tokenScopes },
-    expiresIn || AGENT_TOKEN_EXPIRY,
+    expiresIn || getAgentTokenExpiry(),
   );
 }
 

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -39,7 +39,10 @@
  *                                   configured Redis is unreachable
  */
 
-import { validateJwtSecretEnv } from "@stwd/auth";
+// Import the dependency-light JWT module directly. Importing the auth barrel
+// here would evaluate Worker-sensitive auth modules before bindings are
+// hydrated into process.env.
+import { validateJwtSecretEnv } from "@stwd/auth/jwt";
 import {
   createDbForRequest,
   createNeonTransactionDbForRequest,

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./jwt": "./src/jwt.ts"
+  },
   "scripts": {
     "build": "tsc --noEmit",
     "dev": "tsc --watch",

--- a/packages/auth/src/__tests__/session-hardening.test.ts
+++ b/packages/auth/src/__tests__/session-hardening.test.ts
@@ -34,18 +34,40 @@ describe("validateAgentTokenExpiryEnv (SEC-134)", () => {
   });
 
   it("reads a rotated default at token-mint time instead of module initialization", async () => {
-    process.env.STEWARD_JWT_SECRET = "rotated-expiry-test-secret-at-least-32-chars";
+    const firstSecret = "first-rotated-expiry-test-secret-at-least-32-chars";
+    const rotatedSecret = "second-rotated-expiry-test-secret-at-least-32-chars";
+    process.env.STEWARD_JWT_SECRET = firstSecret;
     process.env.AGENT_TOKEN_EXPIRY = "1h";
-    const first = decodeJwt(
-      await signAgentToken({ agentId: "agent-expiry", tenantId: "tenant-expiry" }),
-    );
+    const firstToken = await signAgentToken({ agentId: "agent-expiry", tenantId: "tenant-expiry" });
+    const first = decodeJwt(firstToken);
+    process.env.STEWARD_JWT_SECRET = rotatedSecret;
     process.env.AGENT_TOKEN_EXPIRY = "5m";
-    const rotated = decodeJwt(
-      await signAgentToken({ agentId: "agent-expiry", tenantId: "tenant-expiry" }),
-    );
+    const rotatedToken = await signAgentToken({
+      agentId: "agent-expiry",
+      tenantId: "tenant-expiry",
+    });
+    const rotated = decodeJwt(rotatedToken);
 
     expect((first.exp ?? 0) - (first.iat ?? 0)).toBe(3600);
     expect((rotated.exp ?? 0) - (rotated.iat ?? 0)).toBe(300);
+    await expect(
+      jwtVerify(firstToken, new TextEncoder().encode(firstSecret)),
+    ).resolves.toBeDefined();
+    await expect(
+      jwtVerify(rotatedToken, new TextEncoder().encode(rotatedSecret)),
+    ).resolves.toBeDefined();
+    await expect(jwtVerify(rotatedToken, new TextEncoder().encode(firstSecret))).rejects.toThrow();
+  });
+
+  it("keeps an explicit bounded TTL independent from the configured default", async () => {
+    process.env.STEWARD_JWT_SECRET = "explicit-expiry-test-secret-at-least-32-chars";
+    process.env.AGENT_TOKEN_EXPIRY = "not-a-duration";
+
+    const token = decodeJwt(
+      await signAgentToken({ agentId: "agent-explicit", tenantId: "tenant-explicit" }, "10m"),
+    );
+
+    expect((token.exp ?? 0) - (token.iat ?? 0)).toBe(600);
   });
 });
 

--- a/packages/auth/src/__tests__/session-hardening.test.ts
+++ b/packages/auth/src/__tests__/session-hardening.test.ts
@@ -1,10 +1,20 @@
-import { describe, expect, it } from "bun:test";
-import { jwtVerify } from "jose";
+import { afterEach, describe, expect, it } from "bun:test";
+import { decodeJwt, jwtVerify } from "jose";
 
-import { validateAgentTokenExpiryEnv } from "../jwt";
+import { signAgentToken, validateAgentTokenExpiryEnv } from "../jwt";
 import { SessionManager } from "../session";
 
 describe("validateAgentTokenExpiryEnv (SEC-134)", () => {
+  const originalExpiry = process.env.AGENT_TOKEN_EXPIRY;
+  const originalSecret = process.env.STEWARD_JWT_SECRET;
+
+  afterEach(() => {
+    if (originalExpiry === undefined) delete process.env.AGENT_TOKEN_EXPIRY;
+    else process.env.AGENT_TOKEN_EXPIRY = originalExpiry;
+    if (originalSecret === undefined) delete process.env.STEWARD_JWT_SECRET;
+    else process.env.STEWARD_JWT_SECRET = originalSecret;
+  });
+
   it("accepts valid durations", () => {
     for (const value of ["30d", "15m", "12h", "1y", "45 minutes", "2 weeks"]) {
       expect(() => validateAgentTokenExpiryEnv(value)).not.toThrow();
@@ -21,6 +31,21 @@ describe("validateAgentTokenExpiryEnv (SEC-134)", () => {
     for (const value of ["2y", "400d", "53 weeks"]) {
       expect(() => validateAgentTokenExpiryEnv(value)).toThrow(/one-year maximum/);
     }
+  });
+
+  it("reads a rotated default at token-mint time instead of module initialization", async () => {
+    process.env.STEWARD_JWT_SECRET = "rotated-expiry-test-secret-at-least-32-chars";
+    process.env.AGENT_TOKEN_EXPIRY = "1h";
+    const first = decodeJwt(
+      await signAgentToken({ agentId: "agent-expiry", tenantId: "tenant-expiry" }),
+    );
+    process.env.AGENT_TOKEN_EXPIRY = "5m";
+    const rotated = decodeJwt(
+      await signAgentToken({ agentId: "agent-expiry", tenantId: "tenant-expiry" }),
+    );
+
+    expect((first.exp ?? 0) - (first.iat ?? 0)).toBe(3600);
+    expect((rotated.exp ?? 0) - (rotated.iat ?? 0)).toBe(300);
   });
 });
 

--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -14,7 +14,8 @@ export const JWT_ISSUER = "steward";
 export const JWT_AUDIENCE = "steward-api";
 export const ACCESS_TOKEN_EXPIRY = "15m";
 export const ACCESS_TOKEN_EXPIRY_SECONDS = 900;
-export const AGENT_TOKEN_EXPIRY = process.env.AGENT_TOKEN_EXPIRY || "30d";
+/** Stable default retained for API compatibility. Runtime overrides are read by getAgentTokenExpiry. */
+export const AGENT_TOKEN_EXPIRY = "30d";
 export const REFRESH_TOKEN_EXPIRY = "30d";
 export const IDENTITY_TOKEN_EXPIRY = ACCESS_TOKEN_EXPIRY;
 
@@ -424,6 +425,15 @@ export function validateAgentTokenExpiryEnv(
   }
 }
 
+/** Resolve and validate the current agent-token TTL at call time. */
+export function getAgentTokenExpiry(
+  value: string = process.env.AGENT_TOKEN_EXPIRY || AGENT_TOKEN_EXPIRY,
+): string {
+  const normalized = value.trim();
+  validateAgentTokenExpiryEnv(normalized);
+  return normalized;
+}
+
 export async function signJwtPayload(
   payload: JWTPayload,
   expiresIn: string,
@@ -494,7 +504,7 @@ export async function signAccessToken(
 
 export async function signAgentToken(
   payload: Omit<AgentTokenPayload, "scope"> & { scope?: "agent"; scopes?: string[] },
-  expiresIn: string = AGENT_TOKEN_EXPIRY,
+  expiresIn: string = getAgentTokenExpiry(),
 ): Promise<string> {
   const merged: Record<string, unknown> = { ...payload, scope: "agent" };
   if (Array.isArray(payload.scopes)) merged.scopes = payload.scopes;


### PR DESCRIPTION
Closes #561

## Summary
- import the dependency-light JWT subpath so Worker boot validation does not evaluate the full auth barrel before bindings are hydrated
- resolve and validate default agent-token expiry at mint time instead of module initialization
- cover initial and rotated Worker expiry bindings with exact token lifetime assertions

## Security impact
Merged #565 made validation synchronous, but its new static auth-barrel import captured Worker-sensitive configuration before bindings existed. A configured tighter AGENT_TOKEN_EXPIRY could validate successfully while default token minting still used the stale 30-day fallback.

## Validation
- `bunx turbo run build --filter=@stwd/api...` (24/24 packages)
- auth suite: 315 pass, 3 environment-gated skips
- Worker/runtime/enrollment focused suite: 27 pass
- Biome and diff checks pass

No workflow files changed.