### PR TITLE
test(capabilities): isolate proxy enforcement fixture

### DIFF
--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -72,6 +72,7 @@ interface ForwardedCapture {
 }
 let lastForwarded: ForwardedCapture | null = null;
 let proxyApp: Hono | null = null;
+let proxyRateLimitChecks = 0;
 const realFetch = globalThis.fetch;
 
 // the policy set the injected getPolicySet returns for the current test.
@@ -128,7 +129,10 @@ beforeAll(async () => {
   // deterministic public ip so route-match -> decrypt -> inject -> forward runs
   // with no external network (mirrors the #149 e2e).
   setResolveProxyHostForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
-  setCheckProxyRateLimitForTests(async () => ({ allowed: true, resetMs: 0 }));
+  setCheckProxyRateLimitForTests(async () => {
+    proxyRateLimitChecks += 1;
+    return { allowed: true, resetMs: 0 };
+  });
   setForwardProxyRequestForTests(async (url, method, headers, body) => {
     const bodyText = body ? await new Response(body).text() : null;
     lastForwarded = { url: url.toString(), method, headers, bodyText };
@@ -170,12 +174,18 @@ beforeAll(async () => {
 
 afterAll(async () => {
   globalThis.fetch = realFetch;
-  resetProxyHandlerTestHooksForTests();
-  await closeDb().catch(() => {});
-  for (const key of TEST_ENV_KEYS) {
-    const original = originalEnv.get(key);
-    if (original === undefined) delete process.env[key];
-    else process.env[key] = original;
+  try {
+    resetProxyHandlerTestHooksForTests?.();
+  } finally {
+    try {
+      await closeDb().catch(() => {});
+    } finally {
+      for (const key of TEST_ENV_KEYS) {
+        const original = originalEnv.get(key);
+        if (original === undefined) delete process.env[key];
+        else process.env[key] = original;
+      }
+    }
   }
 });
 
@@ -305,6 +315,7 @@ beforeEach(async () => {
   await seedTenantAgent();
   currentPolicySet = [];
   lastForwarded = null;
+  proxyRateLimitChecks = 0;
 });
 
 describe("invoke e2e: full arc through the real proxy", () => {
@@ -464,6 +475,7 @@ describe("invoke e2e: full arc through the real proxy", () => {
     });
     // first invoke: count 0 < 1 => forwards (upstream 201).
     expect(first.status).toBe(201);
+    expect(proxyRateLimitChecks).toBe(1);
 
     const second = await app.request("/capabilities/github.pr.comment/invoke", {
       method: "POST",
@@ -472,6 +484,7 @@ describe("invoke e2e: full arc through the real proxy", () => {
     });
     // second invoke: count 1 >= 1 => rate constraint denies the allow => 403.
     expect(second.status).toBe(403);
+    expect(proxyRateLimitChecks).toBe(1);
 
     const rows = await agentInvocations(capId);
     expect(rows.filter((r) => r.decision === "allow").length).toBe(1);
@@ -658,6 +671,7 @@ describe("OpenAI-compatible capability adapter", () => {
       body: JSON.stringify({ model: "gpt-test", messages: [{ role: "user", content: "one" }] }),
     });
     expect(first.status).toBe(200);
+    expect(proxyRateLimitChecks).toBe(1);
 
     const second = await app.request("/capabilities/openai.chat/openai/v1/chat/completions", {
       method: "POST",
@@ -665,6 +679,7 @@ describe("OpenAI-compatible capability adapter", () => {
       body: JSON.stringify({ model: "gpt-test", messages: [{ role: "user", content: "two" }] }),
     });
     expect(second.status).toBe(403);
+    expect(proxyRateLimitChecks).toBe(1);
 
     const rows = await agentInvocations(capId);
     expect(rows.filter((r) => r.decision === "allow").length).toBe(1);

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -50,6 +50,8 @@ let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddle
 let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
 let setForwardProxyRequestForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setForwardProxyRequestForTests"];
 let setResolveProxyHostForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setResolveProxyHostForTests"];
+let setCheckProxyRateLimitForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setCheckProxyRateLimitForTests"];
+let resetProxyHandlerTestHooksForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__resetProxyHandlerTestHooksForTests"];
 
 interface ForwardedCapture {
   url: string;
@@ -60,6 +62,7 @@ interface ForwardedCapture {
 let lastForwarded: ForwardedCapture | null = null;
 let proxyApp: Hono | null = null;
 const realFetch = globalThis.fetch;
+const originalProxyDevMode = process.env.STEWARD_PROXY_DEV_MODE;
 
 // the policy set the injected getPolicySet returns for the current test.
 let currentPolicySet: PolicyRule[] = [];
@@ -89,6 +92,7 @@ beforeAll(async () => {
   process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
   process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.github.com,api.openai.com";
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   // the invoke route reads these to build its proxy client (fail-closed if absent).
   process.env.STEWARD_PROXY_URL = PROXY_URL;
 
@@ -107,11 +111,14 @@ beforeAll(async () => {
     handleProxy,
     __setForwardProxyRequestForTests: setForwardProxyRequestForTests,
     __setResolveProxyHostForTests: setResolveProxyHostForTests,
+    __setCheckProxyRateLimitForTests: setCheckProxyRateLimitForTests,
+    __resetProxyHandlerTestHooksForTests: resetProxyHandlerTestHooksForTests,
   } = await import("@stwd/proxy/src/handlers/proxy"));
 
   // deterministic public ip so route-match -> decrypt -> inject -> forward runs
   // with no external network (mirrors the #149 e2e).
   setResolveProxyHostForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
+  setCheckProxyRateLimitForTests(async () => ({ allowed: true, resetMs: 0 }));
   setForwardProxyRequestForTests(async (url, method, headers, body) => {
     const bodyText = body ? await new Response(body).text() : null;
     lastForwarded = { url: url.toString(), method, headers, bodyText };
@@ -153,6 +160,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   globalThis.fetch = realFetch;
+  resetProxyHandlerTestHooksForTests();
   await closeDb().catch(() => {});
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_MASTER_PASSWORD;
@@ -161,6 +169,8 @@ afterAll(async () => {
   delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
   delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
   delete process.env.STEWARD_PROXY_URL;
+  if (originalProxyDevMode === undefined) delete process.env.STEWARD_PROXY_DEV_MODE;
+  else process.env.STEWARD_PROXY_DEV_MODE = originalProxyDevMode;
 });
 
 let tenantId: string;

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -45,6 +45,17 @@ const FAKE_OPENAI_KEY = "sk-test-openai-e2e-do-not-use-0123456789abcdef";
 const STEWARD_TOKEN_SENTINEL = "steward-agent-token-sentinel-never-upstream";
 const PROXY_URL = "https://proxy.cap-e2e.test";
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
+const TEST_ENV_KEYS = [
+  "STEWARD_PGLITE_MEMORY",
+  "STEWARD_MASTER_PASSWORD",
+  "STEWARD_JWT_SECRET",
+  "STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE",
+  "STEWARD_PROXY_REQUEST_SIGNING_SECRET",
+  "STEWARD_PROXY_ALLOWED_HOSTS",
+  "STEWARD_PROXY_DEV_MODE",
+  "STEWARD_PROXY_URL",
+] as const;
+const originalEnv = new Map(TEST_ENV_KEYS.map((key) => [key, process.env[key]]));
 
 let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddleware"];
 let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
@@ -62,7 +73,6 @@ interface ForwardedCapture {
 let lastForwarded: ForwardedCapture | null = null;
 let proxyApp: Hono | null = null;
 const realFetch = globalThis.fetch;
-const originalProxyDevMode = process.env.STEWARD_PROXY_DEV_MODE;
 
 // the policy set the injected getPolicySet returns for the current test.
 let currentPolicySet: PolicyRule[] = [];
@@ -162,15 +172,11 @@ afterAll(async () => {
   globalThis.fetch = realFetch;
   resetProxyHandlerTestHooksForTests();
   await closeDb().catch(() => {});
-  delete process.env.STEWARD_PGLITE_MEMORY;
-  delete process.env.STEWARD_MASTER_PASSWORD;
-  delete process.env.STEWARD_JWT_SECRET;
-  delete process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE;
-  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
-  delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
-  delete process.env.STEWARD_PROXY_URL;
-  if (originalProxyDevMode === undefined) delete process.env.STEWARD_PROXY_DEV_MODE;
-  else process.env.STEWARD_PROXY_DEV_MODE = originalProxyDevMode;
+  for (const key of TEST_ENV_KEYS) {
+    const original = originalEnv.get(key);
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
 });
 
 let tenantId: string;

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -55,7 +55,7 @@ const TEST_ENV_KEYS = [
   "STEWARD_PROXY_DEV_MODE",
   "STEWARD_PROXY_URL",
 ] as const;
-const originalEnv = new Map(TEST_ENV_KEYS.map((key) => [key, process.env[key]]));
+const originalEnv = new Map<(typeof TEST_ENV_KEYS)[number], string | undefined>();
 
 let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddleware"];
 let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
@@ -97,6 +97,7 @@ function capRule(
 }
 
 beforeAll(async () => {
+  for (const key of TEST_ENV_KEYS) originalEnv.set(key, process.env[key]);
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "cap-invoke-e2e-jwt-secret-with-enough-bytes-0123456789";
@@ -185,6 +186,7 @@ afterAll(async () => {
         if (original === undefined) delete process.env[key];
         else process.env[key] = original;
       }
+      originalEnv.clear();
     }
   }
 });


### PR DESCRIPTION
Closes #575.\n\n## Summary\n- explicitly opt the hermetic capability-to-proxy integration fixture into the development replay-store boundary\n- install an allow-only proxy rate-limit checker so policy call-count tests remain the authority under test\n- restore the original dev-mode environment and every mutable proxy-handler dependency in teardown\n\nProduction replay and rate-limit enforcement remain fail closed.\n\n## Exact-head validation\n- `bun test --isolate packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts` — 16 pass, 72 assertions\n- `bun run build --filter=@stwd/plugin-capabilities...` — 12/12 packages\n- Biome and `git diff --check` — pass