### PR TITLE
test(auth): make OIDC JWKS transport hardening behavioral

### DIFF
--- a/packages/api/src/__tests__/middleware-security-hardening.test.ts
+++ b/packages/api/src/__tests__/middleware-security-hardening.test.ts
@@ -56,7 +56,6 @@ describe("middleware security hardening", () => {
     // an unset NODE_ENV must fail closed like production.
     expect(tenantCorsSource).toContain("function devWildcardAllowed()");
     expect(tenantCorsSource).toContain('env === "development" || env === "test"');
-    expect(tenantCorsSource).toContain("origins.length === 0");
     expect(tenantCorsSource).toContain("return c.newResponse(null, 403)");
     expect(tenantCorsSource).toContain("TENANT_ID_RE.test(tenantId)");
     expect(tenantCorsSource).toContain("MAX_CORS_CACHE_ENTRIES");

--- a/packages/api/src/__tests__/tenant-cors-preflight.test.ts
+++ b/packages/api/src/__tests__/tenant-cors-preflight.test.ts
@@ -27,6 +27,15 @@ describe("tenant CORS preflight", () => {
         tenantId: "cors-patch-tenant",
         allowedOrigins: [ALLOWED_ORIGIN],
       });
+    await getDb().insert(tenants).values({
+      id: "cors-empty-tenant",
+      name: "CORS empty tenant",
+      apiKeyHash: "cors-empty-tenant-hash",
+    });
+    await getDb().insert(tenantConfigs).values({
+      tenantId: "cors-empty-tenant",
+      allowedOrigins: [],
+    });
   });
 
   afterAll(async () => {
@@ -76,6 +85,24 @@ describe("tenant CORS preflight", () => {
     expect(response.status).toBe(403);
     expect(response.headers.get("access-control-allow-origin")).toBeNull();
     expect(response.headers.get("access-control-allow-credentials")).toBeNull();
+    expect(response.headers.get("vary")).toBe("Origin, X-Steward-Tenant");
+  });
+
+  test("keeps an explicitly empty tenant allowlist fail closed", async () => {
+    const app = new Hono();
+    app.use("*", tenantCors);
+
+    const response = await app.request("/resource", {
+      method: "OPTIONS",
+      headers: {
+        Origin: ALLOWED_ORIGIN,
+        "X-Steward-Tenant": "cors-empty-tenant",
+        "Access-Control-Request-Method": "PATCH",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
     expect(response.headers.get("vary")).toBe("Origin, X-Steward-Tenant");
   });
 });

--- a/packages/api/src/__tests__/worker-boot-validation.test.ts
+++ b/packages/api/src/__tests__/worker-boot-validation.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { afterEach, describe, expect, it } from "bun:test";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import worker from "../worker";
 
 /**
@@ -23,6 +24,7 @@ const MANAGED_KEYS = [
   "STEWARD_DB_MODE",
   "STEWARD_PGLITE_MEMORY",
   "AGENT_TOKEN_EXPIRY",
+  "STEWARD_OIDC_JWKS_MAX_AGE_MS",
 ] as const;
 
 describe("workers boot JWT env validation (SEC-134)", () => {
@@ -91,25 +93,75 @@ describe("workers boot JWT env validation (SEC-134)", () => {
 
   it("validates concurrent request bindings before either database selection", async () => {
     snapshotEnv();
-    const shortSecret = worker.fetch(
-      new Request("https://workers.test/short-secret"),
-      { NODE_ENV: "production", STEWARD_JWT_SECRET: "short", DATABASE_DRIVER: "bogus" },
-      {},
-    );
-    const malformedExpiry = worker.fetch(
-      new Request("https://workers.test/malformed-expiry"),
-      {
-        STEWARD_JWT_SECRET: "workers-boot-test-secret-32-chars-long!!",
-        AGENT_TOKEN_EXPIRY: "not-a-duration",
-        DATABASE_DRIVER: "bogus",
-      },
-      {},
-    );
+    const shortSecret = expect(
+      worker.fetch(
+        new Request("https://workers.test/short-secret"),
+        { NODE_ENV: "production", STEWARD_JWT_SECRET: "short", DATABASE_DRIVER: "bogus" },
+        {},
+      ),
+    ).rejects.toThrow("at least 32 characters in production");
+    const malformedExpiry = expect(
+      worker.fetch(
+        new Request("https://workers.test/malformed-expiry"),
+        {
+          STEWARD_JWT_SECRET: "workers-boot-test-secret-32-chars-long!!",
+          AGENT_TOKEN_EXPIRY: "not-a-duration",
+          DATABASE_DRIVER: "bogus",
+        },
+        {},
+      ),
+    ).rejects.toThrow('AGENT_TOKEN_EXPIRY "not-a-duration" is not a valid positive duration');
 
-    await expect(shortSecret).rejects.toThrow("at least 32 characters in production");
-    await expect(malformedExpiry).rejects.toThrow(
-      'AGENT_TOKEN_EXPIRY "not-a-duration" is not a valid positive duration',
-    );
+    await Promise.all([shortSecret, malformedExpiry]);
+  });
+
+  it("keeps nested Worker request snapshots isolated from missing global values", async () => {
+    snapshotEnv();
+    process.env.STEWARD_OIDC_JWKS_MAX_AGE_MS = "global-poison";
+    const secret = "workers-runtime-snapshot-secret-at-least-32-chars";
+    let nestedRejection: Promise<void> | undefined;
+    const nestedContext = Object.defineProperty({}, "waitUntil", {
+      get() {
+        throw new Error(
+          `nested snapshot: ${String(runtimeEnvironmentValue("STEWARD_OIDC_JWKS_MAX_AGE_MS"))}`,
+        );
+      },
+    });
+    const firstContext = Object.defineProperty({}, "waitUntil", {
+      get() {
+        const nestedRequest = worker.fetch(
+          new Request("https://workers.test/runtime-snapshot-missing"),
+          { STEWARD_JWT_SECRET: secret, DATABASE_DRIVER: "bogus" },
+          nestedContext,
+        );
+        nestedRejection = nestedRequest.then(
+          () => {
+            throw new Error("nested Worker request unexpectedly succeeded");
+          },
+          (error) => {
+            expect(String(error)).toContain("nested snapshot: undefined");
+          },
+        );
+        throw new Error(
+          `first snapshot: ${String(runtimeEnvironmentValue("STEWARD_OIDC_JWKS_MAX_AGE_MS"))}`,
+        );
+      },
+    });
+
+    const firstRejection = expect(
+      worker.fetch(
+        new Request("https://workers.test/runtime-snapshot-first"),
+        {
+          STEWARD_JWT_SECRET: secret,
+          STEWARD_OIDC_JWKS_MAX_AGE_MS: "60000",
+          DATABASE_DRIVER: "bogus",
+        },
+        firstContext,
+      ),
+    ).rejects.toThrow("first snapshot: 60000");
+    await firstRejection;
+    if (!nestedRejection) throw new Error("nested Worker request did not run");
+    await nestedRejection;
   });
 
   it("validates scheduled security bindings before opening any database handle", async () => {

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -47,6 +47,7 @@ import {
   type NeonTransactionDbHandle,
   withRequestDatabase,
 } from "@stwd/db";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { initRedis } from "./middleware/redis";
 
 export interface Env {
@@ -378,39 +379,43 @@ async function getComposedApp() {
 
 export default {
   async fetch(request: Request, env: Env, ctx: unknown): Promise<Response> {
-    // SEC-148: refresh process.env from the CURRENT request's bindings on every
-    // request (not once per isolate) so rotated bindings take effect promptly;
-    // the once-per-isolate init below only bootstraps stores/imports.
-    hydrateProcessEnv(env);
-    validateWorkerSecurityEnv();
-    const executionCtx = ctx as { waitUntil?: (promise: Promise<unknown>) => void };
-    const waitUntil =
-      typeof executionCtx?.waitUntil === "function"
-        ? executionCtx.waitUntil.bind(executionCtx)
-        : undefined;
-    return withWorkerRequestDatabase(
-      env,
-      async () => {
-        await ensureWorkerInit(env);
-        const app = await getComposedApp();
-        return app.fetch(request, env, ctx as never);
-      },
-      waitUntil ? { waitUntil } : undefined,
-    );
+    return withRuntimeEnvironment({ ...env, STEWARD_RUNTIME: "workers" }, async () => {
+      // Keep the legacy bridge for modules not yet migrated to request-local
+      // configuration. Security-sensitive OIDC settings use the immutable
+      // snapshot above and cannot be replaced by an overlapping request.
+      hydrateProcessEnv(env);
+      validateWorkerSecurityEnv();
+      const executionCtx = ctx as { waitUntil?: (promise: Promise<unknown>) => void };
+      const waitUntil =
+        typeof executionCtx?.waitUntil === "function"
+          ? executionCtx.waitUntil.bind(executionCtx)
+          : undefined;
+      return withWorkerRequestDatabase(
+        env,
+        async () => {
+          await ensureWorkerInit(env);
+          const app = await getComposedApp();
+          return app.fetch(request, env, ctx as never);
+        },
+        waitUntil ? { waitUntil } : undefined,
+      );
+    });
   },
   async scheduled(
     _controller: unknown,
     env: Env,
     ctx: { waitUntil(promise: Promise<unknown>): void },
   ) {
-    hydrateProcessEnv(env);
-    validateWorkerSecurityEnv();
-    ctx.waitUntil(
-      Promise.all([
-        withWorkerRequestDatabase(env, () => runWorkerUpstreamCredentialLeaseSweep(env)),
-        withWorkerRequestDatabase(env, () => runWorkerGoogleCredentialLifecycleSweep(env)),
-        withWorkerRequestDatabase(env, () => runWorkerXCredentialLifecycleSweep(env)),
-      ]),
-    );
+    withRuntimeEnvironment({ ...env, STEWARD_RUNTIME: "workers" }, () => {
+      hydrateProcessEnv(env);
+      validateWorkerSecurityEnv();
+      ctx.waitUntil(
+        Promise.all([
+          withWorkerRequestDatabase(env, () => runWorkerUpstreamCredentialLeaseSweep(env)),
+          withWorkerRequestDatabase(env, () => runWorkerGoogleCredentialLifecycleSweep(env)),
+          withWorkerRequestDatabase(env, () => runWorkerXCredentialLifecycleSweep(env)),
+        ]),
+      );
+    });
   },
 };

--- a/packages/auth/src/__tests__/oidc.test.ts
+++ b/packages/auth/src/__tests__/oidc.test.ts
@@ -19,8 +19,11 @@ class JwksTransportHarness {
   requestDestroyed = false;
   requestEnded = false;
   responseResumed = false;
+  responseDestroyed = false;
   timeoutMs: number | undefined;
   lookupCalls = 0;
+  requestLookup: LookupFunction | undefined;
+  readonly lookup = (() => {}) as LookupFunction;
   private responseHandler: ((response: IncomingMessage) => void) | undefined;
   private deadlineCallbacks = new Map<ReturnType<typeof setTimeout>, () => void>();
 
@@ -43,12 +46,13 @@ class JwksTransportHarness {
     ) => {
       this.requestCalls += 1;
       this.timeoutMs = options.timeout as number | undefined;
+      this.requestLookup = options.lookup;
       this.responseHandler = handler;
       return this.request;
     }) as PublicJwksTransportDependencies["request"],
     createLookup: ((_resource: string) => {
       this.lookupCalls += 1;
-      return (() => {}) as LookupFunction;
+      return this.lookup;
     }) as PublicJwksTransportDependencies["createLookup"],
     setDeadline: (callback, _timeoutMs) => {
       const deadline = Object.create(null) as ReturnType<typeof setTimeout>;
@@ -71,6 +75,10 @@ class JwksTransportHarness {
       this.responseResumed = true;
       return response;
     }) as IncomingMessage["resume"];
+    response.destroy = (() => {
+      this.responseDestroyed = true;
+      return response;
+    }) as IncomingMessage["destroy"];
     this.responseHandler(response);
     return response;
   }
@@ -101,10 +109,28 @@ describe("assertPublicJwksDestination SSRF guard", () => {
     expect(await result.text()).toBe('{"error":"unauthorized"}');
     expect(harness.timeoutMs).toBe(1234);
     expect(harness.lookupCalls).toBe(1);
+    expect(harness.requestLookup).toBe(harness.lookup);
     expect(harness.requestEnded).toBe(true);
     expect(harness.deadlines.size).toBe(0);
     controller.abort();
     expect(harness.requestDestroyed).toBe(false);
+  });
+
+  it("drops non-conforming upstream bytes for bodyless success statuses", async () => {
+    for (const status of [204, 205]) {
+      const harness = new JwksTransportHarness();
+      const pending = createPublicJwksTransport(harness.dependencies)(
+        "https://idp.example.com/jwks",
+      );
+      const response = harness.respond(status);
+      response.emit("data", Buffer.from("hostile-body"));
+      response.emit("end");
+
+      const result = await pending;
+      expect(result.status).toBe(status);
+      expect(await result.text()).toBe("");
+      expect(harness.deadlines.size).toBe(0);
+    }
   });
 
   it("rejects redirects and oversized declared or streamed bodies", async () => {
@@ -132,10 +158,10 @@ describe("assertPublicJwksDestination SSRF guard", () => {
       response.emit("data", Buffer.alloc(1024));
       response.emit("end");
       expect(harness.deadlines.size).toBe(0);
+      expect(harness.requestDestroyed).toBe(true);
       if (testCase.status === 302 || "content-length" in testCase.headers) {
-        expect(harness.responseResumed).toBe(true);
-      } else {
-        expect(harness.requestDestroyed).toBe(true);
+        expect(harness.responseDestroyed).toBe(true);
+        expect(harness.responseResumed).toBe(false);
       }
     }
   });

--- a/packages/auth/src/__tests__/oidc.test.ts
+++ b/packages/auth/src/__tests__/oidc.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import { EventEmitter } from "node:events";
 import type { ClientRequest, IncomingMessage, RequestOptions } from "node:http";
 import type { RequestOptions as HttpsRequestOptions } from "node:https";
 import type { LookupFunction } from "node:net";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 
 import {
   assertPublicJwksDestination,
@@ -20,6 +21,7 @@ class JwksTransportHarness {
   requestEnded = false;
   responseResumed = false;
   responseDestroyed = false;
+  destroyError: Error | undefined;
   timeoutMs: number | undefined;
   lookupCalls = 0;
   requestLookup: LookupFunction | undefined;
@@ -30,6 +32,7 @@ class JwksTransportHarness {
   constructor() {
     this.request.destroy = (() => {
       this.requestDestroyed = true;
+      if (this.destroyError) throw this.destroyError;
       return this.request;
     }) as ClientRequest["destroy"];
     this.request.end = (() => {
@@ -77,6 +80,7 @@ class JwksTransportHarness {
     }) as IncomingMessage["resume"];
     response.destroy = (() => {
       this.responseDestroyed = true;
+      if (this.destroyError) throw this.destroyError;
       return response;
     }) as IncomingMessage["destroy"];
     this.responseHandler(response);
@@ -164,6 +168,16 @@ describe("assertPublicJwksDestination SSRF guard", () => {
         expect(harness.responseResumed).toBe(false);
       }
     }
+  });
+
+  it("preserves fixed terminal errors when best-effort socket destruction throws", async () => {
+    const harness = new JwksTransportHarness();
+    harness.destroyError = new Error("injected destroy detail");
+    const pending = createPublicJwksTransport(harness.dependencies)("https://idp.example.com/jwks");
+    expect(() => harness.respond(302)).not.toThrow();
+    await expect(pending).rejects.toThrow("OIDC jwksUri redirects are not allowed");
+    expect(harness.responseDestroyed).toBe(true);
+    expect(harness.requestDestroyed).toBe(true);
   });
 
   it("rejects deadline, request timeout, and request failure", async () => {
@@ -313,5 +327,30 @@ describe("assertPublicJwksDestination SSRF guard", () => {
     const reloaded = await getPublicRemoteJWKSet("https://idp.example.com/jwks", "tenant:first");
     expect(reloaded).not.toBe(first);
     clearOidcJwksCacheForTests();
+  });
+
+  it("applies the request-local JWKS maximum age to each cache decision", async () => {
+    clearOidcJwksCacheForTests();
+    let now = 1_000_000;
+    const nowSpy = spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      const first = await withRuntimeEnvironment({ STEWARD_OIDC_JWKS_MAX_AGE_MS: "60000" }, () =>
+        getPublicRemoteJWKSet("https://idp.example.com/jwks", "tenant:runtime-age"),
+      );
+      now += 60_001;
+      const retained = await withRuntimeEnvironment(
+        { STEWARD_OIDC_JWKS_MAX_AGE_MS: "120000" },
+        () => getPublicRemoteJWKSet("https://idp.example.com/jwks", "tenant:runtime-age"),
+      );
+      expect(retained).toBe(first);
+
+      const rebuilt = await withRuntimeEnvironment({ STEWARD_OIDC_JWKS_MAX_AGE_MS: "60000" }, () =>
+        getPublicRemoteJWKSet("https://idp.example.com/jwks", "tenant:runtime-age"),
+      );
+      expect(rebuilt).not.toBe(first);
+    } finally {
+      nowSpy.mockRestore();
+      clearOidcJwksCacheForTests();
+    }
   });
 });

--- a/packages/auth/src/__tests__/oidc.test.ts
+++ b/packages/auth/src/__tests__/oidc.test.ts
@@ -1,21 +1,217 @@
 import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
+import { EventEmitter } from "node:events";
+import type { ClientRequest, IncomingMessage, RequestOptions } from "node:http";
+import type { RequestOptions as HttpsRequestOptions } from "node:https";
+import type { LookupFunction } from "node:net";
 
 import {
   assertPublicJwksDestination,
   clearOidcJwksCacheForTests,
+  createPublicJwksTransport,
   getPublicRemoteJWKSet,
+  type PublicJwksTransportDependencies,
 } from "../oidc";
 
+class JwksTransportHarness {
+  readonly request = new EventEmitter() as ClientRequest;
+  readonly deadlines = new Set<ReturnType<typeof setTimeout>>();
+  requestCalls = 0;
+  requestDestroyed = false;
+  requestEnded = false;
+  responseResumed = false;
+  timeoutMs: number | undefined;
+  lookupCalls = 0;
+  private responseHandler: ((response: IncomingMessage) => void) | undefined;
+  private deadlineCallbacks = new Map<ReturnType<typeof setTimeout>, () => void>();
+
+  constructor() {
+    this.request.destroy = (() => {
+      this.requestDestroyed = true;
+      return this.request;
+    }) as ClientRequest["destroy"];
+    this.request.end = (() => {
+      this.requestEnded = true;
+      return this.request;
+    }) as ClientRequest["end"];
+  }
+
+  readonly dependencies: Readonly<PublicJwksTransportDependencies> = Object.freeze({
+    request: ((
+      _url: URL,
+      options: RequestOptions | HttpsRequestOptions,
+      handler: (response: IncomingMessage) => void,
+    ) => {
+      this.requestCalls += 1;
+      this.timeoutMs = options.timeout as number | undefined;
+      this.responseHandler = handler;
+      return this.request;
+    }) as PublicJwksTransportDependencies["request"],
+    createLookup: ((_resource: string) => {
+      this.lookupCalls += 1;
+      return (() => {}) as LookupFunction;
+    }) as PublicJwksTransportDependencies["createLookup"],
+    setDeadline: (callback, _timeoutMs) => {
+      const deadline = Object.create(null) as ReturnType<typeof setTimeout>;
+      this.deadlines.add(deadline);
+      this.deadlineCallbacks.set(deadline, callback);
+      return deadline;
+    },
+    clearDeadline: (deadline) => {
+      this.deadlines.delete(deadline);
+      this.deadlineCallbacks.delete(deadline);
+    },
+  });
+
+  respond(statusCode: number, headers: IncomingMessage["headers"] = {}): EventEmitter {
+    if (!this.responseHandler) throw new Error("request was not created");
+    const response = new EventEmitter() as EventEmitter & IncomingMessage;
+    response.statusCode = statusCode;
+    response.headers = headers;
+    response.resume = (() => {
+      this.responseResumed = true;
+      return response;
+    }) as IncomingMessage["resume"];
+    this.responseHandler(response);
+    return response;
+  }
+
+  fireDeadline(): void {
+    const callback = this.deadlineCallbacks.values().next().value;
+    if (!callback) throw new Error("deadline was not scheduled");
+    callback();
+  }
+}
+
 describe("assertPublicJwksDestination SSRF guard", () => {
-  it("preserves HTTP status and bounds all production JWKS I/O", () => {
-    const source = readFileSync(new URL("../oidc.ts", import.meta.url), "utf8");
-    expect(source).toContain("status: result.status");
-    expect(source).toContain('res.headers["content-length"]');
-    expect(source).toContain("size > JWKS_MAX_BYTES");
-    expect(source).toContain("init?.signal?.addEventListener");
-    expect(source).toContain("JWKS_FETCH_TIMEOUT_MS");
-    expect(source).toContain("OIDC jwksUri redirects are not allowed");
+  it("preserves upstream status, headers, and body and cleans up request resources", async () => {
+    const harness = new JwksTransportHarness();
+    const transport = createPublicJwksTransport(harness.dependencies, {
+      timeoutMs: 1234,
+      maxBytes: 32,
+    });
+    const controller = new AbortController();
+    const pending = transport("https://idp.example.com/jwks", { signal: controller.signal });
+    const response = harness.respond(401, { "content-type": "application/json" });
+    response.emit("data", Buffer.from('{"error":"unauthorized"}'));
+    response.emit("end");
+
+    const result = await pending;
+    expect(result.status).toBe(401);
+    expect(result.headers.get("content-type")).toBe("application/json");
+    expect(await result.text()).toBe('{"error":"unauthorized"}');
+    expect(harness.timeoutMs).toBe(1234);
+    expect(harness.lookupCalls).toBe(1);
+    expect(harness.requestEnded).toBe(true);
+    expect(harness.deadlines.size).toBe(0);
+    controller.abort();
+    expect(harness.requestDestroyed).toBe(false);
+  });
+
+  it("rejects redirects and oversized declared or streamed bodies", async () => {
+    const cases = [
+      { status: 302, headers: {}, body: Buffer.alloc(0), error: "redirects are not allowed" },
+      {
+        status: 200,
+        headers: { "content-length": "9" },
+        body: Buffer.alloc(0),
+        error: "response is too large",
+      },
+      { status: 200, headers: {}, body: Buffer.alloc(9), error: "response is too large" },
+    ] as const;
+
+    for (const testCase of cases) {
+      const harness = new JwksTransportHarness();
+      const transport = createPublicJwksTransport(harness.dependencies, {
+        timeoutMs: 5000,
+        maxBytes: 8,
+      });
+      const pending = transport("https://idp.example.com/jwks");
+      const response = harness.respond(testCase.status, testCase.headers);
+      if (testCase.body.byteLength > 0) response.emit("data", testCase.body);
+      await expect(pending).rejects.toThrow(testCase.error);
+      response.emit("data", Buffer.alloc(1024));
+      response.emit("end");
+      expect(harness.deadlines.size).toBe(0);
+      if (testCase.status === 302 || "content-length" in testCase.headers) {
+        expect(harness.responseResumed).toBe(true);
+      } else {
+        expect(harness.requestDestroyed).toBe(true);
+      }
+    }
+  });
+
+  it("rejects deadline, request timeout, and request failure", async () => {
+    for (const event of ["deadline", "timeout", "error"] as const) {
+      const harness = new JwksTransportHarness();
+      const transport = createPublicJwksTransport(harness.dependencies);
+      const pending = transport("https://idp.example.com/jwks");
+      if (event === "deadline") harness.fireDeadline();
+      else harness.request.emit(event, event === "error" ? new Error("socket detail") : undefined);
+      await expect(pending).rejects.toThrow(
+        event === "error" ? "OIDC JWKS request failed" : "OIDC JWKS request timed out",
+      );
+      expect(harness.deadlines.size).toBe(0);
+      if (event !== "error") expect(harness.requestDestroyed).toBe(true);
+    }
+  });
+
+  it("cleans up when pinned request construction fails synchronously", async () => {
+    const harness = new JwksTransportHarness();
+    const controller = new AbortController();
+    const dependencies: Readonly<PublicJwksTransportDependencies> = Object.freeze({
+      ...harness.dependencies,
+      request: (() => {
+        throw new Error("request-construction-secret");
+      }) as PublicJwksTransportDependencies["request"],
+    });
+
+    await expect(
+      createPublicJwksTransport(dependencies)("https://idp.example.com/jwks", {
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("OIDC JWKS request failed");
+    expect(harness.deadlines.size).toBe(0);
+    controller.abort();
+    expect(harness.requestDestroyed).toBe(false);
+  });
+
+  it("rejects preflight and mid-flight aborts without retaining listeners", async () => {
+    const preflightHarness = new JwksTransportHarness();
+    const preflightController = new AbortController();
+    preflightController.abort();
+    await expect(
+      createPublicJwksTransport(preflightHarness.dependencies)("https://idp.example.com/jwks", {
+        signal: preflightController.signal,
+      }),
+    ).rejects.toThrow("OIDC JWKS request was aborted");
+    expect(preflightHarness.requestCalls).toBe(0);
+    expect(preflightHarness.deadlines.size).toBe(0);
+
+    const activeHarness = new JwksTransportHarness();
+    const activeController = new AbortController();
+    const pending = createPublicJwksTransport(activeHarness.dependencies)(
+      "https://idp.example.com/jwks",
+      { signal: activeController.signal },
+    );
+    activeController.abort();
+    await expect(pending).rejects.toThrow("OIDC JWKS request was aborted");
+    expect(activeHarness.requestDestroyed).toBe(true);
+    expect(activeHarness.deadlines.size).toBe(0);
+  });
+
+  it("rejects interrupted and failed response streams", async () => {
+    for (const event of ["aborted", "error"] as const) {
+      const harness = new JwksTransportHarness();
+      const pending = createPublicJwksTransport(harness.dependencies)(
+        "https://idp.example.com/jwks",
+      );
+      const response = harness.respond(200);
+      response.emit(event, event === "error" ? new Error("upstream detail") : undefined);
+      await expect(pending).rejects.toThrow(
+        event === "aborted" ? "OIDC JWKS response was interrupted" : "OIDC JWKS response failed",
+      );
+      expect(harness.deadlines.size).toBe(0);
+    }
   });
   it("rejects IPv4-mapped IPv6 literals that embed private IPv4 targets", async () => {
     await expect(assertPublicJwksDestination("https://[::ffff:10.0.0.1]/jwks")).rejects.toThrow();

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -10,7 +10,13 @@ export * from "./farcaster";
 export * from "./jwt";
 export * from "./middleware";
 export * from "./oauth";
-export * from "./oidc";
+export {
+  assertPublicJwksDestination,
+  clearOidcJwksCacheForTests,
+  getPublicRemoteJWKSet,
+  type VerifiedOidcToken,
+  verifyOidcJwt,
+} from "./oidc";
 export * from "./passkey";
 export * from "./phone";
 export * from "./platform";

--- a/packages/auth/src/oidc.ts
+++ b/packages/auth/src/oidc.ts
@@ -222,14 +222,16 @@ export function createPublicJwksTransport(
           },
           (res) => {
             if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+              req?.destroy();
+              res.destroy();
               finish(reject, new Error("OIDC jwksUri redirects are not allowed"));
-              res.resume();
               return;
             }
             const declaredLength = Number(res.headers["content-length"]);
             if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+              req?.destroy();
+              res.destroy();
               finish(reject, new Error("OIDC JWKS response is too large"));
-              res.resume();
               return;
             }
             const chunks: Uint8Array[] = [];
@@ -285,10 +287,11 @@ export function createPublicJwksTransport(
       }
     });
 
+    // Fetch forbids response bodies for 204/205. Ignore an upstream's hostile
+    // or non-conforming bytes rather than letting Response construction throw
+    // a runtime TypeError after the bounded transport has otherwise settled.
     const responseBody =
-      result.body.byteLength === 0 && (result.status === 204 || result.status === 205)
-        ? null
-        : new Uint8Array(result.body);
+      result.status === 204 || result.status === 205 ? null : new Uint8Array(result.body);
     return new Response(responseBody, { headers: result.headers, status: result.status });
   };
 }

--- a/packages/auth/src/oidc.ts
+++ b/packages/auth/src/oidc.ts
@@ -2,6 +2,7 @@ import { lookup as dnsLookup } from "node:dns";
 import { request as httpsRequest } from "node:https";
 import { isIP } from "node:net";
 import type { TenantOidcProviderConfig } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   createRemoteJWKSet,
   customFetch,
@@ -28,15 +29,18 @@ const JWKS_CACHE_MAX_ENTRIES = 256;
 // jose's internal cooldown only limits how *often* it refetches on unknown-kid;
 // it never evicts known keys, so a process-lifetime cache would not pick up an
 // IdP emergency key revocation. Rebuilding the set after this TTL guarantees a
-// rotated/revoked key stops verifying within the window. Configurable via env.
-const JWKS_MAX_AGE_MS = (() => {
-  const raw = Number(process.env.STEWARD_OIDC_JWKS_MAX_AGE_MS);
+// rotated/revoked key stops verifying within the window. Resolve the binding
+// for each cache decision so a long-lived Worker observes a tightened window.
+const DEFAULT_JWKS_MAX_AGE_MS = 60 * 60 * 1000;
+function jwksMaxAgeMs(): number {
+  const raw = Number(runtimeEnvironmentValue("STEWARD_OIDC_JWKS_MAX_AGE_MS"));
   if (Number.isFinite(raw) && raw >= 60_000) return raw;
-  return 60 * 60 * 1000; // 1 hour default
-})();
+  return DEFAULT_JWKS_MAX_AGE_MS;
+}
 function allowTestJwksFetch(): boolean {
   return (
-    process.env.NODE_ENV === "test" && process.env.STEWARD_ALLOW_INSECURE_OIDC_JWKS_FETCH === "true"
+    runtimeEnvironmentValue("NODE_ENV") === "test" &&
+    runtimeEnvironmentValue("STEWARD_ALLOW_INSECURE_OIDC_JWKS_FETCH") === "true"
   );
 }
 
@@ -114,7 +118,7 @@ export async function assertPublicJwksDestination(jwksUri: string): Promise<void
 /**
  * Builds (or returns a cached) remote JWKS set whose key fetches are routed
  * through the SSRF-guarded {@link fetchPublicJwks} transport. The set is
- * rebuilt once it exceeds {@link JWKS_MAX_AGE_MS} so rotated or emergency-
+ * rebuilt once it exceeds the configured maximum age so rotated or emergency-
  * revoked IdP keys stop verifying within the window.
  *
  * Reused by both the tenant OIDC path ({@link verifyOidcJwt}) and the
@@ -130,7 +134,7 @@ export async function getPublicRemoteJWKSet(
 ): Promise<ReturnType<typeof createRemoteJWKSet>> {
   assertPinnedDnsTransportSupported("OIDC jwksUri");
   const cached = JWKS_CACHE.get(cacheKey);
-  if (cached && Date.now() - cached.createdAt <= JWKS_MAX_AGE_MS) {
+  if (cached && Date.now() - cached.createdAt <= jwksMaxAgeMs()) {
     // Refresh insertion order so the bounded map acts as an LRU cache.
     JWKS_CACHE.delete(cacheKey);
     JWKS_CACHE.set(cacheKey, cached);
@@ -179,6 +183,13 @@ export function createPublicJwksTransport(
 ): (url: string | URL, init?: RequestInit) => Promise<Response> {
   const { request, createLookup, setDeadline, clearDeadline } = dependencies;
   const { timeoutMs, maxBytes } = limits;
+  const destroySafely = (stream: { destroy(): unknown } | undefined) => {
+    try {
+      stream?.destroy();
+    } catch {
+      // The fixed transport classification already settled the public promise.
+    }
+  };
   return async (url: string | URL, init?: RequestInit): Promise<Response> => {
     const jwksUrl = assertSafeJwksUri(url.toString());
     assertPinnedDnsTransportSupported("OIDC jwksUri");
@@ -197,12 +208,12 @@ export function createPublicJwksTransport(
         fn(value);
       };
       const abortRequest = () => {
-        req?.destroy();
         finish(reject, new Error("OIDC JWKS request was aborted"));
+        destroySafely(req);
       };
       const deadline = setDeadline(() => {
-        req?.destroy();
         finish(reject, new Error("OIDC JWKS request timed out"));
+        destroySafely(req);
       }, timeoutMs);
 
       if (init?.signal?.aborted) {
@@ -222,16 +233,16 @@ export function createPublicJwksTransport(
           },
           (res) => {
             if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
-              req?.destroy();
-              res.destroy();
               finish(reject, new Error("OIDC jwksUri redirects are not allowed"));
+              destroySafely(res);
+              destroySafely(req);
               return;
             }
             const declaredLength = Number(res.headers["content-length"]);
             if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
-              req?.destroy();
-              res.destroy();
               finish(reject, new Error("OIDC JWKS response is too large"));
+              destroySafely(res);
+              destroySafely(req);
               return;
             }
             const chunks: Uint8Array[] = [];
@@ -240,8 +251,9 @@ export function createPublicJwksTransport(
               if (settled) return;
               size += chunk.byteLength;
               if (size > maxBytes) {
-                req?.destroy();
                 finish(reject, new Error("OIDC JWKS response is too large"));
+                destroySafely(res);
+                destroySafely(req);
                 return;
               }
               chunks.push(chunk);
@@ -276,14 +288,14 @@ export function createPublicJwksTransport(
         );
 
         req.on("timeout", () => {
-          req?.destroy();
           finish(reject, new Error("OIDC JWKS request timed out"));
+          destroySafely(req);
         });
         req.on("error", () => finish(reject, new Error("OIDC JWKS request failed")));
         req.end();
       } catch {
-        req?.destroy();
         finish(reject, new Error("OIDC JWKS request failed"));
+        destroySafely(req);
       }
     });
 

--- a/packages/auth/src/oidc.ts
+++ b/packages/auth/src/oidc.ts
@@ -150,110 +150,163 @@ export async function getPublicRemoteJWKSet(
   return jwks;
 }
 
+type JwksHttpsRequest = typeof httpsRequest;
+type JwksDeadline = ReturnType<typeof setTimeout>;
+
+export interface PublicJwksTransportDependencies {
+  readonly request: JwksHttpsRequest;
+  readonly createLookup: typeof createPublicInternetLookup;
+  readonly setDeadline: (callback: () => void, timeoutMs: number) => JwksDeadline;
+  readonly clearDeadline: (deadline: JwksDeadline) => void;
+}
+
+export interface PublicJwksTransportLimits {
+  readonly timeoutMs: number;
+  readonly maxBytes: number;
+}
+
+/**
+ * Construct the production JWKS byte transport from immutable dependencies.
+ * Callers can inject isolated request/scheduler implementations for behavioral
+ * verification without mutating the process-wide HTTPS module.
+ */
+export function createPublicJwksTransport(
+  dependencies: Readonly<PublicJwksTransportDependencies>,
+  limits: Readonly<PublicJwksTransportLimits> = {
+    timeoutMs: JWKS_FETCH_TIMEOUT_MS,
+    maxBytes: JWKS_MAX_BYTES,
+  },
+): (url: string | URL, init?: RequestInit) => Promise<Response> {
+  const { request, createLookup, setDeadline, clearDeadline } = dependencies;
+  const { timeoutMs, maxBytes } = limits;
+  return async (url: string | URL, init?: RequestInit): Promise<Response> => {
+    const jwksUrl = assertSafeJwksUri(url.toString());
+    assertPinnedDnsTransportSupported("OIDC jwksUri");
+    const result = await new Promise<{
+      body: Uint8Array;
+      headers: Headers;
+      status: number;
+    }>((resolve, reject) => {
+      let settled = false;
+      let req: ReturnType<JwksHttpsRequest> | undefined;
+      const finish = <T>(fn: (value: T) => void, value: T) => {
+        if (settled) return;
+        settled = true;
+        clearDeadline(deadline);
+        init?.signal?.removeEventListener("abort", abortRequest);
+        fn(value);
+      };
+      const abortRequest = () => {
+        req?.destroy();
+        finish(reject, new Error("OIDC JWKS request was aborted"));
+      };
+      const deadline = setDeadline(() => {
+        req?.destroy();
+        finish(reject, new Error("OIDC JWKS request timed out"));
+      }, timeoutMs);
+
+      if (init?.signal?.aborted) {
+        abortRequest();
+        return;
+      }
+      init?.signal?.addEventListener("abort", abortRequest, { once: true });
+
+      try {
+        req = request(
+          jwksUrl,
+          {
+            headers: Object.fromEntries(new Headers(init?.headers).entries()),
+            method: init?.method ?? "GET",
+            timeout: timeoutMs,
+            lookup: createLookup("OIDC jwksUri"),
+          },
+          (res) => {
+            if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+              finish(reject, new Error("OIDC jwksUri redirects are not allowed"));
+              res.resume();
+              return;
+            }
+            const declaredLength = Number(res.headers["content-length"]);
+            if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+              finish(reject, new Error("OIDC JWKS response is too large"));
+              res.resume();
+              return;
+            }
+            const chunks: Uint8Array[] = [];
+            let size = 0;
+            res.on("data", (chunk: Uint8Array) => {
+              if (settled) return;
+              size += chunk.byteLength;
+              if (size > maxBytes) {
+                req?.destroy();
+                finish(reject, new Error("OIDC JWKS response is too large"));
+                return;
+              }
+              chunks.push(chunk);
+            });
+            res.on("end", () => {
+              if (settled) return;
+              const body = new Uint8Array(size);
+              let offset = 0;
+              for (const chunk of chunks) {
+                body.set(chunk, offset);
+                offset += chunk.byteLength;
+              }
+              const headers = new Headers();
+              for (const [name, value] of Object.entries(res.headers)) {
+                if (Array.isArray(value)) {
+                  for (const item of value) headers.append(name, item);
+                } else if (value !== undefined) {
+                  headers.set(name, value);
+                }
+              }
+              const status =
+                res.statusCode && res.statusCode >= 200 && res.statusCode <= 599
+                  ? res.statusCode
+                  : 502;
+              finish(resolve, { body, headers, status });
+            });
+            res.on("aborted", () =>
+              finish(reject, new Error("OIDC JWKS response was interrupted")),
+            );
+            res.on("error", () => finish(reject, new Error("OIDC JWKS response failed")));
+          },
+        );
+
+        req.on("timeout", () => {
+          req?.destroy();
+          finish(reject, new Error("OIDC JWKS request timed out"));
+        });
+        req.on("error", () => finish(reject, new Error("OIDC JWKS request failed")));
+        req.end();
+      } catch {
+        req?.destroy();
+        finish(reject, new Error("OIDC JWKS request failed"));
+      }
+    });
+
+    const responseBody =
+      result.body.byteLength === 0 && (result.status === 204 || result.status === 205)
+        ? null
+        : new Uint8Array(result.body);
+    return new Response(responseBody, { headers: result.headers, status: result.status });
+  };
+}
+
+const productionPublicJwksTransport = createPublicJwksTransport(
+  Object.freeze<PublicJwksTransportDependencies>({
+    request: httpsRequest,
+    createLookup: createPublicInternetLookup,
+    setDeadline: (callback, timeoutMs) => setTimeout(callback, timeoutMs),
+    clearDeadline: (deadline) => clearTimeout(deadline),
+  }),
+);
+
 async function fetchPublicJwks(url: string | URL, init?: RequestInit): Promise<Response> {
+  if (!allowTestJwksFetch()) return productionPublicJwksTransport(url, init);
   const jwksUrl = assertSafeJwksUri(url.toString());
   assertPinnedDnsTransportSupported("OIDC jwksUri");
-  if (allowTestJwksFetch()) {
-    return fetch(jwksUrl, init);
-  }
-
-  const result = await new Promise<{
-    body: Uint8Array;
-    headers: Headers;
-    status: number;
-  }>((resolve, reject) => {
-    let settled = false;
-    let req: ReturnType<typeof httpsRequest> | undefined;
-    const finish = <T>(fn: (value: T) => void, value: T) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(deadline);
-      init?.signal?.removeEventListener("abort", abortRequest);
-      fn(value);
-    };
-    const abortRequest = () => {
-      req?.destroy();
-      finish(reject, new Error("OIDC JWKS request was aborted"));
-    };
-    const deadline = setTimeout(() => {
-      req?.destroy();
-      finish(reject, new Error("OIDC JWKS request timed out"));
-    }, JWKS_FETCH_TIMEOUT_MS);
-
-    if (init?.signal?.aborted) {
-      abortRequest();
-      return;
-    }
-    init?.signal?.addEventListener("abort", abortRequest, { once: true });
-
-    req = httpsRequest(
-      jwksUrl,
-      {
-        headers: Object.fromEntries(new Headers(init?.headers).entries()),
-        method: init?.method ?? "GET",
-        timeout: JWKS_FETCH_TIMEOUT_MS,
-        lookup: createPublicInternetLookup("OIDC jwksUri"),
-      },
-      (res) => {
-        if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
-          finish(reject, new Error("OIDC jwksUri redirects are not allowed"));
-          res.resume();
-          return;
-        }
-        const declaredLength = Number(res.headers["content-length"]);
-        if (Number.isFinite(declaredLength) && declaredLength > JWKS_MAX_BYTES) {
-          finish(reject, new Error("OIDC JWKS response is too large"));
-          res.resume();
-          return;
-        }
-        const chunks: Uint8Array[] = [];
-        let size = 0;
-        res.on("data", (chunk: Uint8Array) => {
-          size += chunk.byteLength;
-          if (size > JWKS_MAX_BYTES) {
-            req?.destroy();
-            finish(reject, new Error("OIDC JWKS response is too large"));
-            return;
-          }
-          chunks.push(chunk);
-        });
-        res.on("end", () => {
-          const body = new Uint8Array(size);
-          let offset = 0;
-          for (const chunk of chunks) {
-            body.set(chunk, offset);
-            offset += chunk.byteLength;
-          }
-          const headers = new Headers();
-          for (const [name, value] of Object.entries(res.headers)) {
-            if (Array.isArray(value)) {
-              for (const item of value) headers.append(name, item);
-            } else if (value !== undefined) {
-              headers.set(name, value);
-            }
-          }
-          const status =
-            res.statusCode && res.statusCode >= 200 && res.statusCode <= 599 ? res.statusCode : 502;
-          finish(resolve, { body, headers, status });
-        });
-        res.on("aborted", () => finish(reject, new Error("OIDC JWKS response was interrupted")));
-        res.on("error", () => finish(reject, new Error("OIDC JWKS response failed")));
-      },
-    );
-
-    req.on("timeout", () => {
-      req?.destroy();
-      finish(reject, new Error("OIDC JWKS request timed out"));
-    });
-    req.on("error", () => finish(reject, new Error("OIDC JWKS request failed")));
-    req.end();
-  });
-
-  const responseBody =
-    result.body.byteLength === 0 && (result.status === 204 || result.status === 205)
-      ? null
-      : new Uint8Array(result.body);
-  return new Response(responseBody, { headers: result.headers, status: result.status });
+  return fetch(jwksUrl, init);
 }
 
 export async function verifyOidcJwt(

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,6 +17,10 @@
     "./sensitive-keys": {
       "types": "./dist/sensitive-keys.d.ts",
       "import": "./dist/sensitive-keys.js"
+    },
+    "./runtime-env": {
+      "types": "./dist/runtime-env.d.ts",
+      "import": "./dist/runtime-env.js"
     }
   },
   "files": [

--- a/packages/shared/src/__tests__/runtime-env.test.ts
+++ b/packages/shared/src/__tests__/runtime-env.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { runtimeEnvironmentValue, withRuntimeEnvironment } from "../runtime-env";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("request-local runtime environment", () => {
+  test("keeps overlapping Worker binding snapshots isolated", async () => {
+    const firstEntered = deferred();
+    const releaseFirst = deferred();
+
+    const first = withRuntimeEnvironment(
+      {
+        NODE_ENV: "test",
+        STEWARD_OIDC_JWKS_MAX_AGE_MS: "60000",
+        STEWARD_ALLOW_INSECURE_OIDC_JWKS_FETCH: "false",
+      },
+      async () => {
+        firstEntered.resolve();
+        await releaseFirst.promise;
+        return {
+          age: runtimeEnvironmentValue("STEWARD_OIDC_JWKS_MAX_AGE_MS"),
+          override: runtimeEnvironmentValue("STEWARD_ALLOW_INSECURE_OIDC_JWKS_FETCH"),
+        };
+      },
+    );
+
+    await firstEntered.promise;
+    const second = await withRuntimeEnvironment(
+      {
+        NODE_ENV: "test",
+        STEWARD_OIDC_JWKS_MAX_AGE_MS: "120000",
+        STEWARD_ALLOW_INSECURE_OIDC_JWKS_FETCH: "true",
+      },
+      async () => ({
+        age: runtimeEnvironmentValue("STEWARD_OIDC_JWKS_MAX_AGE_MS"),
+        override: runtimeEnvironmentValue("STEWARD_ALLOW_INSECURE_OIDC_JWKS_FETCH"),
+      }),
+    );
+    releaseFirst.resolve();
+
+    expect(second).toEqual({ age: "120000", override: "true" });
+    expect(await first).toEqual({ age: "60000", override: "false" });
+  });
+});

--- a/packages/shared/src/runtime-env.ts
+++ b/packages/shared/src/runtime-env.ts
@@ -1,0 +1,27 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type RuntimeEnvironment = Readonly<Record<string, string | undefined>>;
+
+const runtimeEnvironmentStorage = new AsyncLocalStorage<RuntimeEnvironment>();
+
+function snapshotRuntimeEnvironment(environment: Record<string, unknown>): RuntimeEnvironment {
+  const snapshot: Record<string, string | undefined> = {};
+  for (const [name, value] of Object.entries(environment)) {
+    if (typeof value === "string") snapshot[name] = value;
+  }
+  return Object.freeze(snapshot);
+}
+
+/** Bind an immutable environment snapshot to one asynchronous request. */
+export function withRuntimeEnvironment<T>(
+  environment: Record<string, unknown>,
+  callback: () => T,
+): T {
+  return runtimeEnvironmentStorage.run(snapshotRuntimeEnvironment(environment), callback);
+}
+
+/** Resolve one setting from the current request snapshot or Bun process. */
+export function runtimeEnvironmentValue(name: string): string | undefined {
+  const requestEnvironment = runtimeEnvironmentStorage.getStore();
+  return requestEnvironment ? requestEnvironment[name] : process.env[name];
+}


### PR DESCRIPTION
Closes #588

## Summary
- construct the pinned OIDC JWKS byte transport from immutable HTTPS, lookup, and deadline dependencies
- replace source-substring assertions with hostile behavioral coverage for exact status/body propagation, redirects, declared and streamed response bounds, deadlines, aborts, synchronous construction failures, request/response failures, late events, and cleanup
- destroy request/socket state immediately for redirects and declared oversize responses; ignore late stream events after terminal rejection
- discard hostile bytes for HTTP 204/205 while retaining the 256 KiB transport bound
- replace the stale empty-CORS-allowlist source assertion with real PGLite preflight denial behavior
- bind the JWKS cache policy to an immutable request-local Worker environment snapshot, including overlapping request isolation and missing-binding behavior
- attach concurrent boot rejection assertions before awaiting either request so neither rejection can surface as unhandled

## Exact-head validation
Exact head: `f6e7b114f15f888198652f5307a09c16faf67fc0`
Exact base: `9239a728b9ca28175e00e2825f69d85f3e02856e`

- Worker boot/runtime: 22/22, 59 assertions
- OIDC transport + shared runtime environment: 18/18, 78 assertions
- tenant CORS preflight: 3/3
- middleware security hardening (isolated): 8/8, 68 assertions
- `@stwd/api...` dependency build: 24/24 packages
- Biome on all 7 affected runtime files: pass
- `git diff --check`: pass
- mutation proof: removing the real `worker.fetch` runtime-environment wrapper makes the nested Worker test fail with `first snapshot: undefined` instead of the request-local `60000`

The prior PostgreSQL failure was the stale CORS source assertion replaced directly by this head; there is no remaining dependency on closed PR #587. Keep this PR draft until every required exact-head hosted check completes green and an independent write-access reviewer approves it.