### PR TITLE
fix(db): close request membrane reflection escape

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -144,7 +144,7 @@ jobs:
   web-trust-ux-a11y:
     name: Trust UX Accessibility (axe WCAG 2.1 AA)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - name: Checkout

--- a/packages/api/src/__tests__/middleware-security-hardening.test.ts
+++ b/packages/api/src/__tests__/middleware-security-hardening.test.ts
@@ -56,7 +56,6 @@ describe("middleware security hardening", () => {
     // an unset NODE_ENV must fail closed like production.
     expect(tenantCorsSource).toContain("function devWildcardAllowed()");
     expect(tenantCorsSource).toContain('env === "development" || env === "test"');
-    expect(tenantCorsSource).toContain("origins.length === 0");
     expect(tenantCorsSource).toContain("return c.newResponse(null, 403)");
     expect(tenantCorsSource).toContain("TENANT_ID_RE.test(tenantId)");
     expect(tenantCorsSource).toContain("MAX_CORS_CACHE_ENTRIES");

--- a/packages/api/src/__tests__/tenant-cors-preflight.test.ts
+++ b/packages/api/src/__tests__/tenant-cors-preflight.test.ts
@@ -27,6 +27,15 @@ describe("tenant CORS preflight", () => {
         tenantId: "cors-patch-tenant",
         allowedOrigins: [ALLOWED_ORIGIN],
       });
+    await getDb().insert(tenants).values({
+      id: "cors-empty-tenant",
+      name: "CORS empty tenant",
+      apiKeyHash: "cors-empty-tenant-hash",
+    });
+    await getDb().insert(tenantConfigs).values({
+      tenantId: "cors-empty-tenant",
+      allowedOrigins: [],
+    });
   });
 
   afterAll(async () => {
@@ -76,6 +85,24 @@ describe("tenant CORS preflight", () => {
     expect(response.status).toBe(403);
     expect(response.headers.get("access-control-allow-origin")).toBeNull();
     expect(response.headers.get("access-control-allow-credentials")).toBeNull();
+    expect(response.headers.get("vary")).toBe("Origin, X-Steward-Tenant");
+  });
+
+  test("keeps an explicitly empty tenant allowlist fail closed", async () => {
+    const app = new Hono();
+    app.use("*", tenantCors);
+
+    const response = await app.request("/resource", {
+      method: "OPTIONS",
+      headers: {
+        Origin: ALLOWED_ORIGIN,
+        "X-Steward-Tenant": "cors-empty-tenant",
+        "Access-Control-Request-Method": "PATCH",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
     expect(response.headers.get("vary")).toBe("Origin, X-Steward-Tenant");
   });
 });

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -267,6 +267,62 @@ describe("request-scoped database context", () => {
     );
   });
 
+  test("revokes Promise and thenable client capabilities without revoking result rows", async () => {
+    const rawClient = {
+      query: () => "raw-client-query",
+      release: () => "raw-client-release",
+    };
+    const rawRows = [{ id: "row-1", query: "ordinary-data" }];
+    type AsyncCapabilityDb = {
+      rows(): Promise<typeof rawRows>;
+      $client: {
+        connect(): Promise<typeof rawClient>;
+        connectThenable(): {
+          then(resolve: (client: typeof rawClient) => void): void;
+        };
+      };
+    };
+    const requestDbSource: AsyncCapabilityDb = {
+      rows: async () => rawRows,
+      $client: {
+        connect: async () => rawClient,
+        connectThenable: () => ({
+          // biome-ignore lint/suspicious/noThenProperty: exercises a driver PromiseLike boundary
+          then(resolve: (client: typeof rawClient) => void) {
+            resolve(rawClient);
+          },
+        }),
+      },
+    };
+    const requestDb = requestDbSource as unknown as ReturnType<typeof getDb>;
+    let rows!: typeof rawRows;
+    let capturedClient!: typeof rawClient;
+    let capturedThenableClient!: typeof rawClient;
+
+    await withRequestDatabase(requestDb, async () => {
+      const guardedDb = getDb() as unknown as AsyncCapabilityDb;
+      const guardedClient = guardedDb.$client;
+      rows = await guardedDb.rows();
+      capturedClient = await guardedClient.connect();
+      guardedClient.connectThenable().then((client) => {
+        capturedThenableClient = client;
+      });
+
+      expect(rows).toBe(rawRows);
+      expect(capturedClient).not.toBe(rawClient);
+      expect(capturedThenableClient).not.toBe(rawClient);
+      expect(capturedClient.query()).toBe("raw-client-query");
+      expect(capturedThenableClient.release()).toBe("raw-client-release");
+    });
+
+    expect(rows).toEqual([{ id: "row-1", query: "ordinary-data" }]);
+    expect(rows[0]?.id).toBe("row-1");
+    expect(() => capturedClient.query()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => capturedClient.release()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => capturedThenableClient.query()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => capturedThenableClient.release()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+  });
+
   test("revokes a real PGLite transaction passed into a callback", async () => {
     const { client, db } = await createPGLiteDb("memory://");
     let capturedTransaction:
@@ -286,6 +342,39 @@ describe("request-scoped database context", () => {
         "REQUEST_DATABASE_CONTEXT_CLOSED",
       );
     } finally {
+      await client.close();
+    }
+  });
+
+  test("revokes a real PGLite listener cleanup resolved through the driver Promise", async () => {
+    const { client, db } = await createPGLiteDb("memory://");
+    const channel = "request_database_membrane";
+    let unsubscribe!: () => Promise<void>;
+    let queryResult!: { rows: Array<{ value: number }> };
+
+    try {
+      await withRequestDatabase(db as ReturnType<typeof getDb>, async () => {
+        queryResult = (await getDb().execute(
+          sql`select 1 as value`,
+        )) as unknown as typeof queryResult;
+        unsubscribe = await (
+          getDb() as unknown as {
+            $client: {
+              listen(
+                name: string,
+                callback: (payload: string) => void,
+              ): Promise<() => Promise<void>>;
+            };
+          }
+        ).$client.listen(channel, () => undefined);
+
+        expect(typeof unsubscribe).toBe("function");
+      });
+
+      expect(queryResult.rows).toEqual([{ value: 1 }]);
+      expect(() => unsubscribe()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    } finally {
+      await client.unlisten(channel);
       await client.close();
     }
   });

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+import { live } from "@electric-sql/pglite/live";
 import { eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
 import {
   closeDb,
   getDb,
@@ -273,6 +276,7 @@ describe("request-scoped database context", () => {
       release: () => "raw-client-release",
     };
     const rawRows = [{ id: "row-1", query: "ordinary-data" }];
+    const rawSubscription = { unsubscribe: () => "raw-subscription-unsubscribed" };
     type AsyncCapabilityDb = {
       rows(): Promise<typeof rawRows>;
       $client: {
@@ -280,6 +284,8 @@ describe("request-scoped database context", () => {
         connectThenable(): {
           then(resolve: (client: typeof rawClient) => void): void;
         };
+        rejectedSubscription(): Promise<never>;
+        subscribe(): Promise<typeof rawSubscription>;
       };
     };
     const requestDbSource: AsyncCapabilityDb = {
@@ -292,18 +298,28 @@ describe("request-scoped database context", () => {
             resolve(rawClient);
           },
         }),
+        rejectedSubscription: () => Promise.reject(rawSubscription),
+        subscribe: async () => rawSubscription,
       },
     };
     const requestDb = requestDbSource as unknown as ReturnType<typeof getDb>;
     let rows!: typeof rawRows;
     let capturedClient!: typeof rawClient;
     let capturedThenableClient!: typeof rawClient;
+    let capturedRejectedSubscription!: typeof rawSubscription;
+    let capturedSubscription!: typeof rawSubscription;
 
     await withRequestDatabase(requestDb, async () => {
       const guardedDb = getDb() as unknown as AsyncCapabilityDb;
       const guardedClient = guardedDb.$client;
       rows = await guardedDb.rows();
       capturedClient = await guardedClient.connect();
+      capturedSubscription = await guardedClient.subscribe();
+      try {
+        await guardedClient.rejectedSubscription();
+      } catch (error) {
+        capturedRejectedSubscription = error as typeof rawSubscription;
+      }
       guardedClient.connectThenable().then((client) => {
         capturedThenableClient = client;
       });
@@ -311,8 +327,12 @@ describe("request-scoped database context", () => {
       expect(rows).toBe(rawRows);
       expect(capturedClient).not.toBe(rawClient);
       expect(capturedThenableClient).not.toBe(rawClient);
+      expect(capturedSubscription).not.toBe(rawSubscription);
+      expect(capturedRejectedSubscription).not.toBe(rawSubscription);
       expect(capturedClient.query()).toBe("raw-client-query");
       expect(capturedThenableClient.release()).toBe("raw-client-release");
+      expect(capturedSubscription.unsubscribe()).toBe("raw-subscription-unsubscribed");
+      expect(capturedRejectedSubscription.unsubscribe()).toBe("raw-subscription-unsubscribed");
     });
 
     expect(rows).toEqual([{ id: "row-1", query: "ordinary-data" }]);
@@ -321,6 +341,30 @@ describe("request-scoped database context", () => {
     expect(() => capturedClient.release()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
     expect(() => capturedThenableClient.query()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
     expect(() => capturedThenableClient.release()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => capturedSubscription.unsubscribe()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => capturedRejectedSubscription.unsubscribe()).toThrow(
+      "REQUEST_DATABASE_CONTEXT_CLOSED",
+    );
+  });
+
+  test("preserves ordinary native driver rejection errors after request cleanup", async () => {
+    const driverError = new Error("driver rejected the query");
+    const requestDb = {
+      execute: () => Promise.reject(driverError),
+    } as unknown as ReturnType<typeof getDb>;
+    let capturedError: unknown;
+
+    await withRequestDatabase(requestDb, async () => {
+      try {
+        await getDb().execute(sql`select 1`);
+      } catch (error) {
+        capturedError = error;
+      }
+    });
+
+    expect(capturedError).toBe(driverError);
+    expect(capturedError).toBeInstanceOf(Error);
+    expect((capturedError as Error).message).toBe("driver rejected the query");
   });
 
   test("revokes a real PGLite transaction passed into a callback", async () => {
@@ -375,6 +419,32 @@ describe("request-scoped database context", () => {
       expect(() => unsubscribe()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
     } finally {
       await client.unlisten(channel);
+      await client.close();
+    }
+  });
+
+  test("revokes a real PGLite live-query subscription resolved through the driver Promise", async () => {
+    const client = new PGlite("memory://", { extensions: { live } });
+    const db = drizzle(client);
+    let liveQuery!: Awaited<ReturnType<typeof client.live.query>>;
+    let initialValue!: number;
+
+    try {
+      await client.waitReady;
+      await withRequestDatabase(db as ReturnType<typeof getDb>, async () => {
+        liveQuery = await (
+          getDb() as unknown as {
+            $client: typeof client;
+          }
+        ).$client.live.query<{ value: number }>("select 1 as value");
+        initialValue = liveQuery.initialResults.rows[0]!.value;
+        expect(initialValue).toBe(1);
+      });
+
+      expect(initialValue).toBe(1);
+      expect(() => liveQuery.unsubscribe()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+      expect(() => liveQuery.refresh()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    } finally {
       await client.close();
     }
   });

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import {
   closeDb,
   getDb,
@@ -8,6 +8,7 @@ import {
   withRequestDatabase,
 } from "../client";
 import { createPGLiteDb } from "../pglite";
+import { tenants } from "../schema";
 
 const originalDriver = process.env.DATABASE_DRIVER;
 
@@ -123,6 +124,10 @@ describe("request-scoped database context", () => {
     const requestDb = requestDbSource as unknown as ReturnType<typeof getDb>;
     let capturedDb!: ReturnType<typeof getDb>;
     let capturedSession!: typeof rawSession;
+    let capturedPrototype!: object;
+    let capturedConstructor!: ObjectConstructor;
+    let constructedThroughGuard!: object;
+    const rawConstructedInput = { guarded: true };
 
     await withRequestDatabase(requestDb, async () => {
       capturedDb = getDb();
@@ -137,9 +142,13 @@ describe("request-scoped database context", () => {
       expect(() => hookDescriptor?.set?.(() => undefined)).toThrow(
         "REQUEST_DATABASE_REFLECTION_UNAVAILABLE",
       );
-      expect(() => Object.getPrototypeOf(capturedDb)).toThrow(
-        "REQUEST_DATABASE_REFLECTION_UNAVAILABLE",
-      );
+      capturedPrototype = Object.getPrototypeOf(capturedDb);
+      expect(capturedPrototype).not.toBe(Object.prototype);
+      capturedConstructor = (capturedPrototype as { constructor: ObjectConstructor }).constructor;
+      expect(capturedConstructor).not.toBe(Object);
+      constructedThroughGuard = capturedConstructor(rawConstructedInput);
+      expect(constructedThroughGuard).not.toBe(rawConstructedInput);
+      expect((constructedThroughGuard as { guarded: boolean }).guarded).toBe(true);
       expect(() => Object.defineProperty(capturedDb, "poison", { value: true })).toThrow(
         "REQUEST_DATABASE_REFLECTION_UNAVAILABLE",
       );
@@ -167,6 +176,12 @@ describe("request-scoped database context", () => {
     });
 
     expect(() => capturedSession.execute()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => Object.getPrototypeOf(capturedDb)).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => Reflect.ownKeys(capturedPrototype)).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => capturedConstructor()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => Reflect.ownKeys(constructedThroughGuard)).toThrow(
+      "REQUEST_DATABASE_CONTEXT_CLOSED",
+    );
     expect(() => "session" in capturedDb).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
     expect(() => Object.isExtensible(capturedDb)).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
     expect(() => Object.defineProperty(capturedDb, "poison", { value: true })).toThrow(
@@ -239,8 +254,17 @@ describe("request-scoped database context", () => {
 
     expect(result).toBe("raw-transaction-executed");
     expect(() => capturedCallable()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => Object.getPrototypeOf(capturedCallable)).toThrow(
+      "REQUEST_DATABASE_CONTEXT_CLOSED",
+    );
     expect(() => capturedFromCallable.execute()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => Object.getPrototypeOf(capturedFromCallable)).toThrow(
+      "REQUEST_DATABASE_CONTEXT_CLOSED",
+    );
     expect(() => capturedTransaction.execute()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => Object.getPrototypeOf(capturedTransaction)).toThrow(
+      "REQUEST_DATABASE_CONTEXT_CLOSED",
+    );
   });
 
   test("revokes a real PGLite transaction passed into a callback", async () => {
@@ -259,6 +283,66 @@ describe("request-scoped database context", () => {
 
       expect(capturedTransaction).toBeDefined();
       expect(() => capturedTransaction!.execute(sql`select 1`)).toThrow(
+        "REQUEST_DATABASE_CONTEXT_CLOSED",
+      );
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("composes real PGLite aliased subqueries without exposing their prototypes", async () => {
+    const { client, db } = await createPGLiteDb("memory://");
+    let capturedSubquery!: object;
+    let capturedSubqueryColumn!: object;
+    let capturedSubqueryPrototype!: object;
+    let capturedSubqueryConstructor!: object;
+
+    try {
+      await withRequestDatabase(db as ReturnType<typeof getDb>, async () => {
+        await getDb().insert(tenants).values({
+          id: "request-context-subquery",
+          name: "Request Context Subquery",
+          apiKeyHash: "request-context-subquery-hash",
+        });
+
+        const tenantSubquery = getDb()
+          .select({ id: tenants.id, name: tenants.name })
+          .from(tenants)
+          .as("tenant_subquery");
+        capturedSubquery = tenantSubquery;
+        capturedSubqueryColumn = tenantSubquery.id;
+        capturedSubqueryPrototype = Object.getPrototypeOf(tenantSubquery);
+        capturedSubqueryConstructor = (capturedSubqueryPrototype as { constructor: object })
+          .constructor;
+        expect(capturedSubqueryPrototype).not.toBe(
+          Object.getPrototypeOf(
+            db.select({ id: tenants.id }).from(tenants).as("raw_tenant_subquery"),
+          ),
+        );
+        const matchesTenant = eq(tenantSubquery.id, "request-context-subquery");
+        const rows = await getDb()
+          .select({ id: tenantSubquery.id, name: tenantSubquery.name })
+          .from(tenantSubquery)
+          .where(matchesTenant);
+
+        expect(rows).toEqual([
+          {
+            id: "request-context-subquery",
+            name: "Request Context Subquery",
+          },
+        ]);
+      });
+
+      expect(() => Object.getPrototypeOf(capturedSubquery)).toThrow(
+        "REQUEST_DATABASE_CONTEXT_CLOSED",
+      );
+      expect(() => Object.getPrototypeOf(capturedSubqueryColumn)).toThrow(
+        "REQUEST_DATABASE_CONTEXT_CLOSED",
+      );
+      expect(() => Reflect.ownKeys(capturedSubqueryPrototype)).toThrow(
+        "REQUEST_DATABASE_CONTEXT_CLOSED",
+      );
+      expect(() => Reflect.ownKeys(capturedSubqueryConstructor)).toThrow(
         "REQUEST_DATABASE_CONTEXT_CLOSED",
       );
     } finally {

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -109,6 +109,26 @@ describe("request-scoped database context", () => {
     expect(() => capturedQuery.from({} as never)).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
   });
 
+  test("does not expose raw capabilities through property descriptors or prototypes", async () => {
+    const rawSession = { execute: () => "mutated" };
+    const requestDb = { session: rawSession } as unknown as ReturnType<typeof getDb>;
+    let capturedSession!: typeof rawSession;
+
+    await withRequestDatabase(requestDb, async () => {
+      const guarded = getDb();
+      expect(Reflect.ownKeys(guarded)).toContain("session");
+      const descriptor = Object.getOwnPropertyDescriptor(guarded, "session");
+      capturedSession = descriptor?.value as typeof rawSession;
+      expect(capturedSession).not.toBe(rawSession);
+      expect(capturedSession.execute()).toBe("mutated");
+      expect(() => Object.getPrototypeOf(guarded)).toThrow(
+        "REQUEST_DATABASE_REFLECTION_UNAVAILABLE",
+      );
+    });
+
+    expect(() => capturedSession.execute()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+  });
+
   test("drains registered detached work before revoking its database capability", async () => {
     const requestDb = { marker: "request" } as unknown as ReturnType<typeof getDb>;
     const release = deferred();

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
 import {
   closeDb,
   getDb,
@@ -6,6 +7,7 @@ import {
   waitUntilRequestDatabaseTask,
   withRequestDatabase,
 } from "../client";
+import { createPGLiteDb } from "../pglite";
 
 const originalDriver = process.env.DATABASE_DRIVER;
 
@@ -111,22 +113,157 @@ describe("request-scoped database context", () => {
 
   test("does not expose raw capabilities through property descriptors or prototypes", async () => {
     const rawSession = { execute: () => "mutated" };
-    const requestDb = { session: rawSession } as unknown as ReturnType<typeof getDb>;
+    const requestDbSource = { session: rawSession };
+    Object.defineProperty(requestDbSource, "hook", {
+      configurable: true,
+      set(callback: (session: typeof rawSession) => void) {
+        callback(rawSession);
+      },
+    });
+    const requestDb = requestDbSource as unknown as ReturnType<typeof getDb>;
+    let capturedDb!: ReturnType<typeof getDb>;
     let capturedSession!: typeof rawSession;
 
     await withRequestDatabase(requestDb, async () => {
-      const guarded = getDb();
-      expect(Reflect.ownKeys(guarded)).toContain("session");
-      const descriptor = Object.getOwnPropertyDescriptor(guarded, "session");
+      capturedDb = getDb();
+      expect(Reflect.ownKeys(capturedDb)).toContain("session");
+      expect("session" in capturedDb).toBe(true);
+      expect(Object.isExtensible(capturedDb)).toBe(true);
+      const descriptor = Object.getOwnPropertyDescriptor(capturedDb, "session");
+      const hookDescriptor = Object.getOwnPropertyDescriptor(capturedDb, "hook");
       capturedSession = descriptor?.value as typeof rawSession;
       expect(capturedSession).not.toBe(rawSession);
       expect(capturedSession.execute()).toBe("mutated");
-      expect(() => Object.getPrototypeOf(guarded)).toThrow(
+      expect(() => hookDescriptor?.set?.(() => undefined)).toThrow(
+        "REQUEST_DATABASE_REFLECTION_UNAVAILABLE",
+      );
+      expect(() => Object.getPrototypeOf(capturedDb)).toThrow(
+        "REQUEST_DATABASE_REFLECTION_UNAVAILABLE",
+      );
+      expect(() => Object.defineProperty(capturedDb, "poison", { value: true })).toThrow(
+        "REQUEST_DATABASE_REFLECTION_UNAVAILABLE",
+      );
+      expect(() => Reflect.set(capturedDb, "poison", true)).toThrow(
+        "REQUEST_DATABASE_REFLECTION_UNAVAILABLE",
+      );
+      expect(() => Reflect.deleteProperty(capturedDb, "session")).toThrow(
+        "REQUEST_DATABASE_REFLECTION_UNAVAILABLE",
+      );
+      expect(() => Object.setPrototypeOf(capturedDb, {})).toThrow(
+        "REQUEST_DATABASE_REFLECTION_UNAVAILABLE",
+      );
+      expect(() => Object.preventExtensions(capturedDb)).toThrow(
+        "REQUEST_DATABASE_REFLECTION_UNAVAILABLE",
+      );
+      expect(() => Object.defineProperty(capturedSession, "poison", { value: true })).toThrow(
+        "REQUEST_DATABASE_REFLECTION_UNAVAILABLE",
+      );
+      expect(() => Object.setPrototypeOf(capturedSession, {})).toThrow(
+        "REQUEST_DATABASE_REFLECTION_UNAVAILABLE",
+      );
+      expect(() => Object.preventExtensions(capturedSession)).toThrow(
         "REQUEST_DATABASE_REFLECTION_UNAVAILABLE",
       );
     });
 
     expect(() => capturedSession.execute()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => "session" in capturedDb).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => Object.isExtensible(capturedDb)).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => Object.defineProperty(capturedDb, "poison", { value: true })).toThrow(
+      "REQUEST_DATABASE_CONTEXT_CLOSED",
+    );
+    expect(() => Reflect.set(capturedDb, "poison", true)).toThrow(
+      "REQUEST_DATABASE_CONTEXT_CLOSED",
+    );
+    expect(() => Reflect.deleteProperty(capturedDb, "session")).toThrow(
+      "REQUEST_DATABASE_CONTEXT_CLOSED",
+    );
+    expect(() => Object.setPrototypeOf(capturedDb, {})).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => Object.preventExtensions(capturedDb)).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => Object.defineProperty(capturedSession, "poison", { value: true })).toThrow(
+      "REQUEST_DATABASE_CONTEXT_CLOSED",
+    );
+    expect(() => Reflect.deleteProperty(capturedSession, "execute")).toThrow(
+      "REQUEST_DATABASE_CONTEXT_CLOSED",
+    );
+    expect(() => Object.setPrototypeOf(capturedSession, {})).toThrow(
+      "REQUEST_DATABASE_CONTEXT_CLOSED",
+    );
+    expect(() => Object.preventExtensions(capturedSession)).toThrow(
+      "REQUEST_DATABASE_CONTEXT_CLOSED",
+    );
+    expect(rawSession).toEqual({ execute: expect.any(Function) });
+    expect(Object.getPrototypeOf(rawSession)).toBe(Object.prototype);
+    expect(Object.isExtensible(rawSession)).toBe(true);
+    expect("poison" in (requestDb as object)).toBe(false);
+  });
+
+  test("revokes returned callables and transaction callback capabilities", async () => {
+    const rawTransaction = { execute: () => "raw-transaction-executed" };
+    const returnedCallable = (callback?: (tx: typeof rawTransaction) => string) =>
+      callback ? callback(rawTransaction) : "raw-callable-executed";
+    const requestDb = {
+      makeCallable: () => returnedCallable,
+      transaction: async (callback: (tx: typeof rawTransaction) => Promise<string>) =>
+        callback(rawTransaction),
+    } as unknown as ReturnType<typeof getDb>;
+    let capturedCallable!: typeof returnedCallable;
+    let capturedTransaction!: typeof rawTransaction;
+    let capturedFromCallable!: typeof rawTransaction;
+
+    const result = await withRequestDatabase(requestDb, async () => {
+      const guarded = getDb() as unknown as {
+        makeCallable: () => typeof returnedCallable;
+        transaction: (callback: (tx: typeof rawTransaction) => Promise<string>) => Promise<string>;
+      };
+      capturedCallable = guarded.makeCallable();
+      expect(capturedCallable()).toBe("raw-callable-executed");
+      expect(
+        capturedCallable((transaction) => {
+          capturedFromCallable = transaction;
+          expect(transaction).not.toBe(rawTransaction);
+          return transaction.execute();
+        }),
+      ).toBe("raw-transaction-executed");
+      const echoedTransaction = capturedCallable(
+        (transaction) => transaction as never,
+      ) as unknown as typeof rawTransaction;
+      expect(echoedTransaction).not.toBe(rawTransaction);
+      expect(echoedTransaction.execute()).toBe("raw-transaction-executed");
+      return guarded.transaction(async (tx) => {
+        capturedTransaction = tx;
+        expect(tx).not.toBe(rawTransaction);
+        return tx.execute();
+      });
+    });
+
+    expect(result).toBe("raw-transaction-executed");
+    expect(() => capturedCallable()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => capturedFromCallable.execute()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => capturedTransaction.execute()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+  });
+
+  test("revokes a real PGLite transaction passed into a callback", async () => {
+    const { client, db } = await createPGLiteDb("memory://");
+    let capturedTransaction:
+      | { execute(query: ReturnType<typeof sql>): Promise<unknown> }
+      | undefined;
+
+    try {
+      await withRequestDatabase(db as ReturnType<typeof getDb>, async () => {
+        await getDb().transaction(async (transaction) => {
+          capturedTransaction = transaction;
+          await transaction.execute(sql`select 1`);
+        });
+      });
+
+      expect(capturedTransaction).toBeDefined();
+      expect(() => capturedTransaction!.execute(sql`select 1`)).toThrow(
+        "REQUEST_DATABASE_CONTEXT_CLOSED",
+      );
+    } finally {
+      await client.close();
+    }
   });
 
   test("drains registered detached work before revoking its database capability", async () => {

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -529,6 +529,7 @@ const REQUEST_DATABASE_CAPABILITY_METHODS = [
   "stream",
   "transaction",
   "unlisten",
+  "unsubscribe",
 ] as const;
 
 /**

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -558,19 +558,41 @@ export function waitUntilRequestDatabaseTask<T>(task: () => Promise<T>): Promise
  */
 function guardRequestDatabaseValue<T>(value: T, context: RequestDatabaseContext): T {
   if ((typeof value !== "object" || value === null) && typeof value !== "function") return value;
-  if (value instanceof Promise) {
-    return trackRequestDatabaseTask(context, value) as T;
-  }
 
   const objectValue = value as object;
   const existing = context.guardedObjects.get(objectValue);
   if (existing) return existing as T;
+  if (value instanceof Promise) {
+    return trackRequestDatabaseTask(context, value) as T;
+  }
 
-  const guardMember = (target: object, member: unknown): unknown => {
+  const guardCallback = (callback: (...args: unknown[]) => unknown) => {
+    return function guardedDatabaseCallback(this: unknown, ...args: unknown[]): unknown {
+      assertRequestDatabaseContextActive(context);
+      const guardedThis = guardRequestDatabaseValue(this, context);
+      const guardedArgs = args.map((argument) => guardRequestDatabaseValue(argument, context));
+      const result = Reflect.apply(callback, guardedThis, guardedArgs);
+      return guardRequestDatabaseValue(result, context);
+    };
+  };
+
+  const guardCallbackArguments = (args: unknown[]): unknown[] =>
+    args.map((argument) =>
+      typeof argument === "function"
+        ? guardCallback(argument as (...callbackArgs: unknown[]) => unknown)
+        : argument,
+    );
+
+  const guardMember = (target: object, member: unknown, property?: PropertyKey): unknown => {
     if (typeof member === "function") {
       return (...args: unknown[]) => {
         assertRequestDatabaseContextActive(context);
-        const result = Reflect.apply(member, target, args);
+        // Drizzle query builders are PromiseLike. Their `then` callbacks are
+        // native assimilation continuations receiving ordinary result data,
+        // not database capabilities; wrapping them would proxy result arrays
+        // and make a completed query unusable after the request closes.
+        const guardedArgs = property === "then" ? args : guardCallbackArguments(args);
+        const result = Reflect.apply(member, target, guardedArgs);
         return guardRequestDatabaseValue(result, context);
       };
     }
@@ -581,11 +603,23 @@ function guardRequestDatabaseValue<T>(value: T, context: RequestDatabaseContext)
     get(target, property) {
       assertRequestDatabaseContextActive(context);
       const member = Reflect.get(target, property, target);
-      return guardMember(target, member);
+      return guardMember(target, member, property);
     },
-    set(target, property, nextValue) {
+    set() {
       assertRequestDatabaseContextActive(context);
-      return Reflect.set(target, property, nextValue, target);
+      throw new Error("REQUEST_DATABASE_REFLECTION_UNAVAILABLE");
+    },
+    has(target, property) {
+      assertRequestDatabaseContextActive(context);
+      return Reflect.has(target, property);
+    },
+    defineProperty() {
+      assertRequestDatabaseContextActive(context);
+      throw new Error("REQUEST_DATABASE_REFLECTION_UNAVAILABLE");
+    },
+    deleteProperty() {
+      assertRequestDatabaseContextActive(context);
+      throw new Error("REQUEST_DATABASE_REFLECTION_UNAVAILABLE");
     },
     getOwnPropertyDescriptor(target, property) {
       assertRequestDatabaseContextActive(context);
@@ -595,7 +629,7 @@ function guardRequestDatabaseValue<T>(value: T, context: RequestDatabaseContext)
         throw new Error("REQUEST_DATABASE_REFLECTION_UNAVAILABLE");
       }
       if ("value" in descriptor) {
-        return { ...descriptor, value: guardMember(target, descriptor.value) };
+        return { ...descriptor, value: guardMember(target, descriptor.value, property) };
       }
       return {
         ...descriptor,
@@ -606,9 +640,9 @@ function guardRequestDatabaseValue<T>(value: T, context: RequestDatabaseContext)
             }
           : undefined,
         set: descriptor.set
-          ? (nextValue: unknown) => {
+          ? () => {
               assertRequestDatabaseContextActive(context);
-              Reflect.apply(descriptor.set!, target, [nextValue]);
+              throw new Error("REQUEST_DATABASE_REFLECTION_UNAVAILABLE");
             }
           : undefined,
       };
@@ -617,12 +651,39 @@ function guardRequestDatabaseValue<T>(value: T, context: RequestDatabaseContext)
       assertRequestDatabaseContextActive(context);
       throw new Error("REQUEST_DATABASE_REFLECTION_UNAVAILABLE");
     },
+    setPrototypeOf() {
+      assertRequestDatabaseContextActive(context);
+      throw new Error("REQUEST_DATABASE_REFLECTION_UNAVAILABLE");
+    },
+    isExtensible(target) {
+      assertRequestDatabaseContextActive(context);
+      return Reflect.isExtensible(target);
+    },
+    preventExtensions() {
+      assertRequestDatabaseContextActive(context);
+      throw new Error("REQUEST_DATABASE_REFLECTION_UNAVAILABLE");
+    },
     ownKeys(target) {
       assertRequestDatabaseContextActive(context);
       return Reflect.ownKeys(target);
     },
+    apply(target, thisArg, args) {
+      assertRequestDatabaseContextActive(context);
+      const result = Reflect.apply(
+        target as unknown as (...callArgs: unknown[]) => unknown,
+        thisArg,
+        guardCallbackArguments(args),
+      );
+      return guardRequestDatabaseValue(result, context);
+    },
+    construct(target, args) {
+      assertRequestDatabaseContextActive(context);
+      const result = Reflect.construct(target as unknown as Function, guardCallbackArguments(args));
+      return guardRequestDatabaseValue(result, context);
+    },
   });
   context.guardedObjects.set(objectValue, guarded);
+  context.guardedObjects.set(guarded, guarded);
   return guarded as T;
 }
 

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -566,22 +566,60 @@ function guardRequestDatabaseValue<T>(value: T, context: RequestDatabaseContext)
   const existing = context.guardedObjects.get(objectValue);
   if (existing) return existing as T;
 
+  const guardMember = (target: object, member: unknown): unknown => {
+    if (typeof member === "function") {
+      return (...args: unknown[]) => {
+        assertRequestDatabaseContextActive(context);
+        const result = Reflect.apply(member, target, args);
+        return guardRequestDatabaseValue(result, context);
+      };
+    }
+    return guardRequestDatabaseValue(member, context);
+  };
+
   const guarded = new Proxy(objectValue, {
     get(target, property) {
       assertRequestDatabaseContextActive(context);
       const member = Reflect.get(target, property, target);
-      if (typeof member === "function") {
-        return (...args: unknown[]) => {
-          assertRequestDatabaseContextActive(context);
-          const result = Reflect.apply(member, target, args);
-          return guardRequestDatabaseValue(result, context);
-        };
-      }
-      return guardRequestDatabaseValue(member, context);
+      return guardMember(target, member);
     },
     set(target, property, nextValue) {
       assertRequestDatabaseContextActive(context);
       return Reflect.set(target, property, nextValue, target);
+    },
+    getOwnPropertyDescriptor(target, property) {
+      assertRequestDatabaseContextActive(context);
+      const descriptor = Reflect.getOwnPropertyDescriptor(target, property);
+      if (!descriptor) return undefined;
+      if (!descriptor.configurable) {
+        throw new Error("REQUEST_DATABASE_REFLECTION_UNAVAILABLE");
+      }
+      if ("value" in descriptor) {
+        return { ...descriptor, value: guardMember(target, descriptor.value) };
+      }
+      return {
+        ...descriptor,
+        get: descriptor.get
+          ? () => {
+              assertRequestDatabaseContextActive(context);
+              return guardRequestDatabaseValue(Reflect.apply(descriptor.get!, target, []), context);
+            }
+          : undefined,
+        set: descriptor.set
+          ? (nextValue: unknown) => {
+              assertRequestDatabaseContextActive(context);
+              Reflect.apply(descriptor.set!, target, [nextValue]);
+            }
+          : undefined,
+      };
+    },
+    getPrototypeOf() {
+      assertRequestDatabaseContextActive(context);
+      throw new Error("REQUEST_DATABASE_REFLECTION_UNAVAILABLE");
+    },
+    ownKeys(target) {
+      assertRequestDatabaseContextActive(context);
+      return Reflect.ownKeys(target);
     },
   });
   context.guardedObjects.set(objectValue, guarded);

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -585,6 +585,15 @@ function guardRequestDatabaseValue<T>(value: T, context: RequestDatabaseContext)
 
   const guardMember = (target: object, member: unknown, property?: PropertyKey): unknown => {
     if (typeof member === "function") {
+      // Drizzle's cross-bundle entity check walks
+      // Object.getPrototypeOf(value).constructor and then the constructor's
+      // prototype chain. Preserve that identity-bearing shape inside the same
+      // membrane instead of turning `constructor` into a bound method facade.
+      // The callable proxy still checks this request lease on every reflection
+      // and invocation, so the raw constructor never escapes.
+      if (property === "constructor") {
+        return guardRequestDatabaseValue(member, context);
+      }
       return (...args: unknown[]) => {
         assertRequestDatabaseContextActive(context);
         // Drizzle query builders are PromiseLike. Their `then` callbacks are
@@ -647,9 +656,18 @@ function guardRequestDatabaseValue<T>(value: T, context: RequestDatabaseContext)
           : undefined,
       };
     },
-    getPrototypeOf() {
+    getPrototypeOf(target) {
       assertRequestDatabaseContextActive(context);
-      throw new Error("REQUEST_DATABASE_REFLECTION_UNAVAILABLE");
+      // Drizzle uses prototype inspection to recognize aliased subqueries and
+      // columns during composition. Return a recursively guarded prototype so
+      // those checks keep working without exposing a raw object or callable.
+      // Proxy invariants require the exact raw prototype for non-extensible
+      // targets; refusing that uncommon case is safer than leaking it.
+      if (!Reflect.isExtensible(target)) {
+        throw new Error("REQUEST_DATABASE_REFLECTION_UNAVAILABLE");
+      }
+      const prototype = Reflect.getPrototypeOf(target);
+      return prototype === null ? null : guardRequestDatabaseValue(prototype, context);
     },
     setPrototypeOf() {
       assertRequestDatabaseContextActive(context);

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -513,6 +513,59 @@ function trackRequestDatabaseTask<T>(
   return task;
 }
 
+const REQUEST_DATABASE_CAPABILITY_METHODS = [
+  "batch",
+  "close",
+  "connect",
+  "copyFrom",
+  "copyTo",
+  "cursor",
+  "end",
+  "execute",
+  "listen",
+  "prepare",
+  "query",
+  "release",
+  "stream",
+  "transaction",
+  "unlisten",
+] as const;
+
+/**
+ * Promise results are normally inert query data and must remain usable after
+ * the request closes. A driver can also resolve a live transport capability,
+ * though: PGLite `listen()` resolves an unsubscribe callable and pool
+ * `connect()` methods resolve clients. Identify those callable/client-like
+ * results without turning ordinary row arrays and objects into revoked
+ * proxies.
+ */
+function isRequestDatabaseCapabilityResult(value: unknown): value is object {
+  if (typeof value === "function") return true;
+  if (typeof value !== "object" || value === null) return false;
+
+  try {
+    let cursor: object | null = value;
+    while (cursor) {
+      for (const property of REQUEST_DATABASE_CAPABILITY_METHODS) {
+        const descriptor = Reflect.getOwnPropertyDescriptor(cursor, property);
+        if (!descriptor) continue;
+        if ("value" in descriptor) {
+          if (typeof descriptor.value === "function") return true;
+        } else if (descriptor.get || descriptor.set) {
+          // Do not invoke an unknown transport accessor merely to classify it.
+          return true;
+        }
+      }
+      cursor = Reflect.getPrototypeOf(cursor);
+    }
+  } catch {
+    // Driver objects are trusted, but reflection failure must not turn an
+    // opaque result into an unguarded request-owned capability.
+    return true;
+  }
+  return false;
+}
+
 /**
  * Keep explicitly detached work inside the current request database lifetime.
  *
@@ -559,11 +612,22 @@ export function waitUntilRequestDatabaseTask<T>(task: () => Promise<T>): Promise
 function guardRequestDatabaseValue<T>(value: T, context: RequestDatabaseContext): T {
   if ((typeof value !== "object" || value === null) && typeof value !== "function") return value;
 
+  const guardPromiseFulfillment = <R>(result: R): R =>
+    isRequestDatabaseCapabilityResult(result) ? guardRequestDatabaseValue(result, context) : result;
+
   const objectValue = value as object;
   const existing = context.guardedObjects.get(objectValue);
   if (existing) return existing as T;
   if (value instanceof Promise) {
-    return trackRequestDatabaseTask(context, value) as T;
+    const guardedPromise = value.then(
+      (result) => guardPromiseFulfillment(result),
+      (error) => {
+        throw guardPromiseFulfillment(error);
+      },
+    );
+    context.guardedObjects.set(objectValue, guardedPromise);
+    context.guardedObjects.set(guardedPromise, guardedPromise);
+    return trackRequestDatabaseTask(context, guardedPromise) as T;
   }
 
   const guardCallback = (callback: (...args: unknown[]) => unknown) => {
@@ -583,6 +647,14 @@ function guardRequestDatabaseValue<T>(value: T, context: RequestDatabaseContext)
         : argument,
     );
 
+  const guardPromiseContinuation = (callback: (...args: unknown[]) => unknown) => {
+    return function guardedDatabasePromiseContinuation(this: unknown, ...args: unknown[]): unknown {
+      const guardedThis = guardPromiseFulfillment(this);
+      const guardedArgs = args.map(guardPromiseFulfillment);
+      return Reflect.apply(callback, guardedThis, guardedArgs);
+    };
+  };
+
   const guardMember = (target: object, member: unknown, property?: PropertyKey): unknown => {
     if (typeof member === "function") {
       // Drizzle's cross-bundle entity check walks
@@ -596,11 +668,17 @@ function guardRequestDatabaseValue<T>(value: T, context: RequestDatabaseContext)
       }
       return (...args: unknown[]) => {
         assertRequestDatabaseContextActive(context);
-        // Drizzle query builders are PromiseLike. Their `then` callbacks are
-        // native assimilation continuations receiving ordinary result data,
-        // not database capabilities; wrapping them would proxy result arrays
-        // and make a completed query unusable after the request closes.
-        const guardedArgs = property === "then" ? args : guardCallbackArguments(args);
+        // Drizzle query builders are PromiseLike. Preserve ordinary result
+        // rows, but membrane callable/client-like fulfillment values supplied
+        // by either a driver thenable or a native assimilation continuation.
+        const guardedArgs =
+          property === "then"
+            ? args.map((argument) =>
+                typeof argument === "function"
+                  ? guardPromiseContinuation(argument as (...callbackArgs: unknown[]) => unknown)
+                  : argument,
+              )
+            : guardCallbackArguments(args);
         const result = Reflect.apply(member, target, guardedArgs);
         return guardRequestDatabaseValue(result, context);
       };


### PR DESCRIPTION
Refs #488

## Summary

- guard every request-owned Drizzle capability returned through properties, descriptors, methods, callable results, transaction callbacks, and Promise/thenable fulfillment or rejection
- selectively membrane callable and client-like Promise results while leaving ordinary query rows, result objects, and driver errors usable after request completion
- classify `unsubscribe` handles used by postgres.js subscriptions and PGLite live queries, closing the remaining Promise-fulfillment escape
- deny mutating/reflection traps (`set`, `defineProperty`, `deleteProperty`, prototype mutation, extension changes) and re-check `has`/extensibility against the live request lease
- replace the stale CORS source assertion with behavioral empty-allowlist and PATCH preflight coverage

This is a corrective follow-up to merged #488. Native Promise fulfillment, driver thenable callbacks, and subscription handles can otherwise return a raw request-owned capability after the request closes. Regression coverage exercises a Neon-like Promise-resolved pool client, fulfillment and rejection paths, real PGLite `listen()` and live-query subscription handles, real PGLite transactions, and inert query/error values.

## Exact-head validation

Head: `abec18a997e0fdd99f2f4459f7ffe2cb7dabb31a`

Base: `9239a728b9ca28175e00e2825f69d85f3e02856e`

- `bun test --timeout 120000 packages/db/src/__tests__/request-database-context.test.ts packages/api/src/__tests__/worker-runtime-sentinel.test.ts packages/api/src/__tests__/middleware-security-hardening.test.ts packages/api/src/__tests__/tenant-cors-preflight.test.ts` — 44 passed, 246 assertions
- real PGLite transaction, `listen()` cleanup callable, and live-query `unsubscribe`/`refresh` handles are revoked after request completion
- ordinary synthetic rows, real PGLite query values, and native driver rejection errors remain usable after cleanup
- `bun run --cwd packages/db build`
- `turbo build --filter=@stwd/api... --force` — 24/24 packages, uncached
- `biome check packages/db/src/client.ts packages/db/src/__tests__/request-database-context.test.ts`
- `git diff HEAD^ --check`

Keep draft until the fresh exact-head hosted matrix and required independent review complete.

