### PR TITLE
test(proxy-client): configure fail-closed dependencies

### DIFF
--- a/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
+++ b/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
@@ -19,7 +19,7 @@
 
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { signAgentToken } from "@stwd/auth";
-import { agents, closeDb, getDb, tenants } from "@stwd/db";
+import { __resetAuditHmacKeyCacheForTests, agents, closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { PROXY_SCOPE } from "@stwd/proxy/src/config";
 import { SecretVault } from "@stwd/vault";
@@ -31,6 +31,7 @@ setDefaultTimeout(30000);
 const MASTER_PASSWORD = "proxy-client-e2e-master-password";
 const SIGNING_SECRET = "proxy-client-e2e-signing-secret-with-enough-bytes";
 const FAKE_OPENAI_KEY = "sk-test-e2e-do-not-use-0123456789abcdef";
+const FAKE_AUDIT_HMAC_KEY = "proxy-client-e2e-audit-hmac-key-with-enough-entropy";
 
 let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddleware"];
 let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
@@ -38,7 +39,9 @@ let setForwardProxyRequestForTests: typeof import("@stwd/proxy/src/handlers/prox
 let setResolveProxyHostForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setResolveProxyHostForTests"];
 let setCheckProxyRateLimitForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setCheckProxyRateLimitForTests"];
 let setCheckProxySpendLimitForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setCheckProxySpendLimitForTests"];
-let resetProxyHandlerTestHooks: typeof import("@stwd/proxy/src/handlers/proxy")["__resetProxyHandlerTestHooksForTests"];
+let resetProxyHandlerTestHooks:
+  | typeof import("@stwd/proxy/src/handlers/proxy")["__resetProxyHandlerTestHooksForTests"]
+  | undefined;
 
 // Capture what the proxy tried to forward upstream.
 interface ForwardedCapture {
@@ -49,10 +52,21 @@ interface ForwardedCapture {
 let lastForwarded: ForwardedCapture | null = null;
 // Controls whether the stubbed upstream reflects the secret back (leak sim).
 let reflectSecretInResponse = false;
-let previousAuditHmacKey: string | undefined;
-let previousProxyDevMode: string | undefined;
+
+const FIXTURE_ENV_KEYS = [
+  "STEWARD_PGLITE_MEMORY",
+  "STEWARD_MASTER_PASSWORD",
+  "STEWARD_JWT_SECRET",
+  "STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE",
+  "STEWARD_PROXY_REQUEST_SIGNING_SECRET",
+  "STEWARD_AUDIT_HMAC_KEY",
+  "STEWARD_PROXY_DEV_MODE",
+  "STEWARD_PROXY_ALLOWED_HOSTS",
+] as const;
+const previousEnv = new Map<(typeof FIXTURE_ENV_KEYS)[number], string | undefined>();
 
 beforeAll(async () => {
+  for (const key of FIXTURE_ENV_KEYS) previousEnv.set(key, process.env[key]);
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "proxy-client-e2e-jwt-secret-with-enough-bytes";
@@ -60,9 +74,10 @@ beforeAll(async () => {
   // exercises the client's HMAC signer against the proxy verifier.
   process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
   process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
-  previousAuditHmacKey = process.env.STEWARD_AUDIT_HMAC_KEY;
-  process.env.STEWARD_AUDIT_HMAC_KEY = "proxy-client-e2e-audit-hmac-key-with-enough-entropy";
-  previousProxyDevMode = process.env.STEWARD_PROXY_DEV_MODE;
+  process.env.STEWARD_AUDIT_HMAC_KEY = FAKE_AUDIT_HMAC_KEY;
+  // The audit module memoizes its parsed key. Reset after installing this
+  // fixture's non-secret key so an earlier suite cannot bleed into this one.
+  __resetAuditHmacKeyCacheForTests();
   process.env.STEWARD_PROXY_DEV_MODE = "true";
   // api.openai.com is already in the direct-proxy + secret-route default
   // allowlists, but set it explicitly for hermeticity.
@@ -118,18 +133,16 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  resetProxyHandlerTestHooks();
+  resetProxyHandlerTestHooks?.();
   await closeDb().catch(() => {});
-  delete process.env.STEWARD_PGLITE_MEMORY;
-  delete process.env.STEWARD_MASTER_PASSWORD;
-  delete process.env.STEWARD_JWT_SECRET;
-  delete process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE;
-  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
-  delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
-  if (previousAuditHmacKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
-  else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditHmacKey;
-  if (previousProxyDevMode === undefined) delete process.env.STEWARD_PROXY_DEV_MODE;
-  else process.env.STEWARD_PROXY_DEV_MODE = previousProxyDevMode;
+  for (const key of FIXTURE_ENV_KEYS) {
+    const previous = previousEnv.get(key);
+    if (previous === undefined) delete process.env[key];
+    else process.env[key] = previous;
+  }
+  previousEnv.clear();
+  // Do not leave the fixture key cached after restoring the caller's env.
+  __resetAuditHmacKeyCacheForTests();
 });
 
 function buildProxyApp() {
@@ -237,6 +250,9 @@ describe("proxy-client e2e: injection + scrub on the openai alias", () => {
     //    the OUTBOUND (upstream) request.
     expect(lastForwarded?.url).toBe("https://api.openai.com/v1/chat/completions");
     expect(lastForwarded?.headers.get("authorization")).toBe(`Bearer ${FAKE_OPENAI_KEY}`);
+    for (const [, value] of lastForwarded?.headers.entries() ?? []) {
+      expect(value).not.toContain(FAKE_AUDIT_HMAC_KEY);
+    }
 
     // 3. The AGENT-side request never carried the secret in any header or body.
     expect(agentRequests.length).toBe(1);
@@ -245,8 +261,10 @@ describe("proxy-client e2e: injection + scrub on the openai alias", () => {
     expect(agentReq.headers.get("authorization")).not.toContain(FAKE_OPENAI_KEY);
     for (const [, value] of agentReq.headers.entries()) {
       expect(value).not.toContain(FAKE_OPENAI_KEY);
+      expect(value).not.toContain(FAKE_AUDIT_HMAC_KEY);
     }
     expect(agentReq.body ?? "").not.toContain(FAKE_OPENAI_KEY);
+    expect(agentReq.body ?? "").not.toContain(FAKE_AUDIT_HMAC_KEY);
 
     // 3b. The real client attached the proof-of-possession signature +
     //     idempotency key that the proxy required.
@@ -257,6 +275,7 @@ describe("proxy-client e2e: injection + scrub on the openai alias", () => {
     // 4. The response returned to the agent never contains the secret.
     const responseText = await res.text();
     expect(responseText).not.toContain(FAKE_OPENAI_KEY);
+    expect(responseText).not.toContain(FAKE_AUDIT_HMAC_KEY);
   });
 
   it("blocks the response (502) if the upstream reflects the injected secret", async () => {
@@ -289,6 +308,7 @@ describe("proxy-client e2e: injection + scrub on the openai alias", () => {
     expect(res.status).toBe(502);
     const body = await res.text();
     expect(body).not.toContain(FAKE_OPENAI_KEY);
+    expect(body).not.toContain(FAKE_AUDIT_HMAC_KEY);
     expect(body).toContain("reflected injected credential");
   });
 

--- a/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
+++ b/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
@@ -49,6 +49,8 @@ interface ForwardedCapture {
 let lastForwarded: ForwardedCapture | null = null;
 // Controls whether the stubbed upstream reflects the secret back (leak sim).
 let reflectSecretInResponse = false;
+let previousAuditHmacKey: string | undefined;
+let previousProxyDevMode: string | undefined;
 
 beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
@@ -58,6 +60,10 @@ beforeAll(async () => {
   // exercises the client's HMAC signer against the proxy verifier.
   process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
   process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
+  previousAuditHmacKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+  process.env.STEWARD_AUDIT_HMAC_KEY = "proxy-client-e2e-audit-hmac-key-with-enough-entropy";
+  previousProxyDevMode = process.env.STEWARD_PROXY_DEV_MODE;
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   // api.openai.com is already in the direct-proxy + secret-route default
   // allowlists, but set it explicitly for hermeticity.
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.openai.com";
@@ -120,6 +126,10 @@ afterAll(async () => {
   delete process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE;
   delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
   delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
+  if (previousAuditHmacKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+  else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditHmacKey;
+  if (previousProxyDevMode === undefined) delete process.env.STEWARD_PROXY_DEV_MODE;
+  else process.env.STEWARD_PROXY_DEV_MODE = previousProxyDevMode;
 });
 
 function buildProxyApp() {


### PR DESCRIPTION
Closes #573

## Summary
- configure the production-required audit HMAC in the proxy-client forwarding fixture
- opt the hermetic test explicitly into the development in-memory replay store while preserving production fail-closed defaults
- restore both pre-existing environment values exactly after the suite

## Evidence
- reproduced current root `bun run verify` failure: two proxy-client E2E cases returned `503 Shared proxy idempotency store unavailable`
- `bunx turbo run build --filter=@stwd/proxy-client...` (10/10)
- `bun test --cwd packages/proxy-client` (21/21, 56 assertions)
- `bunx biome check packages/proxy-client/src/__tests__/proxy-e2e.test.ts`
- `git diff --check`

Production continues to require shared Redis and required audit persistence.