### PR TITLE
fix(auth): close publication concurrency gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,6 +504,9 @@ jobs:
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
+      - name: Email challenge publication deadline proof (real Redis)
+        run: bun test ./packages/auth/src/__tests__/email-redis-publish.integration.test.ts
+
       - name: Vault custody transition race proof (real Postgres)
         run: bun test ./packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -594,6 +594,9 @@ jobs:
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
+      - name: Email challenge publication deadline proof (real Redis)
+        run: bun test ./packages/auth/src/__tests__/email-redis-publish.integration.test.ts
+
       - name: Vault custody transition race proof (real Postgres)
         run: bun test ./packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts
         env:

--- a/packages/api/src/__tests__/middleware-security-hardening.test.ts
+++ b/packages/api/src/__tests__/middleware-security-hardening.test.ts
@@ -56,7 +56,6 @@ describe("middleware security hardening", () => {
     // an unset NODE_ENV must fail closed like production.
     expect(tenantCorsSource).toContain("function devWildcardAllowed()");
     expect(tenantCorsSource).toContain('env === "development" || env === "test"');
-    expect(tenantCorsSource).toContain("origins.length === 0");
     expect(tenantCorsSource).toContain("return c.newResponse(null, 403)");
     expect(tenantCorsSource).toContain("TENANT_ID_RE.test(tenantId)");
     expect(tenantCorsSource).toContain("MAX_CORS_CACHE_ENTRIES");

--- a/packages/api/src/__tests__/tenant-cors-preflight.test.ts
+++ b/packages/api/src/__tests__/tenant-cors-preflight.test.ts
@@ -27,6 +27,15 @@ describe("tenant CORS preflight", () => {
         tenantId: "cors-patch-tenant",
         allowedOrigins: [ALLOWED_ORIGIN],
       });
+    await getDb().insert(tenants).values({
+      id: "cors-empty-tenant",
+      name: "CORS empty tenant",
+      apiKeyHash: "cors-empty-tenant-hash",
+    });
+    await getDb().insert(tenantConfigs).values({
+      tenantId: "cors-empty-tenant",
+      allowedOrigins: [],
+    });
   });
 
   afterAll(async () => {
@@ -76,6 +85,24 @@ describe("tenant CORS preflight", () => {
     expect(response.status).toBe(403);
     expect(response.headers.get("access-control-allow-origin")).toBeNull();
     expect(response.headers.get("access-control-allow-credentials")).toBeNull();
+    expect(response.headers.get("vary")).toBe("Origin, X-Steward-Tenant");
+  });
+
+  test("keeps an explicitly empty tenant allowlist fail closed", async () => {
+    const app = new Hono();
+    app.use("*", tenantCors);
+
+    const response = await app.request("/resource", {
+      method: "OPTIONS",
+      headers: {
+        Origin: ALLOWED_ORIGIN,
+        "X-Steward-Tenant": "cors-empty-tenant",
+        "Access-Control-Request-Method": "PATCH",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
     expect(response.headers.get("vary")).toBe("Origin, X-Steward-Tenant");
   });
 });

--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -32,7 +32,8 @@ class CapturingBackend implements StoreBackend {
   failReadsAfterActiveCommit = false;
   activeTransitionFailuresAfterCommit = 0;
   failFirstActivationPublishAfterMs = 0;
-  activationPublishTtls: number[] = [];
+  delaySuccessfulActivationPublishMs = 0;
+  activationPublishExpiresAt: number[] = [];
   afterActivationCommitBeforeLostAck?: () => Promise<void>;
   failDeletes = false;
   replaceGuardBeforeTransition = false;
@@ -119,15 +120,18 @@ class CapturingBackend implements StoreBackend {
 
   async publish(entries: readonly StorePublishEntry[]): Promise<boolean> {
     if (this.failWrites) throw new Error("durable store unavailable");
-    const now = Date.now();
     const activationEntry = entries.find((entry) => this.isActivation(entry.key, entry.value));
     if (activationEntry) {
-      this.activationPublishTtls.push(activationEntry.ttlMs);
-      if (this.failFirstActivationPublishAfterMs > 0 && this.activationPublishTtls.length === 1) {
+      this.activationPublishExpiresAt.push(activationEntry.expiresAt);
+      if (
+        this.failFirstActivationPublishAfterMs > 0 &&
+        this.activationPublishExpiresAt.length === 1
+      ) {
         await Bun.sleep(this.failFirstActivationPublishAfterMs);
         throw new Error("delayed durable activation failure");
       }
     }
+    const now = Date.now();
     if (this.replaceGuardBeforeTransition) {
       const guardedTarget = entries.find(
         (entry) => entry.expected !== undefined && entry.key.startsWith("email-login:active:"),
@@ -148,6 +152,9 @@ class CapturingBackend implements StoreBackend {
     });
     if (states.length > 0 && states.every((state) => state.desired)) return true;
     if (states.some((state) => !state.expected)) return false;
+    if (activationEntry && this.delaySuccessfulActivationPublishMs > 0) {
+      await Bun.sleep(this.delaySuccessfulActivationPublishMs);
+    }
     if (
       this.failActiveWrites &&
       entries.some((entry) => this.isActivation(entry.key, entry.value))
@@ -156,7 +163,7 @@ class CapturingBackend implements StoreBackend {
     }
     for (const entry of entries) {
       if (entry.value === null) this.values.delete(entry.key);
-      else this.values.set(entry.key, { value: entry.value, expiresAt: now + entry.ttlMs });
+      else this.values.set(entry.key, { value: entry.value, expiresAt: entry.expiresAt });
     }
     if (
       this.failActiveWritesAfterCommit &&
@@ -882,8 +889,8 @@ describe("fail-closed magic-link delivery", () => {
       tenantId: "tenant-a",
     });
 
-    expect(backend.activationPublishTtls).toHaveLength(2);
-    expect(backend.activationPublishTtls[1]!).toBeLessThan(backend.activationPublishTtls[0]! - 80);
+    expect(backend.activationPublishExpiresAt).toHaveLength(2);
+    expect(backend.activationPublishExpiresAt[1]).toBe(backend.activationPublishExpiresAt[0]);
     for (const entry of backend.values.values()) {
       expect(entry.expiresAt).toBeLessThanOrEqual(expiresAt.getTime());
     }
@@ -892,9 +899,9 @@ describe("fail-closed magic-link delivery", () => {
     auth.destroy();
   });
 
-  it("rejects a publish retry after the challenge absolute expiry", async () => {
+  it("does not extend an OTP after a delayed successful publish passes its advertised expiry", async () => {
     const backend = new CapturingBackend();
-    backend.failFirstActivationPublishAfterMs = 80;
+    backend.delaySuccessfulActivationPublishMs = 80;
     let text = "";
     const auth = buildAuth(
       {
@@ -907,12 +914,43 @@ describe("fail-closed magic-link delivery", () => {
       { tokenTtlMs: 40 },
     );
 
-    await expect(
-      auth.sendOtp("otp-expired-retry@example.com", { tenantId: "tenant-a" }),
-    ).rejects.toThrow(EmailDeliveryError);
-    expect(backend.activationPublishTtls).toHaveLength(1);
+    const { expiresAt } = await auth.sendOtp("otp-expired-publish@example.com", {
+      tenantId: "tenant-a",
+    });
+    expect(Date.now()).toBeGreaterThan(expiresAt.getTime());
+    expect(backend.activationPublishExpiresAt).toHaveLength(1);
     const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
-    expect(await auth.verifyOtp("otp-expired-retry@example.com", code, "tenant-a")).toBe(false);
+    expect(await auth.verifyOtp("otp-expired-publish@example.com", code, "tenant-a")).toBe(false);
+    auth.destroy();
+  });
+
+  it("does not extend a magic link after a delayed successful publish passes its advertised expiry", async () => {
+    const backend = new CapturingBackend();
+    backend.delaySuccessfulActivationPublishMs = 80;
+    let text = "";
+    const auth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          text = body;
+          return { provider: "test", id: "accepted-before-expired-magic-publish" };
+        },
+      },
+      backend,
+      { tokenTtlMs: 40 },
+    );
+
+    const { expiresAt } = await auth.sendMagicLink("magic-expired-publish@example.com", {
+      tenantId: "tenant-a",
+    });
+    expect(Date.now()).toBeGreaterThan(expiresAt.getTime());
+    const token = text.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
+    expect(
+      await auth.verifyMagicLink(token, "magic-expired-publish@example.com", "tenant-a"),
+    ).toMatchObject({ valid: false });
+    expect(
+      await auth.verifyEmailLoginCode("magic-expired-publish@example.com", code, "tenant-a"),
+    ).toMatchObject({ valid: false });
     auth.destroy();
   });
 

--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -31,6 +31,8 @@ class CapturingBackend implements StoreBackend {
   failActiveWritesAfterCommit = false;
   failReadsAfterActiveCommit = false;
   activeTransitionFailuresAfterCommit = 0;
+  failFirstActivationPublishAfterMs = 0;
+  activationPublishTtls: number[] = [];
   afterActivationCommitBeforeLostAck?: () => Promise<void>;
   failDeletes = false;
   replaceGuardBeforeTransition = false;
@@ -118,6 +120,14 @@ class CapturingBackend implements StoreBackend {
   async publish(entries: readonly StorePublishEntry[]): Promise<boolean> {
     if (this.failWrites) throw new Error("durable store unavailable");
     const now = Date.now();
+    const activationEntry = entries.find((entry) => this.isActivation(entry.key, entry.value));
+    if (activationEntry) {
+      this.activationPublishTtls.push(activationEntry.ttlMs);
+      if (this.failFirstActivationPublishAfterMs > 0 && this.activationPublishTtls.length === 1) {
+        await Bun.sleep(this.failFirstActivationPublishAfterMs);
+        throw new Error("delayed durable activation failure");
+      }
+    }
     if (this.replaceGuardBeforeTransition) {
       const guardedTarget = entries.find(
         (entry) => entry.expected !== undefined && entry.key.startsWith("email-login:active:"),
@@ -181,13 +191,18 @@ function restoreEnv(): void {
   else process.env.STEWARD_ALLOW_DEV_SECRET = ORIGINAL_ALLOW_DEV_SECRET;
 }
 
-function buildAuth(provider: EmailProvider | undefined, backend: CapturingBackend): EmailAuth {
+function buildAuth(
+  provider: EmailProvider | undefined,
+  backend: CapturingBackend,
+  options: { tokenTtlMs?: number } = {},
+): EmailAuth {
   return new EmailAuth({
     from: "login@steward.fi",
     baseUrl: "https://steward.fi",
     ...(provider ? { provider } : {}),
     tokenStore: new TokenStore({ backend }),
     codeVerifierSecret: "fail-closed-test-secret-at-least-32-characters",
+    ...options,
   });
 }
 
@@ -845,6 +860,59 @@ describe("fail-closed magic-link delivery", () => {
     expect(backend.activeTransitionFailuresAfterCommit).toBe(1);
     const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
     expect(await auth.verifyOtp("otp-ack-loss@example.com", code, "tenant-a")).toBe(true);
+    auth.destroy();
+  });
+
+  it("preserves the absolute expiry when a delayed publish failure is retried successfully", async () => {
+    const backend = new CapturingBackend();
+    backend.failFirstActivationPublishAfterMs = 120;
+    let text = "";
+    const auth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          text = body;
+          return { provider: "test", id: "accepted-before-delayed-publish" };
+        },
+      },
+      backend,
+      { tokenTtlMs: 500 },
+    );
+
+    const { expiresAt } = await auth.sendOtp("otp-delayed-retry@example.com", {
+      tenantId: "tenant-a",
+    });
+
+    expect(backend.activationPublishTtls).toHaveLength(2);
+    expect(backend.activationPublishTtls[1]!).toBeLessThan(backend.activationPublishTtls[0]! - 80);
+    for (const entry of backend.values.values()) {
+      expect(entry.expiresAt).toBeLessThanOrEqual(expiresAt.getTime());
+    }
+    const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
+    expect(await auth.verifyOtp("otp-delayed-retry@example.com", code, "tenant-a")).toBe(true);
+    auth.destroy();
+  });
+
+  it("rejects a publish retry after the challenge absolute expiry", async () => {
+    const backend = new CapturingBackend();
+    backend.failFirstActivationPublishAfterMs = 80;
+    let text = "";
+    const auth = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          text = body;
+          return { provider: "test", id: "accepted-before-expired-publish" };
+        },
+      },
+      backend,
+      { tokenTtlMs: 40 },
+    );
+
+    await expect(
+      auth.sendOtp("otp-expired-retry@example.com", { tenantId: "tenant-a" }),
+    ).rejects.toThrow(EmailDeliveryError);
+    expect(backend.activationPublishTtls).toHaveLength(1);
+    const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
+    expect(await auth.verifyOtp("otp-expired-retry@example.com", code, "tenant-a")).toBe(false);
     auth.destroy();
   });
 

--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -132,6 +132,7 @@ class CapturingBackend implements StoreBackend {
       }
     }
     const now = Date.now();
+    if (entries.some((entry) => entry.value !== null && entry.expiresAt <= now)) return false;
     if (this.replaceGuardBeforeTransition) {
       const guardedTarget = entries.find(
         (entry) => entry.expected !== undefined && entry.key.startsWith("email-login:active:"),
@@ -155,6 +156,8 @@ class CapturingBackend implements StoreBackend {
     if (activationEntry && this.delaySuccessfulActivationPublishMs > 0) {
       await Bun.sleep(this.delaySuccessfulActivationPublishMs);
     }
+    if (entries.some((entry) => entry.value !== null && entry.expiresAt <= Date.now()))
+      return false;
     if (
       this.failActiveWrites &&
       entries.some((entry) => this.isActivation(entry.key, entry.value))
@@ -899,7 +902,7 @@ describe("fail-closed magic-link delivery", () => {
     auth.destroy();
   });
 
-  it("does not extend an OTP after a delayed successful publish passes its advertised expiry", async () => {
+  it("fails OTP activation when publication is delayed past its advertised expiry", async () => {
     const backend = new CapturingBackend();
     backend.delaySuccessfulActivationPublishMs = 80;
     let text = "";
@@ -914,17 +917,16 @@ describe("fail-closed magic-link delivery", () => {
       { tokenTtlMs: 40 },
     );
 
-    const { expiresAt } = await auth.sendOtp("otp-expired-publish@example.com", {
-      tenantId: "tenant-a",
-    });
-    expect(Date.now()).toBeGreaterThan(expiresAt.getTime());
+    await expect(
+      auth.sendOtp("otp-expired-publish@example.com", { tenantId: "tenant-a" }),
+    ).rejects.toThrow("Email challenge activation failed");
     expect(backend.activationPublishExpiresAt).toHaveLength(1);
     const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
     expect(await auth.verifyOtp("otp-expired-publish@example.com", code, "tenant-a")).toBe(false);
     auth.destroy();
   });
 
-  it("does not extend a magic link after a delayed successful publish passes its advertised expiry", async () => {
+  it("fails magic-link activation when publication is delayed past its advertised expiry", async () => {
     const backend = new CapturingBackend();
     backend.delaySuccessfulActivationPublishMs = 80;
     let text = "";
@@ -939,10 +941,9 @@ describe("fail-closed magic-link delivery", () => {
       { tokenTtlMs: 40 },
     );
 
-    const { expiresAt } = await auth.sendMagicLink("magic-expired-publish@example.com", {
-      tenantId: "tenant-a",
-    });
-    expect(Date.now()).toBeGreaterThan(expiresAt.getTime());
+    await expect(
+      auth.sendMagicLink("magic-expired-publish@example.com", { tenantId: "tenant-a" }),
+    ).rejects.toThrow("Email challenge activation failed");
     const token = text.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
     const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
     expect(

--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -31,6 +31,7 @@ class CapturingBackend implements StoreBackend {
   failActiveWritesAfterCommit = false;
   failReadsAfterActiveCommit = false;
   activeTransitionFailuresAfterCommit = 0;
+  afterActivationCommitBeforeLostAck?: () => Promise<void>;
   failDeletes = false;
   replaceGuardBeforeTransition = false;
 
@@ -152,6 +153,7 @@ class CapturingBackend implements StoreBackend {
       entries.some((entry) => this.isActivation(entry.key, entry.value)) &&
       this.activeTransitionFailuresAfterCommit++ === 0
     ) {
+      await this.afterActivationCommitBeforeLostAck?.();
       throw new Error("durable activation response lost");
     }
     return true;
@@ -825,6 +827,104 @@ describe("fail-closed magic-link delivery", () => {
     const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
     expect(await auth.verifyOtp("otp-ack-loss@example.com", code, "tenant-a")).toBe(true);
     auth.destroy();
+  });
+
+  it("confirms a magic-link commit after lost acknowledgement and a newer failed reservation", async () => {
+    const backend = new CapturingBackend();
+    let firstText = "";
+    let secondProviderStarted!: () => void;
+    const secondProviderEntered = new Promise<void>((resolve) => {
+      secondProviderStarted = resolve;
+    });
+    let rejectSecond!: (reason: unknown) => void;
+    const secondProviderResult = new Promise<never>((_resolve, reject) => {
+      rejectSecond = reject;
+    });
+    const first = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          firstText = body;
+          backend.failActiveWritesAfterCommit = true;
+          return { provider: "test", id: "first-committed-before-ack-loss" };
+        },
+      },
+      backend,
+    );
+    const second = buildAuth(
+      {
+        send: async () => {
+          secondProviderStarted();
+          return secondProviderResult;
+        },
+      },
+      backend,
+    );
+    let secondSend: Promise<unknown> | undefined;
+    backend.afterActivationCommitBeforeLostAck = async () => {
+      secondSend = second.sendMagicLink("ack-reservation@example.com", {
+        tenantId: "tenant-a",
+      });
+      await secondProviderEntered;
+    };
+
+    await first.sendMagicLink("ack-reservation@example.com", { tenantId: "tenant-a" });
+    rejectSecond(new Error("SECOND_PROVIDER_SECRET_CANARY"));
+    if (!secondSend) throw new Error("newer issuance did not start");
+    await expect(secondSend).rejects.toThrow(EmailDeliveryError);
+
+    const token = firstText.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    expect(
+      await first.verifyMagicLink(token, "ack-reservation@example.com", "tenant-a"),
+    ).toMatchObject({ valid: true });
+    first.destroy();
+    second.destroy();
+  });
+
+  it("confirms an OTP commit after lost acknowledgement and a newer failed reservation", async () => {
+    const backend = new CapturingBackend();
+    let firstText = "";
+    let secondProviderStarted!: () => void;
+    const secondProviderEntered = new Promise<void>((resolve) => {
+      secondProviderStarted = resolve;
+    });
+    let rejectSecond!: (reason: unknown) => void;
+    const secondProviderResult = new Promise<never>((_resolve, reject) => {
+      rejectSecond = reject;
+    });
+    const first = buildAuth(
+      {
+        send: async (_to, _subject, body) => {
+          firstText = body;
+          backend.failActiveWritesAfterCommit = true;
+          return { provider: "test", id: "first-otp-committed-before-ack-loss" };
+        },
+      },
+      backend,
+    );
+    const second = buildAuth(
+      {
+        send: async () => {
+          secondProviderStarted();
+          return secondProviderResult;
+        },
+      },
+      backend,
+    );
+    let secondSend: Promise<unknown> | undefined;
+    backend.afterActivationCommitBeforeLostAck = async () => {
+      secondSend = second.sendOtp("otp-ack-reservation@example.com", { tenantId: "tenant-a" });
+      await secondProviderEntered;
+    };
+
+    await first.sendOtp("otp-ack-reservation@example.com", { tenantId: "tenant-a" });
+    rejectSecond(new Error("SECOND_PROVIDER_SECRET_CANARY"));
+    if (!secondSend) throw new Error("newer OTP issuance did not start");
+    await expect(secondSend).rejects.toThrow(EmailDeliveryError);
+
+    const code = firstText.match(/\b(\d{6})\b/)?.[1] ?? "";
+    expect(await first.verifyOtp("otp-ack-reservation@example.com", code, "tenant-a")).toBe(true);
+    first.destroy();
+    second.destroy();
   });
 
   it("keeps only the newest concurrently published challenge across independent instances", async () => {

--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -185,6 +185,17 @@ class CapturingBackend implements StoreBackend {
   }
 }
 
+class DelayedMemoryPublishBackend extends MemoryBackend {
+  delayNextPublishMs = 0;
+
+  override async publish(entries: readonly StorePublishEntry[]): Promise<boolean> {
+    const delayMs = this.delayNextPublishMs;
+    this.delayNextPublishMs = 0;
+    if (delayMs > 0) await Bun.sleep(delayMs);
+    return super.publish(entries);
+  }
+}
+
 const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
 const ORIGINAL_CODE_SECRET = process.env.STEWARD_EMAIL_CODE_SECRET;
 const ORIGINAL_ALLOW_DEV_SECRETS = process.env.STEWARD_ALLOW_DEV_SECRETS;
@@ -953,6 +964,86 @@ describe("fail-closed magic-link delivery", () => {
       await auth.verifyEmailLoginCode("magic-expired-publish@example.com", code, "tenant-a"),
     ).toMatchObject({ valid: false });
     auth.destroy();
+  });
+
+  it("preserves the prior memory OTP when a delayed replacement passes its deadline", async () => {
+    const backend = new DelayedMemoryPublishBackend();
+    let priorText = "";
+    const prior = new EmailAuth({
+      from: "login@steward.fi",
+      baseUrl: "https://steward.fi",
+      provider: {
+        send: async (_to, _subject, body) => {
+          priorText = body;
+          return { provider: "test", id: "prior-memory-otp" };
+        },
+      },
+      tokenStore: new TokenStore({ backend }),
+      tokenTtlMs: 60_000,
+      codeVerifierSecret: "fail-closed-test-secret-at-least-32-characters",
+    });
+    const delayed = new EmailAuth({
+      from: "login@steward.fi",
+      baseUrl: "https://steward.fi",
+      provider: {
+        send: async () => {
+          backend.delayNextPublishMs = 80;
+          return { provider: "test", id: "expired-memory-otp" };
+        },
+      },
+      tokenStore: new TokenStore({ backend }),
+      tokenTtlMs: 40,
+      codeVerifierSecret: "fail-closed-test-secret-at-least-32-characters",
+    });
+
+    await prior.sendOtp("memory-prior-otp@example.com", { tenantId: "tenant-a" });
+    const priorCode = priorText.match(/\b(\d{6})\b/)?.[1] ?? "";
+    await expect(
+      delayed.sendOtp("memory-prior-otp@example.com", { tenantId: "tenant-a" }),
+    ).rejects.toThrow(EmailDeliveryError);
+    expect(await prior.verifyOtp("memory-prior-otp@example.com", priorCode, "tenant-a")).toBe(true);
+    backend.destroy();
+  });
+
+  it("preserves the prior memory magic link when a delayed replacement passes its deadline", async () => {
+    const backend = new DelayedMemoryPublishBackend();
+    let priorText = "";
+    const prior = new EmailAuth({
+      from: "login@steward.fi",
+      baseUrl: "https://steward.fi",
+      provider: {
+        send: async (_to, _subject, body) => {
+          priorText = body;
+          return { provider: "test", id: "prior-memory-magic" };
+        },
+      },
+      tokenStore: new TokenStore({ backend }),
+      tokenTtlMs: 60_000,
+      codeVerifierSecret: "fail-closed-test-secret-at-least-32-characters",
+    });
+    const delayed = new EmailAuth({
+      from: "login@steward.fi",
+      baseUrl: "https://steward.fi",
+      provider: {
+        send: async () => {
+          backend.delayNextPublishMs = 80;
+          return { provider: "test", id: "expired-memory-magic" };
+        },
+      },
+      tokenStore: new TokenStore({ backend }),
+      tokenTtlMs: 40,
+      codeVerifierSecret: "fail-closed-test-secret-at-least-32-characters",
+    });
+
+    await prior.sendMagicLink("memory-prior-magic@example.com", { tenantId: "tenant-a" });
+    const priorToken = priorText.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    await expect(
+      delayed.sendMagicLink("memory-prior-magic@example.com", { tenantId: "tenant-a" }),
+    ).rejects.toThrow(EmailDeliveryError);
+    expect(
+      await prior.verifyMagicLink(priorToken, "memory-prior-magic@example.com", "tenant-a"),
+    ).toMatchObject({ valid: true });
+    backend.destroy();
   });
 
   it("confirms a magic-link commit after lost acknowledgement and a newer failed reservation", async () => {

--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -191,6 +191,25 @@ function buildAuth(provider: EmailProvider | undefined, backend: CapturingBacken
   });
 }
 
+function expectOpaqueBoundedPublicationReceipt(
+  backend: CapturingBackend,
+  canaries: readonly string[],
+): void {
+  const receipts = [...backend.values.entries()].filter(([key]) =>
+    key.startsWith("email-issuance:published:"),
+  );
+  expect(receipts).toHaveLength(1);
+  const [key, receipt] = receipts[0]!;
+  expect(key).toMatch(/^email-issuance:published:[0-9a-f]{64}$/);
+  expect(receipt.value).toMatch(/^published:[0-9a-f]{64}$/);
+  expect(key.slice("email-issuance:published:".length)).toBe(
+    receipt.value.slice("published:".length),
+  );
+  expect(receipt.expiresAt).toBeGreaterThan(Date.now());
+  expect(receipt.expiresAt).toBeLessThanOrEqual(Date.now() + 10 * 60_000);
+  for (const canary of canaries) expect(`${key}:${receipt.value}`).not.toContain(canary);
+}
+
 async function legacyVerifyMagicLink(backend: StoreBackend, token: string): Promise<boolean> {
   const challengeId = await backend.consume(`email-login:link:${hashSha256Hex(token)}`);
   if (!challengeId) return false;
@@ -873,6 +892,11 @@ describe("fail-closed magic-link delivery", () => {
     await expect(secondSend).rejects.toThrow(EmailDeliveryError);
 
     const token = firstText.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    expectOpaqueBoundedPublicationReceipt(backend, [
+      "ack-reservation@example.com",
+      "tenant-a",
+      token,
+    ]);
     expect(
       await first.verifyMagicLink(token, "ack-reservation@example.com", "tenant-a"),
     ).toMatchObject({ valid: true });
@@ -922,6 +946,11 @@ describe("fail-closed magic-link delivery", () => {
     await expect(secondSend).rejects.toThrow(EmailDeliveryError);
 
     const code = firstText.match(/\b(\d{6})\b/)?.[1] ?? "";
+    expectOpaqueBoundedPublicationReceipt(backend, [
+      "otp-ack-reservation@example.com",
+      "tenant-a",
+      code,
+    ]);
     expect(await first.verifyOtp("otp-ack-reservation@example.com", code, "tenant-a")).toBe(true);
     first.destroy();
     second.destroy();

--- a/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
@@ -9,9 +9,7 @@ const sql = databaseUrl ? postgres(databaseUrl, { max: 3 }) : null;
 
 setDefaultTimeout(30_000);
 
-type ObservedOutcome<T> =
-  | { ok: true; value: T }
-  | { ok: false; error: unknown };
+type ObservedOutcome<T> = { ok: true; value: T } | { ok: false; error: unknown };
 
 function observePromise<T>(promise: Promise<T>): Promise<ObservedOutcome<T>> {
   return promise.then(

--- a/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
@@ -148,7 +148,7 @@ integration("Postgres email challenge publication", () => {
     expect(await backend.get("duplicate")).toBeNull();
   });
 
-  it("keeps the supplied deadline when a successful publication is delayed past expiry", async () => {
+  it("rejects a publication delayed past expiry without applying any write", async () => {
     if (!sql) throw new Error("DATABASE_URL required");
     const namespace = `email-publish-expiry-${crypto.randomUUID()}`;
     const backend = new PostgresBackend(namespace);
@@ -192,14 +192,15 @@ integration("Postgres email challenge publication", () => {
     if (!publicationOutcome || !publication) throw new Error("publication did not start");
     const result = await publicationOutcome;
     if (!result.ok) throw result.error;
-    expect(result.value).toBe(true);
+    expect(result.value).toBe(false);
     expect(await backend.get(credentialKey)).toBeNull();
+    expect(await backend.get(reservationKey)).toBe("reserved");
     const rows = await sql<Array<{ expiresAt: Date }>>`
       SELECT expires_at AS "expiresAt"
         FROM auth_kv_store
        WHERE id = ${credentialKey} AND namespace = ${namespace}
     `;
-    expect(rows[0]?.expiresAt.getTime()).toBe(expiresAt);
+    expect(rows).toHaveLength(0);
     await sql`DELETE FROM auth_kv_store WHERE namespace = ${namespace}`;
   });
 

--- a/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
@@ -1,7 +1,11 @@
 import { afterAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import postgres from "postgres";
 
+import { hashSha256Hex } from "../crypto";
+import { EmailAuth } from "../email";
+import { EmailDeliveryError } from "../email-provider";
 import { PostgresBackend } from "../store-backends";
+import { TokenStore } from "../token-store";
 
 const databaseUrl = process.env.DATABASE_URL;
 const integration = describe.skipIf(!databaseUrl);
@@ -148,13 +152,15 @@ integration("Postgres email challenge publication", () => {
     expect(await backend.get("duplicate")).toBeNull();
   });
 
-  it("rejects a publication delayed past expiry without applying any write", async () => {
+  it("rejects a delayed expired publication before replacing prior state", async () => {
     if (!sql) throw new Error("DATABASE_URL required");
     const namespace = `email-publish-expiry-${crypto.randomUUID()}`;
     const backend = new PostgresBackend(namespace);
     const reservationKey = "reservation";
     const credentialKey = "credential";
+    const priorCredentialKey = "prior-credential";
     await backend.set(reservationKey, "reserved", 60_000);
+    await backend.set(priorCredentialKey, "still-active", 60_000);
 
     const locker = await sql.reserve();
     const lockKey = `${namespace}:${reservationKey}`;
@@ -169,6 +175,7 @@ integration("Postgres email challenge publication", () => {
       await locker`SELECT pg_advisory_lock(hashtextextended(${lockKey}, 0))`;
       locked = true;
       publication = backend.publish([
+        { key: priorCredentialKey, value: null, expiresAt },
         { key: credentialKey, value: "active", expiresAt },
         {
           key: reservationKey,
@@ -194,13 +201,135 @@ integration("Postgres email challenge publication", () => {
     if (!result.ok) throw result.error;
     expect(result.value).toBe(false);
     expect(await backend.get(credentialKey)).toBeNull();
+    expect(await backend.get(priorCredentialKey)).toBe("still-active");
     expect(await backend.get(reservationKey)).toBe("reserved");
-    const rows = await sql<Array<{ expiresAt: Date }>>`
-      SELECT expires_at AS "expiresAt"
-        FROM auth_kv_store
-       WHERE id = ${credentialKey} AND namespace = ${namespace}
-    `;
-    expect(rows).toHaveLength(0);
+    await sql`DELETE FROM auth_kv_store WHERE namespace = ${namespace}`;
+  });
+
+  it("preserves a prior OTP when replacement publication succeeds only after expiry", async () => {
+    if (!sql) throw new Error("DATABASE_URL required");
+    const namespace = `email-otp-expiry-${crypto.randomUUID()}`;
+    const backend = new PostgresBackend(namespace);
+    const email = "postgres-prior-otp@example.com";
+    const tenantId = "tenant-a";
+    let priorText = "";
+    const prior = new EmailAuth({
+      from: "login@steward.fi",
+      baseUrl: "https://steward.fi",
+      provider: {
+        send: async (_to, _subject, body) => {
+          priorText = body;
+          return { provider: "test", id: "prior-postgres-otp" };
+        },
+      },
+      tokenStore: new TokenStore({ backend }),
+      tokenTtlMs: 60_000,
+      codeVerifierSecret: "postgres-email-test-secret-at-least-32-characters",
+    });
+    await prior.sendOtp(email, { tenantId });
+    const priorCode = priorText.match(/\b(\d{6})\b/)?.[1] ?? "";
+    const priorCredentialKey = hashSha256Hex(`email-otp:${tenantId}:${email}:${priorCode}`);
+    const lockKey = `${namespace}:${priorCredentialKey}`;
+    const locker = await sql.reserve();
+    const [{ pid: lockerPid }] = await locker<
+      Array<{ pid: number }>
+    >`SELECT pg_backend_pid() AS pid`;
+    let locked = false;
+    let replacementOutcome: Promise<ObservedOutcome<{ expiresAt: Date }>> | undefined;
+    try {
+      await locker`SELECT pg_advisory_lock(hashtextextended(${lockKey}, 0))`;
+      locked = true;
+      const replacement = new EmailAuth({
+        from: "login@steward.fi",
+        baseUrl: "https://steward.fi",
+        provider: {
+          send: async () => ({ provider: "test", id: "expired-postgres-otp" }),
+        },
+        tokenStore: new TokenStore({ backend }),
+        tokenTtlMs: 250,
+        codeVerifierSecret: "postgres-email-test-secret-at-least-32-characters",
+      });
+      replacementOutcome = observePromise(replacement.sendOtp(email, { tenantId }));
+      await waitForBlockedPublisher(lockKey, lockerPid);
+      await Bun.sleep(300);
+    } finally {
+      if (locked) await locker`SELECT pg_advisory_unlock(hashtextextended(${lockKey}, 0))`;
+      locker.release();
+    }
+
+    if (!replacementOutcome) throw new Error("OTP replacement did not start");
+    const replacementResult = await replacementOutcome;
+    expect(replacementResult.ok).toBe(false);
+    if (!replacementResult.ok) expect(replacementResult.error).toBeInstanceOf(EmailDeliveryError);
+    expect(await prior.verifyOtp(email, priorCode, tenantId)).toBe(true);
+    await sql`DELETE FROM auth_kv_store WHERE namespace = ${namespace}`;
+  });
+
+  it("preserves a prior magic link when replacement publication succeeds only after expiry", async () => {
+    if (!sql) throw new Error("DATABASE_URL required");
+    const namespace = `email-magic-expiry-${crypto.randomUUID()}`;
+    const backend = new PostgresBackend(namespace);
+    const email = "postgres-prior-magic@example.com";
+    const tenantId = "tenant-a";
+    let priorText = "";
+    const prior = new EmailAuth({
+      from: "login@steward.fi",
+      baseUrl: "https://steward.fi",
+      provider: {
+        send: async (_to, _subject, body) => {
+          priorText = body;
+          return { provider: "test", id: "prior-postgres-magic" };
+        },
+      },
+      tokenStore: new TokenStore({ backend }),
+      tokenTtlMs: 60_000,
+      codeVerifierSecret: "postgres-email-test-secret-at-least-32-characters",
+    });
+    const priorResult = await prior.sendMagicLink(email, { tenantId });
+    const priorToken = priorText.match(/[?&]token=([a-f0-9]{64})/)?.[1] ?? "";
+    const priorCredentialKey = `email-login:pending:${priorResult.challengeId}`;
+    const lockKey = `${namespace}:${priorCredentialKey}`;
+    const locker = await sql.reserve();
+    const [{ pid: lockerPid }] = await locker<
+      Array<{ pid: number }>
+    >`SELECT pg_backend_pid() AS pid`;
+    let locked = false;
+    let replacementOutcome:
+      | Promise<
+          ObservedOutcome<{
+            tokenHash: string;
+            expiresAt: Date;
+            challengeId: string;
+            pollSecret: string;
+          }>
+        >
+      | undefined;
+    try {
+      await locker`SELECT pg_advisory_lock(hashtextextended(${lockKey}, 0))`;
+      locked = true;
+      const replacement = new EmailAuth({
+        from: "login@steward.fi",
+        baseUrl: "https://steward.fi",
+        provider: {
+          send: async () => ({ provider: "test", id: "expired-postgres-magic" }),
+        },
+        tokenStore: new TokenStore({ backend }),
+        tokenTtlMs: 250,
+        codeVerifierSecret: "postgres-email-test-secret-at-least-32-characters",
+      });
+      replacementOutcome = observePromise(replacement.sendMagicLink(email, { tenantId }));
+      await waitForBlockedPublisher(lockKey, lockerPid);
+      await Bun.sleep(300);
+    } finally {
+      if (locked) await locker`SELECT pg_advisory_unlock(hashtextextended(${lockKey}, 0))`;
+      locker.release();
+    }
+
+    if (!replacementOutcome) throw new Error("magic-link replacement did not start");
+    const replacementResult = await replacementOutcome;
+    expect(replacementResult.ok).toBe(false);
+    if (!replacementResult.ok) expect(replacementResult.error).toBeInstanceOf(EmailDeliveryError);
+    expect(await prior.verifyMagicLink(priorToken, email, tenantId)).toMatchObject({ valid: true });
     await sql`DELETE FROM auth_kv_store WHERE namespace = ${namespace}`;
   });
 

--- a/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
@@ -9,6 +9,17 @@ const sql = databaseUrl ? postgres(databaseUrl, { max: 3 }) : null;
 
 setDefaultTimeout(30_000);
 
+type ObservedOutcome<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: unknown };
+
+function observePromise<T>(promise: Promise<T>): Promise<ObservedOutcome<T>> {
+  return promise.then(
+    (value) => ({ ok: true, value }),
+    (error) => ({ ok: false, error }),
+  );
+}
+
 async function waitForBlockedPublisher(lockKey: string, lockerPid: number): Promise<number> {
   if (!sql) throw new Error("DATABASE_URL required");
   for (let attempt = 0; attempt < 500; attempt += 1) {
@@ -81,6 +92,7 @@ integration("Postgres email challenge publication", () => {
     >`SELECT pg_backend_pid() AS pid`;
     let locked = false;
     let stale: Promise<boolean> | undefined;
+    let staleOutcome: Promise<ObservedOutcome<boolean>> | undefined;
     try {
       await locker`SELECT pg_advisory_lock(hashtextextended(${lockKey}, 0))`;
       locked = true;
@@ -93,6 +105,7 @@ integration("Postgres email challenge publication", () => {
           expected: "generation-old",
         },
       ]);
+      staleOutcome = observePromise(stale);
 
       const publisherPid = await waitForBlockedPublisher(lockKey, lockerPid);
       expect(publisherPid).not.toBe(lockerPid);
@@ -106,10 +119,13 @@ integration("Postgres email challenge publication", () => {
         await locker`SELECT pg_advisory_unlock(hashtextextended(${lockKey}, 0))`;
       }
       locker.release();
+      if (staleOutcome) await staleOutcome;
     }
 
-    if (!stale) throw new Error("stale publication did not start");
-    expect(await stale).toBe(false);
+    if (!staleOutcome || !stale) throw new Error("stale publication did not start");
+    const staleResult = await staleOutcome;
+    if (!staleResult.ok) throw staleResult.error;
+    expect(staleResult.value).toBe(false);
     expect(await backend.get("challenge-old")).toBeNull();
     const current = [
       { key: "challenge-new", value: "active-new", ttlMs: 60_000 },
@@ -144,6 +160,7 @@ integration("Postgres email challenge publication", () => {
     >`SELECT pg_backend_pid() AS pid`;
     let transactionOpen = false;
     let publication: Promise<boolean> | undefined;
+    let publicationOutcome: Promise<ObservedOutcome<boolean>> | undefined;
     try {
       await locker`BEGIN`;
       transactionOpen = true;
@@ -162,6 +179,7 @@ integration("Postgres email challenge publication", () => {
           expected: "generation-old",
         },
       ]);
+      publicationOutcome = observePromise(publication);
 
       const publisherPid = await waitForPublisherBlockedAfterGuard(
         `${namespace}:${targetKey}`,
@@ -182,10 +200,13 @@ integration("Postgres email challenge publication", () => {
     } finally {
       if (transactionOpen) await locker`ROLLBACK`;
       locker.release();
+      if (publicationOutcome) await publicationOutcome;
     }
 
-    if (!publication) throw new Error("publication did not start");
-    expect(await publication).toBe(false);
+    if (!publicationOutcome || !publication) throw new Error("publication did not start");
+    const publicationResult = await publicationOutcome;
+    if (!publicationResult.ok) throw publicationResult.error;
+    expect(publicationResult.value).toBe(false);
     expect(await backend.get(targetKey)).toBe("generation-ordinary");
     expect(await backend.get(blockerKey)).toBe("blocker-original");
     expect(await backend.get("challenge")).toBeNull();
@@ -212,6 +233,7 @@ integration("Postgres email challenge publication", () => {
       >`SELECT pg_backend_pid() AS pid`;
       let transactionOpen = false;
       let publication: Promise<boolean> | undefined;
+      let publicationOutcome: Promise<ObservedOutcome<boolean>> | undefined;
       try {
         await locker`BEGIN`;
         transactionOpen = true;
@@ -225,6 +247,7 @@ integration("Postgres email challenge publication", () => {
           { key: "challenge", value: "active", ttlMs: 60_000 },
           { key: targetKey, value: "generation-published", ttlMs: 60_000, expected: null },
         ]);
+        publicationOutcome = observePromise(publication);
 
         await waitForPublisherBlockedAfterGuard(`${namespace}:${targetKey}`, lockerPid);
         await sql`
@@ -238,10 +261,13 @@ integration("Postgres email challenge publication", () => {
       } finally {
         if (transactionOpen) await locker`ROLLBACK`;
         locker.release();
+        if (publicationOutcome) await publicationOutcome;
       }
 
-      if (!publication) throw new Error("publication did not start");
-      expect(await publication).toBe(false);
+      if (!publicationOutcome || !publication) throw new Error("publication did not start");
+      const publicationResult = await publicationOutcome;
+      if (!publicationResult.ok) throw publicationResult.error;
+      expect(publicationResult.value).toBe(false);
       expect(await backend.get(targetKey)).toBe("generation-ordinary");
       expect(await backend.get(blockerKey)).toBe("blocker-original");
       expect(await backend.get("challenge")).toBeNull();

--- a/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
@@ -5,7 +5,7 @@ import { PostgresBackend } from "../store-backends";
 
 const databaseUrl = process.env.DATABASE_URL;
 const integration = describe.skipIf(!databaseUrl);
-const sql = databaseUrl ? postgres(databaseUrl, { max: 2 }) : null;
+const sql = databaseUrl ? postgres(databaseUrl, { max: 3 }) : null;
 
 setDefaultTimeout(30_000);
 
@@ -31,6 +31,35 @@ async function waitForBlockedPublisher(lockKey: string, lockerPid: number): Prom
     await Bun.sleep(10);
   }
   throw new Error("timed out waiting for the stale publisher to block on the guarded key");
+}
+
+async function waitForPublisherBlockedAfterGuard(
+  guardedLockKey: string,
+  lockerPid: number,
+): Promise<number> {
+  if (!sql) throw new Error("DATABASE_URL required");
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    const rows = await sql<Array<{ pid: number }>>`
+      WITH target AS (
+        SELECT hashtextextended(${guardedLockKey}, 0)::bigint AS key
+      )
+      SELECT DISTINCT locks.pid
+        FROM pg_locks AS locks
+        JOIN pg_stat_activity AS activity ON activity.pid = locks.pid
+        CROSS JOIN target
+       WHERE locks.locktype = 'advisory'
+         AND locks.granted = true
+         AND locks.pid <> ${lockerPid}
+         AND locks.database = (SELECT oid FROM pg_database WHERE datname = current_database())
+         AND locks.classid::bigint = ((target.key >> 32) & 4294967295)
+         AND locks.objid::bigint = (target.key & 4294967295)
+         AND locks.objsubid = 1
+         AND activity.wait_event_type = 'Lock'
+    `;
+    if (rows[0]) return rows[0].pid;
+    await Bun.sleep(10);
+  }
+  throw new Error("timed out waiting for publication after its guard read");
 }
 
 integration("Postgres email challenge publication", () => {
@@ -98,5 +127,67 @@ integration("Postgres email challenge publication", () => {
       ]),
     ).rejects.toThrow("Store publication contains duplicate keys");
     expect(await backend.get("duplicate")).toBeNull();
+  });
+
+  it("never overwrites an ordinary writer that commits after the guard read", async () => {
+    if (!sql) throw new Error("DATABASE_URL required");
+    const namespace = `email-publish-post-guard-${crypto.randomUUID()}`;
+    const backend = new PostgresBackend(namespace);
+    const blockerKey = "00-blocker";
+    const targetKey = "target";
+    await backend.set(blockerKey, "blocker-original", 60_000);
+    await backend.set(targetKey, "generation-old", 60_000);
+
+    const locker = await sql.reserve();
+    const [{ pid: lockerPid }] = await locker<
+      Array<{ pid: number }>
+    >`SELECT pg_backend_pid() AS pid`;
+    let transactionOpen = false;
+    let publication: Promise<boolean> | undefined;
+    try {
+      await locker`BEGIN`;
+      transactionOpen = true;
+      await locker`
+        SELECT value FROM auth_kv_store
+         WHERE id = ${blockerKey} AND namespace = ${namespace}
+         FOR UPDATE
+      `;
+      publication = backend.publish([
+        { key: blockerKey, value: "blocker-published", ttlMs: 60_000 },
+        { key: "challenge", value: "active", ttlMs: 60_000 },
+        {
+          key: targetKey,
+          value: "generation-published",
+          ttlMs: 60_000,
+          expected: "generation-old",
+        },
+      ]);
+
+      const publisherPid = await waitForPublisherBlockedAfterGuard(
+        `${namespace}:${targetKey}`,
+        lockerPid,
+      );
+      expect(publisherPid).not.toBe(lockerPid);
+
+      // This is the write used by a pre-#550 pod: it deliberately does not
+      // participate in the new publisher's advisory-lock protocol.
+      await sql`
+        INSERT INTO auth_kv_store (id, namespace, value, expires_at)
+        VALUES (${targetKey}, ${namespace}, 'generation-ordinary', now() + interval '1 minute')
+        ON CONFLICT (id, namespace) DO UPDATE
+          SET value = EXCLUDED.value, expires_at = EXCLUDED.expires_at
+      `;
+      await locker`COMMIT`;
+      transactionOpen = false;
+    } finally {
+      if (transactionOpen) await locker`ROLLBACK`;
+      locker.release();
+    }
+
+    if (!publication) throw new Error("publication did not start");
+    expect(await publication).toBe(false);
+    expect(await backend.get(targetKey)).toBe("generation-ordinary");
+    expect(await backend.get(blockerKey)).toBe("blocker-original");
+    expect(await backend.get("challenge")).toBeNull();
   });
 });

--- a/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
@@ -204,6 +204,58 @@ integration("Postgres email challenge publication", () => {
     await sql`DELETE FROM auth_kv_store WHERE namespace = ${namespace}`;
   });
 
+  it("rolls back when a row lock delays a write past expiry", async () => {
+    if (!sql) throw new Error("DATABASE_URL required");
+    const namespace = `email-publish-write-expiry-${crypto.randomUUID()}`;
+    const backend = new PostgresBackend(namespace);
+    const reservationKey = "reservation";
+    const credentialKey = "credential";
+    await backend.set(reservationKey, "reserved", 60_000);
+    await backend.set(credentialKey, "original", 60_000);
+
+    const locker = await sql.reserve();
+    const [{ pid: lockerPid }] = await locker<
+      Array<{ pid: number }>
+    >`SELECT pg_backend_pid() AS pid`;
+    const expiresAt = Date.now() + 300;
+    let transactionOpen = false;
+    let publicationOutcome: Promise<ObservedOutcome<boolean>> | undefined;
+    try {
+      await locker`BEGIN`;
+      transactionOpen = true;
+      await locker`
+        SELECT value FROM auth_kv_store
+         WHERE id = ${credentialKey} AND namespace = ${namespace}
+         FOR UPDATE
+      `;
+      publicationOutcome = observePromise(
+        backend.publish([
+          {
+            key: reservationKey,
+            value: "published",
+            expiresAt,
+            expected: "reserved",
+          },
+          { key: credentialKey, value: "active", expiresAt },
+        ]),
+      );
+      await waitForPublisherBlockedAfterGuard(`${namespace}:${reservationKey}`, lockerPid);
+      const delayMs = expiresAt - Date.now() + 30;
+      if (delayMs > 0) await Bun.sleep(delayMs);
+    } finally {
+      if (transactionOpen) await locker`COMMIT`;
+      locker.release();
+    }
+
+    if (!publicationOutcome) throw new Error("publication did not start");
+    const result = await publicationOutcome;
+    if (!result.ok) throw result.error;
+    expect(result.value).toBe(false);
+    expect(await backend.get(credentialKey)).toBe("original");
+    expect(await backend.get(reservationKey)).toBe("reserved");
+    await sql`DELETE FROM auth_kv_store WHERE namespace = ${namespace}`;
+  });
+
   it("never overwrites an ordinary writer that commits after the guard read", async () => {
     if (!sql) throw new Error("DATABASE_URL required");
     const namespace = `email-publish-post-guard-${crypto.randomUUID()}`;

--- a/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
@@ -190,4 +190,61 @@ integration("Postgres email challenge publication", () => {
     expect(await backend.get(blockerKey)).toBe("blocker-original");
     expect(await backend.get("challenge")).toBeNull();
   });
+
+  it("protects absent and expired guards from an ordinary post-read insert", async () => {
+    if (!sql) throw new Error("DATABASE_URL required");
+    for (const initialState of ["absent", "expired"] as const) {
+      const namespace = `email-publish-null-guard-${initialState}-${crypto.randomUUID()}`;
+      const backend = new PostgresBackend(namespace);
+      const blockerKey = "00-blocker";
+      const targetKey = "target";
+      await backend.set(blockerKey, "blocker-original", 60_000);
+      if (initialState === "expired") {
+        await sql`
+          INSERT INTO auth_kv_store (id, namespace, value, expires_at)
+          VALUES (${targetKey}, ${namespace}, 'generation-expired', now() - interval '1 minute')
+        `;
+      }
+
+      const locker = await sql.reserve();
+      const [{ pid: lockerPid }] = await locker<
+        Array<{ pid: number }>
+      >`SELECT pg_backend_pid() AS pid`;
+      let transactionOpen = false;
+      let publication: Promise<boolean> | undefined;
+      try {
+        await locker`BEGIN`;
+        transactionOpen = true;
+        await locker`
+          SELECT value FROM auth_kv_store
+           WHERE id = ${blockerKey} AND namespace = ${namespace}
+           FOR UPDATE
+        `;
+        publication = backend.publish([
+          { key: blockerKey, value: "blocker-published", ttlMs: 60_000 },
+          { key: "challenge", value: "active", ttlMs: 60_000 },
+          { key: targetKey, value: "generation-published", ttlMs: 60_000, expected: null },
+        ]);
+
+        await waitForPublisherBlockedAfterGuard(`${namespace}:${targetKey}`, lockerPid);
+        await sql`
+          INSERT INTO auth_kv_store (id, namespace, value, expires_at)
+          VALUES (${targetKey}, ${namespace}, 'generation-ordinary', now() + interval '1 minute')
+          ON CONFLICT (id, namespace) DO UPDATE
+            SET value = EXCLUDED.value, expires_at = EXCLUDED.expires_at
+        `;
+        await locker`COMMIT`;
+        transactionOpen = false;
+      } finally {
+        if (transactionOpen) await locker`ROLLBACK`;
+        locker.release();
+      }
+
+      if (!publication) throw new Error("publication did not start");
+      expect(await publication).toBe(false);
+      expect(await backend.get(targetKey)).toBe("generation-ordinary");
+      expect(await backend.get(blockerKey)).toBe("blocker-original");
+      expect(await backend.get("challenge")).toBeNull();
+    }
+  });
 });

--- a/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-postgres-publish.integration.test.ts
@@ -95,11 +95,11 @@ integration("Postgres email challenge publication", () => {
       await locker`SELECT pg_advisory_lock(hashtextextended(${lockKey}, 0))`;
       locked = true;
       stale = backend.publish([
-        { key: "challenge-old", value: "active-old", ttlMs: 60_000 },
+        { key: "challenge-old", value: "active-old", expiresAt: Date.now() + 60_000 },
         {
           key: reservationKey,
           value: "published-old",
-          ttlMs: 60_000,
+          expiresAt: Date.now() + 60_000,
           expected: "generation-old",
         },
       ]);
@@ -126,8 +126,13 @@ integration("Postgres email challenge publication", () => {
     expect(staleResult.value).toBe(false);
     expect(await backend.get("challenge-old")).toBeNull();
     const current = [
-      { key: "challenge-new", value: "active-new", ttlMs: 60_000 },
-      { key: reservationKey, value: "published-new", ttlMs: 60_000, expected: "generation-new" },
+      { key: "challenge-new", value: "active-new", expiresAt: Date.now() + 60_000 },
+      {
+        key: reservationKey,
+        value: "published-new",
+        expiresAt: Date.now() + 60_000,
+        expected: "generation-new",
+      },
     ] as const;
     expect(await backend.publish(current)).toBe(true);
     expect(await backend.consume("challenge-new")).toBe("active-new");
@@ -136,11 +141,66 @@ integration("Postgres email challenge publication", () => {
 
     await expect(
       backend.publish([
-        { key: "duplicate", value: "first", ttlMs: 60_000 },
-        { key: "duplicate", value: "second", ttlMs: 60_000 },
+        { key: "duplicate", value: "first", expiresAt: Date.now() + 60_000 },
+        { key: "duplicate", value: "second", expiresAt: Date.now() + 60_000 },
       ]),
     ).rejects.toThrow("Store publication contains duplicate keys");
     expect(await backend.get("duplicate")).toBeNull();
+  });
+
+  it("keeps the supplied deadline when a successful publication is delayed past expiry", async () => {
+    if (!sql) throw new Error("DATABASE_URL required");
+    const namespace = `email-publish-expiry-${crypto.randomUUID()}`;
+    const backend = new PostgresBackend(namespace);
+    const reservationKey = "reservation";
+    const credentialKey = "credential";
+    await backend.set(reservationKey, "reserved", 60_000);
+
+    const locker = await sql.reserve();
+    const lockKey = `${namespace}:${reservationKey}`;
+    const [{ pid: lockerPid }] = await locker<
+      Array<{ pid: number }>
+    >`SELECT pg_backend_pid() AS pid`;
+    const expiresAt = Date.now() + 250;
+    let locked = false;
+    let publication: Promise<boolean> | undefined;
+    let publicationOutcome: Promise<ObservedOutcome<boolean>> | undefined;
+    try {
+      await locker`SELECT pg_advisory_lock(hashtextextended(${lockKey}, 0))`;
+      locked = true;
+      publication = backend.publish([
+        { key: credentialKey, value: "active", expiresAt },
+        {
+          key: reservationKey,
+          value: "published",
+          expiresAt,
+          expected: "reserved",
+        },
+      ]);
+      publicationOutcome = observePromise(publication);
+      await waitForBlockedPublisher(lockKey, lockerPid);
+      const delayMs = expiresAt - Date.now() + 30;
+      if (delayMs > 0) await Bun.sleep(delayMs);
+    } finally {
+      if (locked) {
+        await locker`SELECT pg_advisory_unlock(hashtextextended(${lockKey}, 0))`;
+      }
+      locker.release();
+      if (publicationOutcome) await publicationOutcome;
+    }
+
+    if (!publicationOutcome || !publication) throw new Error("publication did not start");
+    const result = await publicationOutcome;
+    if (!result.ok) throw result.error;
+    expect(result.value).toBe(true);
+    expect(await backend.get(credentialKey)).toBeNull();
+    const rows = await sql<Array<{ expiresAt: Date }>>`
+      SELECT expires_at AS "expiresAt"
+        FROM auth_kv_store
+       WHERE id = ${credentialKey} AND namespace = ${namespace}
+    `;
+    expect(rows[0]?.expiresAt.getTime()).toBe(expiresAt);
+    await sql`DELETE FROM auth_kv_store WHERE namespace = ${namespace}`;
   });
 
   it("never overwrites an ordinary writer that commits after the guard read", async () => {
@@ -168,12 +228,12 @@ integration("Postgres email challenge publication", () => {
          FOR UPDATE
       `;
       publication = backend.publish([
-        { key: blockerKey, value: "blocker-published", ttlMs: 60_000 },
-        { key: "challenge", value: "active", ttlMs: 60_000 },
+        { key: blockerKey, value: "blocker-published", expiresAt: Date.now() + 60_000 },
+        { key: "challenge", value: "active", expiresAt: Date.now() + 60_000 },
         {
           key: targetKey,
           value: "generation-published",
-          ttlMs: 60_000,
+          expiresAt: Date.now() + 60_000,
           expected: "generation-old",
         },
       ]);
@@ -241,9 +301,14 @@ integration("Postgres email challenge publication", () => {
            FOR UPDATE
         `;
         publication = backend.publish([
-          { key: blockerKey, value: "blocker-published", ttlMs: 60_000 },
-          { key: "challenge", value: "active", ttlMs: 60_000 },
-          { key: targetKey, value: "generation-published", ttlMs: 60_000, expected: null },
+          { key: blockerKey, value: "blocker-published", expiresAt: Date.now() + 60_000 },
+          { key: "challenge", value: "active", expiresAt: Date.now() + 60_000 },
+          {
+            key: targetKey,
+            value: "generation-published",
+            expiresAt: Date.now() + 60_000,
+            expected: null,
+          },
         ]);
         publicationOutcome = observePromise(publication);
 

--- a/packages/auth/src/__tests__/email-redis-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-redis-publish.integration.test.ts
@@ -19,10 +19,13 @@ integration("Redis email challenge publication", () => {
     const backend = new RedisBackend(redis, prefix);
     const guardKey = "reservation";
     const credentialKey = "credential";
+    const priorCredentialKey = "prior-credential";
     await backend.set(guardKey, "reserved", 60_000);
+    await backend.set(priorCredentialKey, "still-active", 60_000);
 
     expect(
       await backend.publish([
+        { key: priorCredentialKey, value: null, expiresAt: Date.now() - 1 },
         { key: credentialKey, value: "active", expiresAt: Date.now() - 1 },
         {
           key: guardKey,
@@ -32,10 +35,12 @@ integration("Redis email challenge publication", () => {
         },
       ]),
     ).toBe(false);
+    expect(await backend.get(priorCredentialKey)).toBe("still-active");
     expect(await backend.get(credentialKey)).toBeNull();
     expect(await backend.get(guardKey)).toBe("reserved");
 
     await backend.delete(guardKey);
+    await backend.delete(priorCredentialKey);
     await backend.delete(credentialKey);
   });
 

--- a/packages/auth/src/__tests__/email-redis-publish.integration.test.ts
+++ b/packages/auth/src/__tests__/email-redis-publish.integration.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { Redis } from "ioredis";
+
+import { RedisBackend } from "../store-backends";
+
+const redisUrl = process.env.REDIS_URL;
+const integration = describe.skipIf(!redisUrl);
+const redis = redisUrl ? new Redis(redisUrl, { lazyConnect: true }) : null;
+
+integration("Redis email challenge publication", () => {
+  afterAll(async () => {
+    if (redis) await redis.quit();
+  });
+
+  it("rejects an expired absolute deadline before applying any write", async () => {
+    if (!redis) throw new Error("REDIS_URL is required");
+    await redis.connect();
+    const prefix = `auth-email-publish-${crypto.randomUUID()}:`;
+    const backend = new RedisBackend(redis, prefix);
+    const guardKey = "reservation";
+    const credentialKey = "credential";
+    await backend.set(guardKey, "reserved", 60_000);
+
+    expect(
+      await backend.publish([
+        { key: credentialKey, value: "active", expiresAt: Date.now() - 1 },
+        {
+          key: guardKey,
+          value: "published",
+          expiresAt: Date.now() - 1,
+          expected: "reserved",
+        },
+      ]),
+    ).toBe(false);
+    expect(await backend.get(credentialKey)).toBeNull();
+    expect(await backend.get(guardKey)).toBe("reserved");
+
+    await backend.delete(guardKey);
+    await backend.delete(credentialKey);
+  });
+
+  it("expires a publication at the supplied deadline rather than write time plus TTL", async () => {
+    if (!redis) throw new Error("REDIS_URL is required");
+    if (redis.status !== "ready") await redis.connect();
+    const prefix = `auth-email-publish-${crypto.randomUUID()}:`;
+    const backend = new RedisBackend(redis, prefix);
+    const expiresAt = Date.now() + 100;
+
+    expect(await backend.publish([{ key: "credential", value: "active", expiresAt }])).toBe(true);
+    await Bun.sleep(130);
+    expect(await backend.get("credential")).toBeNull();
+    await backend.delete("credential");
+  });
+});

--- a/packages/auth/src/__tests__/email.test.ts
+++ b/packages/auth/src/__tests__/email.test.ts
@@ -58,7 +58,7 @@ class CapturingBackend implements StoreBackend {
     if (states.some((state) => !state.expected)) return false;
     for (const entry of entries) {
       if (entry.value === null) this.values.delete(entry.key);
-      else this.values.set(entry.key, { value: entry.value, expiresAt: now + entry.ttlMs });
+      else this.values.set(entry.key, { value: entry.value, expiresAt: entry.expiresAt });
     }
     return true;
   }

--- a/packages/auth/src/__tests__/store-backends.test.ts
+++ b/packages/auth/src/__tests__/store-backends.test.ts
@@ -101,23 +101,27 @@ describe("NamespacedStoreBackend", () => {
     backend.destroy();
   });
 
-  it("rejects an expired memory publication without applying any write", async () => {
+  it("rejects an expired memory publication before deleting prior credentials", async () => {
     const backend = new MemoryBackend();
-    await backend.set("reservation", "reserved", 60_000);
+    await backend.set("generation", "reservation", 60_000);
+    await backend.set("prior-credential", "still-active", 60_000);
+    const expired = Date.now() - 1;
 
     expect(
       await backend.publish([
-        { key: "credential", value: "active", expiresAt: Date.now() - 1 },
+        { key: "prior-credential", value: null, expiresAt: expired },
+        { key: "replacement", value: "already-expired", expiresAt: expired },
         {
-          key: "reservation",
+          key: "generation",
           value: "published",
-          expiresAt: Date.now() - 1,
-          expected: "reserved",
+          expiresAt: expired,
+          expected: "reservation",
         },
       ]),
     ).toBe(false);
-    expect(await backend.get("credential")).toBeNull();
-    expect(await backend.get("reservation")).toBe("reserved");
+    expect(await backend.get("prior-credential")).toBe("still-active");
+    expect(await backend.get("replacement")).toBeNull();
+    expect(await backend.get("generation")).toBe("reservation");
     backend.destroy();
   });
 

--- a/packages/auth/src/__tests__/store-backends.test.ts
+++ b/packages/auth/src/__tests__/store-backends.test.ts
@@ -92,12 +92,41 @@ describe("buildBackend Redis smoke test", () => {
 });
 
 describe("NamespacedStoreBackend", () => {
+  it("keeps the exact absolute publication deadline in memory", async () => {
+    const backend = new MemoryBackend();
+    const expiresAt = Date.now() + 30;
+    expect(await backend.publish([{ key: "credential", value: "active", expiresAt }])).toBe(true);
+    await Bun.sleep(40);
+    expect(await backend.get("credential")).toBeNull();
+    backend.destroy();
+  });
+
+  it("passes absolute deadlines to an atomic Redis server-time publication", async () => {
+    let observedScript = "";
+    let observedArgs: Array<string | number> = [];
+    const backend = new RedisBackend(
+      redisLike({
+        eval: async (script, _numberOfKeys, ...args) => {
+          observedScript = script;
+          observedArgs = args;
+          return -1;
+        },
+      }),
+      "test:",
+    );
+    const expiresAt = Date.now() + 60_000;
+    expect(await backend.publish([{ key: "credential", value: "active", expiresAt }])).toBe(false);
+    expect(observedScript).toContain("redis.call('TIME')");
+    expect(observedScript).toContain("if ttl<=0 then return -1 end");
+    expect(observedArgs).toContain(expiresAt);
+  });
+
   it("rejects duplicate publish keys without applying either value", async () => {
     for (const backend of [new MemoryBackend(), new RedisBackend(redisLike(), "test:")]) {
       await expect(
         backend.publish([
-          { key: "credential", value: "first", ttlMs: 60_000 },
-          { key: "credential", value: "second", ttlMs: 60_000 },
+          { key: "credential", value: "first", expiresAt: Date.now() + 60_000 },
+          { key: "credential", value: "second", expiresAt: Date.now() + 60_000 },
         ]),
       ).rejects.toThrow("Store publication contains duplicate keys");
       expect(await backend.get("credential")).toBeNull();
@@ -113,11 +142,11 @@ describe("NamespacedStoreBackend", () => {
         {
           key: "generation",
           value: "published-a",
-          ttlMs: 60_000,
+          expiresAt: Date.now() + 60_000,
           expected: "reservation-a",
         },
-        { key: "credential", value: "active", ttlMs: 60_000 },
-        { key: "prior-credential", value: null, ttlMs: 60_000 },
+        { key: "credential", value: "active", expiresAt: Date.now() + 60_000 },
+        { key: "prior-credential", value: null, expiresAt: Date.now() + 60_000 },
       ] as const;
       expect(await backend.publish(entries)).toBe(true);
       expect(await backend.consume("credential")).toBe("active");
@@ -130,7 +159,7 @@ describe("NamespacedStoreBackend", () => {
       expect(
         await backend.publish([
           ...entries,
-          { key: "should-not-publish", value: "unsafe", ttlMs: 60_000 },
+          { key: "should-not-publish", value: "unsafe", expiresAt: Date.now() + 60_000 },
         ]),
       ).toBe(false);
       expect(await backend.get("generation")).toBe("reservation-newer");

--- a/packages/auth/src/__tests__/store-backends.test.ts
+++ b/packages/auth/src/__tests__/store-backends.test.ts
@@ -101,6 +101,26 @@ describe("NamespacedStoreBackend", () => {
     backend.destroy();
   });
 
+  it("rejects an expired memory publication without applying any write", async () => {
+    const backend = new MemoryBackend();
+    await backend.set("reservation", "reserved", 60_000);
+
+    expect(
+      await backend.publish([
+        { key: "credential", value: "active", expiresAt: Date.now() - 1 },
+        {
+          key: "reservation",
+          value: "published",
+          expiresAt: Date.now() - 1,
+          expected: "reserved",
+        },
+      ]),
+    ).toBe(false);
+    expect(await backend.get("credential")).toBeNull();
+    expect(await backend.get("reservation")).toBe("reserved");
+    backend.destroy();
+  });
+
   it("passes absolute deadlines to an atomic Redis server-time publication", async () => {
     let observedScript = "";
     let observedArgs: Array<string | number> = [];

--- a/packages/auth/src/__tests__/store-backends.test.ts
+++ b/packages/auth/src/__tests__/store-backends.test.ts
@@ -150,6 +150,20 @@ describe("NamespacedStoreBackend", () => {
     }
   });
 
+  it("replaces a memory set-if-absent entry at its exact deadline", async () => {
+    const now = spyOn(Date, "now").mockReturnValue(1_000);
+    const backend = new MemoryBackend();
+    try {
+      expect(await backend.setIfNotExists("reservation", "old", 1_000)).toBe(true);
+      now.mockReturnValue(2_000);
+      expect(await backend.setIfNotExists("reservation", "replacement", 1_000)).toBe(true);
+      expect(await backend.get("reservation")).toBe("replacement");
+    } finally {
+      backend.destroy();
+      now.mockRestore();
+    }
+  });
+
   it("passes absolute deadlines to an atomic Redis server-time publication", async () => {
     let observedScript = "";
     let observedArgs: Array<string | number> = [];

--- a/packages/auth/src/__tests__/store-backends.test.ts
+++ b/packages/auth/src/__tests__/store-backends.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 
 import {
   buildBackend,
@@ -123,6 +123,31 @@ describe("NamespacedStoreBackend", () => {
     expect(await backend.get("replacement")).toBeNull();
     expect(await backend.get("generation")).toBe("reservation");
     backend.destroy();
+  });
+
+  it("treats an existing memory guard as expired at its exact deadline", async () => {
+    const now = spyOn(Date, "now").mockReturnValue(1_000);
+    const backend = new MemoryBackend();
+    try {
+      await backend.set("guard", "reserved", 1_000);
+      now.mockReturnValue(2_000);
+      expect(
+        await backend.publish([
+          {
+            key: "guard",
+            value: "published",
+            expiresAt: 3_000,
+            expected: "reserved",
+          },
+          { key: "credential", value: "active", expiresAt: 3_000 },
+        ]),
+      ).toBe(false);
+      expect(await backend.get("guard")).toBeNull();
+      expect(await backend.get("credential")).toBeNull();
+    } finally {
+      backend.destroy();
+      now.mockRestore();
+    }
   });
 
   it("passes absolute deadlines to an atomic Redis server-time publication", async () => {

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -569,23 +569,11 @@ export class EmailAuth {
   private async publishChallenge(
     entries: readonly StorePublishEntry[],
     confirmOwnPublication?: () => Promise<boolean>,
-    absoluteExpiresAtMs?: number,
   ): Promise<boolean> {
     let lastError: unknown;
     for (let attempt = 0; attempt < 3; attempt += 1) {
-      let attemptEntries = entries;
-      if (absoluteExpiresAtMs !== undefined) {
-        const remainingTtlMs = absoluteExpiresAtMs - Date.now();
-        if (remainingTtlMs <= 0) {
-          throw new Error("Email challenge expired before publication completed");
-        }
-        attemptEntries = entries.map((entry) => ({
-          ...entry,
-          ttlMs: Math.min(entry.ttlMs, remainingTtlMs),
-        }));
-      }
       try {
-        const published = await this.tokenStore.publish(attemptEntries);
+        const published = await this.tokenStore.publish(entries);
         if (published || !lastError || !confirmOwnPublication) return published;
         return await confirmOwnPublication();
       } catch (error) {
@@ -615,7 +603,12 @@ export class EmailAuth {
       const reservation = encodeIssuanceReservation(reservationId, prior);
       if (
         await this.publishChallenge([
-          { key: reservationKey, value: reservation, ttlMs, expected: current },
+          {
+            key: reservationKey,
+            value: reservation,
+            expiresAt: Date.now() + ttlMs,
+            expected: current,
+          },
         ])
       ) {
         return { reservationKey, reservation, prior };
@@ -631,7 +624,7 @@ export class EmailAuth {
   ): Promise<void> {
     try {
       await this.publishChallenge([
-        { key: reservationKey, value: null, ttlMs, expected: reservation },
+        { key: reservationKey, value: null, expiresAt: Date.now() + ttlMs, expected: reservation },
       ]);
     } catch {
       // A newer issuance may own the target. Never overwrite its reservation.
@@ -746,18 +739,18 @@ export class EmailAuth {
       // commits, neither old nor new pods can discover the staged credential.
       const published = await this.publishChallenge(
         [
-          { key: stagingKey, value: null, ttlMs: remainingTtlMs },
+          { key: stagingKey, value: null, expiresAt: expiresAt.getTime() },
           ...(priorChallengeId
             ? [
                 {
                   key: emailLoginChallengeKey(priorChallengeId),
                   value: null,
-                  ttlMs: remainingTtlMs,
+                  expiresAt: expiresAt.getTime(),
                 },
                 {
                   key: emailLoginStatusKey(priorChallengeId),
                   value: null,
-                  ttlMs: remainingTtlMs,
+                  expiresAt: expiresAt.getTime(),
                 },
               ]
             : []),
@@ -767,7 +760,7 @@ export class EmailAuth {
               ...challenge,
               status: "pending",
             } satisfies EmailLoginChallengeRecord),
-            ttlMs: remainingTtlMs,
+            expiresAt: expiresAt.getTime(),
           },
           {
             key: emailLoginStatusKey(challengeId),
@@ -775,33 +768,40 @@ export class EmailAuth {
               ...stagedStatus,
               status: "pending",
             } satisfies EmailLoginStatusRecord),
-            ttlMs: remainingTtlMs,
+            expiresAt: expiresAt.getTime(),
           },
-          { key: emailLoginLinkAliasKey(tokenHash), value: challengeId, ttlMs: remainingTtlMs },
-          { key: emailLoginCodeAliasKey(codeVerifier), value: challengeId, ttlMs: remainingTtlMs },
+          {
+            key: emailLoginLinkAliasKey(tokenHash),
+            value: challengeId,
+            expiresAt: expiresAt.getTime(),
+          },
+          {
+            key: emailLoginCodeAliasKey(codeVerifier),
+            value: challengeId,
+            expiresAt: expiresAt.getTime(),
+          },
           {
             key: targetKey,
             value: challengeId,
-            ttlMs: remainingTtlMs,
+            expiresAt: expiresAt.getTime(),
             expected: priorChallengeId,
           },
           {
             key: reservationKey,
             value: publicationReceipt,
-            ttlMs: remainingTtlMs,
+            expiresAt: expiresAt.getTime(),
             expected: reservation,
           },
           {
             key: publicationReceiptKey,
             value: publicationReceipt,
-            ttlMs: remainingTtlMs,
+            expiresAt: expiresAt.getTime(),
             expected: null,
           },
         ],
         async () =>
           (await this.tokenStore.verify(publicationReceiptKey)) === publicationReceipt &&
           (await this.tokenStore.verify(targetKey)) === challengeId,
-        expiresAt.getTime(),
       );
       if (!published) throw new Error("email issuance was superseded");
     } catch (err) {
@@ -908,37 +908,38 @@ export class EmailAuth {
     try {
       const published = await this.publishChallenge(
         [
-          { key: stagingKey, value: null, ttlMs: remainingTtlMs },
-          ...(priorStoreKey ? [{ key: priorStoreKey, value: null, ttlMs: remainingTtlMs }] : []),
+          { key: stagingKey, value: null, expiresAt: expiresAt.getTime() },
+          ...(priorStoreKey
+            ? [{ key: priorStoreKey, value: null, expiresAt: expiresAt.getTime() }]
+            : []),
           {
             key: storeKey,
             // Deployed pre-staging readers accept only the raw two-field payload.
             value: JSON.stringify(payload),
-            ttlMs: remainingTtlMs,
+            expiresAt: expiresAt.getTime(),
           },
           {
             key: targetKey,
             value: storeKey,
-            ttlMs: remainingTtlMs,
+            expiresAt: expiresAt.getTime(),
             expected: priorStoreKey,
           },
           {
             key: reservationKey,
             value: publicationReceipt,
-            ttlMs: remainingTtlMs,
+            expiresAt: expiresAt.getTime(),
             expected: reservation,
           },
           {
             key: publicationReceiptKey,
             value: publicationReceipt,
-            ttlMs: remainingTtlMs,
+            expiresAt: expiresAt.getTime(),
             expected: null,
           },
         ],
         async () =>
           (await this.tokenStore.verify(publicationReceiptKey)) === publicationReceipt &&
           (await this.tokenStore.verify(targetKey)) === storeKey,
-        expiresAt.getTime(),
       );
       if (!published) throw new Error("email issuance was superseded");
     } catch (err) {

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -251,6 +251,10 @@ function issuancePublicationMarker(reservation: string): string {
   return `published:${hashSha256Hex(reservation)}`;
 }
 
+function issuancePublicationReceiptKey(reservation: string): string {
+  return `email-issuance:published:${hashSha256Hex(reservation)}`;
+}
+
 function parseIssuanceReservation(value: string | null): IssuanceReservation | null {
   if (!value?.startsWith("{")) return null;
   try {
@@ -562,13 +566,25 @@ export class EmailAuth {
     );
   }
 
-  private async publishChallenge(entries: readonly StorePublishEntry[]): Promise<boolean> {
+  private async publishChallenge(
+    entries: readonly StorePublishEntry[],
+    confirmOwnPublication?: () => Promise<boolean>,
+  ): Promise<boolean> {
     let lastError: unknown;
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
-        return await this.tokenStore.publish(entries);
+        const published = await this.tokenStore.publish(entries);
+        if (published || !lastError || !confirmOwnPublication) return published;
+        return await confirmOwnPublication();
       } catch (error) {
         lastError = error;
+        if (confirmOwnPublication) {
+          try {
+            if (await confirmOwnPublication()) return true;
+          } catch {
+            // The durable outcome remains ambiguous; retry the atomic publish.
+          }
+        }
       }
     }
     throw lastError;
@@ -641,6 +657,8 @@ export class EmailAuth {
       reservation,
       prior: priorChallengeId,
     } = await this.reserveIssuance(targetKey, challengeId, ttlMs);
+    const publicationReceiptKey = issuancePublicationReceiptKey(reservation);
+    const publicationReceipt = issuancePublicationMarker(reservation);
 
     const codeVerifier = this.codeVerifier(email, context.tenantId, code);
     const challenge: EmailLoginChallengeRecord = {
@@ -714,53 +732,64 @@ export class EmailAuth {
     try {
       // Publish only legacy-readable records. Until this atomic operation
       // commits, neither old nor new pods can discover the staged credential.
-      const published = await this.publishChallenge([
-        { key: stagingKey, value: null, ttlMs: remainingTtlMs },
-        ...(priorChallengeId
-          ? [
-              {
-                key: emailLoginChallengeKey(priorChallengeId),
-                value: null,
-                ttlMs: remainingTtlMs,
-              },
-              {
-                key: emailLoginStatusKey(priorChallengeId),
-                value: null,
-                ttlMs: remainingTtlMs,
-              },
-            ]
-          : []),
-        {
-          key: emailLoginChallengeKey(challengeId),
-          value: JSON.stringify({
-            ...challenge,
-            status: "pending",
-          } satisfies EmailLoginChallengeRecord),
-          ttlMs: remainingTtlMs,
-        },
-        {
-          key: emailLoginStatusKey(challengeId),
-          value: JSON.stringify({
-            ...stagedStatus,
-            status: "pending",
-          } satisfies EmailLoginStatusRecord),
-          ttlMs: remainingTtlMs,
-        },
-        { key: emailLoginLinkAliasKey(tokenHash), value: challengeId, ttlMs: remainingTtlMs },
-        { key: emailLoginCodeAliasKey(codeVerifier), value: challengeId, ttlMs: remainingTtlMs },
-        {
-          key: targetKey,
-          value: challengeId,
-          ttlMs: remainingTtlMs,
-          expected: priorChallengeId,
-        },
-        {
-          key: reservationKey,
-          value: issuancePublicationMarker(reservation),
-          ttlMs: remainingTtlMs,
-          expected: reservation,
-        },
-      ]);
+      const published = await this.publishChallenge(
+        [
+          { key: stagingKey, value: null, ttlMs: remainingTtlMs },
+          ...(priorChallengeId
+            ? [
+                {
+                  key: emailLoginChallengeKey(priorChallengeId),
+                  value: null,
+                  ttlMs: remainingTtlMs,
+                },
+                {
+                  key: emailLoginStatusKey(priorChallengeId),
+                  value: null,
+                  ttlMs: remainingTtlMs,
+                },
+              ]
+            : []),
+          {
+            key: emailLoginChallengeKey(challengeId),
+            value: JSON.stringify({
+              ...challenge,
+              status: "pending",
+            } satisfies EmailLoginChallengeRecord),
+            ttlMs: remainingTtlMs,
+          },
+          {
+            key: emailLoginStatusKey(challengeId),
+            value: JSON.stringify({
+              ...stagedStatus,
+              status: "pending",
+            } satisfies EmailLoginStatusRecord),
+            ttlMs: remainingTtlMs,
+          },
+          { key: emailLoginLinkAliasKey(tokenHash), value: challengeId, ttlMs: remainingTtlMs },
+          { key: emailLoginCodeAliasKey(codeVerifier), value: challengeId, ttlMs: remainingTtlMs },
+          {
+            key: targetKey,
+            value: challengeId,
+            ttlMs: remainingTtlMs,
+            expected: priorChallengeId,
+          },
+          {
+            key: reservationKey,
+            value: publicationReceipt,
+            ttlMs: remainingTtlMs,
+            expected: reservation,
+          },
+          {
+            key: publicationReceiptKey,
+            value: publicationReceipt,
+            ttlMs: remainingTtlMs,
+            expected: null,
+          },
+        ],
+        async () =>
+          (await this.tokenStore.verify(publicationReceiptKey)) === publicationReceipt &&
+          (await this.tokenStore.verify(targetKey)) === challengeId,
+      );
       if (!published) throw new Error("email issuance was superseded");
     } catch (err) {
       await Promise.all([
@@ -798,6 +827,8 @@ export class EmailAuth {
       reservation,
       prior: priorStoreKey,
     } = await this.reserveIssuance(targetKey, stagingId, this.tokenTtlMs);
+    const publicationReceiptKey = issuancePublicationReceiptKey(reservation);
+    const publicationReceipt = issuancePublicationMarker(reservation);
     let storeKey = otpStoreKey(email, context.tenantId, code);
     // A repeated six-digit code would derive the prior issuance's exact key
     // and make an old email valid again. Regenerate before superseding it.
@@ -862,28 +893,39 @@ export class EmailAuth {
       throw new EmailDeliveryError("Email challenge activation failed");
     }
     try {
-      const published = await this.publishChallenge([
-        { key: stagingKey, value: null, ttlMs: remainingTtlMs },
-        ...(priorStoreKey ? [{ key: priorStoreKey, value: null, ttlMs: remainingTtlMs }] : []),
-        {
-          key: storeKey,
-          // Deployed pre-staging readers accept only the raw two-field payload.
-          value: JSON.stringify(payload),
-          ttlMs: remainingTtlMs,
-        },
-        {
-          key: targetKey,
-          value: storeKey,
-          ttlMs: remainingTtlMs,
-          expected: priorStoreKey,
-        },
-        {
-          key: reservationKey,
-          value: issuancePublicationMarker(reservation),
-          ttlMs: remainingTtlMs,
-          expected: reservation,
-        },
-      ]);
+      const published = await this.publishChallenge(
+        [
+          { key: stagingKey, value: null, ttlMs: remainingTtlMs },
+          ...(priorStoreKey ? [{ key: priorStoreKey, value: null, ttlMs: remainingTtlMs }] : []),
+          {
+            key: storeKey,
+            // Deployed pre-staging readers accept only the raw two-field payload.
+            value: JSON.stringify(payload),
+            ttlMs: remainingTtlMs,
+          },
+          {
+            key: targetKey,
+            value: storeKey,
+            ttlMs: remainingTtlMs,
+            expected: priorStoreKey,
+          },
+          {
+            key: reservationKey,
+            value: publicationReceipt,
+            ttlMs: remainingTtlMs,
+            expected: reservation,
+          },
+          {
+            key: publicationReceiptKey,
+            value: publicationReceipt,
+            ttlMs: remainingTtlMs,
+            expected: null,
+          },
+        ],
+        async () =>
+          (await this.tokenStore.verify(publicationReceiptKey)) === publicationReceipt &&
+          (await this.tokenStore.verify(targetKey)) === storeKey,
+      );
       if (!published) throw new Error("email issuance was superseded");
     } catch (err) {
       await Promise.all([

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -569,11 +569,23 @@ export class EmailAuth {
   private async publishChallenge(
     entries: readonly StorePublishEntry[],
     confirmOwnPublication?: () => Promise<boolean>,
+    absoluteExpiresAtMs?: number,
   ): Promise<boolean> {
     let lastError: unknown;
     for (let attempt = 0; attempt < 3; attempt += 1) {
+      let attemptEntries = entries;
+      if (absoluteExpiresAtMs !== undefined) {
+        const remainingTtlMs = absoluteExpiresAtMs - Date.now();
+        if (remainingTtlMs <= 0) {
+          throw new Error("Email challenge expired before publication completed");
+        }
+        attemptEntries = entries.map((entry) => ({
+          ...entry,
+          ttlMs: Math.min(entry.ttlMs, remainingTtlMs),
+        }));
+      }
       try {
-        const published = await this.tokenStore.publish(entries);
+        const published = await this.tokenStore.publish(attemptEntries);
         if (published || !lastError || !confirmOwnPublication) return published;
         return await confirmOwnPublication();
       } catch (error) {
@@ -789,6 +801,7 @@ export class EmailAuth {
         async () =>
           (await this.tokenStore.verify(publicationReceiptKey)) === publicationReceipt &&
           (await this.tokenStore.verify(targetKey)) === challengeId,
+        expiresAt.getTime(),
       );
       if (!published) throw new Error("email issuance was superseded");
     } catch (err) {
@@ -925,6 +938,7 @@ export class EmailAuth {
         async () =>
           (await this.tokenStore.verify(publicationReceiptKey)) === publicationReceipt &&
           (await this.tokenStore.verify(targetKey)) === storeKey,
+        expiresAt.getTime(),
       );
       if (!published) throw new Error("email issuance was superseded");
     } catch (err) {

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -21,7 +21,8 @@ export interface StorePublishEntry {
   key: string;
   /** A null value deletes the key as part of the atomic publication. */
   value: string | null;
-  ttlMs: number;
+  /** Absolute Unix epoch deadline. Publication must never extend this expiry. */
+  expiresAt: number;
   /**
    * Optional compare-and-publish guard. Null means the key must be absent or
    * expired. If every guard already contains its desired value, publication
@@ -221,7 +222,7 @@ export class MemoryBackend implements StoreBackend {
     if (states.some((state) => !state.expected)) return false;
     for (const entry of entries) {
       if (entry.value === null) this.store.delete(entry.key);
-      else this.store.set(entry.key, { value: entry.value, expiresAt: now + entry.ttlMs });
+      else this.store.set(entry.key, { value: entry.value, expiresAt: entry.expiresAt });
     }
     return true;
   }
@@ -349,12 +350,12 @@ export class RedisBackend implements StoreBackend {
     const args = entries.flatMap((entry) => [
       entry.value === null ? "D" : "S",
       entry.value ?? "",
-      entry.ttlMs,
+      entry.expiresAt,
       entry.expected === undefined ? "0" : entry.expected === null ? "1" : "2",
       entry.expected ?? "",
     ]);
     const result = await this.client.eval(
-      "local guarded=0; local all_expected=true; local all_desired=true; for i=1,#KEYS do local j=(i-1)*5; local v=redis.call('GET',KEYS[i]); local kind=ARGV[j+4]; if kind~='0' then guarded=guarded+1; local expected=(kind=='1' and not v) or (kind=='2' and v==ARGV[j+5]); local desired=(ARGV[j+1]=='D' and not v) or (ARGV[j+1]=='S' and v==ARGV[j+2]); if not expected then all_expected=false end; if not desired then all_desired=false end end end; if guarded>0 and all_desired then return 1 end; if not all_expected then return 0 end; for i=1,#KEYS do local j=(i-1)*5; if ARGV[j+1]=='D' then redis.call('DEL',KEYS[i]) else redis.call('SET',KEYS[i],ARGV[j+2],'PX',ARGV[j+3]) end end; return 1",
+      "local guarded=0; local all_expected=true; local all_desired=true; for i=1,#KEYS do local j=(i-1)*5; local v=redis.call('GET',KEYS[i]); local kind=ARGV[j+4]; if kind~='0' then guarded=guarded+1; local expected=(kind=='1' and not v) or (kind=='2' and v==ARGV[j+5]); local desired=(ARGV[j+1]=='D' and not v) or (ARGV[j+1]=='S' and v==ARGV[j+2]); if not expected then all_expected=false end; if not desired then all_desired=false end end end; if guarded>0 and all_desired then return 1 end; if not all_expected then return 0 end; local now=redis.call('TIME'); local now_ms=tonumber(now[1])*1000+math.floor(tonumber(now[2])/1000); local ttls={}; for i=1,#KEYS do local j=(i-1)*5; if ARGV[j+1]=='S' then local ttl=tonumber(ARGV[j+3])-now_ms; if ttl<=0 then return -1 end; ttls[i]=ttl end end; for i=1,#KEYS do local j=(i-1)*5; if ARGV[j+1]=='D' then redis.call('DEL',KEYS[i]) else redis.call('SET',KEYS[i],ARGV[j+2],'PX',ttls[i]) end end; return 1",
       keys.length,
       ...keys,
       ...args,
@@ -527,7 +528,7 @@ export class PostgresBackend implements StoreBackend {
     const sql = this.getSqlClient();
     const prepared = entries.map((entry) => ({
       ...entry,
-      expiresAt: new Date(Date.now() + entry.ttlMs).toISOString(),
+      expiresAtIso: new Date(entry.expiresAt).toISOString(),
     }));
     for (let attempt = 0; attempt < 3; attempt += 1) {
       let published = true;
@@ -577,7 +578,7 @@ export class PostgresBackend implements StoreBackend {
             } else {
               await transaction`
                 INSERT INTO auth_kv_store (id, namespace, value, expires_at)
-                VALUES (${entry.key}, ${this.namespace}, ${entry.value}, ${entry.expiresAt})
+                VALUES (${entry.key}, ${this.namespace}, ${entry.value}, ${entry.expiresAtIso})
                 ON CONFLICT (id, namespace) DO UPDATE
                   SET value      = EXCLUDED.value,
                       expires_at = EXCLUDED.expires_at

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -282,6 +282,8 @@ function postgresErrorCode(error: unknown): string | undefined {
     : undefined;
 }
 
+class PublicationExpiredError extends Error {}
+
 /**
  * Redis-backed store backend.
  * Uses atomic SET key value PX ttlMs for writes; native TTL handles expiry.
@@ -556,15 +558,17 @@ export class PostgresBackend implements StoreBackend {
               )
             `;
           }
-          if (earliestValueExpiry !== null) {
+          const valueDeadlineIsLive = async (): Promise<boolean> => {
+            if (earliestValueExpiry === null) return true;
             const [{ valid }] = await transaction<Array<{ valid: boolean }>>`
               SELECT clock_timestamp() < ${new Date(earliestValueExpiry).toISOString()}::timestamptz
                 AS valid
             `;
-            if (!valid) {
-              published = false;
-              return;
-            }
+            return valid;
+          };
+          if (!(await valueDeadlineIsLive())) {
+            published = false;
+            return;
           }
           let allExpected = true;
           let allDesired = guarded.length > 0;
@@ -603,9 +607,13 @@ export class PostgresBackend implements StoreBackend {
               `;
             }
           }
+          // A legacy writer or database lock can delay the UPSERT after the
+          // first deadline check. Roll back the whole batch if that happened.
+          if (!(await valueDeadlineIsLive())) throw new PublicationExpiredError();
         });
         return published;
       } catch (error) {
+        if (error instanceof PublicationExpiredError) return false;
         if (postgresErrorCode(error) !== "40001" || attempt === 2) throw error;
       }
     }

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -272,6 +272,14 @@ type TransactionSql = <T extends readonly unknown[] = readonly unknown[]>(
   ...values: readonly unknown[]
 ) => Promise<T>;
 
+function postgresErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const descriptor = Object.getOwnPropertyDescriptor(error, "code");
+  return descriptor && "value" in descriptor && typeof descriptor.value === "string"
+    ? descriptor.value
+    : undefined;
+}
+
 /**
  * Redis-backed store backend.
  * Uses atomic SET key value PX ttlMs for writes; native TTL handles expiry.
@@ -521,58 +529,68 @@ export class PostgresBackend implements StoreBackend {
       ...entry,
       expiresAt: new Date(Date.now() + entry.ttlMs).toISOString(),
     }));
-    let published = true;
-    await sql.begin(async (transaction: TransactionSql) => {
-      const ordered = [...prepared].sort((left, right) => left.key.localeCompare(right.key));
-      const guarded = ordered.filter((entry) => entry.expected !== undefined);
-      for (const entry of ordered) {
-        // An advisory transaction lock also serializes the absent-row case,
-        // which SELECT ... FOR UPDATE alone cannot protect at READ COMMITTED.
-        await transaction`
-          SELECT pg_advisory_xact_lock(
-            hashtextextended(${`${this.namespace}:${entry.key}`}, 0)
-          )
-        `;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      let published = true;
+      try {
+        await sql.begin("isolation level serializable", async (transaction: TransactionSql) => {
+          const ordered = [...prepared].sort((left, right) =>
+            left.key < right.key ? -1 : left.key > right.key ? 1 : 0,
+          );
+          const guarded = ordered.filter((entry) => entry.expected !== undefined);
+          for (const entry of ordered) {
+            // Cooperative publishers serialize absent rows here. SERIALIZABLE
+            // additionally detects older binaries and ordinary writers that do
+            // not participate in this advisory-lock protocol.
+            await transaction`
+              SELECT pg_advisory_xact_lock(
+                hashtextextended(${`${this.namespace}:${entry.key}`}, 0)
+              )
+            `;
+          }
+          let allExpected = true;
+          let allDesired = guarded.length > 0;
+          for (const entry of guarded) {
+            const rows = await transaction<Array<{ value: string }>>`
+              SELECT value
+                FROM auth_kv_store
+               WHERE id = ${entry.key}
+                 AND namespace = ${this.namespace}
+                 AND expires_at > now()
+               LIMIT 1
+            `;
+            const current = rows[0]?.value ?? null;
+            if (current !== entry.expected) allExpected = false;
+            if (current !== entry.value) allDesired = false;
+          }
+          if (allDesired) return;
+          if (!allExpected) {
+            published = false;
+            return;
+          }
+          for (const entry of prepared) {
+            if (entry.value === null) {
+              await transaction`
+                DELETE FROM auth_kv_store
+                 WHERE id = ${entry.key}
+                   AND namespace = ${this.namespace}
+              `;
+            } else {
+              await transaction`
+                INSERT INTO auth_kv_store (id, namespace, value, expires_at)
+                VALUES (${entry.key}, ${this.namespace}, ${entry.value}, ${entry.expiresAt})
+                ON CONFLICT (id, namespace) DO UPDATE
+                  SET value      = EXCLUDED.value,
+                      expires_at = EXCLUDED.expires_at
+              `;
+            }
+          }
+        });
+        return published;
+      } catch (error) {
+        if (postgresErrorCode(error) !== "40001" || attempt === 2) throw error;
       }
-      let allExpected = true;
-      let allDesired = guarded.length > 0;
-      for (const entry of guarded) {
-        const rows = await transaction<Array<{ value: string }>>`
-          SELECT value
-            FROM auth_kv_store
-           WHERE id = ${entry.key}
-             AND namespace = ${this.namespace}
-             AND expires_at > now()
-           LIMIT 1
-        `;
-        const current = rows[0]?.value ?? null;
-        if (current !== entry.expected) allExpected = false;
-        if (current !== entry.value) allDesired = false;
-      }
-      if (allDesired) return;
-      if (!allExpected) {
-        published = false;
-        return;
-      }
-      for (const entry of prepared) {
-        if (entry.value === null) {
-          await transaction`
-            DELETE FROM auth_kv_store
-             WHERE id = ${entry.key}
-               AND namespace = ${this.namespace}
-          `;
-        } else {
-          await transaction`
-            INSERT INTO auth_kv_store (id, namespace, value, expires_at)
-            VALUES (${entry.key}, ${this.namespace}, ${entry.value}, ${entry.expiresAt})
-            ON CONFLICT (id, namespace) DO UPDATE
-              SET value      = EXCLUDED.value,
-                  expires_at = EXCLUDED.expires_at
-          `;
-        }
-      }
-    });
-    return published;
+    }
+    return false;
   }
 
   async delete(key: string): Promise<void> {

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -166,7 +166,7 @@ export class MemoryBackend implements StoreBackend {
   async get(key: string): Promise<string | null> {
     const entry = this.store.get(key);
     if (!entry) return null;
-    if (Date.now() > entry.expiresAt) {
+    if (Date.now() >= entry.expiresAt) {
       this.store.delete(key);
       return null;
     }
@@ -177,7 +177,7 @@ export class MemoryBackend implements StoreBackend {
     const entry = this.store.get(key);
     if (!entry) return null;
     this.store.delete(key);
-    if (Date.now() > entry.expiresAt) return null;
+    if (Date.now() >= entry.expiresAt) return null;
     return entry.value;
   }
 
@@ -190,13 +190,13 @@ export class MemoryBackend implements StoreBackend {
   ): Promise<boolean> {
     if (guard) {
       const guarded = this.store.get(guard.key);
-      if (!guarded || Date.now() > guarded.expiresAt || guarded.value !== guard.expected) {
-        if (guarded && Date.now() > guarded.expiresAt) this.store.delete(guard.key);
+      if (!guarded || Date.now() >= guarded.expiresAt || guarded.value !== guard.expected) {
+        if (guarded && Date.now() >= guarded.expiresAt) this.store.delete(guard.key);
         return false;
       }
     }
     const entry = this.store.get(key);
-    if (!entry || Date.now() > entry.expiresAt) {
+    if (!entry || Date.now() >= entry.expiresAt) {
       this.store.delete(key);
       return false;
     }
@@ -215,7 +215,7 @@ export class MemoryBackend implements StoreBackend {
     if (entries.some((entry) => entry.value !== null && entry.expiresAt <= now)) return false;
     const currentValue = (key: string): string | null => {
       const current = this.store.get(key);
-      if (!current || now > current.expiresAt) return null;
+      if (!current || now >= current.expiresAt) return null;
       return current.value;
     };
     const guarded = entries.filter((entry) => entry.expected !== undefined);
@@ -239,7 +239,7 @@ export class MemoryBackend implements StoreBackend {
   private _cleanup(): void {
     const now = Date.now();
     for (const [key, entry] of this.store.entries()) {
-      if (now > entry.expiresAt) this.store.delete(key);
+      if (now >= entry.expiresAt) this.store.delete(key);
     }
   }
 

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -208,6 +208,10 @@ export class MemoryBackend implements StoreBackend {
   async publish(entries: readonly StorePublishEntry[]): Promise<boolean> {
     assertUniquePublishKeys(entries);
     const now = Date.now();
+    // Absolute SET deadlines are a commit precondition, not merely the TTL to
+    // attach after publication. Reject before evaluating guards or deleting
+    // prior credentials so a delayed provider acknowledgement cannot replace
+    // a still-valid challenge with already-expired state.
     if (entries.some((entry) => entry.value !== null && entry.expiresAt <= now)) return false;
     const currentValue = (key: string): string | null => {
       const current = this.store.get(key);
@@ -560,6 +564,9 @@ export class PostgresBackend implements StoreBackend {
           }
           const valueDeadlineIsLive = async (): Promise<boolean> => {
             if (earliestValueExpiry === null) return true;
+            // now() is fixed at transaction start and can predate a blocking
+            // advisory lock. clock_timestamp() is authoritative at this
+            // post-lock commit boundary.
             const [{ valid }] = await transaction<Array<{ valid: boolean }>>`
               SELECT clock_timestamp() < ${new Date(earliestValueExpiry).toISOString()}::timestamptz
                 AS valid
@@ -578,7 +585,7 @@ export class PostgresBackend implements StoreBackend {
                 FROM auth_kv_store
                WHERE id = ${entry.key}
                  AND namespace = ${this.namespace}
-                 AND expires_at > now()
+                 AND expires_at > clock_timestamp()
                LIMIT 1
             `;
             const current = rows[0]?.value ?? null;

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -21,7 +21,7 @@ export interface StorePublishEntry {
   key: string;
   /** A null value deletes the key as part of the atomic publication. */
   value: string | null;
-  /** Absolute Unix epoch deadline. Publication must never extend this expiry. */
+  /** Absolute Unix epoch deadline. A value is not published after this deadline. */
   expiresAt: number;
   /**
    * Optional compare-and-publish guard. Null means the key must be absent or
@@ -57,7 +57,7 @@ export interface StoreBackend {
     ttlMs: number,
     guard?: { key: string; expected: string },
   ): Promise<boolean>;
-  /** Atomically make every entry visible, or make none of them visible. */
+  /** Atomically apply every entry, or none; returns false after any value deadline. */
   publish(entries: readonly StorePublishEntry[]): Promise<boolean>;
   delete(key: string): Promise<void>;
 }
@@ -208,6 +208,7 @@ export class MemoryBackend implements StoreBackend {
   async publish(entries: readonly StorePublishEntry[]): Promise<boolean> {
     assertUniquePublishKeys(entries);
     const now = Date.now();
+    if (entries.some((entry) => entry.value !== null && entry.expiresAt <= now)) return false;
     const currentValue = (key: string): string | null => {
       const current = this.store.get(key);
       if (!current || now > current.expiresAt) return null;
@@ -355,7 +356,7 @@ export class RedisBackend implements StoreBackend {
       entry.expected ?? "",
     ]);
     const result = await this.client.eval(
-      "local guarded=0; local all_expected=true; local all_desired=true; for i=1,#KEYS do local j=(i-1)*5; local v=redis.call('GET',KEYS[i]); local kind=ARGV[j+4]; if kind~='0' then guarded=guarded+1; local expected=(kind=='1' and not v) or (kind=='2' and v==ARGV[j+5]); local desired=(ARGV[j+1]=='D' and not v) or (ARGV[j+1]=='S' and v==ARGV[j+2]); if not expected then all_expected=false end; if not desired then all_desired=false end end end; if guarded>0 and all_desired then return 1 end; if not all_expected then return 0 end; local now=redis.call('TIME'); local now_ms=tonumber(now[1])*1000+math.floor(tonumber(now[2])/1000); local ttls={}; for i=1,#KEYS do local j=(i-1)*5; if ARGV[j+1]=='S' then local ttl=tonumber(ARGV[j+3])-now_ms; if ttl<=0 then return -1 end; ttls[i]=ttl end end; for i=1,#KEYS do local j=(i-1)*5; if ARGV[j+1]=='D' then redis.call('DEL',KEYS[i]) else redis.call('SET',KEYS[i],ARGV[j+2],'PX',ttls[i]) end end; return 1",
+      "local now=redis.call('TIME'); local now_ms=tonumber(now[1])*1000+math.floor(tonumber(now[2])/1000); local ttls={}; for i=1,#KEYS do local j=(i-1)*5; if ARGV[j+1]=='S' then local ttl=tonumber(ARGV[j+3])-now_ms; if ttl<=0 then return -1 end; ttls[i]=ttl end end; local guarded=0; local all_expected=true; local all_desired=true; for i=1,#KEYS do local j=(i-1)*5; local v=redis.call('GET',KEYS[i]); local kind=ARGV[j+4]; if kind~='0' then guarded=guarded+1; local expected=(kind=='1' and not v) or (kind=='2' and v==ARGV[j+5]); local desired=(ARGV[j+1]=='D' and not v) or (ARGV[j+1]=='S' and v==ARGV[j+2]); if not expected then all_expected=false end; if not desired then all_desired=false end end end; if guarded>0 and all_desired then return 1 end; if not all_expected then return 0 end; for i=1,#KEYS do local j=(i-1)*5; if ARGV[j+1]=='D' then redis.call('DEL',KEYS[i]) else redis.call('SET',KEYS[i],ARGV[j+2],'PX',ttls[i]) end end; return 1",
       keys.length,
       ...keys,
       ...args,
@@ -530,6 +531,13 @@ export class PostgresBackend implements StoreBackend {
       ...entry,
       expiresAtIso: new Date(entry.expiresAt).toISOString(),
     }));
+    const earliestValueExpiry = prepared
+      .filter((entry) => entry.value !== null)
+      .reduce<number | null>(
+        (earliest, entry) =>
+          earliest === null || entry.expiresAt < earliest ? entry.expiresAt : earliest,
+        null,
+      );
     for (let attempt = 0; attempt < 3; attempt += 1) {
       let published = true;
       try {
@@ -547,6 +555,16 @@ export class PostgresBackend implements StoreBackend {
                 hashtextextended(${`${this.namespace}:${entry.key}`}, 0)
               )
             `;
+          }
+          if (earliestValueExpiry !== null) {
+            const [{ valid }] = await transaction<Array<{ valid: boolean }>>`
+              SELECT clock_timestamp() < ${new Date(earliestValueExpiry).toISOString()}::timestamptz
+                AS valid
+            `;
+            if (!valid) {
+              published = false;
+              return;
+            }
           }
           let allExpected = true;
           let allDesired = guarded.length > 0;

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -156,7 +156,7 @@ export class MemoryBackend implements StoreBackend {
   async setIfNotExists(key: string, value: string, ttlMs: number): Promise<boolean> {
     const existing = this.store.get(key);
     if (existing) {
-      if (Date.now() <= existing.expiresAt) return false;
+      if (Date.now() < existing.expiresAt) return false;
       this.store.delete(key);
     }
     this.store.set(key, { value, expiresAt: Date.now() + ttlMs });


### PR DESCRIPTION
Closes #564.

## Summary
- run PostgreSQL guarded batch publication at `SERIALIZABLE` with bounded serialization retries, closing races with ordinary and rolling old-pod writers
- persist an opaque TTL-bounded per-issuance commit receipt so a magic-link or OTP publication can confirm its own commit after acknowledgement loss
- bind confirmation to both the exact receipt and still-active target; superseded credentials are revoked/fail closed
- preserve one absolute credential expiry through retries and reject the entire publication once any value deadline has elapsed
- enforce the preflight before any delete/write with `Date.now()` in Memory, Redis server `TIME`, and PostgreSQL `clock_timestamp()` after advisory locks
- treat Memory entries and guards as expired at the exact millisecond deadline (`>=`), matching Redis/PostgreSQL authority
- allow Memory `setIfNotExists` to replace an entry exactly at expiry, matching Redis/PG absence semantics
- re-check PostgreSQL time after all writes and roll back the transaction if row-lock contention crossed the deadline
- preserve the previously valid OTP or magic link when a delayed replacement misses its commit deadline
- run the real Redis deadline proof in both hosted integration workflows that provide a Redis service and `REDIS_URL`
- prove an expired Redis batch cannot delete the previously valid credential
- retain the shared empty-CORS-allowlist behavioral preflight correction

This clean survivor contains only the reviewed #564 publication work and excludes the rejected runtime/cache portions of closed #587.

## Exact validation
Exact head: `384b1ae8ab20f374ae0fd59ea32363636c4b3fa5`
Exact tree: `869cd4fc05c565d544c05aeb82dd8c03d8a10de4`
Exact base: `9239a728b9ca28175e00e2825f69d85f3e02856e`

- focused Memory boundary suite: 18 pass, 60 assertions
- full auth suite: 326 pass, 12 integration skips, 1,027 assertions
- real PostgreSQL publication suite: 7 pass, 35 assertions
- real Redis publication suite: 2 pass, 6 assertions
- auth dependency build: 27/27 tasks
- Biome on all changed TypeScript files: clean
- `git diff --check`: clean

Keep draft until exact hosted CI and independent review are green.
