### PR TITLE
test(security): isolate fail-closed proxy fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,10 +163,10 @@ jobs:
           if [ "${{ matrix.package }}" = "packages/sdk" ]; then
             mapfile -t sdk_tests < <(find packages/sdk/src -type f \( -name '*.test.ts' -o -name '*.spec.ts' \) | sort)
             bun test --isolate "${sdk_tests[@]}"
-          elif [ "${{ matrix.package }}" = "packages/plugin-sdk" ] || [ "${{ matrix.package }}" = "packages/plugin-example" ]; then
-            # These facade suites intentionally preload a hermetic PGLite
-            # context from their package-local bunfig.toml. Running them from
-            # the repository root skips that preload and fails at module init.
+          elif [ "${{ matrix.package }}" = "packages/plugin-sdk" ] || [ "${{ matrix.package }}" = "packages/plugin-example" ] || [ "${{ matrix.package }}" = "packages/plugin-capabilities" ]; then
+            # These packages own their test-process isolation or package-local
+            # preload. Running them from the repository root bypasses that
+            # contract and can leak mutable fixtures between files.
             (cd "${{ matrix.package }}" && bun run test)
           elif [ "${{ matrix.package }}" = "packages/trade-sessions" ]; then
             # PGLite migrations can exceed Bun's 5s default on hosted runners.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -249,10 +249,10 @@ jobs:
           if [ "${{ matrix.package }}" = "packages/sdk" ]; then
             mapfile -t sdk_tests < <(find packages/sdk/src -type f \( -name '*.test.ts' -o -name '*.spec.ts' \) | sort)
             bun test --isolate "${sdk_tests[@]}"
-          elif [ "${{ matrix.package }}" = "packages/plugin-sdk" ] || [ "${{ matrix.package }}" = "packages/plugin-example" ]; then
-            # These facade suites intentionally preload a hermetic PGLite
-            # context from their package-local bunfig.toml. Running them from
-            # the repository root skips that preload and fails at module init.
+          elif [ "${{ matrix.package }}" = "packages/plugin-sdk" ] || [ "${{ matrix.package }}" = "packages/plugin-example" ] || [ "${{ matrix.package }}" = "packages/plugin-capabilities" ]; then
+            # These packages own their test-process isolation or package-local
+            # preload. Running them from the repository root bypasses that
+            # contract and can leak mutable fixtures between files.
             (cd "${{ matrix.package }}" && bun run test)
           elif [ "${{ matrix.package }}" = "packages/trade-sessions" ]; then
             # PGLite migrations can exceed Bun's 5s default on hosted runners.

--- a/packages/api/src/__tests__/agent-client-e2e.test.ts
+++ b/packages/api/src/__tests__/agent-client-e2e.test.ts
@@ -42,6 +42,17 @@ const PROXY_URL = "https://proxy.a3-e2e.test";
 const CAP_MIGRATIONS = fileURLToPath(
   new URL("../../../plugin-capabilities/drizzle", import.meta.url),
 );
+const TEST_ENV_KEYS = [
+  "STEWARD_PGLITE_MEMORY",
+  "STEWARD_MASTER_PASSWORD",
+  "STEWARD_JWT_SECRET",
+  "STEWARD_AUDIT_HMAC_KEY",
+  "STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE",
+  "STEWARD_PROXY_REQUEST_SIGNING_SECRET",
+  "STEWARD_PROXY_ALLOWED_HOSTS",
+  "STEWARD_PROXY_DEV_MODE",
+  "STEWARD_PROXY_URL",
+] as const;
 
 let keypair: Awaited<ReturnType<typeof generateP256KeyPair>>;
 let tenantId: string;
@@ -51,6 +62,8 @@ let capName: string;
 let forwarded: { url: string; auth: string | null; bodyText: string | null } | null = null;
 let proxyApp: Hono | null = null;
 const realFetch = globalThis.fetch;
+let originalEnv = new Map<string, string | undefined>();
+let resetProxyHandlerTestHooksForTests: (() => void) | undefined;
 
 // Real A1 route factories + agent-jwt middleware.
 let agentEnrollRoutes: Hono<{ Variables: AppVariables }>;
@@ -125,12 +138,15 @@ async function buildStewardAppContext() {
 }
 
 beforeAll(async () => {
+  originalEnv = new Map(TEST_ENV_KEYS.map((key) => [key, process.env[key]]));
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "a3-agent-client-e2e-jwt-secret-with-enough-bytes-0123456789";
+  process.env.STEWARD_AUDIT_HMAC_KEY = "a3-agent-client-e2e-audit-hmac-key-with-enough-bytes";
   process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
   process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.github.com";
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   process.env.STEWARD_PROXY_URL = PROXY_URL;
 
   const { db, client } = await createPGLiteDb("memory://");
@@ -148,8 +164,12 @@ beforeAll(async () => {
     handleProxy,
     __setForwardProxyRequestForTests: setForward,
     __setResolveProxyHostForTests: setResolveHost,
+    __setCheckProxyRateLimitForTests: setCheckProxyRateLimitForTests,
+    __resetProxyHandlerTestHooksForTests: resetProxyHooks,
   } = await import("@stwd/proxy/src/handlers/proxy");
+  resetProxyHandlerTestHooksForTests = resetProxyHooks;
   setResolveHost(async () => [{ address: "93.184.216.34", family: 4 }]);
+  setCheckProxyRateLimitForTests(async () => ({ allowed: true, resetMs: 0 }));
   setForward(async (url, method, headers, body) => {
     const bodyText = body ? await new Response(body).text() : null;
     forwarded = {
@@ -244,17 +264,12 @@ beforeAll(async () => {
 
 afterAll(async () => {
   globalThis.fetch = realFetch;
+  resetProxyHandlerTestHooksForTests?.();
   await closeDb().catch(() => {});
-  for (const k of [
-    "STEWARD_PGLITE_MEMORY",
-    "STEWARD_MASTER_PASSWORD",
-    "STEWARD_JWT_SECRET",
-    "STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE",
-    "STEWARD_PROXY_REQUEST_SIGNING_SECRET",
-    "STEWARD_PROXY_ALLOWED_HOSTS",
-    "STEWARD_PROXY_URL",
-  ]) {
-    delete process.env[k];
+  for (const key of TEST_ENV_KEYS) {
+    const original = originalEnv.get(key);
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
   }
 });
 

--- a/packages/api/src/__tests__/agent-client-e2e.test.ts
+++ b/packages/api/src/__tests__/agent-client-e2e.test.ts
@@ -52,6 +52,9 @@ const CAP_MIGRATIONS = fileURLToPath(
   new URL("../../../plugin-capabilities/drizzle", import.meta.url),
 );
 const TEST_ENV_KEYS = [
+  "NODE_ENV",
+  "STEWARD_KDF_SALT",
+  "REDIS_REQUIRED",
   "STEWARD_PGLITE_MEMORY",
   "STEWARD_MASTER_PASSWORD",
   "STEWARD_JWT_SECRET",
@@ -149,6 +152,9 @@ async function buildStewardAppContext() {
 
 beforeAll(async () => {
   originalEnv = new Map(TEST_ENV_KEYS.map((key) => [key, process.env[key]]));
+  process.env.NODE_ENV = "test";
+  process.env.STEWARD_KDF_SALT = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  process.env.REDIS_REQUIRED = "false";
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "a3-agent-client-e2e-jwt-secret-with-enough-bytes-0123456789";

--- a/packages/api/src/__tests__/agent-client-e2e.test.ts
+++ b/packages/api/src/__tests__/agent-client-e2e.test.ts
@@ -23,8 +23,16 @@
 
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { fileURLToPath } from "node:url";
-import { generateP256KeyPair } from "@stwd/auth";
-import { agentSigners, agents, closeDb, getDb, runPluginMigrations, tenants } from "@stwd/db";
+import { generateP256KeyPair, signAgentToken } from "@stwd/auth";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  agentSigners,
+  agents,
+  closeDb,
+  getDb,
+  runPluginMigrations,
+  tenants,
+} from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { CapabilityStore } from "@stwd/plugin-capabilities";
 import { AgentClient, AgentKeypair } from "@stwd/sdk";
@@ -38,6 +46,7 @@ setDefaultTimeout(30000);
 const MASTER_PASSWORD = "a3-agent-client-e2e-master-password-32chars";
 const SIGNING_SECRET = "a3-agent-client-e2e-signing-secret-32bytes-min";
 const FAKE_PAT = "ghp_a3_e2e_do_not_use_0123456789abcdef";
+const AUDIT_HMAC_KEY = "a3-agent-client-e2e-audit-hmac-key-with-enough-bytes";
 const PROXY_URL = "https://proxy.a3-e2e.test";
 const CAP_MIGRATIONS = fileURLToPath(
   new URL("../../../plugin-capabilities/drizzle", import.meta.url),
@@ -60,6 +69,7 @@ let agentId: string;
 let capName: string;
 
 let forwarded: { url: string; auth: string | null; bodyText: string | null } | null = null;
+let proxyRequest: { headers: Headers; bodyText: string | null } | null = null;
 let proxyApp: Hono | null = null;
 const realFetch = globalThis.fetch;
 let originalEnv = new Map<string, string | undefined>();
@@ -142,7 +152,8 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "a3-agent-client-e2e-jwt-secret-with-enough-bytes-0123456789";
-  process.env.STEWARD_AUDIT_HMAC_KEY = "a3-agent-client-e2e-audit-hmac-key-with-enough-bytes";
+  process.env.STEWARD_AUDIT_HMAC_KEY = AUDIT_HMAC_KEY;
+  __resetAuditHmacKeyCacheForTests();
   process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
   process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.github.com";
@@ -256,6 +267,10 @@ beforeAll(async () => {
     }
     if (url.startsWith(PROXY_URL) && proxyApp) {
       const path = url.slice(PROXY_URL.length) || "/";
+      proxyRequest = {
+        headers: new Headers(init?.headers),
+        bodyText: typeof init?.body === "string" ? init.body : null,
+      };
       return proxyApp.request(path, init as RequestInit);
     }
     return realFetch(input as RequestInfo, init);
@@ -271,10 +286,28 @@ afterAll(async () => {
     if (original === undefined) delete process.env[key];
     else process.env[key] = original;
   }
+  __resetAuditHmacKeyCacheForTests();
+  originalEnv.clear();
 });
 
 describe("A3 agent-client E2E (real API, seeded p256 signer)", () => {
+  it("keeps the proxy fail-closed for unsigned agent requests", async () => {
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", "api:proxy"] }, "5m");
+    const response = await proxyApp!.request(
+      "/proxy/api.github.com/repos/acme/app/issues/1/comments",
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "X-Steward-Signature header required",
+    });
+  });
+
   it("boots keypair-only and runs enroll → manifest → issue → invoke", async () => {
+    forwarded = null;
+    proxyRequest = null;
     // The agent holds ONLY its private key (imported non-extractable).
     const kp = await AgentKeypair.fromPkcs8Base64(await exportPkcs8Base64(keypair.privateKey));
     const client = new AgentClient({
@@ -312,9 +345,17 @@ describe("A3 agent-client E2E (real API, seeded p256 signer)", () => {
     // the credential reached the UPSTREAM (proxy→github), never the agent.
     expect(forwarded).not.toBeNull();
     expect(forwarded!.auth).toBe(`Bearer ${FAKE_PAT}`);
+    expect(forwarded!.bodyText).not.toContain(FAKE_PAT);
+    // The API→proxy leg really is signed; dev-mode test plumbing must not make
+    // this happy path vacuous by allowing an unsigned request through.
+    expect(proxyRequest).not.toBeNull();
+    expect(proxyRequest!.headers.get("x-steward-signature")).toMatch(/^v1=[0-9a-f]{64}$/);
+    expect(proxyRequest!.headers.get("x-steward-request-timestamp")).toMatch(/^\d+$/);
+    expect(proxyRequest!.bodyText).not.toContain(FAKE_PAT);
     // the agent-visible response body never contains the PAT.
     expect(JSON.stringify(res.data)).not.toContain(FAKE_PAT);
     expect(JSON.stringify(res.data)).not.toContain("ghp_");
+    expect(JSON.stringify(res.data)).not.toContain(AUDIT_HMAC_KEY);
 
     client.stopRenewalLoop();
   });

--- a/packages/api/src/__tests__/tenant-cors-preflight.test.ts
+++ b/packages/api/src/__tests__/tenant-cors-preflight.test.ts
@@ -103,6 +103,7 @@ describe("tenant CORS preflight", () => {
 
     expect(response.status).toBe(403);
     expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(response.headers.get("access-control-allow-credentials")).toBeNull();
     expect(response.headers.get("vary")).toBe("Origin, X-Steward-Tenant");
   });
 });

--- a/packages/auth/src/__tests__/middleware.test.ts
+++ b/packages/auth/src/__tests__/middleware.test.ts
@@ -8,15 +8,16 @@
  * (status, body, and content type), so requesters cannot enumerate tenant ids.
  */
 
-import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout, spyOn } from "bun:test";
 import { closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { Hono } from "hono";
 
-import { generateApiKey } from "../api-keys";
+import * as apiKeys from "../api-keys";
 
 const TENANT_ID = "sec132-known-tenant";
 const ENV_KEYS = ["STEWARD_PGLITE_MEMORY", "STEWARD_DB_MODE", "STEWARD_MASTER_PASSWORD"] as const;
+const UNKNOWN_TENANT_DUMMY_HASH = apiKeys.hashApiKey("steward-unknown-tenant-dummy-key");
 
 setDefaultTimeout(30_000);
 
@@ -24,18 +25,20 @@ describe("tenantAuthMiddleware unknown-tenant hardening (SEC-132)", () => {
   const savedEnv: Record<string, string | undefined> = {};
   let app: Hono;
   let validKey: string;
+  let validateApiKeySpy: ReturnType<typeof spyOn> | undefined;
 
   beforeAll(async () => {
     for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_DB_MODE = "pglite";
     process.env.STEWARD_MASTER_PASSWORD ??= "sec132-middleware-test-master-password";
+    validateApiKeySpy = spyOn(apiKeys, "validateApiKey");
     const { db, client } = await createPGLiteDb("memory://");
     setPGLiteOverride(db, async () => {
       await client.close();
     });
 
-    const keyPair = generateApiKey();
+    const keyPair = apiKeys.generateApiKey();
     validKey = keyPair.key;
     await getDb()
       .insert(tenants)
@@ -50,12 +53,19 @@ describe("tenantAuthMiddleware unknown-tenant hardening (SEC-132)", () => {
   });
 
   afterAll(async () => {
-    await closeDb();
-    for (const key of ENV_KEYS) {
-      if (savedEnv[key] === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = savedEnv[key];
+    try {
+      await closeDb();
+    } finally {
+      try {
+        validateApiKeySpy?.mockRestore();
+      } finally {
+        for (const key of ENV_KEYS) {
+          if (savedEnv[key] === undefined) {
+            delete process.env[key];
+          } else {
+            process.env[key] = savedEnv[key];
+          }
+        }
       }
     }
   });
@@ -87,6 +97,7 @@ describe("tenantAuthMiddleware unknown-tenant hardening (SEC-132)", () => {
     expect(unknownTenantRes.headers.get("content-type")).toBe(
       knownBadKeyRes.headers.get("content-type"),
     );
+    expect(validateApiKeySpy).toHaveBeenCalledWith("stw_wrong_key", UNKNOWN_TENANT_DUMMY_HASH);
   });
 
   it("keeps the healthcheck bypass exact: GET / and /health only", async () => {

--- a/packages/auth/src/__tests__/middleware.test.ts
+++ b/packages/auth/src/__tests__/middleware.test.ts
@@ -4,16 +4,11 @@
  * the dummy-hash comparison, so response shape/timing cannot enumerate valid
  * tenant ids.
  *
- * Two layers of proof:
- *   - behavioral: known-tenant/wrong-key and unknown-tenant responses are
- *     byte-identical 403s (status, body, content type);
- *   - structural: the middleware source pins the dummy-hash mechanism (a
- *     timing assertion would be flaky in CI).
+ * Known-tenant/wrong-key and unknown-tenant responses are byte-identical 403s
+ * (status, body, and content type), so requesters cannot enumerate tenant ids.
  */
 
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { Hono } from "hono";
@@ -22,6 +17,8 @@ import { generateApiKey } from "../api-keys";
 
 const TENANT_ID = "sec132-known-tenant";
 const ENV_KEYS = ["STEWARD_PGLITE_MEMORY", "STEWARD_DB_MODE", "STEWARD_MASTER_PASSWORD"] as const;
+
+setDefaultTimeout(30_000);
 
 describe("tenantAuthMiddleware unknown-tenant hardening (SEC-132)", () => {
   const savedEnv: Record<string, string | undefined> = {};
@@ -90,19 +87,6 @@ describe("tenantAuthMiddleware unknown-tenant hardening (SEC-132)", () => {
     expect(unknownTenantRes.headers.get("content-type")).toBe(
       knownBadKeyRes.headers.get("content-type"),
     );
-  });
-
-  it("pins the dummy-hash comparison in the middleware source", () => {
-    // The unknown-tenant path must still run validateApiKey against a dummy
-    // hash so response TIMING matches the known-tenant path. Pinning the
-    // construction beats a wall-clock assertion, which flakes under CI load.
-    const source = readFileSync(join(import.meta.dir, "..", "middleware.ts"), "utf8");
-    expect(source).toContain('hashApiKey("steward-unknown-tenant-dummy-key")');
-    expect(source).toContain(
-      "validateApiKey(apiKey, tenant?.apiKeyHash ?? UNKNOWN_TENANT_DUMMY_HASH)",
-    );
-    // One shared denial: no branch may reveal WHICH leg failed.
-    expect(source).toContain("if (!tenant || !keyValid)");
   });
 
   it("keeps the healthcheck bypass exact: GET / and /health only", async () => {

--- a/packages/plugin-capabilities/package.json
+++ b/packages/plugin-capabilities/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --noEmit",
     "dev": "tsc --watch",
-    "test": "bun test --isolate --timeout 30000",
+    "test": "bun scripts/run-tests-isolated.ts",
     "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit"
   },

--- a/packages/plugin-capabilities/scripts/run-tests-isolated.ts
+++ b/packages/plugin-capabilities/scripts/run-tests-isolated.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env bun
+/** Run every test file in a separate process so fixture globals cannot cross files. */
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const packageRoot = join(import.meta.dir, "..");
+const testRoot = join(packageRoot, "src", "__tests__");
+const filters = process.argv.slice(2);
+
+function findTests(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) return findTests(path);
+      return entry.name.endsWith(".test.ts") ? [path] : [];
+    })
+    .sort();
+}
+
+const relativeName = (path: string): string => path.slice(testRoot.length + 1);
+const tests = findTests(testRoot).filter(
+  (path) => filters.length === 0 || filters.some((filter) => relativeName(path).includes(filter)),
+);
+if (tests.length === 0) {
+  throw new Error(`No plugin-capabilities tests matched: ${filters.join(", ")}`);
+}
+
+const timeout = process.env.TEST_TIMEOUT ?? "30000";
+const results: Array<{ path: string; exitCode: number; output: string }> = [];
+
+for (const path of tests) {
+  const child = Bun.spawn(["bun", "test", "--timeout", timeout, path], {
+    cwd: packageRoot,
+    env: process.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  const output = `${stdout}${stderr}`;
+  results.push({ path, exitCode, output });
+  console.log(`[isolated] ${exitCode === 0 ? "PASS" : "FAIL"} ${relativeName(path)}`);
+  if (exitCode !== 0) console.error(output.trim());
+}
+
+const failures = results.filter(({ exitCode }) => exitCode !== 0);
+if (failures.length > 0) {
+  throw new Error(
+    `${failures.length}/${results.length} isolated test files failed: ${failures
+      .map(({ path }) => relativeName(path))
+      .join(", ")}`,
+  );
+}
+
+console.log(`[isolated] ${results.length}/${results.length} test files passed`);

--- a/packages/plugin-capabilities/scripts/run-tests-isolated.ts
+++ b/packages/plugin-capabilities/scripts/run-tests-isolated.ts
@@ -1,58 +1,138 @@
 #!/usr/bin/env bun
-/** Run every test file in a separate process so fixture globals cannot cross files. */
+/** Run each test file in its own bounded process so fixture globals cannot cross files. */
 import { readdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 const packageRoot = join(import.meta.dir, "..");
-const testRoot = join(packageRoot, "src", "__tests__");
+const testRoot = process.env.ISOLATED_TEST_ROOT ?? join(packageRoot, "src", "__tests__");
 const filters = process.argv.slice(2);
+const TEST_FILE_PATTERN = /\.(?:test|spec)\.(?:ts|tsx)$/u;
+const timeout = Number(process.env.TEST_TIMEOUT ?? "30000");
+const wallTimeout = Number(process.env.TEST_WALL_TIMEOUT_MS ?? "180000");
+const killGrace = Number(process.env.TEST_KILL_GRACE_MS ?? "2000");
+const tailBytes = Number(process.env.TEST_FAILURE_TAIL_BYTES ?? String(16 * 1024));
 
 function findTests(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true })
     .flatMap((entry) => {
       const path = join(directory, entry.name);
       if (entry.isDirectory()) return findTests(path);
-      return entry.name.endsWith(".test.ts") ? [path] : [];
+      return TEST_FILE_PATTERN.test(entry.name) ? [path] : [];
     })
     .sort();
 }
 
-const relativeName = (path: string): string => path.slice(testRoot.length + 1);
+const relativeName = (path: string): string => relative(testRoot, path);
 const tests = findTests(testRoot).filter(
   (path) => filters.length === 0 || filters.some((filter) => relativeName(path).includes(filter)),
 );
 if (tests.length === 0) {
-  throw new Error(`No plugin-capabilities tests matched: ${filters.join(", ")}`);
+  console.error(`[isolated] no tests matched: ${filters.join(", ") || testRoot}`);
+  process.exit(1);
+}
+if (
+  !Number.isFinite(timeout) ||
+  timeout <= 0 ||
+  !Number.isFinite(wallTimeout) ||
+  wallTimeout <= 0 ||
+  !Number.isFinite(killGrace) ||
+  killGrace <= 0 ||
+  !Number.isFinite(tailBytes) ||
+  tailBytes <= 0
+) {
+  throw new Error("runner timeout, kill grace, and failure tail limits must be positive numbers");
 }
 
-const timeout = process.env.TEST_TIMEOUT ?? "30000";
-const results: Array<{ path: string; exitCode: number; output: string }> = [];
+type Child = ReturnType<typeof Bun.spawn>;
+const active = new Set<Child>();
+let interruptedSignal: "SIGINT" | "SIGTERM" | undefined;
 
-for (const path of tests) {
-  const child = Bun.spawn(["bun", "test", "--timeout", timeout, path], {
-    cwd: packageRoot,
-    env: process.env,
-    stdout: "pipe",
-    stderr: "pipe",
+function signalTree(child: Child, signal: "SIGTERM" | "SIGKILL"): void {
+  const pid = child.pid;
+  if (!Number.isSafeInteger(pid) || pid <= 1) return;
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {}
+  }
+}
+
+async function terminate(child: Child): Promise<void> {
+  signalTree(child, "SIGTERM");
+  const killer = setTimeout(() => signalTree(child, "SIGKILL"), killGrace);
+  try {
+    await child.exited;
+  } finally {
+    clearTimeout(killer);
+    active.delete(child);
+  }
+}
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.on(signal, () => {
+    if (interruptedSignal) return;
+    interruptedSignal = signal;
+    void Promise.all([...active].map(terminate)).finally(() => {
+      process.exit(signal === "SIGINT" ? 130 : 143);
+    });
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(child.stdout).text(),
-    new Response(child.stderr).text(),
-    child.exited,
-  ]);
-  const output = `${stdout}${stderr}`;
-  results.push({ path, exitCode, output });
-  console.log(`[isolated] ${exitCode === 0 ? "PASS" : "FAIL"} ${relativeName(path)}`);
-  if (exitCode !== 0) console.error(output.trim());
 }
 
-const failures = results.filter(({ exitCode }) => exitCode !== 0);
+async function drainTail(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  let retained = new Uint8Array();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    const combined = new Uint8Array(retained.length + value.length);
+    combined.set(retained);
+    combined.set(value, retained.length);
+    retained = combined.length > tailBytes ? combined.slice(combined.length - tailBytes) : combined;
+  }
+  return new TextDecoder().decode(retained);
+}
+
+const failures: string[] = [];
+try {
+  for (const path of tests) {
+    const child = Bun.spawn(["bun", "test", "--timeout", String(timeout), path], {
+      cwd: packageRoot,
+      env: process.env,
+      stdout: "pipe",
+      stderr: "pipe",
+      detached: true,
+    });
+    active.add(child);
+    let timedOut = false;
+    const deadline = setTimeout(() => {
+      timedOut = true;
+      void terminate(child);
+    }, wallTimeout);
+    const [stdout, stderr, exitCode] = await Promise.all([
+      drainTail(child.stdout),
+      drainTail(child.stderr),
+      child.exited,
+    ]);
+    clearTimeout(deadline);
+    active.delete(child);
+    const ok = exitCode === 0 && !timedOut;
+    console.log(`[isolated] ${ok ? "PASS" : "FAIL"} ${relativeName(path)}`);
+    if (!ok) {
+      failures.push(relativeName(path));
+      const reason = timedOut ? `[isolated] wall timeout after ${wallTimeout}ms\n` : "";
+      console.error(`${reason}${stdout}${stderr}`.trim());
+    }
+    if (interruptedSignal) break;
+  }
+} finally {
+  await Promise.all([...active].map(terminate));
+}
+
+if (interruptedSignal) process.exit(interruptedSignal === "SIGINT" ? 130 : 143);
 if (failures.length > 0) {
-  throw new Error(
-    `${failures.length}/${results.length} isolated test files failed: ${failures
-      .map(({ path }) => relativeName(path))
-      .join(", ")}`,
-  );
+  console.error(`[isolated] ${failures.length}/${tests.length} failed: ${failures.join(", ")}`);
+  process.exit(1);
 }
-
-console.log(`[isolated] ${results.length}/${results.length} test files passed`);
+console.log(`[isolated] ${tests.length}/${tests.length} test files passed`);

--- a/packages/plugin-capabilities/scripts/run-tests-isolated.ts
+++ b/packages/plugin-capabilities/scripts/run-tests-isolated.ts
@@ -68,11 +68,11 @@ function terminate(child: Child): Promise<void> {
   let termination!: Promise<void>;
   termination = (async () => {
     signalTree(child, "SIGTERM");
-    const killer = setTimeout(() => signalTree(child, "SIGKILL"), killGrace);
     try {
+      await Bun.sleep(killGrace);
+      signalTree(child, "SIGKILL");
       await child.exited;
     } finally {
-      clearTimeout(killer);
       active.delete(child);
     }
   })().finally(() => terminations.delete(child));
@@ -120,7 +120,7 @@ try {
       detached: true,
     });
     active.add(child);
-    const exited = child.exited.finally(() => active.delete(child));
+    const exited = child.exited;
     let timedOut = false;
     const deadline = setTimeout(() => {
       if (!active.has(child)) return;
@@ -136,6 +136,8 @@ try {
         drainTail(child.stderr),
         exited,
       ]);
+      const pendingTermination = terminations.get(child);
+      if (pendingTermination) await pendingTermination;
     } catch (error) {
       if (active.has(child)) await terminate(child);
       throw error;

--- a/packages/plugin-capabilities/scripts/run-tests-isolated.ts
+++ b/packages/plugin-capabilities/scripts/run-tests-isolated.ts
@@ -45,6 +45,7 @@ if (
 
 type Child = ReturnType<typeof Bun.spawn>;
 const active = new Set<Child>();
+const terminations = new Map<Child, Promise<void>>();
 let interruptedSignal: "SIGINT" | "SIGTERM" | undefined;
 
 function signalTree(child: Child, signal: "SIGTERM" | "SIGKILL"): void {
@@ -59,15 +60,24 @@ function signalTree(child: Child, signal: "SIGTERM" | "SIGKILL"): void {
   }
 }
 
-async function terminate(child: Child): Promise<void> {
-  signalTree(child, "SIGTERM");
-  const killer = setTimeout(() => signalTree(child, "SIGKILL"), killGrace);
-  try {
-    await child.exited;
-  } finally {
-    clearTimeout(killer);
-    active.delete(child);
-  }
+function terminate(child: Child): Promise<void> {
+  if (!active.has(child)) return child.exited.then(() => {});
+  const pending = terminations.get(child);
+  if (pending) return pending;
+
+  let termination!: Promise<void>;
+  termination = (async () => {
+    signalTree(child, "SIGTERM");
+    const killer = setTimeout(() => signalTree(child, "SIGKILL"), killGrace);
+    try {
+      await child.exited;
+    } finally {
+      clearTimeout(killer);
+      active.delete(child);
+    }
+  })().finally(() => terminations.delete(child));
+  terminations.set(child, termination);
+  return termination;
 }
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {
@@ -86,6 +96,11 @@ async function drainTail(stream: ReadableStream<Uint8Array>): Promise<string> {
   for (;;) {
     const { done, value } = await reader.read();
     if (done) break;
+    // Allows the runner's own adversarial tests to exercise rejected stream reads.
+    const drainFailureSentinel = process.env.ISOLATED_RUNNER_TEST_DRAIN_FAILURE_AFTER;
+    if (drainFailureSentinel && new TextDecoder().decode(value).includes(drainFailureSentinel)) {
+      throw new Error("simulated isolated runner stream failure");
+    }
     const combined = new Uint8Array(retained.length + value.length);
     combined.set(retained);
     combined.set(value, retained.length);
@@ -105,18 +120,29 @@ try {
       detached: true,
     });
     active.add(child);
+    const exited = child.exited.finally(() => active.delete(child));
     let timedOut = false;
     const deadline = setTimeout(() => {
+      if (!active.has(child)) return;
       timedOut = true;
       void terminate(child);
     }, wallTimeout);
-    const [stdout, stderr, exitCode] = await Promise.all([
-      drainTail(child.stdout),
-      drainTail(child.stderr),
-      child.exited,
-    ]);
-    clearTimeout(deadline);
-    active.delete(child);
+    let stdout: string;
+    let stderr: string;
+    let exitCode: number;
+    try {
+      [stdout, stderr, exitCode] = await Promise.all([
+        drainTail(child.stdout),
+        drainTail(child.stderr),
+        exited,
+      ]);
+    } catch (error) {
+      if (active.has(child)) await terminate(child);
+      throw error;
+    } finally {
+      clearTimeout(deadline);
+      active.delete(child);
+    }
     const ok = exitCode === 0 && !timedOut;
     console.log(`[isolated] ${ok ? "PASS" : "FAIL"} ${relativeName(path)}`);
     if (!ok) {

--- a/packages/plugin-capabilities/src/__tests__/fixtures/isolated-runner-fixture.ts
+++ b/packages/plugin-capabilities/src/__tests__/fixtures/isolated-runner-fixture.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test";
+import { existsSync, writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+
+const root = process.env.ISOLATED_FIXTURE_ROOT;
+if (!root) throw new Error("ISOLATED_FIXTURE_ROOT is required");
+
+const role = process.argv[2] ?? basename(import.meta.path).split(".")[0];
+const fixturePath = (name: string) => join(root, name);
+
+switch (role) {
+  case "hang":
+    await new Promise(() => {});
+    break;
+  case "kill": {
+    process.on("SIGTERM", () => {
+      writeFileSync(fixturePath("child-term"), "term");
+      setTimeout(() => process.exit(0), 50);
+    });
+    Bun.spawn(["bun", import.meta.path, "kill-descendant"], {
+      env: process.env,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    writeFileSync(fixturePath("child-pid"), String(process.pid));
+    await new Promise(() => {});
+    break;
+  }
+  case "kill-descendant":
+    process.on("SIGTERM", () => writeFileSync(fixturePath("descendant-term"), "term"));
+    writeFileSync(fixturePath("descendant-pid"), String(process.pid));
+    await new Promise(() => {});
+    break;
+  case "clean-leader":
+    test("clean leader", async () => {
+      const child = Bun.spawn(["bun", import.meta.path, "clean-leader-descendant"], {
+        env: process.env,
+        stdout: "inherit",
+        stderr: "inherit",
+      });
+      child.unref();
+      for (let i = 0; i < 400; i += 1) {
+        if (
+          await readFile(fixturePath("clean-leader-descendant-pid"))
+            .then((value) => value.length > 0)
+            .catch(() => false)
+        )
+          break;
+        await Bun.sleep(20);
+      }
+      expect(await readFile(fixturePath("clean-leader-descendant-pid"), "utf8")).not.toBe("");
+    });
+    break;
+  case "clean-leader-descendant":
+    writeFileSync(fixturePath("clean-leader-descendant-pid"), String(process.pid));
+    await new Promise(() => {});
+    break;
+  case "signal":
+    process.on("SIGTERM", () => {
+      writeFileSync(fixturePath("term-marker"), "term");
+      process.exit(143);
+    });
+    writeFileSync(fixturePath("term-handler-ready"), "ready");
+    await new Promise(() => {});
+    break;
+  case "orphan":
+    writeFileSync(fixturePath("child-pid"), String(process.pid));
+    await new Promise(() => {});
+    break;
+  case "drain-failure":
+    writeFileSync(fixturePath("drain-failure-pid"), String(process.pid));
+    writeFileSync(fixturePath("drain-failure-ready"), "ready");
+    while (!existsSync(fixturePath("drain-failure-trigger"))) await Bun.sleep(10);
+    process.stdout.write("DRAIN_FAILURE_SENTINEL\n");
+    process.on("SIGTERM", () => {});
+    await new Promise(() => {});
+    break;
+  case "failure":
+    test("bad", () => {
+      console.error("A".repeat(200_000));
+      throw new Error("TAIL_SENTINEL");
+    });
+    break;
+  case "explicit-failure":
+    test("no", () => {
+      throw new Error("FAIL_SENTINEL");
+    });
+    break;
+  case "success":
+    test("ok", () => console.log("SUCCESS_SECRET"));
+    break;
+  default:
+    test("ok", () => expect(1).toBe(1));
+}

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -72,6 +72,7 @@ interface ForwardedCapture {
 }
 let lastForwarded: ForwardedCapture | null = null;
 let proxyApp: Hono | null = null;
+let proxyRateLimitChecks = 0;
 const realFetch = globalThis.fetch;
 
 // the policy set the injected getPolicySet returns for the current test.
@@ -128,7 +129,10 @@ beforeAll(async () => {
   // deterministic public ip so route-match -> decrypt -> inject -> forward runs
   // with no external network (mirrors the #149 e2e).
   setResolveProxyHostForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
-  setCheckProxyRateLimitForTests(async () => ({ allowed: true, resetMs: 0 }));
+  setCheckProxyRateLimitForTests(async () => {
+    proxyRateLimitChecks += 1;
+    return { allowed: true, resetMs: 0 };
+  });
   setForwardProxyRequestForTests(async (url, method, headers, body) => {
     const bodyText = body ? await new Response(body).text() : null;
     lastForwarded = { url: url.toString(), method, headers, bodyText };
@@ -170,12 +174,18 @@ beforeAll(async () => {
 
 afterAll(async () => {
   globalThis.fetch = realFetch;
-  resetProxyHandlerTestHooksForTests();
-  await closeDb().catch(() => {});
-  for (const key of TEST_ENV_KEYS) {
-    const original = originalEnv.get(key);
-    if (original === undefined) delete process.env[key];
-    else process.env[key] = original;
+  try {
+    resetProxyHandlerTestHooksForTests?.();
+  } finally {
+    try {
+      await closeDb().catch(() => {});
+    } finally {
+      for (const key of TEST_ENV_KEYS) {
+        const original = originalEnv.get(key);
+        if (original === undefined) delete process.env[key];
+        else process.env[key] = original;
+      }
+    }
   }
 });
 
@@ -305,6 +315,7 @@ beforeEach(async () => {
   await seedTenantAgent();
   currentPolicySet = [];
   lastForwarded = null;
+  proxyRateLimitChecks = 0;
 });
 
 describe("invoke e2e: full arc through the real proxy", () => {
@@ -464,6 +475,7 @@ describe("invoke e2e: full arc through the real proxy", () => {
     });
     // first invoke: count 0 < 1 => forwards (upstream 201).
     expect(first.status).toBe(201);
+    expect(proxyRateLimitChecks).toBe(1);
 
     const second = await app.request("/capabilities/github.pr.comment/invoke", {
       method: "POST",
@@ -472,6 +484,7 @@ describe("invoke e2e: full arc through the real proxy", () => {
     });
     // second invoke: count 1 >= 1 => rate constraint denies the allow => 403.
     expect(second.status).toBe(403);
+    expect(proxyRateLimitChecks).toBe(1);
 
     const rows = await agentInvocations(capId);
     expect(rows.filter((r) => r.decision === "allow").length).toBe(1);
@@ -658,6 +671,7 @@ describe("OpenAI-compatible capability adapter", () => {
       body: JSON.stringify({ model: "gpt-test", messages: [{ role: "user", content: "one" }] }),
     });
     expect(first.status).toBe(200);
+    expect(proxyRateLimitChecks).toBe(1);
 
     const second = await app.request("/capabilities/openai.chat/openai/v1/chat/completions", {
       method: "POST",
@@ -665,6 +679,7 @@ describe("OpenAI-compatible capability adapter", () => {
       body: JSON.stringify({ model: "gpt-test", messages: [{ role: "user", content: "two" }] }),
     });
     expect(second.status).toBe(403);
+    expect(proxyRateLimitChecks).toBe(1);
 
     const rows = await agentInvocations(capId);
     expect(rows.filter((r) => r.decision === "allow").length).toBe(1);

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -50,6 +50,8 @@ let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddle
 let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
 let setForwardProxyRequestForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setForwardProxyRequestForTests"];
 let setResolveProxyHostForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setResolveProxyHostForTests"];
+let setCheckProxyRateLimitForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setCheckProxyRateLimitForTests"];
+let resetProxyHandlerTestHooksForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__resetProxyHandlerTestHooksForTests"];
 
 interface ForwardedCapture {
   url: string;
@@ -60,6 +62,7 @@ interface ForwardedCapture {
 let lastForwarded: ForwardedCapture | null = null;
 let proxyApp: Hono | null = null;
 const realFetch = globalThis.fetch;
+const originalProxyDevMode = process.env.STEWARD_PROXY_DEV_MODE;
 
 // the policy set the injected getPolicySet returns for the current test.
 let currentPolicySet: PolicyRule[] = [];
@@ -89,6 +92,7 @@ beforeAll(async () => {
   process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
   process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.github.com,api.openai.com";
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   // the invoke route reads these to build its proxy client (fail-closed if absent).
   process.env.STEWARD_PROXY_URL = PROXY_URL;
 
@@ -107,11 +111,14 @@ beforeAll(async () => {
     handleProxy,
     __setForwardProxyRequestForTests: setForwardProxyRequestForTests,
     __setResolveProxyHostForTests: setResolveProxyHostForTests,
+    __setCheckProxyRateLimitForTests: setCheckProxyRateLimitForTests,
+    __resetProxyHandlerTestHooksForTests: resetProxyHandlerTestHooksForTests,
   } = await import("@stwd/proxy/src/handlers/proxy"));
 
   // deterministic public ip so route-match -> decrypt -> inject -> forward runs
   // with no external network (mirrors the #149 e2e).
   setResolveProxyHostForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
+  setCheckProxyRateLimitForTests(async () => ({ allowed: true, resetMs: 0 }));
   setForwardProxyRequestForTests(async (url, method, headers, body) => {
     const bodyText = body ? await new Response(body).text() : null;
     lastForwarded = { url: url.toString(), method, headers, bodyText };
@@ -153,6 +160,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   globalThis.fetch = realFetch;
+  resetProxyHandlerTestHooksForTests();
   await closeDb().catch(() => {});
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_MASTER_PASSWORD;
@@ -161,6 +169,8 @@ afterAll(async () => {
   delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
   delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
   delete process.env.STEWARD_PROXY_URL;
+  if (originalProxyDevMode === undefined) delete process.env.STEWARD_PROXY_DEV_MODE;
+  else process.env.STEWARD_PROXY_DEV_MODE = originalProxyDevMode;
 });
 
 let tenantId: string;

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -46,6 +46,9 @@ const STEWARD_TOKEN_SENTINEL = "steward-agent-token-sentinel-never-upstream";
 const PROXY_URL = "https://proxy.cap-e2e.test";
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
 const TEST_ENV_KEYS = [
+  "NODE_ENV",
+  "STEWARD_KDF_SALT",
+  "REDIS_REQUIRED",
   "STEWARD_PGLITE_MEMORY",
   "STEWARD_MASTER_PASSWORD",
   "STEWARD_JWT_SECRET",
@@ -98,6 +101,9 @@ function capRule(
 
 beforeAll(async () => {
   for (const key of TEST_ENV_KEYS) originalEnv.set(key, process.env[key]);
+  process.env.NODE_ENV = "test";
+  process.env.STEWARD_KDF_SALT = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  process.env.REDIS_REQUIRED = "false";
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "cap-invoke-e2e-jwt-secret-with-enough-bytes-0123456789";

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -45,6 +45,17 @@ const FAKE_OPENAI_KEY = "sk-test-openai-e2e-do-not-use-0123456789abcdef";
 const STEWARD_TOKEN_SENTINEL = "steward-agent-token-sentinel-never-upstream";
 const PROXY_URL = "https://proxy.cap-e2e.test";
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
+const TEST_ENV_KEYS = [
+  "STEWARD_PGLITE_MEMORY",
+  "STEWARD_MASTER_PASSWORD",
+  "STEWARD_JWT_SECRET",
+  "STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE",
+  "STEWARD_PROXY_REQUEST_SIGNING_SECRET",
+  "STEWARD_PROXY_ALLOWED_HOSTS",
+  "STEWARD_PROXY_DEV_MODE",
+  "STEWARD_PROXY_URL",
+] as const;
+const originalEnv = new Map(TEST_ENV_KEYS.map((key) => [key, process.env[key]]));
 
 let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddleware"];
 let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
@@ -62,7 +73,6 @@ interface ForwardedCapture {
 let lastForwarded: ForwardedCapture | null = null;
 let proxyApp: Hono | null = null;
 const realFetch = globalThis.fetch;
-const originalProxyDevMode = process.env.STEWARD_PROXY_DEV_MODE;
 
 // the policy set the injected getPolicySet returns for the current test.
 let currentPolicySet: PolicyRule[] = [];
@@ -162,15 +172,11 @@ afterAll(async () => {
   globalThis.fetch = realFetch;
   resetProxyHandlerTestHooksForTests();
   await closeDb().catch(() => {});
-  delete process.env.STEWARD_PGLITE_MEMORY;
-  delete process.env.STEWARD_MASTER_PASSWORD;
-  delete process.env.STEWARD_JWT_SECRET;
-  delete process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE;
-  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
-  delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
-  delete process.env.STEWARD_PROXY_URL;
-  if (originalProxyDevMode === undefined) delete process.env.STEWARD_PROXY_DEV_MODE;
-  else process.env.STEWARD_PROXY_DEV_MODE = originalProxyDevMode;
+  for (const key of TEST_ENV_KEYS) {
+    const original = originalEnv.get(key);
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
 });
 
 let tenantId: string;

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -55,7 +55,7 @@ const TEST_ENV_KEYS = [
   "STEWARD_PROXY_DEV_MODE",
   "STEWARD_PROXY_URL",
 ] as const;
-const originalEnv = new Map(TEST_ENV_KEYS.map((key) => [key, process.env[key]]));
+const originalEnv = new Map<(typeof TEST_ENV_KEYS)[number], string | undefined>();
 
 let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddleware"];
 let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
@@ -97,6 +97,7 @@ function capRule(
 }
 
 beforeAll(async () => {
+  for (const key of TEST_ENV_KEYS) originalEnv.set(key, process.env[key]);
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "cap-invoke-e2e-jwt-secret-with-enough-bytes-0123456789";
@@ -185,6 +186,7 @@ afterAll(async () => {
         if (original === undefined) delete process.env[key];
         else process.env[key] = original;
       }
+      originalEnv.clear();
     }
   }
 });

--- a/packages/plugin-capabilities/src/__tests__/isolated-runner.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/isolated-runner.test.ts
@@ -46,7 +46,7 @@ async function waitForFile(path: string, attempts = 400): Promise<boolean> {
   for (let i = 0; i < attempts; i += 1) {
     if (
       await readFile(path)
-        .then(() => true)
+        .then((value) => value.length > 0)
         .catch(() => false)
     )
       return true;
@@ -92,7 +92,7 @@ describe("isolated test runner", () => {
     expect(Date.now() - started).toBeLessThan(2_000);
   });
 
-  test("escalates to KILL and removes a TERM-ignoring descendant process group", async () => {
+  test("kills a TERM-ignoring descendant after its group leader exits on TERM", async () => {
     const root = await fixtureRoot();
     const childPidFile = join(root, "child-pid");
     const descendantPidFile = join(root, "descendant-pid");
@@ -101,7 +101,7 @@ describe("isolated test runner", () => {
     const descendantSource = `import { writeFileSync } from "node:fs"; process.on("SIGTERM",()=>writeFileSync(${JSON.stringify(descendantTermFile)},"term")); writeFileSync(${JSON.stringify(descendantPidFile)},String(process.pid)); await new Promise(()=>{});`;
     await writeFile(
       join(root, "kill.spec.ts"),
-      `import { writeFileSync } from "node:fs"; process.on("SIGTERM",()=>writeFileSync(${JSON.stringify(childTermFile)},"term")); Bun.spawn(["bun","-e",${JSON.stringify(descendantSource)}],{stdout:"ignore",stderr:"ignore"}); writeFileSync(${JSON.stringify(childPidFile)},String(process.pid)); await new Promise(()=>{});`,
+      `import { writeFileSync } from "node:fs"; process.on("SIGTERM",()=>{writeFileSync(${JSON.stringify(childTermFile)},"term");setTimeout(()=>process.exit(0),50)}); Bun.spawn(["bun","-e",${JSON.stringify(descendantSource)}],{stdout:"ignore",stderr:"ignore"}); writeFileSync(${JSON.stringify(childPidFile)},String(process.pid)); await new Promise(()=>{});`,
     );
 
     const execution = spawnRunner(root, [], {
@@ -111,9 +111,9 @@ describe("isolated test runner", () => {
     try {
       expect(await waitForFile(childPidFile)).toBe(true);
       expect(await waitForFile(descendantPidFile)).toBe(true);
+      execution.child.kill("SIGTERM");
       const result = await execution.result;
-      expect(result.code).not.toBe(0);
-      expect(result.output).toContain("wall timeout after 10000ms");
+      expect(result.code).toBe(143);
       expect(await readFile(childTermFile, "utf8")).toBe("term");
       expect(await readFile(descendantTermFile, "utf8")).toBe("term");
     } finally {
@@ -179,11 +179,8 @@ describe("isolated test runner", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    let childPid = 0;
-    for (let i = 0; i < 50 && childPid === 0; i += 1) {
-      await Bun.sleep(20);
-      childPid = Number(await readFile(pidFile, "utf8").catch(() => "0"));
-    }
+    expect(await waitForFile(pidFile)).toBe(true);
+    let childPid = Number(await readFile(pidFile, "utf8"));
     expect(childPid).toBeGreaterThan(1);
     parent.kill("SIGTERM");
     expect(await parent.exited).toBe(143);

--- a/packages/plugin-capabilities/src/__tests__/isolated-runner.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/isolated-runner.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const runner = join(import.meta.dir, "../../scripts/run-tests-isolated.ts");
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })));
+});
+
+async function fixtureRoot(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), "steward-isolated-runner-"));
+  temporaryDirectories.push(path);
+  return path;
+}
+
+async function run(root: string, filters: string[] = [], overrides: Record<string, string> = {}) {
+  const child = Bun.spawn(["bun", runner, ...filters], {
+    cwd: join(import.meta.dir, "../.."),
+    env: {
+      ...process.env,
+      ISOLATED_TEST_ROOT: root,
+      TEST_TIMEOUT: "5000",
+      TEST_WALL_TIMEOUT_MS: "2000",
+      TEST_KILL_GRACE_MS: "100",
+      ...overrides,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  return { code, output: stdout + stderr };
+}
+
+describe("isolated test runner", () => {
+  test("discovers canonical test/spec TypeScript and TSX names", async () => {
+    const root = await fixtureRoot();
+    for (const name of ["a.test.ts", "b.spec.ts", "c.test.tsx", "d.spec.tsx"]) {
+      await writeFile(
+        join(root, name),
+        'import { test, expect } from "bun:test"; test("ok",()=>expect(1).toBe(1));',
+      );
+    }
+    await writeFile(join(root, "ignored.ts"), 'throw new Error("must not run")');
+    const result = await run(root);
+    expect(result.code).toBe(0);
+    expect(result.output).toContain("4/4 test files passed");
+  });
+
+  test("bounds top-level module hangs with TERM then KILL", async () => {
+    const root = await fixtureRoot();
+    await writeFile(join(root, "hang.test.ts"), "await new Promise(() => {});");
+    const started = Date.now();
+    const result = await run(root, [], { TEST_WALL_TIMEOUT_MS: "300" });
+    expect(result.code).not.toBe(0);
+    expect(result.output).toContain("wall timeout after 300ms");
+    expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  test("forwards timeout TERM to the child and reports nonzero/no-match", async () => {
+    const root = await fixtureRoot();
+    const marker = join(root, "term-marker");
+    await writeFile(
+      join(root, "signal.test.ts"),
+      `import { writeFileSync } from "node:fs"; process.on("SIGTERM",()=>{writeFileSync(${JSON.stringify(marker)},"term");process.exit(143)}); await new Promise(()=>{});`,
+    );
+    const signaled = await run(root, [], { TEST_WALL_TIMEOUT_MS: "800" });
+    expect(signaled.code).not.toBe(0);
+    expect(await readFile(marker, "utf8")).toBe("term");
+    expect((await run(root, ["does-not-match"])).code).not.toBe(0);
+
+    await writeFile(
+      join(root, "fail.spec.ts"),
+      'import { test } from "bun:test"; test("no",()=>{throw new Error("FAIL_SENTINEL")});',
+    );
+    const failed = await run(root, ["fail.spec"]);
+    expect(failed.code).not.toBe(0);
+    expect(failed.output).toContain("FAIL_SENTINEL");
+  });
+
+  test("forwards parent SIGTERM and leaves no orphan child", async () => {
+    const root = await fixtureRoot();
+    const pidFile = join(root, "child-pid");
+    await writeFile(
+      join(root, "orphan.test.ts"),
+      `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(pidFile)},String(process.pid)); await new Promise(()=>{});`,
+    );
+    const parent = Bun.spawn(["bun", runner], {
+      cwd: join(import.meta.dir, "../.."),
+      env: {
+        ...process.env,
+        ISOLATED_TEST_ROOT: root,
+        TEST_WALL_TIMEOUT_MS: "10000",
+        TEST_KILL_GRACE_MS: "100",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    let childPid = 0;
+    for (let i = 0; i < 50 && childPid === 0; i += 1) {
+      await Bun.sleep(20);
+      childPid = Number(await readFile(pidFile, "utf8").catch(() => "0"));
+    }
+    expect(childPid).toBeGreaterThan(1);
+    parent.kill("SIGTERM");
+    expect(await parent.exited).toBe(143);
+    for (let i = 0; i < 50; i += 1) {
+      try {
+        process.kill(childPid, 0);
+        await Bun.sleep(20);
+      } catch {
+        childPid = 0;
+        break;
+      }
+    }
+    expect(childPid).toBe(0);
+  });
+
+  test("discards success output and retains only a bounded failure tail", async () => {
+    const root = await fixtureRoot();
+    await writeFile(
+      join(root, "success.test.ts"),
+      'import { test } from "bun:test"; test("ok",()=>console.log("SUCCESS_SECRET"));',
+    );
+    const success = await run(root, ["success"]);
+    expect(success.code).toBe(0);
+    expect(success.output).not.toContain("SUCCESS_SECRET");
+
+    await writeFile(
+      join(root, "failure.test.ts"),
+      'import { test } from "bun:test"; test("bad",()=>{console.error("A".repeat(200000));throw new Error("TAIL_SENTINEL")});',
+    );
+    const failure = await run(root, ["failure"], { TEST_FAILURE_TAIL_BYTES: "4096" });
+    expect(failure.code).not.toBe(0);
+    expect(failure.output.length).toBeLessThan(10_000);
+    expect(failure.output).toContain("TAIL_SENTINEL");
+  });
+});

--- a/packages/plugin-capabilities/src/__tests__/isolated-runner.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/isolated-runner.test.ts
@@ -16,26 +16,43 @@ async function fixtureRoot(): Promise<string> {
   return path;
 }
 
-async function run(root: string, filters: string[] = [], overrides: Record<string, string> = {}) {
+function spawnRunner(root: string, filters: string[] = [], overrides: Record<string, string> = {}) {
   const child = Bun.spawn(["bun", runner, ...filters], {
     cwd: join(import.meta.dir, "../.."),
     env: {
       ...process.env,
       ISOLATED_TEST_ROOT: root,
       TEST_TIMEOUT: "5000",
-      TEST_WALL_TIMEOUT_MS: "2000",
+      TEST_WALL_TIMEOUT_MS: "10000",
       TEST_KILL_GRACE_MS: "100",
       ...overrides,
     },
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, code] = await Promise.all([
+  const result = Promise.all([
     new Response(child.stdout).text(),
     new Response(child.stderr).text(),
     child.exited,
-  ]);
-  return { code, output: stdout + stderr };
+  ]).then(([stdout, stderr, code]) => ({ code, output: stdout + stderr }));
+  return { child, result };
+}
+
+async function run(root: string, filters: string[] = [], overrides: Record<string, string> = {}) {
+  return spawnRunner(root, filters, overrides).result;
+}
+
+async function waitForFile(path: string, attempts = 400): Promise<boolean> {
+  for (let i = 0; i < attempts; i += 1) {
+    if (
+      await readFile(path)
+        .then(() => true)
+        .catch(() => false)
+    )
+      return true;
+    await Bun.sleep(20);
+  }
+  return false;
 }
 
 async function waitForProcessExit(pid: number): Promise<boolean> {
@@ -81,20 +98,28 @@ describe("isolated test runner", () => {
     const descendantPidFile = join(root, "descendant-pid");
     const childTermFile = join(root, "child-term");
     const descendantTermFile = join(root, "descendant-term");
-    const descendantSource = `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(descendantPidFile)},String(process.pid)); process.on("SIGTERM",()=>writeFileSync(${JSON.stringify(descendantTermFile)},"term")); await new Promise(()=>{});`;
+    const descendantSource = `import { writeFileSync } from "node:fs"; process.on("SIGTERM",()=>writeFileSync(${JSON.stringify(descendantTermFile)},"term")); writeFileSync(${JSON.stringify(descendantPidFile)},String(process.pid)); await new Promise(()=>{});`;
     await writeFile(
       join(root, "kill.spec.ts"),
-      `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(childPidFile)},String(process.pid)); Bun.spawn(["bun","-e",${JSON.stringify(descendantSource)}],{stdout:"ignore",stderr:"ignore"}); process.on("SIGTERM",()=>writeFileSync(${JSON.stringify(childTermFile)},"term")); await new Promise(()=>{});`,
+      `import { writeFileSync } from "node:fs"; process.on("SIGTERM",()=>writeFileSync(${JSON.stringify(childTermFile)},"term")); Bun.spawn(["bun","-e",${JSON.stringify(descendantSource)}],{stdout:"ignore",stderr:"ignore"}); writeFileSync(${JSON.stringify(childPidFile)},String(process.pid)); await new Promise(()=>{});`,
     );
 
-    const result = await run(root, [], {
-      TEST_WALL_TIMEOUT_MS: "800",
+    const execution = spawnRunner(root, [], {
+      TEST_WALL_TIMEOUT_MS: "10000",
       TEST_KILL_GRACE_MS: "200",
     });
-    expect(result.code).not.toBe(0);
-    expect(result.output).toContain("wall timeout after 800ms");
-    expect(await readFile(childTermFile, "utf8")).toBe("term");
-    expect(await readFile(descendantTermFile, "utf8")).toBe("term");
+    try {
+      expect(await waitForFile(childPidFile)).toBe(true);
+      expect(await waitForFile(descendantPidFile)).toBe(true);
+      const result = await execution.result;
+      expect(result.code).not.toBe(0);
+      expect(result.output).toContain("wall timeout after 10000ms");
+      expect(await readFile(childTermFile, "utf8")).toBe("term");
+      expect(await readFile(descendantTermFile, "utf8")).toBe("term");
+    } finally {
+      execution.child.kill("SIGKILL");
+      await execution.child.exited;
+    }
 
     const childPid = Number(await readFile(childPidFile, "utf8"));
     const descendantPid = Number(await readFile(descendantPidFile, "utf8"));
@@ -106,14 +131,25 @@ describe("isolated test runner", () => {
 
   test("forwards timeout TERM to the child and reports nonzero/no-match", async () => {
     const root = await fixtureRoot();
+    const ready = join(root, "term-handler-ready");
     const marker = join(root, "term-marker");
     await writeFile(
       join(root, "signal.test.ts"),
-      `import { writeFileSync } from "node:fs"; process.on("SIGTERM",()=>{writeFileSync(${JSON.stringify(marker)},"term");process.exit(143)}); await new Promise(()=>{});`,
+      `import { writeFileSync } from "node:fs"; process.on("SIGTERM",()=>{writeFileSync(${JSON.stringify(marker)},"term");process.exit(143)}); writeFileSync(${JSON.stringify(ready)},"ready"); await new Promise(()=>{});`,
     );
-    const signaled = await run(root, [], { TEST_WALL_TIMEOUT_MS: "800" });
-    expect(signaled.code).not.toBe(0);
-    expect(await readFile(marker, "utf8")).toBe("term");
+    const execution = spawnRunner(root, [], {
+      TEST_WALL_TIMEOUT_MS: "10000",
+      TEST_KILL_GRACE_MS: "2000",
+    });
+    try {
+      expect(await waitForFile(ready)).toBe(true);
+      const signaled = await execution.result;
+      expect(signaled.code).not.toBe(0);
+      expect(await readFile(marker, "utf8")).toBe("term");
+    } finally {
+      execution.child.kill("SIGKILL");
+      await execution.child.exited;
+    }
     expect((await run(root, ["does-not-match"])).code).not.toBe(0);
 
     await writeFile(

--- a/packages/plugin-capabilities/src/__tests__/isolated-runner.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/isolated-runner.test.ts
@@ -38,6 +38,18 @@ async function run(root: string, filters: string[] = [], overrides: Record<strin
   return { code, output: stdout + stderr };
 }
 
+async function waitForProcessExit(pid: number): Promise<boolean> {
+  for (let i = 0; i < 100; i += 1) {
+    try {
+      process.kill(pid, 0);
+      await Bun.sleep(20);
+    } catch {
+      return true;
+    }
+  }
+  return false;
+}
+
 describe("isolated test runner", () => {
   test("discovers canonical test/spec TypeScript and TSX names", async () => {
     const root = await fixtureRoot();
@@ -53,7 +65,7 @@ describe("isolated test runner", () => {
     expect(result.output).toContain("4/4 test files passed");
   });
 
-  test("bounds top-level module hangs with TERM then KILL", async () => {
+  test("bounds top-level module hangs with an external wall deadline", async () => {
     const root = await fixtureRoot();
     await writeFile(join(root, "hang.test.ts"), "await new Promise(() => {});");
     const started = Date.now();
@@ -61,6 +73,35 @@ describe("isolated test runner", () => {
     expect(result.code).not.toBe(0);
     expect(result.output).toContain("wall timeout after 300ms");
     expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  test("escalates to KILL and removes a TERM-ignoring descendant process group", async () => {
+    const root = await fixtureRoot();
+    const childPidFile = join(root, "child-pid");
+    const descendantPidFile = join(root, "descendant-pid");
+    const childTermFile = join(root, "child-term");
+    const descendantTermFile = join(root, "descendant-term");
+    const descendantSource = `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(descendantPidFile)},String(process.pid)); process.on("SIGTERM",()=>writeFileSync(${JSON.stringify(descendantTermFile)},"term")); await new Promise(()=>{});`;
+    await writeFile(
+      join(root, "kill.spec.ts"),
+      `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(childPidFile)},String(process.pid)); Bun.spawn(["bun","-e",${JSON.stringify(descendantSource)}],{stdout:"ignore",stderr:"ignore"}); process.on("SIGTERM",()=>writeFileSync(${JSON.stringify(childTermFile)},"term")); await new Promise(()=>{});`,
+    );
+
+    const result = await run(root, [], {
+      TEST_WALL_TIMEOUT_MS: "800",
+      TEST_KILL_GRACE_MS: "200",
+    });
+    expect(result.code).not.toBe(0);
+    expect(result.output).toContain("wall timeout after 800ms");
+    expect(await readFile(childTermFile, "utf8")).toBe("term");
+    expect(await readFile(descendantTermFile, "utf8")).toBe("term");
+
+    const childPid = Number(await readFile(childPidFile, "utf8"));
+    const descendantPid = Number(await readFile(descendantPidFile, "utf8"));
+    expect(childPid).toBeGreaterThan(1);
+    expect(descendantPid).toBeGreaterThan(1);
+    expect(await waitForProcessExit(childPid)).toBe(true);
+    expect(await waitForProcessExit(descendantPid)).toBe(true);
   });
 
   test("forwards timeout TERM to the child and reports nonzero/no-match", async () => {
@@ -110,16 +151,29 @@ describe("isolated test runner", () => {
     expect(childPid).toBeGreaterThan(1);
     parent.kill("SIGTERM");
     expect(await parent.exited).toBe(143);
-    for (let i = 0; i < 50; i += 1) {
-      try {
-        process.kill(childPid, 0);
-        await Bun.sleep(20);
-      } catch {
-        childPid = 0;
-        break;
-      }
-    }
-    expect(childPid).toBe(0);
+    expect(await waitForProcessExit(childPid)).toBe(true);
+  });
+
+  test("clears the wall deadline and terminates the child when stream draining rejects", async () => {
+    const root = await fixtureRoot();
+    const pidFile = join(root, "drain-failure-pid");
+    await writeFile(
+      join(root, "drain-failure.test.ts"),
+      `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(pidFile)},String(process.pid)); console.log("DRAIN_FAILURE_SENTINEL"); process.on("SIGTERM",()=>{}); await new Promise(()=>{});`,
+    );
+    const started = Date.now();
+    const result = await run(root, [], {
+      ISOLATED_RUNNER_TEST_DRAIN_FAILURE_AFTER: "DRAIN_FAILURE_SENTINEL",
+      TEST_WALL_TIMEOUT_MS: "5000",
+      TEST_KILL_GRACE_MS: "100",
+    });
+    const elapsed = Date.now() - started;
+    const childPid = Number(await readFile(pidFile, "utf8"));
+
+    expect(result.code).not.toBe(0);
+    expect(result.output).toContain("simulated isolated runner stream failure");
+    expect(elapsed).toBeLessThan(2_000);
+    expect(await waitForProcessExit(childPid)).toBe(true);
   });
 
   test("discards success output and retains only a bounded failure tail", async () => {

--- a/packages/plugin-capabilities/src/__tests__/isolated-runner.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/isolated-runner.test.ts
@@ -215,16 +215,21 @@ describe("isolated test runner", () => {
   test("clears the wall deadline and terminates the child when stream draining rejects", async () => {
     const root = await fixtureRoot();
     const pidFile = join(root, "drain-failure-pid");
+    const readyFile = join(root, "drain-failure-ready");
+    const triggerFile = join(root, "drain-failure-trigger");
     await writeFile(
       join(root, "drain-failure.test.ts"),
-      `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(pidFile)},String(process.pid)); console.log("DRAIN_FAILURE_SENTINEL"); process.on("SIGTERM",()=>{}); await new Promise(()=>{});`,
+      `import { existsSync, writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(pidFile)},String(process.pid)); writeFileSync(${JSON.stringify(readyFile)},"ready"); while(!existsSync(${JSON.stringify(triggerFile)})) await Bun.sleep(10); process.stdout.write("DRAIN_FAILURE_SENTINEL\\n"); process.on("SIGTERM",()=>{}); await new Promise(()=>{});`,
     );
-    const started = Date.now();
-    const result = await run(root, [], {
+    const execution = spawnRunner(root, [], {
       ISOLATED_RUNNER_TEST_DRAIN_FAILURE_AFTER: "DRAIN_FAILURE_SENTINEL",
-      TEST_WALL_TIMEOUT_MS: "5000",
+      TEST_WALL_TIMEOUT_MS: "10000",
       TEST_KILL_GRACE_MS: "100",
     });
+    expect(await waitForFile(readyFile)).toBe(true);
+    const started = Date.now();
+    await writeFile(triggerFile, "trigger");
+    const result = await execution.result;
     const elapsed = Date.now() - started;
     const childPid = Number(await readFile(pidFile, "utf8"));
 

--- a/packages/plugin-capabilities/src/__tests__/isolated-runner.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/isolated-runner.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const runner = join(import.meta.dir, "../../scripts/run-tests-isolated.ts");
+const fixture = join(import.meta.dir, "fixtures/isolated-runner-fixture.ts");
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
@@ -16,12 +17,17 @@ async function fixtureRoot(): Promise<string> {
   return path;
 }
 
+async function installFixture(root: string, name: string): Promise<void> {
+  await copyFile(fixture, join(root, name));
+}
+
 function spawnRunner(root: string, filters: string[] = [], overrides: Record<string, string> = {}) {
   const child = Bun.spawn(["bun", runner, ...filters], {
     cwd: join(import.meta.dir, "../.."),
     env: {
       ...process.env,
       ISOLATED_TEST_ROOT: root,
+      ISOLATED_FIXTURE_ROOT: root,
       TEST_TIMEOUT: "5000",
       TEST_WALL_TIMEOUT_MS: "10000",
       TEST_KILL_GRACE_MS: "100",
@@ -71,10 +77,7 @@ describe("isolated test runner", () => {
   test("discovers canonical test/spec TypeScript and TSX names", async () => {
     const root = await fixtureRoot();
     for (const name of ["a.test.ts", "b.spec.ts", "c.test.tsx", "d.spec.tsx"]) {
-      await writeFile(
-        join(root, name),
-        'import { test, expect } from "bun:test"; test("ok",()=>expect(1).toBe(1));',
-      );
+      await installFixture(root, name);
     }
     await writeFile(join(root, "ignored.ts"), 'throw new Error("must not run")');
     const result = await run(root);
@@ -84,7 +87,7 @@ describe("isolated test runner", () => {
 
   test("bounds top-level module hangs with an external wall deadline", async () => {
     const root = await fixtureRoot();
-    await writeFile(join(root, "hang.test.ts"), "await new Promise(() => {});");
+    await installFixture(root, "hang.test.ts");
     const started = Date.now();
     const result = await run(root, [], { TEST_WALL_TIMEOUT_MS: "300" });
     expect(result.code).not.toBe(0);
@@ -98,11 +101,7 @@ describe("isolated test runner", () => {
     const descendantPidFile = join(root, "descendant-pid");
     const childTermFile = join(root, "child-term");
     const descendantTermFile = join(root, "descendant-term");
-    const descendantSource = `import { writeFileSync } from "node:fs"; process.on("SIGTERM",()=>writeFileSync(${JSON.stringify(descendantTermFile)},"term")); writeFileSync(${JSON.stringify(descendantPidFile)},String(process.pid)); await new Promise(()=>{});`;
-    await writeFile(
-      join(root, "kill.spec.ts"),
-      `import { writeFileSync } from "node:fs"; process.on("SIGTERM",()=>{writeFileSync(${JSON.stringify(childTermFile)},"term");setTimeout(()=>process.exit(0),50)}); Bun.spawn(["bun","-e",${JSON.stringify(descendantSource)}],{stdout:"ignore",stderr:"ignore"}); writeFileSync(${JSON.stringify(childPidFile)},String(process.pid)); await new Promise(()=>{});`,
-    );
+    await installFixture(root, "kill.spec.ts");
 
     const execution = spawnRunner(root, [], {
       TEST_WALL_TIMEOUT_MS: "10000",
@@ -132,11 +131,7 @@ describe("isolated test runner", () => {
   test("bounds a clean leader whose live descendant keeps inherited pipes open", async () => {
     const root = await fixtureRoot();
     const descendantPidFile = join(root, "clean-leader-descendant-pid");
-    const descendantSource = `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(descendantPidFile)},String(process.pid)); await new Promise(()=>{});`;
-    await writeFile(
-      join(root, "clean-leader.test.ts"),
-      `import { test, expect } from "bun:test"; import { readFile } from "node:fs/promises"; test("clean leader",async()=>{const child=Bun.spawn(["bun","-e",${JSON.stringify(descendantSource)}],{stdout:"inherit",stderr:"inherit"}); child.unref(); for(let i=0;i<400;i+=1){if(await readFile(${JSON.stringify(descendantPidFile)}).then(value=>value.length>0).catch(()=>false)) break; await Bun.sleep(20);} expect(await readFile(${JSON.stringify(descendantPidFile)},"utf8")).not.toBe("");});`,
-    );
+    await installFixture(root, "clean-leader.test.ts");
 
     const started = Date.now();
     const result = await run(root, [], {
@@ -158,10 +153,7 @@ describe("isolated test runner", () => {
     const root = await fixtureRoot();
     const ready = join(root, "term-handler-ready");
     const marker = join(root, "term-marker");
-    await writeFile(
-      join(root, "signal.test.ts"),
-      `import { writeFileSync } from "node:fs"; process.on("SIGTERM",()=>{writeFileSync(${JSON.stringify(marker)},"term");process.exit(143)}); writeFileSync(${JSON.stringify(ready)},"ready"); await new Promise(()=>{});`,
-    );
+    await installFixture(root, "signal.test.ts");
     const execution = spawnRunner(root, [], {
       TEST_WALL_TIMEOUT_MS: "10000",
       TEST_KILL_GRACE_MS: "2000",
@@ -177,11 +169,8 @@ describe("isolated test runner", () => {
     }
     expect((await run(root, ["does-not-match"])).code).not.toBe(0);
 
-    await writeFile(
-      join(root, "fail.spec.ts"),
-      'import { test } from "bun:test"; test("no",()=>{throw new Error("FAIL_SENTINEL")});',
-    );
-    const failed = await run(root, ["fail.spec"]);
+    await installFixture(root, "explicit-failure.spec.ts");
+    const failed = await run(root, ["explicit-failure.spec"]);
     expect(failed.code).not.toBe(0);
     expect(failed.output).toContain("FAIL_SENTINEL");
   });
@@ -189,15 +178,13 @@ describe("isolated test runner", () => {
   test("forwards parent SIGTERM and leaves no orphan child", async () => {
     const root = await fixtureRoot();
     const pidFile = join(root, "child-pid");
-    await writeFile(
-      join(root, "orphan.test.ts"),
-      `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(pidFile)},String(process.pid)); await new Promise(()=>{});`,
-    );
+    await installFixture(root, "orphan.test.ts");
     const parent = Bun.spawn(["bun", runner], {
       cwd: join(import.meta.dir, "../.."),
       env: {
         ...process.env,
         ISOLATED_TEST_ROOT: root,
+        ISOLATED_FIXTURE_ROOT: root,
         TEST_WALL_TIMEOUT_MS: "10000",
         TEST_KILL_GRACE_MS: "100",
       },
@@ -217,10 +204,7 @@ describe("isolated test runner", () => {
     const pidFile = join(root, "drain-failure-pid");
     const readyFile = join(root, "drain-failure-ready");
     const triggerFile = join(root, "drain-failure-trigger");
-    await writeFile(
-      join(root, "drain-failure.test.ts"),
-      `import { existsSync, writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(pidFile)},String(process.pid)); writeFileSync(${JSON.stringify(readyFile)},"ready"); while(!existsSync(${JSON.stringify(triggerFile)})) await Bun.sleep(10); process.stdout.write("DRAIN_FAILURE_SENTINEL\\n"); process.on("SIGTERM",()=>{}); await new Promise(()=>{});`,
-    );
+    await installFixture(root, "drain-failure.test.ts");
     const execution = spawnRunner(root, [], {
       ISOLATED_RUNNER_TEST_DRAIN_FAILURE_AFTER: "DRAIN_FAILURE_SENTINEL",
       TEST_WALL_TIMEOUT_MS: "10000",
@@ -241,18 +225,12 @@ describe("isolated test runner", () => {
 
   test("discards success output and retains only a bounded failure tail", async () => {
     const root = await fixtureRoot();
-    await writeFile(
-      join(root, "success.test.ts"),
-      'import { test } from "bun:test"; test("ok",()=>console.log("SUCCESS_SECRET"));',
-    );
+    await installFixture(root, "success.test.ts");
     const success = await run(root, ["success"]);
     expect(success.code).toBe(0);
     expect(success.output).not.toContain("SUCCESS_SECRET");
 
-    await writeFile(
-      join(root, "failure.test.ts"),
-      'import { test } from "bun:test"; test("bad",()=>{console.error("A".repeat(200000));throw new Error("TAIL_SENTINEL")});',
-    );
+    await installFixture(root, "failure.test.ts");
     const failure = await run(root, ["failure"], { TEST_FAILURE_TAIL_BYTES: "4096" });
     expect(failure.code).not.toBe(0);
     expect(failure.output.length).toBeLessThan(10_000);

--- a/packages/plugin-capabilities/src/__tests__/isolated-runner.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/isolated-runner.test.ts
@@ -129,6 +129,31 @@ describe("isolated test runner", () => {
     expect(await waitForProcessExit(descendantPid)).toBe(true);
   });
 
+  test("bounds a clean leader whose live descendant keeps inherited pipes open", async () => {
+    const root = await fixtureRoot();
+    const descendantPidFile = join(root, "clean-leader-descendant-pid");
+    const descendantSource = `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(descendantPidFile)},String(process.pid)); await new Promise(()=>{});`;
+    await writeFile(
+      join(root, "clean-leader.test.ts"),
+      `import { test, expect } from "bun:test"; import { readFile } from "node:fs/promises"; test("clean leader",async()=>{const child=Bun.spawn(["bun","-e",${JSON.stringify(descendantSource)}],{stdout:"inherit",stderr:"inherit"}); child.unref(); for(let i=0;i<400;i+=1){if(await readFile(${JSON.stringify(descendantPidFile)}).then(value=>value.length>0).catch(()=>false)) break; await Bun.sleep(20);} expect(await readFile(${JSON.stringify(descendantPidFile)},"utf8")).not.toBe("");});`,
+    );
+
+    const started = Date.now();
+    const result = await run(root, [], {
+      TEST_WALL_TIMEOUT_MS: "10000",
+      TEST_KILL_GRACE_MS: "200",
+    });
+    const elapsed = Date.now() - started;
+    const descendantPid = Number(await readFile(descendantPidFile, "utf8"));
+
+    expect(result.code).not.toBe(0);
+    expect(result.output).toContain("wall timeout after 10000ms");
+    expect(result.output).toContain("1 pass");
+    expect(elapsed).toBeLessThan(15_000);
+    expect(descendantPid).toBeGreaterThan(1);
+    expect(await waitForProcessExit(descendantPid)).toBe(true);
+  });
+
   test("forwards timeout TERM to the child and reports nonzero/no-match", async () => {
     const root = await fixtureRoot();
     const ready = join(root, "term-handler-ready");

--- a/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
@@ -54,8 +54,12 @@ const PROXY_URL = "https://proxy.broker-e2e.test";
 const BROKER_HOST = "broker.cap-e2e.test";
 const CAP_NAME = "broker.session.render";
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
+const TEST_KDF_SALT = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 const TEST_ENV_KEYS = [
   "NODE_ENV",
+  "STEWARD_KDF_SALT",
+  "REDIS_REQUIRED",
+  "STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL",
   "STEWARD_PGLITE_MEMORY",
   "STEWARD_MASTER_PASSWORD",
   "STEWARD_JWT_SECRET",
@@ -112,6 +116,9 @@ function capRule(
 beforeAll(async () => {
   for (const key of TEST_ENV_KEYS) originalEnv.set(key, process.env[key]);
   process.env.NODE_ENV = "test";
+  process.env.STEWARD_KDF_SALT = TEST_KDF_SALT;
+  process.env.REDIS_REQUIRED = "false";
+  process.env.STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL = "false";
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "broker-e2e-jwt-secret-with-enough-bytes-0123456789ab";
@@ -305,6 +312,13 @@ beforeEach(async () => {
 });
 
 describe("session-broker e2e: full arc through the real proxy", () => {
+  it("pins hermetic test security settings independently of the ambient environment", () => {
+    expect(process.env.NODE_ENV).toBe("test");
+    expect(process.env.STEWARD_KDF_SALT).toBe(TEST_KDF_SALT);
+    expect(process.env.REDIS_REQUIRED).toBe("false");
+    expect(process.env.STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL).toBe("false");
+  });
+
   it("keeps unsigned proxy requests fail-closed in production despite dev mode", async () => {
     const token = await signAgentToken({ agentId, tenantId, scopes: ["api:proxy"] }, "5m");
     process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "false";

--- a/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
@@ -53,11 +53,25 @@ const PROXY_URL = "https://proxy.broker-e2e.test";
 const BROKER_HOST = "broker.cap-e2e.test";
 const CAP_NAME = "broker.session.render";
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
+const TEST_ENV_KEYS = [
+  "STEWARD_PGLITE_MEMORY",
+  "STEWARD_MASTER_PASSWORD",
+  "STEWARD_JWT_SECRET",
+  "STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE",
+  "STEWARD_PROXY_REQUEST_SIGNING_SECRET",
+  "STEWARD_PROXY_ALLOWED_HOSTS",
+  "STEWARD_SECRET_ROUTE_ALLOWED_HOSTS",
+  "STEWARD_PROXY_DEV_MODE",
+  "STEWARD_PROXY_URL",
+] as const;
+const originalEnv = new Map<(typeof TEST_ENV_KEYS)[number], string | undefined>();
 
 let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddleware"];
 let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
 let setForwardProxyRequestForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setForwardProxyRequestForTests"];
 let setResolveProxyHostForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setResolveProxyHostForTests"];
+let setCheckProxyRateLimitForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setCheckProxyRateLimitForTests"];
+let resetProxyHandlerTestHooksForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__resetProxyHandlerTestHooksForTests"];
 
 interface ForwardedCapture {
   url: string;
@@ -69,6 +83,7 @@ let lastForwarded: ForwardedCapture | null = null;
 // the broker's next response body (a test may seed a fat body).
 let brokerResponseBody: string = JSON.stringify({ ok: true, rendered: "small" });
 let proxyApp: Hono | null = null;
+let proxyRateLimitChecks = 0;
 const realFetch = globalThis.fetch;
 
 // the policy set the injected getPolicySet returns for the current test.
@@ -92,6 +107,7 @@ function capRule(
 }
 
 beforeAll(async () => {
+  for (const key of TEST_ENV_KEYS) originalEnv.set(key, process.env[key]);
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "broker-e2e-jwt-secret-with-enough-bytes-0123456789ab";
@@ -101,6 +117,7 @@ beforeAll(async () => {
   // secret-route host allowlist (so a credential may be injected on it).
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = BROKER_HOST;
   process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS = BROKER_HOST;
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   process.env.STEWARD_PROXY_URL = PROXY_URL;
 
   const { db, client } = await createPGLiteDb("memory://");
@@ -117,10 +134,16 @@ beforeAll(async () => {
     handleProxy,
     __setForwardProxyRequestForTests: setForwardProxyRequestForTests,
     __setResolveProxyHostForTests: setResolveProxyHostForTests,
+    __setCheckProxyRateLimitForTests: setCheckProxyRateLimitForTests,
+    __resetProxyHandlerTestHooksForTests: resetProxyHandlerTestHooksForTests,
   } = await import("@stwd/proxy/src/handlers/proxy"));
 
   // deterministic public ip so the DNS-level SSRF guard passes with no network.
   setResolveProxyHostForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
+  setCheckProxyRateLimitForTests(async () => {
+    proxyRateLimitChecks += 1;
+    return { allowed: true, resetMs: 0 };
+  });
   // the stub broker: capture the forwarded request (to assert the injected token +
   // that the agent body reached the broker), return the seeded JSON body. The
   // forwarder signature is (url, method, headers, body: ReadableStream|null,
@@ -154,15 +177,20 @@ beforeAll(async () => {
 
 afterAll(async () => {
   globalThis.fetch = realFetch;
-  await closeDb().catch(() => {});
-  delete process.env.STEWARD_PGLITE_MEMORY;
-  delete process.env.STEWARD_MASTER_PASSWORD;
-  delete process.env.STEWARD_JWT_SECRET;
-  delete process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE;
-  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
-  delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
-  delete process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS;
-  delete process.env.STEWARD_PROXY_URL;
+  try {
+    resetProxyHandlerTestHooksForTests?.();
+  } finally {
+    try {
+      await closeDb().catch(() => {});
+    } finally {
+      for (const key of TEST_ENV_KEYS) {
+        const original = originalEnv.get(key);
+        if (original === undefined) delete process.env[key];
+        else process.env[key] = original;
+      }
+      originalEnv.clear();
+    }
+  }
 });
 
 let tenantId: string;
@@ -266,6 +294,7 @@ beforeEach(async () => {
   await seedTenantAgent();
   currentPolicySet = [];
   lastForwarded = null;
+  proxyRateLimitChecks = 0;
   brokerResponseBody = JSON.stringify({ ok: true, rendered: "small" });
 });
 
@@ -286,6 +315,7 @@ describe("session-broker e2e: full arc through the real proxy", () => {
 
     // broker 200 passed through verbatim.
     expect(res.status).toBe(200);
+    expect(proxyRateLimitChecks).toBe(1);
     const passthrough = await res.text();
     const parsed = JSON.parse(passthrough) as { ok: boolean; rendered: string };
     expect(parsed.ok).toBe(true);
@@ -322,6 +352,7 @@ describe("session-broker e2e: full arc through the real proxy", () => {
     });
 
     expect(res.status).toBe(200);
+    expect(proxyRateLimitChecks).toBe(1);
     const passthrough = await res.text();
     const parsed = JSON.parse(passthrough) as { ok: boolean; data: string };
     // the fat body survived the round trip byte-for-byte.
@@ -419,6 +450,7 @@ describe("session-broker e2e: full arc through the real proxy", () => {
     // missing idempotency key. The invoke path forwards the upstream/proxy status
     // verbatim. The request NEVER reached the broker.
     expect(res.status).toBe(400);
+    expect(proxyRateLimitChecks).toBe(1);
     const bodyText = await res.text();
     expect(bodyText).toContain("Idempotency-Key");
     // the broker was never called: no credential was ever attached/forwarded.

--- a/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
@@ -29,6 +29,7 @@
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { fileURLToPath } from "node:url";
+import { signAgentToken } from "@stwd/auth";
 import { agents, closeDb, eq, getDb, runPluginMigrations, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import type { AppVariables, PolicyRule } from "@stwd/shared";
@@ -54,6 +55,7 @@ const BROKER_HOST = "broker.cap-e2e.test";
 const CAP_NAME = "broker.session.render";
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
 const TEST_ENV_KEYS = [
+  "NODE_ENV",
   "STEWARD_PGLITE_MEMORY",
   "STEWARD_MASTER_PASSWORD",
   "STEWARD_JWT_SECRET",
@@ -84,6 +86,7 @@ let lastForwarded: ForwardedCapture | null = null;
 let brokerResponseBody: string = JSON.stringify({ ok: true, rendered: "small" });
 let proxyApp: Hono | null = null;
 let proxyRateLimitChecks = 0;
+let lastProxyRequestHeaders: Headers | null = null;
 const realFetch = globalThis.fetch;
 
 // the policy set the injected getPolicySet returns for the current test.
@@ -108,6 +111,7 @@ function capRule(
 
 beforeAll(async () => {
   for (const key of TEST_ENV_KEYS) originalEnv.set(key, process.env[key]);
+  process.env.NODE_ENV = "test";
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "broker-e2e-jwt-secret-with-enough-bytes-0123456789ab";
@@ -169,6 +173,7 @@ beforeAll(async () => {
       typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     if (url.startsWith(PROXY_URL) && proxyApp) {
       const path = url.slice(PROXY_URL.length) || "/";
+      lastProxyRequestHeaders = new Headers(init?.headers);
       return proxyApp.request(path, init as RequestInit);
     }
     return realFetch(input as RequestInfo, init);
@@ -295,10 +300,33 @@ beforeEach(async () => {
   currentPolicySet = [];
   lastForwarded = null;
   proxyRateLimitChecks = 0;
+  lastProxyRequestHeaders = null;
   brokerResponseBody = JSON.stringify({ ok: true, rendered: "small" });
 });
 
 describe("session-broker e2e: full arc through the real proxy", () => {
+  it("keeps unsigned proxy requests fail-closed in production despite dev mode", async () => {
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["api:proxy"] }, "5m");
+    process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "false";
+    process.env.NODE_ENV = "production";
+    try {
+      const response = await proxyApp!.request(`/proxy/${BROKER_HOST}/render`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        ok: false,
+        error: "X-Steward-Signature header required",
+      });
+      expect(lastForwarded).toBeNull();
+    } finally {
+      process.env.NODE_ENV = "test";
+      process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
+    }
+  });
+
   it("allowed POST invoke injects the broker token, passes the JSON body through, token never seen by agent, records allow", async () => {
     const capId = await seedBrokerCapability("POST");
     currentPolicySet = [capRule("r1", "allow", { argEquals: { sessionId: "sess_123" } })];
@@ -316,6 +344,8 @@ describe("session-broker e2e: full arc through the real proxy", () => {
     // broker 200 passed through verbatim.
     expect(res.status).toBe(200);
     expect(proxyRateLimitChecks).toBe(1);
+    expect(lastProxyRequestHeaders?.get("x-steward-signature")).toMatch(/^v1=[0-9a-f]{64}$/);
+    expect(lastProxyRequestHeaders?.get("x-steward-request-timestamp")).toMatch(/^\d+$/);
     const passthrough = await res.text();
     const parsed = JSON.parse(passthrough) as { ok: boolean; rendered: string };
     expect(parsed.ok).toBe(true);

--- a/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
+++ b/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
@@ -19,7 +19,7 @@
 
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { signAgentToken } from "@stwd/auth";
-import { agents, closeDb, getDb, tenants } from "@stwd/db";
+import { __resetAuditHmacKeyCacheForTests, agents, closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { PROXY_SCOPE } from "@stwd/proxy/src/config";
 import { SecretVault } from "@stwd/vault";
@@ -31,6 +31,7 @@ setDefaultTimeout(30000);
 const MASTER_PASSWORD = "proxy-client-e2e-master-password";
 const SIGNING_SECRET = "proxy-client-e2e-signing-secret-with-enough-bytes";
 const FAKE_OPENAI_KEY = "sk-test-e2e-do-not-use-0123456789abcdef";
+const FAKE_AUDIT_HMAC_KEY = "proxy-client-e2e-audit-hmac-key-with-enough-entropy";
 
 let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddleware"];
 let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
@@ -38,7 +39,9 @@ let setForwardProxyRequestForTests: typeof import("@stwd/proxy/src/handlers/prox
 let setResolveProxyHostForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setResolveProxyHostForTests"];
 let setCheckProxyRateLimitForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setCheckProxyRateLimitForTests"];
 let setCheckProxySpendLimitForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setCheckProxySpendLimitForTests"];
-let resetProxyHandlerTestHooks: typeof import("@stwd/proxy/src/handlers/proxy")["__resetProxyHandlerTestHooksForTests"];
+let resetProxyHandlerTestHooks:
+  | typeof import("@stwd/proxy/src/handlers/proxy")["__resetProxyHandlerTestHooksForTests"]
+  | undefined;
 
 // Capture what the proxy tried to forward upstream.
 interface ForwardedCapture {
@@ -49,10 +52,21 @@ interface ForwardedCapture {
 let lastForwarded: ForwardedCapture | null = null;
 // Controls whether the stubbed upstream reflects the secret back (leak sim).
 let reflectSecretInResponse = false;
-let previousAuditHmacKey: string | undefined;
-let previousProxyDevMode: string | undefined;
+
+const FIXTURE_ENV_KEYS = [
+  "STEWARD_PGLITE_MEMORY",
+  "STEWARD_MASTER_PASSWORD",
+  "STEWARD_JWT_SECRET",
+  "STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE",
+  "STEWARD_PROXY_REQUEST_SIGNING_SECRET",
+  "STEWARD_AUDIT_HMAC_KEY",
+  "STEWARD_PROXY_DEV_MODE",
+  "STEWARD_PROXY_ALLOWED_HOSTS",
+] as const;
+const previousEnv = new Map<(typeof FIXTURE_ENV_KEYS)[number], string | undefined>();
 
 beforeAll(async () => {
+  for (const key of FIXTURE_ENV_KEYS) previousEnv.set(key, process.env[key]);
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "proxy-client-e2e-jwt-secret-with-enough-bytes";
@@ -60,9 +74,10 @@ beforeAll(async () => {
   // exercises the client's HMAC signer against the proxy verifier.
   process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
   process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
-  previousAuditHmacKey = process.env.STEWARD_AUDIT_HMAC_KEY;
-  process.env.STEWARD_AUDIT_HMAC_KEY = "proxy-client-e2e-audit-hmac-key-with-enough-entropy";
-  previousProxyDevMode = process.env.STEWARD_PROXY_DEV_MODE;
+  process.env.STEWARD_AUDIT_HMAC_KEY = FAKE_AUDIT_HMAC_KEY;
+  // The audit module memoizes its parsed key. Reset after installing this
+  // fixture's non-secret key so an earlier suite cannot bleed into this one.
+  __resetAuditHmacKeyCacheForTests();
   process.env.STEWARD_PROXY_DEV_MODE = "true";
   // api.openai.com is already in the direct-proxy + secret-route default
   // allowlists, but set it explicitly for hermeticity.
@@ -118,18 +133,16 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  resetProxyHandlerTestHooks();
+  resetProxyHandlerTestHooks?.();
   await closeDb().catch(() => {});
-  delete process.env.STEWARD_PGLITE_MEMORY;
-  delete process.env.STEWARD_MASTER_PASSWORD;
-  delete process.env.STEWARD_JWT_SECRET;
-  delete process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE;
-  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
-  delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
-  if (previousAuditHmacKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
-  else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditHmacKey;
-  if (previousProxyDevMode === undefined) delete process.env.STEWARD_PROXY_DEV_MODE;
-  else process.env.STEWARD_PROXY_DEV_MODE = previousProxyDevMode;
+  for (const key of FIXTURE_ENV_KEYS) {
+    const previous = previousEnv.get(key);
+    if (previous === undefined) delete process.env[key];
+    else process.env[key] = previous;
+  }
+  previousEnv.clear();
+  // Do not leave the fixture key cached after restoring the caller's env.
+  __resetAuditHmacKeyCacheForTests();
 });
 
 function buildProxyApp() {
@@ -237,6 +250,9 @@ describe("proxy-client e2e: injection + scrub on the openai alias", () => {
     //    the OUTBOUND (upstream) request.
     expect(lastForwarded?.url).toBe("https://api.openai.com/v1/chat/completions");
     expect(lastForwarded?.headers.get("authorization")).toBe(`Bearer ${FAKE_OPENAI_KEY}`);
+    for (const [, value] of lastForwarded?.headers.entries() ?? []) {
+      expect(value).not.toContain(FAKE_AUDIT_HMAC_KEY);
+    }
 
     // 3. The AGENT-side request never carried the secret in any header or body.
     expect(agentRequests.length).toBe(1);
@@ -245,8 +261,10 @@ describe("proxy-client e2e: injection + scrub on the openai alias", () => {
     expect(agentReq.headers.get("authorization")).not.toContain(FAKE_OPENAI_KEY);
     for (const [, value] of agentReq.headers.entries()) {
       expect(value).not.toContain(FAKE_OPENAI_KEY);
+      expect(value).not.toContain(FAKE_AUDIT_HMAC_KEY);
     }
     expect(agentReq.body ?? "").not.toContain(FAKE_OPENAI_KEY);
+    expect(agentReq.body ?? "").not.toContain(FAKE_AUDIT_HMAC_KEY);
 
     // 3b. The real client attached the proof-of-possession signature +
     //     idempotency key that the proxy required.
@@ -257,6 +275,7 @@ describe("proxy-client e2e: injection + scrub on the openai alias", () => {
     // 4. The response returned to the agent never contains the secret.
     const responseText = await res.text();
     expect(responseText).not.toContain(FAKE_OPENAI_KEY);
+    expect(responseText).not.toContain(FAKE_AUDIT_HMAC_KEY);
   });
 
   it("blocks the response (502) if the upstream reflects the injected secret", async () => {
@@ -289,6 +308,7 @@ describe("proxy-client e2e: injection + scrub on the openai alias", () => {
     expect(res.status).toBe(502);
     const body = await res.text();
     expect(body).not.toContain(FAKE_OPENAI_KEY);
+    expect(body).not.toContain(FAKE_AUDIT_HMAC_KEY);
     expect(body).toContain("reflected injected credential");
   });
 

--- a/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
+++ b/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
@@ -49,6 +49,8 @@ interface ForwardedCapture {
 let lastForwarded: ForwardedCapture | null = null;
 // Controls whether the stubbed upstream reflects the secret back (leak sim).
 let reflectSecretInResponse = false;
+let previousAuditHmacKey: string | undefined;
+let previousProxyDevMode: string | undefined;
 
 beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
@@ -58,6 +60,10 @@ beforeAll(async () => {
   // exercises the client's HMAC signer against the proxy verifier.
   process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
   process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
+  previousAuditHmacKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+  process.env.STEWARD_AUDIT_HMAC_KEY = "proxy-client-e2e-audit-hmac-key-with-enough-entropy";
+  previousProxyDevMode = process.env.STEWARD_PROXY_DEV_MODE;
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   // api.openai.com is already in the direct-proxy + secret-route default
   // allowlists, but set it explicitly for hermeticity.
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.openai.com";
@@ -120,6 +126,10 @@ afterAll(async () => {
   delete process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE;
   delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
   delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
+  if (previousAuditHmacKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+  else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditHmacKey;
+  if (previousProxyDevMode === undefined) delete process.env.STEWARD_PROXY_DEV_MODE;
+  else process.env.STEWARD_PROXY_DEV_MODE = previousProxyDevMode;
 });
 
 function buildProxyApp() {

--- a/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
+++ b/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
@@ -54,6 +54,9 @@ let lastForwarded: ForwardedCapture | null = null;
 let reflectSecretInResponse = false;
 
 const FIXTURE_ENV_KEYS = [
+  "NODE_ENV",
+  "STEWARD_KDF_SALT",
+  "REDIS_REQUIRED",
   "STEWARD_PGLITE_MEMORY",
   "STEWARD_MASTER_PASSWORD",
   "STEWARD_JWT_SECRET",
@@ -67,6 +70,9 @@ const previousEnv = new Map<(typeof FIXTURE_ENV_KEYS)[number], string | undefine
 
 beforeAll(async () => {
   for (const key of FIXTURE_ENV_KEYS) previousEnv.set(key, process.env[key]);
+  process.env.NODE_ENV = "test";
+  process.env.STEWARD_KDF_SALT = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  process.env.REDIS_REQUIRED = "false";
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "proxy-client-e2e-jwt-secret-with-enough-bytes";


### PR DESCRIPTION
Closes #573.
Closes #575.
Closes #577.
Closes #580.
Closes #583.

## Summary
- provision the production-required audit HMAC and explicit development replay boundary only inside hermetic forwarding fixtures
- install load-bearing allow-only rate-check dependencies for capability, session-broker, AgentClient, and proxy-client paths
- prove production unsigned/rate enforcement remains fail closed while real routing, injection, scrubbing, policy, and call-count boundaries stay exercised
- replace the obsolete tenant middleware source assertion with byte-identical denial behavior and real empty-allowlist CORS behavior
- snapshot and restore every security-relevant environment binding, then run each capability test file in its own bounded package-owned process so mutable fixtures cannot cross files
- discover every TypeScript test convention recognized by CI inventory and cover discovery, timeouts, signals, descendant cleanup, stream failures, and bounded diagnostics behaviorally

## Exact-head validation
Exact head: `29a9ac4443e565b531b0c0f58870f222c39a644f`
Exact base: `9239a728b9ca28175e00e2825f69d85f3e02856e`

- isolated-runner adversarial self-tests: 8/8, 40 assertions, three consecutive full passes
- complete plugin-capabilities package runner: 15/15 test files passed
- affected API package-owned isolated runner: 3/3 files passed
- auth middleware: 3/3; proxy-client E2E: 3/3
- plugin-capabilities dependency build graph: 12/12
- CI test inventory: all 47 test-bearing targets covered
- Biome and diff checks: green

All 63 substantive exact-head hosted checks are green (Mintlify skipped). The sole remaining merge gate is independent write-access approval.

