### PR TITLE
test(capabilities): isolate session broker proxy fixture

### DIFF
--- a/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
@@ -53,11 +53,25 @@ const PROXY_URL = "https://proxy.broker-e2e.test";
 const BROKER_HOST = "broker.cap-e2e.test";
 const CAP_NAME = "broker.session.render";
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
+const TEST_ENV_KEYS = [
+  "STEWARD_PGLITE_MEMORY",
+  "STEWARD_MASTER_PASSWORD",
+  "STEWARD_JWT_SECRET",
+  "STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE",
+  "STEWARD_PROXY_REQUEST_SIGNING_SECRET",
+  "STEWARD_PROXY_ALLOWED_HOSTS",
+  "STEWARD_SECRET_ROUTE_ALLOWED_HOSTS",
+  "STEWARD_PROXY_DEV_MODE",
+  "STEWARD_PROXY_URL",
+] as const;
+const originalEnv = new Map<(typeof TEST_ENV_KEYS)[number], string | undefined>();
 
 let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddleware"];
 let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
 let setForwardProxyRequestForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setForwardProxyRequestForTests"];
 let setResolveProxyHostForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setResolveProxyHostForTests"];
+let setCheckProxyRateLimitForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setCheckProxyRateLimitForTests"];
+let resetProxyHandlerTestHooksForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__resetProxyHandlerTestHooksForTests"];
 
 interface ForwardedCapture {
   url: string;
@@ -69,6 +83,7 @@ let lastForwarded: ForwardedCapture | null = null;
 // the broker's next response body (a test may seed a fat body).
 let brokerResponseBody: string = JSON.stringify({ ok: true, rendered: "small" });
 let proxyApp: Hono | null = null;
+let proxyRateLimitChecks = 0;
 const realFetch = globalThis.fetch;
 
 // the policy set the injected getPolicySet returns for the current test.
@@ -92,6 +107,7 @@ function capRule(
 }
 
 beforeAll(async () => {
+  for (const key of TEST_ENV_KEYS) originalEnv.set(key, process.env[key]);
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "broker-e2e-jwt-secret-with-enough-bytes-0123456789ab";
@@ -101,6 +117,7 @@ beforeAll(async () => {
   // secret-route host allowlist (so a credential may be injected on it).
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = BROKER_HOST;
   process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS = BROKER_HOST;
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   process.env.STEWARD_PROXY_URL = PROXY_URL;
 
   const { db, client } = await createPGLiteDb("memory://");
@@ -117,10 +134,16 @@ beforeAll(async () => {
     handleProxy,
     __setForwardProxyRequestForTests: setForwardProxyRequestForTests,
     __setResolveProxyHostForTests: setResolveProxyHostForTests,
+    __setCheckProxyRateLimitForTests: setCheckProxyRateLimitForTests,
+    __resetProxyHandlerTestHooksForTests: resetProxyHandlerTestHooksForTests,
   } = await import("@stwd/proxy/src/handlers/proxy"));
 
   // deterministic public ip so the DNS-level SSRF guard passes with no network.
   setResolveProxyHostForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
+  setCheckProxyRateLimitForTests(async () => {
+    proxyRateLimitChecks += 1;
+    return { allowed: true, resetMs: 0 };
+  });
   // the stub broker: capture the forwarded request (to assert the injected token +
   // that the agent body reached the broker), return the seeded JSON body. The
   // forwarder signature is (url, method, headers, body: ReadableStream|null,
@@ -154,15 +177,20 @@ beforeAll(async () => {
 
 afterAll(async () => {
   globalThis.fetch = realFetch;
-  await closeDb().catch(() => {});
-  delete process.env.STEWARD_PGLITE_MEMORY;
-  delete process.env.STEWARD_MASTER_PASSWORD;
-  delete process.env.STEWARD_JWT_SECRET;
-  delete process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE;
-  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
-  delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
-  delete process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS;
-  delete process.env.STEWARD_PROXY_URL;
+  try {
+    resetProxyHandlerTestHooksForTests?.();
+  } finally {
+    try {
+      await closeDb().catch(() => {});
+    } finally {
+      for (const key of TEST_ENV_KEYS) {
+        const original = originalEnv.get(key);
+        if (original === undefined) delete process.env[key];
+        else process.env[key] = original;
+      }
+      originalEnv.clear();
+    }
+  }
 });
 
 let tenantId: string;
@@ -266,6 +294,7 @@ beforeEach(async () => {
   await seedTenantAgent();
   currentPolicySet = [];
   lastForwarded = null;
+  proxyRateLimitChecks = 0;
   brokerResponseBody = JSON.stringify({ ok: true, rendered: "small" });
 });
 
@@ -286,6 +315,7 @@ describe("session-broker e2e: full arc through the real proxy", () => {
 
     // broker 200 passed through verbatim.
     expect(res.status).toBe(200);
+    expect(proxyRateLimitChecks).toBe(1);
     const passthrough = await res.text();
     const parsed = JSON.parse(passthrough) as { ok: boolean; rendered: string };
     expect(parsed.ok).toBe(true);
@@ -322,6 +352,7 @@ describe("session-broker e2e: full arc through the real proxy", () => {
     });
 
     expect(res.status).toBe(200);
+    expect(proxyRateLimitChecks).toBe(1);
     const passthrough = await res.text();
     const parsed = JSON.parse(passthrough) as { ok: boolean; data: string };
     // the fat body survived the round trip byte-for-byte.
@@ -419,6 +450,7 @@ describe("session-broker e2e: full arc through the real proxy", () => {
     // missing idempotency key. The invoke path forwards the upstream/proxy status
     // verbatim. The request NEVER reached the broker.
     expect(res.status).toBe(400);
+    expect(proxyRateLimitChecks).toBe(1);
     const bodyText = await res.text();
     expect(bodyText).toContain("Idempotency-Key");
     // the broker was never called: no credential was ever attached/forwarded.

--- a/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
@@ -29,6 +29,7 @@
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { fileURLToPath } from "node:url";
+import { signAgentToken } from "@stwd/auth";
 import { agents, closeDb, eq, getDb, runPluginMigrations, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import type { AppVariables, PolicyRule } from "@stwd/shared";
@@ -54,6 +55,7 @@ const BROKER_HOST = "broker.cap-e2e.test";
 const CAP_NAME = "broker.session.render";
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
 const TEST_ENV_KEYS = [
+  "NODE_ENV",
   "STEWARD_PGLITE_MEMORY",
   "STEWARD_MASTER_PASSWORD",
   "STEWARD_JWT_SECRET",
@@ -84,6 +86,7 @@ let lastForwarded: ForwardedCapture | null = null;
 let brokerResponseBody: string = JSON.stringify({ ok: true, rendered: "small" });
 let proxyApp: Hono | null = null;
 let proxyRateLimitChecks = 0;
+let lastProxyRequestHeaders: Headers | null = null;
 const realFetch = globalThis.fetch;
 
 // the policy set the injected getPolicySet returns for the current test.
@@ -108,6 +111,7 @@ function capRule(
 
 beforeAll(async () => {
   for (const key of TEST_ENV_KEYS) originalEnv.set(key, process.env[key]);
+  process.env.NODE_ENV = "test";
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "broker-e2e-jwt-secret-with-enough-bytes-0123456789ab";
@@ -169,6 +173,7 @@ beforeAll(async () => {
       typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     if (url.startsWith(PROXY_URL) && proxyApp) {
       const path = url.slice(PROXY_URL.length) || "/";
+      lastProxyRequestHeaders = new Headers(init?.headers);
       return proxyApp.request(path, init as RequestInit);
     }
     return realFetch(input as RequestInfo, init);
@@ -295,10 +300,33 @@ beforeEach(async () => {
   currentPolicySet = [];
   lastForwarded = null;
   proxyRateLimitChecks = 0;
+  lastProxyRequestHeaders = null;
   brokerResponseBody = JSON.stringify({ ok: true, rendered: "small" });
 });
 
 describe("session-broker e2e: full arc through the real proxy", () => {
+  it("keeps unsigned proxy requests fail-closed in production despite dev mode", async () => {
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["api:proxy"] }, "5m");
+    process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "false";
+    process.env.NODE_ENV = "production";
+    try {
+      const response = await proxyApp!.request(`/proxy/${BROKER_HOST}/render`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        ok: false,
+        error: "X-Steward-Signature header required",
+      });
+      expect(lastForwarded).toBeNull();
+    } finally {
+      process.env.NODE_ENV = "test";
+      process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
+    }
+  });
+
   it("allowed POST invoke injects the broker token, passes the JSON body through, token never seen by agent, records allow", async () => {
     const capId = await seedBrokerCapability("POST");
     currentPolicySet = [capRule("r1", "allow", { argEquals: { sessionId: "sess_123" } })];
@@ -316,6 +344,8 @@ describe("session-broker e2e: full arc through the real proxy", () => {
     // broker 200 passed through verbatim.
     expect(res.status).toBe(200);
     expect(proxyRateLimitChecks).toBe(1);
+    expect(lastProxyRequestHeaders?.get("x-steward-signature")).toMatch(/^v1=[0-9a-f]{64}$/);
+    expect(lastProxyRequestHeaders?.get("x-steward-request-timestamp")).toMatch(/^\d+$/);
     const passthrough = await res.text();
     const parsed = JSON.parse(passthrough) as { ok: boolean; rendered: string };
     expect(parsed.ok).toBe(true);


### PR DESCRIPTION
Closes #583.

## Summary
- explicitly opts the session-broker fixture into proxy dev mode
- installs an allow-only proxy rate checker and proves forwarded requests cross it
- proves unsigned requests remain rejected in production despite fixture dev mode
- asserts the signed proxy leg carries the Steward signature and timestamp
- restores every mutated environment value and resets all proxy handler hooks

## Security boundary
Production enforcement is unchanged. The checker is installed only through the existing test dependency seam, and the suite continues to exercise signed proxy requests.

## Exact-head validation
- isolated session-broker E2E: 6/6 pass
- dependency-aware build: 12/12 tasks
- Biome: pass
- diff-check: pass

Keep draft until exact hosted checks are green.