### PR TITLE
test(auth): make tenant middleware fixture load-safe

### DIFF
--- a/packages/auth/src/__tests__/middleware.test.ts
+++ b/packages/auth/src/__tests__/middleware.test.ts
@@ -8,15 +8,16 @@
  * (status, body, and content type), so requesters cannot enumerate tenant ids.
  */
 
-import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout, spyOn } from "bun:test";
 import { closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { Hono } from "hono";
 
-import { generateApiKey } from "../api-keys";
+import * as apiKeys from "../api-keys";
 
 const TENANT_ID = "sec132-known-tenant";
 const ENV_KEYS = ["STEWARD_PGLITE_MEMORY", "STEWARD_DB_MODE", "STEWARD_MASTER_PASSWORD"] as const;
+const UNKNOWN_TENANT_DUMMY_HASH = apiKeys.hashApiKey("steward-unknown-tenant-dummy-key");
 
 setDefaultTimeout(30_000);
 
@@ -24,18 +25,20 @@ describe("tenantAuthMiddleware unknown-tenant hardening (SEC-132)", () => {
   const savedEnv: Record<string, string | undefined> = {};
   let app: Hono;
   let validKey: string;
+  let validateApiKeySpy: ReturnType<typeof spyOn> | undefined;
 
   beforeAll(async () => {
     for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_DB_MODE = "pglite";
     process.env.STEWARD_MASTER_PASSWORD ??= "sec132-middleware-test-master-password";
+    validateApiKeySpy = spyOn(apiKeys, "validateApiKey");
     const { db, client } = await createPGLiteDb("memory://");
     setPGLiteOverride(db, async () => {
       await client.close();
     });
 
-    const keyPair = generateApiKey();
+    const keyPair = apiKeys.generateApiKey();
     validKey = keyPair.key;
     await getDb()
       .insert(tenants)
@@ -50,12 +53,19 @@ describe("tenantAuthMiddleware unknown-tenant hardening (SEC-132)", () => {
   });
 
   afterAll(async () => {
-    await closeDb();
-    for (const key of ENV_KEYS) {
-      if (savedEnv[key] === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = savedEnv[key];
+    try {
+      await closeDb();
+    } finally {
+      try {
+        validateApiKeySpy?.mockRestore();
+      } finally {
+        for (const key of ENV_KEYS) {
+          if (savedEnv[key] === undefined) {
+            delete process.env[key];
+          } else {
+            process.env[key] = savedEnv[key];
+          }
+        }
       }
     }
   });
@@ -87,6 +97,7 @@ describe("tenantAuthMiddleware unknown-tenant hardening (SEC-132)", () => {
     expect(unknownTenantRes.headers.get("content-type")).toBe(
       knownBadKeyRes.headers.get("content-type"),
     );
+    expect(validateApiKeySpy).toHaveBeenCalledWith("stw_wrong_key", UNKNOWN_TENANT_DUMMY_HASH);
   });
 
   it("keeps the healthcheck bypass exact: GET / and /health only", async () => {

--- a/packages/auth/src/__tests__/middleware.test.ts
+++ b/packages/auth/src/__tests__/middleware.test.ts
@@ -4,16 +4,11 @@
  * the dummy-hash comparison, so response shape/timing cannot enumerate valid
  * tenant ids.
  *
- * Two layers of proof:
- *   - behavioral: known-tenant/wrong-key and unknown-tenant responses are
- *     byte-identical 403s (status, body, content type);
- *   - structural: the middleware source pins the dummy-hash mechanism (a
- *     timing assertion would be flaky in CI).
+ * Known-tenant/wrong-key and unknown-tenant responses are byte-identical 403s
+ * (status, body, and content type), so requesters cannot enumerate tenant ids.
  */
 
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { Hono } from "hono";
@@ -22,6 +17,8 @@ import { generateApiKey } from "../api-keys";
 
 const TENANT_ID = "sec132-known-tenant";
 const ENV_KEYS = ["STEWARD_PGLITE_MEMORY", "STEWARD_DB_MODE", "STEWARD_MASTER_PASSWORD"] as const;
+
+setDefaultTimeout(30_000);
 
 describe("tenantAuthMiddleware unknown-tenant hardening (SEC-132)", () => {
   const savedEnv: Record<string, string | undefined> = {};
@@ -90,19 +87,6 @@ describe("tenantAuthMiddleware unknown-tenant hardening (SEC-132)", () => {
     expect(unknownTenantRes.headers.get("content-type")).toBe(
       knownBadKeyRes.headers.get("content-type"),
     );
-  });
-
-  it("pins the dummy-hash comparison in the middleware source", () => {
-    // The unknown-tenant path must still run validateApiKey against a dummy
-    // hash so response TIMING matches the known-tenant path. Pinning the
-    // construction beats a wall-clock assertion, which flakes under CI load.
-    const source = readFileSync(join(import.meta.dir, "..", "middleware.ts"), "utf8");
-    expect(source).toContain('hashApiKey("steward-unknown-tenant-dummy-key")');
-    expect(source).toContain(
-      "validateApiKey(apiKey, tenant?.apiKeyHash ?? UNKNOWN_TENANT_DUMMY_HASH)",
-    );
-    // One shared denial: no branch may reveal WHICH leg failed.
-    expect(source).toContain("if (!tenant || !keyValid)");
   });
 
   it("keeps the healthcheck bypass exact: GET / and /health only", async () => {


### PR DESCRIPTION
Closes #577.\n\n## Summary\n- gives the PGLite-backed tenant middleware fixture a bounded 30-second timeout for the full parallel root matrix\n- retains byte-identical 403 behavior for known-tenant bad keys and unknown tenants\n- retains the exact healthcheck bypass contract\n- removes the remaining implementation-source string scan and unused filesystem imports\n\nProduction middleware is unchanged.\n\n## Exact-head validation\n- focused tenant middleware: 3/3 pass, 10 assertions\n- affected auth dependency build: 7/7 packages\n- Biome and diff-check: pass