### PR TITLE
fix(worker): apply rotated security bindings at request time

### DIFF
--- a/packages/api/src/__tests__/authorization-signature-middleware.test.ts
+++ b/packages/api/src/__tests__/authorization-signature-middleware.test.ts
@@ -46,7 +46,7 @@ function makeDefaultApp() {
   return app;
 }
 
-async function signedHeaders(path = "/vault/agent-1/sign", body = BODY) {
+async function signedHeaders(path = "/vault/agent-1/sign", body = BODY, secret = SECRET) {
   const authorization = "Bearer token-a";
   const signature = await createAuthorizationSignature(
     {
@@ -58,7 +58,7 @@ async function signedHeaders(path = "/vault/agent-1/sign", body = BODY) {
       idempotencyKey: "idem-key-123",
       body,
     },
-    SECRET,
+    secret,
   );
   return {
     "content-type": "application/json",
@@ -126,6 +126,74 @@ async function signedAppSecretHeaders(path = "/agents", body = BODY) {
 }
 
 describe("authorizationSignature", () => {
+  it("applies rotated required mode and signing secrets without rebuilding", async () => {
+    const originalRequire = process.env.STEWARD_REQUIRE_AUTH_SIGNATURE;
+    const originalSecret = process.env.STEWARD_REQUEST_SIGNING_SECRET;
+    const originalSecrets = process.env.STEWARD_REQUEST_SIGNING_SECRETS;
+    const originalNodeEnv = process.env.NODE_ENV;
+    const firstSecret = "first-worker-request-signing-secret-with-enough-entropy";
+    const rotatedSecret = "rotated-worker-request-signing-secret-with-enough-entropy";
+    try {
+      process.env.NODE_ENV = "test";
+      delete process.env.STEWARD_REQUIRE_AUTH_SIGNATURE;
+      delete process.env.STEWARD_REQUEST_SIGNING_SECRETS;
+      process.env.STEWARD_REQUEST_SIGNING_SECRET = firstSecret;
+      const app = new Hono<{ Variables: { requestSignatureVerified?: boolean } }>();
+      app.use("*", authorizationSignature());
+      app.post("/vault/:agentId/sign", (c) =>
+        c.json({ ok: true, verified: Boolean(c.get("requestSignatureVerified")) }),
+      );
+
+      expect(
+        (await app.request("/vault/agent-1/sign", { method: "POST", body: BODY })).status,
+      ).toBe(200);
+      process.env.STEWARD_REQUIRE_AUTH_SIGNATURE = "true";
+      expect(
+        (await app.request("/vault/agent-1/sign", { method: "POST", body: BODY })).status,
+      ).toBe(401);
+
+      const firstHeaders = await signedHeaders("/vault/agent-1/sign", BODY, firstSecret);
+      expect(
+        (
+          await app.request("/vault/agent-1/sign", {
+            method: "POST",
+            headers: firstHeaders,
+            body: BODY,
+          })
+        ).status,
+      ).toBe(200);
+
+      process.env.STEWARD_REQUEST_SIGNING_SECRET = rotatedSecret;
+      expect(
+        (
+          await app.request("/vault/agent-1/sign", {
+            method: "POST",
+            headers: firstHeaders,
+            body: BODY,
+          })
+        ).status,
+      ).toBe(401);
+      expect(
+        (
+          await app.request("/vault/agent-1/sign", {
+            method: "POST",
+            headers: await signedHeaders("/vault/agent-1/sign", BODY, rotatedSecret),
+            body: BODY,
+          })
+        ).status,
+      ).toBe(200);
+    } finally {
+      if (originalRequire === undefined) delete process.env.STEWARD_REQUIRE_AUTH_SIGNATURE;
+      else process.env.STEWARD_REQUIRE_AUTH_SIGNATURE = originalRequire;
+      if (originalSecret === undefined) delete process.env.STEWARD_REQUEST_SIGNING_SECRET;
+      else process.env.STEWARD_REQUEST_SIGNING_SECRET = originalSecret;
+      if (originalSecrets === undefined) delete process.env.STEWARD_REQUEST_SIGNING_SECRETS;
+      else process.env.STEWARD_REQUEST_SIGNING_SECRETS = originalSecrets;
+      if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
   it("allows sensitive mutating requests without a signature while optional", async () => {
     const app = makeApp();
 

--- a/packages/api/src/__tests__/global-rate-limit.test.ts
+++ b/packages/api/src/__tests__/global-rate-limit.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { Hono } from "hono";
 import { workersGlobalRateLimit } from "../middleware/global-rate-limit";
+import { configuredDefaultTenantId } from "../routes/auth";
 
 /**
  * SEC-068: the Workers entry has no in-memory global limiter (no cross-isolate
@@ -19,6 +20,9 @@ const ENV_VARS = [
   "UPSTASH_REDIS_REST_TOKEN",
   "STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL",
   "STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX",
+  "STEWARD_RATE_LIMIT_WINDOW_MS",
+  "STEWARD_RATE_LIMIT_MAX_REQUESTS",
+  "STEWARD_DEFAULT_TENANT_ID",
 ] as const;
 const saved = new Map<string, string | undefined>();
 
@@ -57,6 +61,33 @@ function probeApp() {
 }
 
 describe("workersGlobalRateLimit (SEC-068)", () => {
+  test("uses rotated Worker limits without rebuilding the middleware", async () => {
+    redisUnconfigured();
+    process.env.NODE_ENV = "production";
+    process.env.STEWARD_RATE_LIMIT_WINDOW_MS = "1000";
+    process.env.STEWARD_RATE_LIMIT_MAX_REQUESTS = "7";
+    const app = probeApp();
+
+    const initial = await app.request("/thing");
+    expect(initial.status).toBe(429);
+    expect(initial.headers.get("RateLimit-Policy")).toContain("w=1");
+
+    process.env.STEWARD_RATE_LIMIT_WINDOW_MS = "2000";
+    process.env.STEWARD_RATE_LIMIT_MAX_REQUESTS = "9";
+    const rotated = await app.request("/thing");
+    expect(rotated.status).toBe(429);
+    expect(rotated.headers.get("RateLimit-Policy")).toContain("w=2");
+  });
+
+  test("resolves the default tenant from the current Worker binding", () => {
+    process.env.STEWARD_DEFAULT_TENANT_ID = "tenant-before-rotation";
+    expect(configuredDefaultTenantId()).toBe("tenant-before-rotation");
+    process.env.STEWARD_DEFAULT_TENANT_ID = "tenant-after-rotation";
+    expect(configuredDefaultTenantId()).toBe("tenant-after-rotation");
+    delete process.env.STEWARD_DEFAULT_TENANT_ID;
+    expect(configuredDefaultTenantId()).toBe("default");
+  });
+
   test("fails closed in production when Redis was never configured", async () => {
     redisUnconfigured();
     process.env.NODE_ENV = "production";

--- a/packages/api/src/__tests__/global-wallet.test.ts
+++ b/packages/api/src/__tests__/global-wallet.test.ts
@@ -621,6 +621,29 @@ describe("global wallet routes", () => {
       }),
     });
 
+    process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING = "false";
+    process.env.STEWARD_ALLOW_GLOBAL_WALLET_PERSONAL_SIGN = "false";
+    try {
+      const disabledAfterRotation = await routes.request("/rpc", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await token()}`,
+          "Content-Type": "application/json",
+          Origin: ORIGIN,
+        },
+        body: JSON.stringify({
+          app_id: appId(),
+          method: "personal_sign",
+          params: ["hello steward", walletAddress],
+        }),
+      });
+      expect(disabledAfterRotation.status).toBe(403);
+      expect(await disabledAfterRotation.text()).toContain("personal_sign is disabled");
+    } finally {
+      process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING = "true";
+      process.env.STEWARD_ALLOW_GLOBAL_WALLET_PERSONAL_SIGN = "true";
+    }
+
     const staleMfa = await routes.request("/rpc", {
       method: "POST",
       headers: {

--- a/packages/api/src/__tests__/request-expiry-middleware.test.ts
+++ b/packages/api/src/__tests__/request-expiry-middleware.test.ts
@@ -48,6 +48,27 @@ function makeDefaultApp() {
 }
 
 describe("requestExpiry", () => {
+  it("applies a rotated requirement without rebuilding the middleware", async () => {
+    const originalRequire = process.env.STEWARD_REQUIRE_REQUEST_EXPIRY;
+    const originalNodeEnv = process.env.NODE_ENV;
+    try {
+      process.env.NODE_ENV = "test";
+      delete process.env.STEWARD_REQUIRE_REQUEST_EXPIRY;
+      const app = makeDefaultApp();
+
+      expect((await app.request("/vault/agent-1/sign", { method: "POST" })).status).toBe(200);
+      process.env.STEWARD_REQUIRE_REQUEST_EXPIRY = "true";
+      expect((await app.request("/vault/agent-1/sign", { method: "POST" })).status).toBe(400);
+      delete process.env.STEWARD_REQUIRE_REQUEST_EXPIRY;
+      expect((await app.request("/vault/agent-1/sign", { method: "POST" })).status).toBe(200);
+    } finally {
+      if (originalRequire === undefined) delete process.env.STEWARD_REQUIRE_REQUEST_EXPIRY;
+      else process.env.STEWARD_REQUIRE_REQUEST_EXPIRY = originalRequire;
+      if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
   it("allows sensitive mutating requests without expiry while hook is optional", async () => {
     const app = makeApp();
 

--- a/packages/api/src/__tests__/webhook-url-validation.test.ts
+++ b/packages/api/src/__tests__/webhook-url-validation.test.ts
@@ -2,6 +2,21 @@ import { describe, expect, it } from "bun:test";
 import { validateWebhookUrl, validateWebhookUrlResolved } from "../services/webhook-url";
 
 describe("webhook URL validation", () => {
+  it("revokes insecure HTTP immediately after a binding rotation", () => {
+    const original = process.env.STEWARD_ALLOW_INSECURE_WEBHOOK_URLS;
+    try {
+      delete process.env.STEWARD_ALLOW_INSECURE_WEBHOOK_URLS;
+      expect(validateWebhookUrl("http://93.184.216.34/hook")).toBe("url must use https");
+      process.env.STEWARD_ALLOW_INSECURE_WEBHOOK_URLS = "true";
+      expect(validateWebhookUrl("http://93.184.216.34/hook")).toBeNull();
+      delete process.env.STEWARD_ALLOW_INSECURE_WEBHOOK_URLS;
+      expect(validateWebhookUrl("http://93.184.216.34/hook")).toBe("url must use https");
+    } finally {
+      if (original === undefined) delete process.env.STEWARD_ALLOW_INSECURE_WEBHOOK_URLS;
+      else process.env.STEWARD_ALLOW_INSECURE_WEBHOOK_URLS = original;
+    }
+  });
+
   it("rejects IPv4-mapped IPv6 private addresses in dotted and hex forms", () => {
     for (const url of [
       "https://[::ffff:127.0.0.1]/hook",

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -157,11 +157,10 @@ export function createApp(): Hono<{ Variables: AppVariables }> {
   // strict mode so browser/unsigned SDK clients keep working until an operator
   // has rolled out signing clients. Mounted here (phase 1) so they always run
   // BEFORE the idempotency middleware (phase 2).
-  app.use("*", requestExpiry({ required: process.env.STEWARD_REQUIRE_REQUEST_EXPIRY === "true" }));
-  app.use(
-    "*",
-    authorizationSignature({ required: process.env.STEWARD_REQUIRE_AUTH_SIGNATURE === "true" }),
-  );
+  // Resolve binding-backed strictness and signing secrets per request so a
+  // long-lived Worker isolate cannot retain a revoked deployment setting.
+  app.use("*", requestExpiry());
+  app.use("*", authorizationSignature());
 
   // ─── Auth middleware per route group ────────────────────────────────────────
 

--- a/packages/api/src/middleware/authorization-signature.ts
+++ b/packages/api/src/middleware/authorization-signature.ts
@@ -801,23 +801,10 @@ export async function buildAuthorizationCanonicalString(
 }
 
 export function authorizationSignature(options?: AuthorizationSignatureOptions) {
-  const required =
-    options?.required ??
-    (process.env.STEWARD_REQUIRE_AUTH_SIGNATURE === "true" ||
-      process.env.NODE_ENV === "production");
-  const secrets = options?.secrets ?? configuredSecrets();
   const appSecretResolver = options?.appSecretResolver ?? appClientSecretSigningCandidates;
   const tenantKeyStoreFactory =
     options?.tenantKeyStoreFactory ??
     ((masterPassword, masterSalt, domain) => new KeyStore(masterPassword, masterSalt, domain));
-  const maxClockSkewMs = parsePositiveInt(
-    process.env.STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS,
-    DEFAULT_MAX_CLOCK_SKEW_MS,
-  );
-  const timestampTtlMs = parsePositiveInt(
-    process.env.STEWARD_REQUEST_TIMESTAMP_TTL_MS,
-    DEFAULT_TIMESTAMP_TTL_MS,
-  );
 
   return createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
     if (!MUTATING_METHODS.has(c.req.method.toUpperCase()) || !isSensitivePath(c.req.path)) {
@@ -826,9 +813,23 @@ export function authorizationSignature(options?: AuthorizationSignatureOptions) 
 
     const rawSignature = c.req.header("X-Steward-Signature");
     if (!rawSignature) {
+      const required =
+        options?.required ??
+        (process.env.STEWARD_REQUIRE_AUTH_SIGNATURE === "true" ||
+          process.env.NODE_ENV === "production");
       if (!required) return next();
       return c.json<ApiResponse>({ ok: false, error: "X-Steward-Signature header required" }, 401);
     }
+
+    const secrets = options?.secrets ?? configuredSecrets();
+    const maxClockSkewMs = parsePositiveInt(
+      process.env.STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS,
+      DEFAULT_MAX_CLOCK_SKEW_MS,
+    );
+    const timestampTtlMs = parsePositiveInt(
+      process.env.STEWARD_REQUEST_TIMESTAMP_TTL_MS,
+      DEFAULT_TIMESTAMP_TTL_MS,
+    );
 
     // Scheme selection: the SAME header carries either an HMAC `v1=` signature
     // or an asymmetric P-256 `p256=` signature. The prefix is self-describing;

--- a/packages/api/src/middleware/global-rate-limit.ts
+++ b/packages/api/src/middleware/global-rate-limit.ts
@@ -14,7 +14,7 @@
 
 import type { Context, Next } from "hono";
 import { checkAuthRateLimit } from "../routes/auth";
-import { RATE_LIMIT_MAX_REQUESTS, RATE_LIMIT_WINDOW_MS } from "../services/context";
+import { getRateLimitMaxRequests, getRateLimitWindowMs } from "../services/context";
 
 export async function workersGlobalRateLimit(
   c: Context,
@@ -28,8 +28,8 @@ export async function workersGlobalRateLimit(
   const verdict = await checkAuthRateLimit(
     c,
     "global",
-    RATE_LIMIT_WINDOW_MS,
-    RATE_LIMIT_MAX_REQUESTS,
+    getRateLimitWindowMs(),
+    getRateLimitMaxRequests(),
   );
   if (!verdict.allowed) {
     return c.json(

--- a/packages/api/src/middleware/request-expiry.ts
+++ b/packages/api/src/middleware/request-expiry.ts
@@ -34,17 +34,6 @@ function parseHttpTime(value: string | undefined): number | null {
 }
 
 export function requestExpiry(options?: RequestExpiryOptions) {
-  const required =
-    options?.required ??
-    (process.env.STEWARD_REQUIRE_REQUEST_EXPIRY === "true" ||
-      (process.env.NODE_ENV === "production" &&
-        process.env.STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS !== "true"));
-  const maxClockSkewMs =
-    options?.maxClockSkewMs ??
-    parsePositiveInt(process.env.STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS, DEFAULT_MAX_CLOCK_SKEW_MS);
-  const timestampTtlMs =
-    options?.timestampTtlMs ??
-    parsePositiveInt(process.env.STEWARD_REQUEST_TIMESTAMP_TTL_MS, DEFAULT_TIMESTAMP_TTL_MS);
   const now = options?.now ?? (() => Date.now());
 
   return createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
@@ -56,10 +45,21 @@ export function requestExpiry(options?: RequestExpiryOptions) {
     const timestampHeader = c.req.header("X-Steward-Request-Timestamp");
 
     if (!expiresAtHeader && !timestampHeader) {
+      const required =
+        options?.required ??
+        (process.env.STEWARD_REQUIRE_REQUEST_EXPIRY === "true" ||
+          (process.env.NODE_ENV === "production" &&
+            process.env.STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS !== "true"));
       if (!required) return next();
       return c.json<ApiResponse>({ ok: false, error: "Request expiry header required" }, 400);
     }
 
+    const maxClockSkewMs =
+      options?.maxClockSkewMs ??
+      parsePositiveInt(process.env.STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS, DEFAULT_MAX_CLOCK_SKEW_MS);
+    const timestampTtlMs =
+      options?.timestampTtlMs ??
+      parsePositiveInt(process.env.STEWARD_REQUEST_TIMESTAMP_TTL_MS, DEFAULT_TIMESTAMP_TTL_MS);
     const currentTime = now();
     const expiresAt = parseHttpTime(expiresAtHeader);
     if (expiresAtHeader && expiresAt === null) {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -162,7 +162,9 @@ import { dispatchWebhook } from "../services/webhook-dispatch";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const _DEFAULT_TENANT_ID = process.env.STEWARD_DEFAULT_TENANT_ID || "default";
+export function configuredDefaultTenantId(): string {
+  return process.env.STEWARD_DEFAULT_TENANT_ID || "default";
+}
 
 function isValidTenantId(value: unknown): value is string {
   return typeof value === "string" && /^[a-zA-Z0-9_\-.:]{1,64}$/.test(value);
@@ -761,7 +763,9 @@ async function validateExplicitAuthTenantHint(
 }
 
 function authTenantHint(c: Context, bodyTenantId?: string): string {
-  return c.req.header("X-Steward-Tenant")?.trim() || bodyTenantId?.trim() || _DEFAULT_TENANT_ID;
+  return (
+    c.req.header("X-Steward-Tenant")?.trim() || bodyTenantId?.trim() || configuredDefaultTenantId()
+  );
 }
 
 function smsLoginPurpose(tenantId: string): string {
@@ -3822,7 +3826,8 @@ async function completeEmailAuth(
   tenantId?: string,
   opts: { allowTenantJoin?: boolean } = {},
 ): Promise<CompletedEmailAuthResult> {
-  const hintedTenantId = c.req.header("X-Steward-Tenant") || tenantId || _DEFAULT_TENANT_ID;
+  const hintedTenantId =
+    c.req.header("X-Steward-Tenant") || tenantId || configuredDefaultTenantId();
   const hintedAuthAbuseConfig = await getTenantAuthAbuseConfig(hintedTenantId);
   const hintedEmailPolicyError = validateEmailAbusePolicy(email, hintedAuthAbuseConfig);
   if (hintedEmailPolicyError) {
@@ -7932,7 +7937,9 @@ auth.post("/passkey/register/options", async (c) => {
 
   if (typeof body.emailGrant === "string" && body.emailGrant.length > 0) {
     const resolvedTenantId =
-      c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || _DEFAULT_TENANT_ID;
+      c.req.header("X-Steward-Tenant")?.trim() ||
+      body.tenantId?.trim() ||
+      configuredDefaultTenantId();
     const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "passkey");
     if (methodResponse) return methodResponse;
     // Peek (not consume): the grant is only burned at register/verify so a
@@ -8053,7 +8060,9 @@ auth.post("/passkey/register/verify", async (c) => {
     // user's OTP verification, while consumption before any state change
     // keeps it strictly single-use.
     grantTenantId =
-      c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || _DEFAULT_TENANT_ID;
+      c.req.header("X-Steward-Tenant")?.trim() ||
+      body.tenantId?.trim() ||
+      configuredDefaultTenantId();
     const grantOk = await peekEmailGrant(body.emailGrant as string, email, grantTenantId);
     if (!grantOk) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired email grant" }, 401);
@@ -8412,7 +8421,7 @@ auth.post("/email/send", async (c) => {
   const email = body.email.toLowerCase().trim();
   const headerTenantId = c.req.header("X-Steward-Tenant")?.trim();
   const bodyTenantId = body.tenantId?.trim();
-  const resolvedTenantId = headerTenantId || bodyTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = headerTenantId || bodyTenantId || configuredDefaultTenantId();
   const tenantHintError = await validateExplicitAuthTenantHint(
     resolvedTenantId,
     Boolean(headerTenantId || bodyTenantId),
@@ -8494,7 +8503,7 @@ auth.get("/callback/email", async (c) => {
   }
 
   const email = emailParam.toLowerCase().trim();
-  const resolvedTenantId = tenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = tenantId || configuredDefaultTenantId();
   const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "email");
   if (methodResponse) return redirectEmailAuthFailure(c, "method_disabled");
   const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(
@@ -8593,7 +8602,7 @@ auth.post("/email/verify", async (c) => {
   const email = body.email.toLowerCase().trim();
   const headerTenantId = c.req.header("X-Steward-Tenant")?.trim();
   const bodyTenantId = body.tenantId?.trim();
-  const resolvedTenantId = headerTenantId || bodyTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = headerTenantId || bodyTenantId || configuredDefaultTenantId();
   const tenantHintError = await validateExplicitAuthTenantHint(
     resolvedTenantId,
     Boolean(headerTenantId || bodyTenantId),
@@ -8657,7 +8666,8 @@ auth.post("/email/code/verify", async (c) => {
 
   const email = body.email.toLowerCase().trim();
   const code = body.code.trim();
-  const resolvedTenantId = c.req.header("X-Steward-Tenant") || body.tenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId =
+    c.req.header("X-Steward-Tenant") || body.tenantId || configuredDefaultTenantId();
   const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "email");
   if (methodResponse) return methodResponse;
   const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(
@@ -8722,7 +8732,7 @@ auth.post("/email/status", async (c) => {
   }
   const headerTenantId = c.req.header("X-Steward-Tenant")?.trim();
   const bodyTenantId = body.tenantId?.trim();
-  const resolvedTenantId = headerTenantId || bodyTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = headerTenantId || bodyTenantId || configuredDefaultTenantId();
   const tenantHintError = await validateExplicitAuthTenantHint(
     resolvedTenantId,
     Boolean(headerTenantId || bodyTenantId),
@@ -8769,7 +8779,7 @@ auth.post("/email/otp/send", async (c) => {
   const email = body.email.toLowerCase().trim();
   const headerTenantId = c.req.header("X-Steward-Tenant")?.trim();
   const bodyTenantId = body.tenantId?.trim();
-  const resolvedTenantId = headerTenantId || bodyTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = headerTenantId || bodyTenantId || configuredDefaultTenantId();
   const tenantHintError = await validateExplicitAuthTenantHint(
     resolvedTenantId,
     Boolean(headerTenantId || bodyTenantId),
@@ -8844,7 +8854,8 @@ auth.post("/email/otp/verify", async (c) => {
 
   const email = body.email.toLowerCase().trim();
   const code = body.code.trim();
-  const resolvedTenantId = c.req.header("X-Steward-Tenant") || body.tenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId =
+    c.req.header("X-Steward-Tenant") || body.tenantId || configuredDefaultTenantId();
   const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "email");
   if (methodResponse) return methodResponse;
   const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(
@@ -8927,7 +8938,7 @@ async function resolveGuestTenant(
   const requested =
     headerTenant ||
     (typeof bodyTenantId === "string" ? bodyTenantId.trim() : "") ||
-    _DEFAULT_TENANT_ID;
+    configuredDefaultTenantId();
 
   if (!isValidTenantId(requested)) {
     return { ok: false, status: 400, error: "Invalid tenant id format" };
@@ -8938,7 +8949,7 @@ async function resolveGuestTenant(
   if (!(await tenantExists(requested))) {
     return { ok: false, status: 404, error: `Tenant '${requested}' not found` };
   }
-  if (requested === _DEFAULT_TENANT_ID) {
+  if (requested === configuredDefaultTenantId()) {
     return { ok: true, tenantId: requested, isPersonal: false };
   }
   const [config] = await getDb()
@@ -10561,7 +10572,7 @@ async function getAllowedOAuthRedirectEntries(
   clientId?: string,
 ): Promise<string[]> {
   const explicitTenantId = tenantId?.trim() || undefined;
-  const resolvedTenantId = explicitTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = explicitTenantId || configuredDefaultTenantId();
   const entries = new Set<string>();
 
   const normalizedClientId = normalizePublicClientId(clientId);

--- a/packages/api/src/routes/global-wallet.ts
+++ b/packages/api/src/routes/global-wallet.ts
@@ -60,13 +60,9 @@ const SIGNING_RPC_METHODS = new Set([
   "wallet_signCalls",
 ]);
 const MFA_MAX_AGE_MS = 10 * 60_000;
-const ALLOW_UNSAFE_MESSAGE_SIGNING = process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING === "true";
-const ALLOW_GLOBAL_WALLET_PERSONAL_SIGN =
-  process.env.STEWARD_ALLOW_GLOBAL_WALLET_PERSONAL_SIGN === "true";
-const ALLOW_GLOBAL_WALLET_TYPED_DATA_SIGNING =
-  process.env.STEWARD_ALLOW_GLOBAL_WALLET_TYPED_DATA_SIGNING === "true";
-const ALLOW_GLOBAL_WALLET_SEND_TRANSACTION =
-  process.env.STEWARD_ALLOW_GLOBAL_WALLET_SEND_TRANSACTION === "true";
+function envFlag(name: string): boolean {
+  return process.env[name] === "true";
+}
 const ACTION_CONFIRMATION_TTL_MS = 5 * 60_000;
 const MAX_TRANSACTION_DATA_BYTES = 16_384;
 
@@ -1174,6 +1170,7 @@ globalWalletRoutes.post("/rpc/scan", async (c) => {
     },
   ];
   const blocked = hasCalldata;
+  const executionSupported = envFlag("STEWARD_ALLOW_GLOBAL_WALLET_SEND_TRANSACTION") && !blocked;
   await writeGlobalWalletAudit(c, {
     tenantId: parsed.tenantId,
     action: "global_wallet.rpc.transaction_scanned",
@@ -1203,13 +1200,12 @@ globalWalletRoutes.post("/rpc/scan", async (c) => {
       riskLevel: blocked ? "blocked" : parsedTx.valueWei === "0" ? "low" : "medium",
       warnings,
       confirmationRequired: true,
-      executionSupported: ALLOW_GLOBAL_WALLET_SEND_TRANSACTION && !blocked,
-      unsupportedReason:
-        ALLOW_GLOBAL_WALLET_SEND_TRANSACTION && !blocked
-          ? null
-          : blocked
-            ? "Global wallet transaction execution is disabled for contract calldata until selector-aware scanning is configured."
-            : "Global wallet transaction execution is disabled. Set STEWARD_ALLOW_GLOBAL_WALLET_SEND_TRANSACTION=true only after native transfer controls are audited.",
+      executionSupported,
+      unsupportedReason: executionSupported
+        ? null
+        : blocked
+          ? "Global wallet transaction execution is disabled for contract calldata until selector-aware scanning is configured."
+          : "Global wallet transaction execution is disabled. Set STEWARD_ALLOW_GLOBAL_WALLET_SEND_TRANSACTION=true only after native transfer controls are audited.",
     },
   });
 });
@@ -1296,7 +1292,10 @@ globalWalletRoutes.post("/rpc", async (c) => {
   }
 
   if (method === "personal_sign") {
-    if (!ALLOW_UNSAFE_MESSAGE_SIGNING || !ALLOW_GLOBAL_WALLET_PERSONAL_SIGN) {
+    if (
+      !envFlag("STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING") ||
+      !envFlag("STEWARD_ALLOW_GLOBAL_WALLET_PERSONAL_SIGN")
+    ) {
       return c.json<ApiResponse>(
         {
           ok: false,
@@ -1395,7 +1394,7 @@ globalWalletRoutes.post("/rpc", async (c) => {
   }
 
   if (method === "eth_signTypedData_v4") {
-    if (!ALLOW_GLOBAL_WALLET_TYPED_DATA_SIGNING) {
+    if (!envFlag("STEWARD_ALLOW_GLOBAL_WALLET_TYPED_DATA_SIGNING")) {
       return c.json<ApiResponse>(
         {
           ok: false,
@@ -1498,7 +1497,7 @@ globalWalletRoutes.post("/rpc", async (c) => {
   }
 
   if (method === "eth_sendTransaction") {
-    if (!ALLOW_GLOBAL_WALLET_SEND_TRANSACTION) {
+    if (!envFlag("STEWARD_ALLOW_GLOBAL_WALLET_SEND_TRANSACTION")) {
       return c.json<ApiResponse>(
         {
           ok: false,

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -83,6 +83,13 @@ function positiveIntEnv(name: string, fallback: number): number {
 // falls back to that default, so this can never weaken the guard unintentionally.
 export const RATE_LIMIT_WINDOW_MS = positiveIntEnv("STEWARD_RATE_LIMIT_WINDOW_MS", 60_000);
 export const RATE_LIMIT_MAX_REQUESTS = positiveIntEnv("STEWARD_RATE_LIMIT_MAX_REQUESTS", 100);
+/** Resolve Worker binding rotations without changing the Bun entry's startup snapshot. */
+export function getRateLimitWindowMs(): number {
+  return positiveIntEnv("STEWARD_RATE_LIMIT_WINDOW_MS", 60_000);
+}
+export function getRateLimitMaxRequests(): number {
+  return positiveIntEnv("STEWARD_RATE_LIMIT_MAX_REQUESTS", 100);
+}
 export const AGENT_TOKEN_EXPIRY = process.env.AGENT_TOKEN_EXPIRY || "30d";
 export const isWorkersRuntime =
   process.env.STEWARD_RUNTIME === "workers" ||

--- a/packages/api/src/services/webhook-url.ts
+++ b/packages/api/src/services/webhook-url.ts
@@ -1,7 +1,9 @@
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
 
-const ALLOW_INSECURE_WEBHOOK_URLS = process.env.STEWARD_ALLOW_INSECURE_WEBHOOK_URLS === "true";
+function allowInsecureWebhookUrls(): boolean {
+  return process.env.STEWARD_ALLOW_INSECURE_WEBHOOK_URLS === "true";
+}
 
 function isNonPublicIpv4(hostname: string): boolean {
   const octets = hostname.split(".").map((part) => Number(part));
@@ -155,7 +157,7 @@ export function validateWebhookUrl(url: string): string | null {
     if (parsed.username || parsed.password) return "url must not include credentials";
 
     if (parsed.protocol !== "https:") {
-      if (!ALLOW_INSECURE_WEBHOOK_URLS || parsed.protocol !== "http:") {
+      if (!allowInsecureWebhookUrls() || parsed.protocol !== "http:") {
         return "url must use https";
       }
     }


### PR DESCRIPTION
## Summary
- resolve request-expiry and authorization-signature requirements, HMAC secrets, and freshness limits per request
- revoke global-wallet execution opt-ins and insecure webhook HTTP immediately when Worker bindings rotate
- refresh Worker global rate limits and the auth default tenant from current bindings while preserving Bun startup constants
- add same-instance rotation regressions for every corrected gate

## Security impact
A long-lived Worker isolate could retain a permissive or obsolete value captured when the app/module was first composed. Removing an unsafe-wallet, insecure-webhook, request-signature, or request-expiry binding would not take effect until isolate recycle; a rotated HMAC secret could also leave the old secret valid. These gates now read the currently hydrated binding synchronously on each request.

## Validation
- request-expiry, authorization-signature, webhook URL: 41/41
- global-wallet route suite: 13/13
- Worker global-rate/default-tenant suite: 5/5
- `bun run --cwd packages/api build`
- Biome on all 13 changed files
- `git diff --check`

No workflow files changed.