### PR TITLE
test(api): isolate agent-client proxy fixture

### DIFF
--- a/packages/api/src/__tests__/agent-client-e2e.test.ts
+++ b/packages/api/src/__tests__/agent-client-e2e.test.ts
@@ -23,8 +23,16 @@
 
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { fileURLToPath } from "node:url";
-import { generateP256KeyPair } from "@stwd/auth";
-import { agentSigners, agents, closeDb, getDb, runPluginMigrations, tenants } from "@stwd/db";
+import { generateP256KeyPair, signAgentToken } from "@stwd/auth";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  agentSigners,
+  agents,
+  closeDb,
+  getDb,
+  runPluginMigrations,
+  tenants,
+} from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { CapabilityStore } from "@stwd/plugin-capabilities";
 import { AgentClient, AgentKeypair } from "@stwd/sdk";
@@ -38,6 +46,7 @@ setDefaultTimeout(30000);
 const MASTER_PASSWORD = "a3-agent-client-e2e-master-password-32chars";
 const SIGNING_SECRET = "a3-agent-client-e2e-signing-secret-32bytes-min";
 const FAKE_PAT = "ghp_a3_e2e_do_not_use_0123456789abcdef";
+const AUDIT_HMAC_KEY = "a3-agent-client-e2e-audit-hmac-key-with-enough-bytes";
 const PROXY_URL = "https://proxy.a3-e2e.test";
 const CAP_MIGRATIONS = fileURLToPath(
   new URL("../../../plugin-capabilities/drizzle", import.meta.url),
@@ -60,6 +69,7 @@ let agentId: string;
 let capName: string;
 
 let forwarded: { url: string; auth: string | null; bodyText: string | null } | null = null;
+let proxyRequest: { headers: Headers; bodyText: string | null } | null = null;
 let proxyApp: Hono | null = null;
 const realFetch = globalThis.fetch;
 let originalEnv = new Map<string, string | undefined>();
@@ -142,7 +152,8 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "a3-agent-client-e2e-jwt-secret-with-enough-bytes-0123456789";
-  process.env.STEWARD_AUDIT_HMAC_KEY = "a3-agent-client-e2e-audit-hmac-key-with-enough-bytes";
+  process.env.STEWARD_AUDIT_HMAC_KEY = AUDIT_HMAC_KEY;
+  __resetAuditHmacKeyCacheForTests();
   process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
   process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.github.com";
@@ -256,6 +267,10 @@ beforeAll(async () => {
     }
     if (url.startsWith(PROXY_URL) && proxyApp) {
       const path = url.slice(PROXY_URL.length) || "/";
+      proxyRequest = {
+        headers: new Headers(init?.headers),
+        bodyText: typeof init?.body === "string" ? init.body : null,
+      };
       return proxyApp.request(path, init as RequestInit);
     }
     return realFetch(input as RequestInfo, init);
@@ -271,10 +286,28 @@ afterAll(async () => {
     if (original === undefined) delete process.env[key];
     else process.env[key] = original;
   }
+  __resetAuditHmacKeyCacheForTests();
+  originalEnv.clear();
 });
 
 describe("A3 agent-client E2E (real API, seeded p256 signer)", () => {
+  it("keeps the proxy fail-closed for unsigned agent requests", async () => {
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", "api:proxy"] }, "5m");
+    const response = await proxyApp!.request(
+      "/proxy/api.github.com/repos/acme/app/issues/1/comments",
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "X-Steward-Signature header required",
+    });
+  });
+
   it("boots keypair-only and runs enroll → manifest → issue → invoke", async () => {
+    forwarded = null;
+    proxyRequest = null;
     // The agent holds ONLY its private key (imported non-extractable).
     const kp = await AgentKeypair.fromPkcs8Base64(await exportPkcs8Base64(keypair.privateKey));
     const client = new AgentClient({
@@ -312,9 +345,17 @@ describe("A3 agent-client E2E (real API, seeded p256 signer)", () => {
     // the credential reached the UPSTREAM (proxy→github), never the agent.
     expect(forwarded).not.toBeNull();
     expect(forwarded!.auth).toBe(`Bearer ${FAKE_PAT}`);
+    expect(forwarded!.bodyText).not.toContain(FAKE_PAT);
+    // The API→proxy leg really is signed; dev-mode test plumbing must not make
+    // this happy path vacuous by allowing an unsigned request through.
+    expect(proxyRequest).not.toBeNull();
+    expect(proxyRequest!.headers.get("x-steward-signature")).toMatch(/^v1=[0-9a-f]{64}$/);
+    expect(proxyRequest!.headers.get("x-steward-request-timestamp")).toMatch(/^\d+$/);
+    expect(proxyRequest!.bodyText).not.toContain(FAKE_PAT);
     // the agent-visible response body never contains the PAT.
     expect(JSON.stringify(res.data)).not.toContain(FAKE_PAT);
     expect(JSON.stringify(res.data)).not.toContain("ghp_");
+    expect(JSON.stringify(res.data)).not.toContain(AUDIT_HMAC_KEY);
 
     client.stopRenewalLoop();
   });

--- a/packages/api/src/__tests__/agent-client-e2e.test.ts
+++ b/packages/api/src/__tests__/agent-client-e2e.test.ts
@@ -1,5 +1,5 @@
 /**
- * agent-client-e2e.test.ts — Pillar A / lane A3 happy-path E2E.
+ * agent-client-e2e.test.ts — sovereign-custody happy-path E2E.
  *
  * Drives the REAL @stwd/sdk AgentClient against a REAL, in-process Steward API
  * surface — the actual A1 route handlers (agent-enroll + manifest/issuance +
@@ -42,6 +42,17 @@ const PROXY_URL = "https://proxy.a3-e2e.test";
 const CAP_MIGRATIONS = fileURLToPath(
   new URL("../../../plugin-capabilities/drizzle", import.meta.url),
 );
+const TEST_ENV_KEYS = [
+  "STEWARD_PGLITE_MEMORY",
+  "STEWARD_MASTER_PASSWORD",
+  "STEWARD_JWT_SECRET",
+  "STEWARD_AUDIT_HMAC_KEY",
+  "STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE",
+  "STEWARD_PROXY_REQUEST_SIGNING_SECRET",
+  "STEWARD_PROXY_ALLOWED_HOSTS",
+  "STEWARD_PROXY_DEV_MODE",
+  "STEWARD_PROXY_URL",
+] as const;
 
 let keypair: Awaited<ReturnType<typeof generateP256KeyPair>>;
 let tenantId: string;
@@ -51,6 +62,8 @@ let capName: string;
 let forwarded: { url: string; auth: string | null; bodyText: string | null } | null = null;
 let proxyApp: Hono | null = null;
 const realFetch = globalThis.fetch;
+let originalEnv = new Map<string, string | undefined>();
+let resetProxyHandlerTestHooksForTests: (() => void) | undefined;
 
 // Real A1 route factories + agent-jwt middleware.
 let agentEnrollRoutes: Hono<{ Variables: AppVariables }>;
@@ -125,12 +138,15 @@ async function buildStewardAppContext() {
 }
 
 beforeAll(async () => {
+  originalEnv = new Map(TEST_ENV_KEYS.map((key) => [key, process.env[key]]));
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "a3-agent-client-e2e-jwt-secret-with-enough-bytes-0123456789";
+  process.env.STEWARD_AUDIT_HMAC_KEY = "a3-agent-client-e2e-audit-hmac-key-with-enough-bytes";
   process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
   process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.github.com";
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   process.env.STEWARD_PROXY_URL = PROXY_URL;
 
   const { db, client } = await createPGLiteDb("memory://");
@@ -148,8 +164,12 @@ beforeAll(async () => {
     handleProxy,
     __setForwardProxyRequestForTests: setForward,
     __setResolveProxyHostForTests: setResolveHost,
+    __setCheckProxyRateLimitForTests: setCheckProxyRateLimitForTests,
+    __resetProxyHandlerTestHooksForTests: resetProxyHooks,
   } = await import("@stwd/proxy/src/handlers/proxy");
+  resetProxyHandlerTestHooksForTests = resetProxyHooks;
   setResolveHost(async () => [{ address: "93.184.216.34", family: 4 }]);
+  setCheckProxyRateLimitForTests(async () => ({ allowed: true, resetMs: 0 }));
   setForward(async (url, method, headers, body) => {
     const bodyText = body ? await new Response(body).text() : null;
     forwarded = {
@@ -244,17 +264,12 @@ beforeAll(async () => {
 
 afterAll(async () => {
   globalThis.fetch = realFetch;
+  resetProxyHandlerTestHooksForTests?.();
   await closeDb().catch(() => {});
-  for (const k of [
-    "STEWARD_PGLITE_MEMORY",
-    "STEWARD_MASTER_PASSWORD",
-    "STEWARD_JWT_SECRET",
-    "STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE",
-    "STEWARD_PROXY_REQUEST_SIGNING_SECRET",
-    "STEWARD_PROXY_ALLOWED_HOSTS",
-    "STEWARD_PROXY_URL",
-  ]) {
-    delete process.env[k];
+  for (const key of TEST_ENV_KEYS) {
+    const original = originalEnv.get(key);
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
   }
 });
 


### PR DESCRIPTION
Closes #580.\n\n## Summary\n- explicitly opts this hermetic real-AgentClient integration fixture into the development replay-store boundary\n- installs an allow-only rate checker while preserving policy/call-count behavior above the proxy\n- configures the audit HMAC required by the real proxy path\n- snapshots and restores every changed environment binding\n- resets every mutable proxy handler dependency during teardown\n\nProduction enforcement remains fail closed.\n\n## Exact-head validation\n- agent-client E2E: 1/1 pass, 12 assertions\n- affected API dependency build: 24/24 packages\n- Biome and diff-check: pass