### PR TITLE
fix(provider-x): bind staged recovery to account lineage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,6 +509,16 @@ jobs:
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
+      - name: X disable and recovery lineage concurrency (real Postgres)
+        run: >-
+          bun test ./packages/api/src/__tests__/provider-x-connect.test.ts
+          --test-name-pattern "concurrent recovery wins"
+        env:
+          DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
+          STEWARD_X_CONNECT_REAL_PG: "true"
+          STEWARD_MASTER_PASSWORD: "ci-test-secret"
+          STEWARD_AUDIT_HMAC_KEY: "ci-audit-hmac-key-must-be-at-least-32-bytes-long"
+
       - name: Start API test server
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -599,6 +599,16 @@ jobs:
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
+      - name: X disable and recovery lineage concurrency (real Postgres)
+        run: >-
+          bun test ./packages/api/src/__tests__/provider-x-connect.test.ts
+          --test-name-pattern "concurrent recovery wins"
+        env:
+          DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
+          STEWARD_X_CONNECT_REAL_PG: "true"
+          STEWARD_MASTER_PASSWORD: "ci-test-secret"
+          STEWARD_AUDIT_HMAC_KEY: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+
       - name: Start API test server
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"

--- a/packages/api/src/__tests__/middleware-security-hardening.test.ts
+++ b/packages/api/src/__tests__/middleware-security-hardening.test.ts
@@ -56,7 +56,6 @@ describe("middleware security hardening", () => {
     // an unset NODE_ENV must fail closed like production.
     expect(tenantCorsSource).toContain("function devWildcardAllowed()");
     expect(tenantCorsSource).toContain('env === "development" || env === "test"');
-    expect(tenantCorsSource).toContain("origins.length === 0");
     expect(tenantCorsSource).toContain("return c.newResponse(null, 403)");
     expect(tenantCorsSource).toContain("TENANT_ID_RE.test(tenantId)");
     expect(tenantCorsSource).toContain("MAX_CORS_CACHE_ENTRIES");

--- a/packages/api/src/__tests__/provider-authority.test.ts
+++ b/packages/api/src/__tests__/provider-authority.test.ts
@@ -165,6 +165,17 @@ async function seedCore() {
       riskClass: "read",
     },
   ]);
+  await db.insert(providerRoleBindings).values({
+    id: "50000000-0000-4000-8000-000000000001",
+    tenantId: "tenant-main",
+    workspaceId: WORKSPACE_A,
+    principalType: "human",
+    principalId: ADMIN,
+    roleKey: "workspace_admin",
+    status: "active",
+    grantedByUserId: OWNER,
+    reason: "hermetic provider-account mutation authority",
+  });
 }
 
 describe("provider authority foundation", () => {

--- a/packages/api/src/__tests__/provider-authority.test.ts
+++ b/packages/api/src/__tests__/provider-authority.test.ts
@@ -325,12 +325,12 @@ describe("provider authority foundation", () => {
       .select()
       .from(providerAccounts)
       .where(eq(providerAccounts.id, accountId));
-    store.faultHooks.beforeProviderAccountDisableUpdate = () => {
+    const failingUpdateStore = new ProviderAuthorityStore(async () => {
       throw new Error("simulated provider-account disable update failure");
-    };
+    });
     try {
       await expect(
-        store.disableProviderAccount(
+        failingUpdateStore.disableProviderAccount(
           mutation({
             actorUserId: ADMIN,
             tenantRole: "admin",
@@ -351,7 +351,6 @@ describe("provider authority foundation", () => {
         .where(eq(persistedAuditEvents.resourceId, accountId));
       expect(events.map(({ action }) => action)).toEqual(["provider.account.disable"]);
     } finally {
-      store.faultHooks = {};
       await getDb().delete(providerAccounts).where(eq(providerAccounts.id, accountId));
     }
   });
@@ -425,12 +424,6 @@ describe("provider authority foundation", () => {
       .select()
       .from(providerAccounts)
       .where(eq(providerAccounts.id, accountId));
-    store.faultHooks.beforeProviderAccountDisableUpdate = async () => {
-      await getDb()
-        .update(providerAccounts)
-        .set({ revision: sql`${providerAccounts.revision} + 1` })
-        .where(eq(providerAccounts.id, accountId));
-    };
     try {
       await expect(
         store.disableProviderAccount(
@@ -438,7 +431,13 @@ describe("provider authority foundation", () => {
             actorUserId: ADMIN,
             tenantRole: "admin",
             expectedRevision: before.revision,
-            audit: persistedAuthorityAudit,
+            audit: async (event) => {
+              await persistedAuthorityAudit(event);
+              await getDb()
+                .update(providerAccounts)
+                .set({ revision: sql`${providerAccounts.revision} + 1` })
+                .where(eq(providerAccounts.id, accountId));
+            },
           }),
           accountId,
         ),
@@ -454,7 +453,6 @@ describe("provider authority foundation", () => {
         .where(eq(persistedAuditEvents.resourceId, accountId));
       expect(events.map(({ action }) => action)).toEqual(["provider.account.disable"]);
     } finally {
-      store.faultHooks = {};
       await getDb().delete(providerAccounts).where(eq(providerAccounts.id, accountId));
     }
   });
@@ -487,12 +485,6 @@ describe("provider authority foundation", () => {
       .select()
       .from(providerAccounts)
       .where(eq(providerAccounts.id, accountId));
-    store.faultHooks.beforeProviderAccountDisableUpdate = async () => {
-      await getDb()
-        .update(providerRoleBindings)
-        .set({ status: "revoked" })
-        .where(eq(providerRoleBindings.id, bindingId));
-    };
     try {
       await expect(
         store.disableProviderAccount(
@@ -500,7 +492,13 @@ describe("provider authority foundation", () => {
             actorUserId: OTHER,
             tenantRole: "member",
             expectedRevision: before.revision,
-            audit: persistedAuthorityAudit,
+            audit: async (event) => {
+              await persistedAuthorityAudit(event);
+              await getDb()
+                .update(providerRoleBindings)
+                .set({ status: "revoked" })
+                .where(eq(providerRoleBindings.id, bindingId));
+            },
           }),
           accountId,
         ),
@@ -516,7 +514,6 @@ describe("provider authority foundation", () => {
         .where(eq(persistedAuditEvents.resourceId, accountId));
       expect(events.map(({ action }) => action)).toEqual(["provider.account.disable"]);
     } finally {
-      store.faultHooks = {};
       await getDb().delete(providerAccounts).where(eq(providerAccounts.id, accountId));
       await getDb().delete(providerRoleBindings).where(eq(providerRoleBindings.id, bindingId));
     }

--- a/packages/api/src/__tests__/provider-authority.test.ts
+++ b/packages/api/src/__tests__/provider-authority.test.ts
@@ -448,6 +448,69 @@ describe("provider authority foundation", () => {
     }
   });
 
+  test("revalidates workspace authority under the disable transaction lock", async () => {
+    const accountId = crypto.randomUUID();
+    const bindingId = crypto.randomUUID();
+    await getDb()
+      .insert(providerAccounts)
+      .values({
+        id: accountId,
+        tenantId: "tenant-main",
+        workspaceId: WORKSPACE_A,
+        adapterKey: "github",
+        externalRef: `disable-authority-race-${accountId}`,
+        displayName: "Disable authority race",
+      });
+    await getDb().insert(providerRoleBindings).values({
+      id: bindingId,
+      tenantId: "tenant-main",
+      workspaceId: WORKSPACE_A,
+      principalType: "human",
+      principalId: OTHER,
+      roleKey: "workspace_admin",
+      status: "active",
+      grantedByUserId: ADMIN,
+      reason: "disable authority race fixture",
+    });
+    const [before] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    store.faultHooks.beforeProviderAccountDisableUpdate = async () => {
+      await getDb()
+        .update(providerRoleBindings)
+        .set({ status: "revoked" })
+        .where(eq(providerRoleBindings.id, bindingId));
+    };
+    try {
+      await expect(
+        store.disableProviderAccount(
+          mutation({
+            actorUserId: OTHER,
+            tenantRole: "member",
+            expectedRevision: before.revision,
+            audit: persistedAuthorityAudit,
+          }),
+          accountId,
+        ),
+      ).rejects.toMatchObject({ code: "not_found", status: 404 });
+      const [after] = await getDb()
+        .select()
+        .from(providerAccounts)
+        .where(eq(providerAccounts.id, accountId));
+      expect(after).toEqual(before);
+      const events = await getDb()
+        .select({ action: persistedAuditEvents.action })
+        .from(persistedAuditEvents)
+        .where(eq(persistedAuditEvents.resourceId, accountId));
+      expect(events.map(({ action }) => action)).toEqual(["provider.account.disable"]);
+    } finally {
+      store.faultHooks = {};
+      await getDb().delete(providerAccounts).where(eq(providerAccounts.id, accountId));
+      await getDb().delete(providerRoleBindings).where(eq(providerRoleBindings.id, bindingId));
+    }
+  });
+
   test("enforces matrix scope and non-enumerating cross-workspace/tenant behavior", async () => {
     await getDb()
       .insert(providerRoleBindings)

--- a/packages/api/src/__tests__/provider-authority.test.ts
+++ b/packages/api/src/__tests__/provider-authority.test.ts
@@ -12,10 +12,12 @@ import {
   tenants,
   users,
   userTenants,
+  withTenantAuditedTransaction,
   workspaces,
+  writeAuditEvent,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { type AuthorityAudit, ProviderAuthorityStore } from "../services/provider-authority-store";
 
 setDefaultTimeout(120_000);
@@ -36,6 +38,18 @@ const store = new ProviderAuthorityStore();
 const auditEvents: Array<{ action: string; resourceType: string }> = [];
 const audit: AuthorityAudit = async (event) => {
   auditEvents.push(event);
+};
+
+const persistedAuthorityAudit: AuthorityAudit = async (event) => {
+  await writeAuditEvent({
+    tenantId: "tenant-main",
+    actorType: "user",
+    actorId: ADMIN,
+    action: event.action,
+    resourceType: event.resourceType,
+    resourceId: event.resourceId,
+    metadata: event.metadata,
+  });
 };
 
 function mutation(
@@ -242,6 +256,196 @@ describe("provider authority foundation", () => {
       ),
     ).rejects.toThrow("audit unavailable");
     expect((await getDb().select().from(workspaces)).length).toBe(before);
+  });
+
+  test("couples provider-account disable state to its authoritative completion audit", async () => {
+    const accountId = crypto.randomUUID();
+    await getDb()
+      .insert(providerAccounts)
+      .values({
+        id: accountId,
+        tenantId: "tenant-main",
+        workspaceId: WORKSPACE_A,
+        adapterKey: "github",
+        externalRef: `disable-success-${accountId}`,
+        displayName: "Disable success",
+      });
+    const [before] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    try {
+      const disabled = await store.disableProviderAccount(
+        mutation({
+          actorUserId: ADMIN,
+          tenantRole: "admin",
+          expectedRevision: before.revision,
+          audit: persistedAuthorityAudit,
+        }),
+        accountId,
+      );
+      expect(disabled).toMatchObject({ status: "disabled", revision: before.revision + 1 });
+      const events = await getDb()
+        .select({ action: persistedAuditEvents.action })
+        .from(persistedAuditEvents)
+        .where(eq(persistedAuditEvents.resourceId, accountId));
+      expect(events.map(({ action }) => action)).toEqual([
+        "provider.account.disable",
+        "provider.account.disable.completed",
+      ]);
+    } finally {
+      await getDb().delete(providerAccounts).where(eq(providerAccounts.id, accountId));
+    }
+  });
+
+  test("does not publish disable completion when the update fails after intent audit", async () => {
+    const accountId = crypto.randomUUID();
+    await getDb()
+      .insert(providerAccounts)
+      .values({
+        id: accountId,
+        tenantId: "tenant-main",
+        workspaceId: WORKSPACE_A,
+        adapterKey: "github",
+        externalRef: `disable-update-failure-${accountId}`,
+        displayName: "Disable update failure",
+      });
+    const [before] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    store.faultHooks.beforeProviderAccountDisableUpdate = () => {
+      throw new Error("simulated provider-account disable update failure");
+    };
+    try {
+      await expect(
+        store.disableProviderAccount(
+          mutation({
+            actorUserId: ADMIN,
+            tenantRole: "admin",
+            expectedRevision: before.revision,
+            audit: persistedAuthorityAudit,
+          }),
+          accountId,
+        ),
+      ).rejects.toThrow("simulated provider-account disable update failure");
+      const [after] = await getDb()
+        .select()
+        .from(providerAccounts)
+        .where(eq(providerAccounts.id, accountId));
+      expect(after).toEqual(before);
+      const events = await getDb()
+        .select({ action: persistedAuditEvents.action })
+        .from(persistedAuditEvents)
+        .where(eq(persistedAuditEvents.resourceId, accountId));
+      expect(events.map(({ action }) => action)).toEqual(["provider.account.disable"]);
+    } finally {
+      store.faultHooks = {};
+      await getDb().delete(providerAccounts).where(eq(providerAccounts.id, accountId));
+    }
+  });
+
+  test("rolls back the disable state when its completion audit cannot commit", async () => {
+    const accountId = crypto.randomUUID();
+    await getDb()
+      .insert(providerAccounts)
+      .values({
+        id: accountId,
+        tenantId: "tenant-main",
+        workspaceId: WORKSPACE_A,
+        adapterKey: "github",
+        externalRef: `disable-audit-failure-${accountId}`,
+        displayName: "Disable completion audit failure",
+      });
+    const [before] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    const failingCompletionStore = new ProviderAuthorityStore((tenantId, fn) =>
+      withTenantAuditedTransaction(tenantId, (txRaw, appendRequiredAudit) =>
+        fn(txRaw, async (event) => {
+          if (event.action === "provider.account.disable.completed") {
+            throw new Error("simulated disable completion audit failure");
+          }
+          await appendRequiredAudit(event);
+        }),
+      ),
+    );
+    try {
+      await expect(
+        failingCompletionStore.disableProviderAccount(
+          mutation({
+            actorUserId: ADMIN,
+            tenantRole: "admin",
+            expectedRevision: before.revision,
+            audit: persistedAuthorityAudit,
+          }),
+          accountId,
+        ),
+      ).rejects.toThrow("simulated disable completion audit failure");
+      const [after] = await getDb()
+        .select()
+        .from(providerAccounts)
+        .where(eq(providerAccounts.id, accountId));
+      expect(after).toEqual(before);
+      const events = await getDb()
+        .select({ action: persistedAuditEvents.action })
+        .from(persistedAuditEvents)
+        .where(eq(persistedAuditEvents.resourceId, accountId));
+      expect(events.map(({ action }) => action)).toEqual(["provider.account.disable"]);
+    } finally {
+      await getDb().delete(providerAccounts).where(eq(providerAccounts.id, accountId));
+    }
+  });
+
+  test("does not publish disable completion when the account CAS loses after intent audit", async () => {
+    const accountId = crypto.randomUUID();
+    await getDb()
+      .insert(providerAccounts)
+      .values({
+        id: accountId,
+        tenantId: "tenant-main",
+        workspaceId: WORKSPACE_A,
+        adapterKey: "github",
+        externalRef: `disable-cas-loss-${accountId}`,
+        displayName: "Disable CAS loss",
+      });
+    const [before] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    store.faultHooks.beforeProviderAccountDisableUpdate = async () => {
+      await getDb()
+        .update(providerAccounts)
+        .set({ revision: sql`${providerAccounts.revision} + 1` })
+        .where(eq(providerAccounts.id, accountId));
+    };
+    try {
+      await expect(
+        store.disableProviderAccount(
+          mutation({
+            actorUserId: ADMIN,
+            tenantRole: "admin",
+            expectedRevision: before.revision,
+            audit: persistedAuthorityAudit,
+          }),
+          accountId,
+        ),
+      ).rejects.toMatchObject({ code: "revision_conflict", status: 409 });
+      const [after] = await getDb()
+        .select()
+        .from(providerAccounts)
+        .where(eq(providerAccounts.id, accountId));
+      expect(after).toMatchObject({ status: "active", revision: before.revision + 1 });
+      const events = await getDb()
+        .select({ action: persistedAuditEvents.action })
+        .from(persistedAuditEvents)
+        .where(eq(persistedAuditEvents.resourceId, accountId));
+      expect(events.map(({ action }) => action)).toEqual(["provider.account.disable"]);
+    } finally {
+      store.faultHooks = {};
+      await getDb().delete(providerAccounts).where(eq(providerAccounts.id, accountId));
+    }
   });
 
   test("enforces matrix scope and non-enumerating cross-workspace/tenant behavior", async () => {

--- a/packages/api/src/__tests__/provider-authority.test.ts
+++ b/packages/api/src/__tests__/provider-authority.test.ts
@@ -165,8 +165,12 @@ async function seedCore() {
       riskClass: "read",
     },
   ]);
-  await db.insert(providerRoleBindings).values({
-    id: "50000000-0000-4000-8000-000000000001",
+}
+
+async function grantWorkspaceAdminForTest(): Promise<string> {
+  const id = crypto.randomUUID();
+  await getDb().insert(providerRoleBindings).values({
+    id,
     tenantId: "tenant-main",
     workspaceId: WORKSPACE_A,
     principalType: "human",
@@ -174,8 +178,9 @@ async function seedCore() {
     roleKey: "workspace_admin",
     status: "active",
     grantedByUserId: OWNER,
-    reason: "hermetic provider-account mutation authority",
+    reason: "scoped provider-account mutation test authority",
   });
+  return id;
 }
 
 describe("provider authority foundation", () => {
@@ -271,6 +276,7 @@ describe("provider authority foundation", () => {
 
   test("couples provider-account disable state to its authoritative completion audit", async () => {
     const accountId = crypto.randomUUID();
+    const authorityBindingId = await grantWorkspaceAdminForTest();
     await getDb()
       .insert(providerAccounts)
       .values({
@@ -306,11 +312,15 @@ describe("provider authority foundation", () => {
       ]);
     } finally {
       await getDb().delete(providerAccounts).where(eq(providerAccounts.id, accountId));
+      await getDb()
+        .delete(providerRoleBindings)
+        .where(eq(providerRoleBindings.id, authorityBindingId));
     }
   });
 
   test("does not publish disable completion when the update fails after intent audit", async () => {
     const accountId = crypto.randomUUID();
+    const authorityBindingId = await grantWorkspaceAdminForTest();
     await getDb()
       .insert(providerAccounts)
       .values({
@@ -352,11 +362,15 @@ describe("provider authority foundation", () => {
       expect(events.map(({ action }) => action)).toEqual(["provider.account.disable"]);
     } finally {
       await getDb().delete(providerAccounts).where(eq(providerAccounts.id, accountId));
+      await getDb()
+        .delete(providerRoleBindings)
+        .where(eq(providerRoleBindings.id, authorityBindingId));
     }
   });
 
   test("rolls back the disable state when its completion audit cannot commit", async () => {
     const accountId = crypto.randomUUID();
+    const authorityBindingId = await grantWorkspaceAdminForTest();
     await getDb()
       .insert(providerAccounts)
       .values({
@@ -405,11 +419,15 @@ describe("provider authority foundation", () => {
       expect(events.map(({ action }) => action)).toEqual(["provider.account.disable"]);
     } finally {
       await getDb().delete(providerAccounts).where(eq(providerAccounts.id, accountId));
+      await getDb()
+        .delete(providerRoleBindings)
+        .where(eq(providerRoleBindings.id, authorityBindingId));
     }
   });
 
   test("does not publish disable completion when the account CAS loses after intent audit", async () => {
     const accountId = crypto.randomUUID();
+    const authorityBindingId = await grantWorkspaceAdminForTest();
     await getDb()
       .insert(providerAccounts)
       .values({
@@ -454,6 +472,9 @@ describe("provider authority foundation", () => {
       expect(events.map(({ action }) => action)).toEqual(["provider.account.disable"]);
     } finally {
       await getDb().delete(providerAccounts).where(eq(providerAccounts.id, accountId));
+      await getDb()
+        .delete(providerRoleBindings)
+        .where(eq(providerRoleBindings.id, authorityBindingId));
     }
   });
 

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -47,6 +47,7 @@ import {
   disconnectXProviderCredential,
   initiateXConnect,
   type PendingConnectStore,
+  reconcileXConnectLifecycle,
   refreshXProviderCredential,
   runXCredentialLifecycleSweep,
   X_ADAPTER_KEY,
@@ -77,6 +78,8 @@ const CONFIG = { clientId: "x-client-id", clientSecret: "x-client-secret" };
 
 const MASTER = process.env.STEWARD_MASTER_PASSWORD ?? "steward-api-test-suite-master-password";
 const vault = new SecretVault(MASTER);
+const USING_REAL_POSTGRES =
+  process.env.STEWARD_X_CONNECT_REAL_PG === "true" && Boolean(process.env.DATABASE_URL);
 
 async function readAuditActions(tenantId: string): Promise<string[]> {
   const db = getDb();
@@ -286,19 +289,30 @@ async function seed() {
 beforeAll(async () => {
   process.env.STEWARD_MASTER_PASSWORD ??= MASTER;
   process.env.STEWARD_AUDIT_HMAC_KEY ??= "a".repeat(64);
-  process.env.STEWARD_PGLITE_MEMORY ??= "true";
-  process.env.STEWARD_DB_MODE ??= "pglite";
-  // Fresh, isolated schema for this file (matches the per-file convention). The
-  // override's teardown closes the client exactly once via closeDb() in afterAll.
-  const { db, client } = await createPGLiteDb("memory://");
-  setPGLiteOverride(db, async () => {
-    await client.close();
-  });
+  if (!USING_REAL_POSTGRES) {
+    process.env.STEWARD_PGLITE_MEMORY ??= "true";
+    process.env.STEWARD_DB_MODE ??= "pglite";
+    // Fresh, isolated schema for this file (matches the per-file convention).
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => {
+      await client.close();
+    });
+  } else {
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_DB_MODE;
+  }
   await seed();
 });
 
 afterAll(async () => {
   __setXForwardForTests(null);
+  if (USING_REAL_POSTGRES) {
+    const db = getDb();
+    await db.delete(auditEventsTable).where(eq(auditEventsTable.tenantId, TENANT));
+    await db.execute(sql`DELETE FROM audit_chain_heads WHERE tenant_id = ${TENANT}`);
+    await db.delete(tenants).where(eq(tenants.id, TENANT));
+    await db.delete(users).where(inArray(users.id, [ADMIN, APPROVER, VIEWER, OUTSIDER]));
+  }
   await closeDb();
 });
 
@@ -1370,6 +1384,99 @@ describe("connect exchange recovery", () => {
     recovery.restore();
   });
 
+  test("recovery preserves a legacy disable whose intent and exact account CAS both landed", async () => {
+    const initial = await connectHappy(new MemoryConnectStore());
+    const accountId = initial.completed.providerAccountId;
+    const [accountBeforeDisable] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    const credentialBeforeDisable = await decryptCredential(accountId);
+
+    const staleStore = new MemoryConnectStore();
+    const stagedFake = installFakeX({
+      exchangeToken: {
+        access_token: "access-staged-before-legacy-disable",
+        refresh_token: "refresh-staged-before-legacy-disable",
+      },
+    });
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store: staleStore,
+    });
+    __setAfterXCredentialStageForTests(async () => {
+      throw new Error("simulated crash before legacy generic disable");
+    });
+    await expect(
+      completeXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        callerUserId: ADMIN,
+        code: "auth-code",
+        state: initiated.state,
+        connectToken: initiated.connectToken,
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store: staleStore,
+        vault,
+      }),
+    ).rejects.toThrow("simulated crash before legacy generic disable");
+    __setAfterXCredentialStageForTests(null);
+    stagedFake.restore();
+
+    await writeAuditEvent({
+      tenantId: TENANT,
+      actorType: "user",
+      actorId: ADMIN,
+      action: "provider.account.disable",
+      resourceType: "provider_account",
+      resourceId: accountId,
+      metadata: {
+        workspaceId: WORKSPACE,
+        expectedRevision: accountBeforeDisable.revision,
+        reason: "simulated pre-completion-event generic disable",
+      },
+    });
+    await getDb()
+      .update(providerAccounts)
+      .set({
+        status: "disabled",
+        revision: accountBeforeDisable.revision + 1,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(providerAccounts.id, accountId),
+          eq(providerAccounts.revision, accountBeforeDisable.revision),
+        ),
+      );
+
+    const recovery = installFakeX({ revokeStatuses: [200] });
+    const swept = await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(Date.now() + 70_000),
+    });
+    expect(swept).toMatchObject({ processed: 1, adopted: 0, revoked: 1, attention: 0 });
+    const [accountAfterRecovery] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    expect(accountAfterRecovery).toMatchObject({
+      status: "disabled",
+      revision: accountBeforeDisable.revision + 1,
+      credentialSecretId: accountBeforeDisable.credentialSecretId,
+      credentialVersion: accountBeforeDisable.credentialVersion,
+    });
+    expect(await decryptCredential(accountId)).toEqual(credentialBeforeDisable);
+    expect(recovery.counters).toMatchObject({ identity: 1, revoke: 1 });
+    recovery.restore();
+  });
+
   test("recovery ignores a disable intent whose account update never completed", async () => {
     const initial = await connectHappy(new MemoryConnectStore());
     const accountId = initial.completed.providerAccountId;
@@ -1451,6 +1558,146 @@ describe("connect exchange recovery", () => {
     });
     expect(recovery.counters).toMatchObject({ identity: 1, revoke: 0 });
     recovery.restore();
+  });
+
+  test("concurrent recovery wins a disable CAS only when no completion lineage exists", async () => {
+    const initial = await connectHappy(new MemoryConnectStore());
+    const accountId = initial.completed.providerAccountId;
+    const [accountBeforeRace] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+
+    const staleStore = new MemoryConnectStore();
+    const stagedFake = installFakeX({
+      exchangeToken: {
+        access_token: "access-staged-disable-race",
+        refresh_token: "refresh-staged-disable-race",
+      },
+    });
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store: staleStore,
+    });
+    __setAfterXCredentialStageForTests(async () => {
+      throw new Error("simulated crash before disable/recovery race");
+    });
+    await expect(
+      completeXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        callerUserId: ADMIN,
+        code: "auth-code",
+        state: initiated.state,
+        connectToken: initiated.connectToken,
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store: staleStore,
+        vault,
+      }),
+    ).rejects.toThrow("simulated crash before disable/recovery race");
+    __setAfterXCredentialStageForTests(null);
+    stagedFake.restore();
+    const [stagedLifecycle] = await getDb()
+      .select({ id: providerXCredentialLifecycles.id })
+      .from(providerXCredentialLifecycles)
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.kind, "connect_exchange"),
+          eq(providerXCredentialLifecycles.state, "credential_staged"),
+        ),
+      );
+    if (!stagedLifecycle) throw new Error("expected staged connect lifecycle");
+
+    let signalDisableIntent!: () => void;
+    const disableIntentWritten = new Promise<void>((resolve) => {
+      signalDisableIntent = resolve;
+    });
+    let releaseDisable!: () => void;
+    const disableMayContinue = new Promise<void>((resolve) => {
+      releaseDisable = resolve;
+    });
+    providerAuthorityStore.faultHooks.beforeProviderAccountDisableUpdate = async () => {
+      signalDisableIntent();
+      await disableMayContinue;
+    };
+    const disablePromise = providerAuthorityStore.disableProviderAccount(
+      {
+        tenantId: TENANT,
+        actorUserId: ADMIN,
+        tenantRole: "admin",
+        mfaVerifiedAt: Date.now(),
+        idempotencyKey: `disable-recovery-race-${crypto.randomUUID()}`,
+        expectedRevision: accountBeforeRace.revision,
+        reason: "test disable and staged recovery CAS",
+        audit: async (event) => {
+          await writeAuditEvent({
+            tenantId: TENANT,
+            actorType: "user",
+            actorId: ADMIN,
+            action: event.action,
+            resourceType: event.resourceType,
+            resourceId: event.resourceId,
+            metadata: event.metadata,
+          });
+        },
+      },
+      accountId,
+    );
+    await disableIntentWritten;
+
+    const recovery = installFakeX();
+    try {
+      expect(
+        await reconcileXConnectLifecycle({
+          tenantId: TENANT,
+          workspaceId: WORKSPACE,
+          lifecycleId: stagedLifecycle.id,
+          vault,
+          config: CONFIG,
+        }),
+      ).toMatchObject({
+        providerAccountId: accountId,
+        credentialVersion: (accountBeforeRace.credentialVersion as number) + 1,
+        reconnected: true,
+      });
+      releaseDisable();
+      await expect(disablePromise).rejects.toMatchObject({
+        code: "revision_conflict",
+        status: 409,
+      });
+      const [accountAfterRace] = await getDb()
+        .select()
+        .from(providerAccounts)
+        .where(eq(providerAccounts.id, accountId));
+      expect(accountAfterRace).toMatchObject({
+        status: "active",
+        revision: accountBeforeRace.revision + 1,
+        credentialVersion: (accountBeforeRace.credentialVersion as number) + 1,
+      });
+      const disableActions = await getDb()
+        .select({ action: auditEventsTable.action })
+        .from(auditEventsTable)
+        .where(
+          and(
+            eq(auditEventsTable.tenantId, TENANT),
+            eq(auditEventsTable.resourceId, accountId),
+            inArray(auditEventsTable.action, [
+              "provider.account.disable",
+              "provider.account.disable.completed",
+            ]),
+          ),
+        );
+      expect(disableActions.map(({ action }) => action)).toEqual(["provider.account.disable"]);
+    } finally {
+      releaseDisable();
+      providerAuthorityStore.faultHooks = {};
+      recovery.restore();
+    }
   });
 
   test("a staged connect cannot re-enable an account disabled by the generic authority path", async () => {

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -1198,6 +1198,24 @@ describe("connect exchange recovery", () => {
       .select()
       .from(providerAccounts)
       .where(eq(providerAccounts.id, accountId));
+    // Failed legacy disables are durable authorization intents, not account
+    // mutations. Even a long run of them must not hide the completed refresh
+    // that authoritatively superseded the staged connect response.
+    for (let index = 0; index < 17; index += 1) {
+      await writeAuditEvent({
+        tenantId: TENANT,
+        actorType: "user",
+        actorId: ADMIN,
+        action: "provider.account.disable",
+        resourceType: "provider_account",
+        resourceId: accountId,
+        metadata: {
+          workspaceId: WORKSPACE,
+          expectedRevision: accountBeforeRecovery.revision,
+          reason: `simulated failed generic disable ${index}`,
+        },
+      });
+    }
     const credentialBeforeRecovery = await decryptCredential(accountId);
     expect(credentialBeforeRecovery).toMatchObject({
       accessToken: "access-current-after-refresh",
@@ -1623,10 +1641,6 @@ describe("connect exchange recovery", () => {
     const disableMayContinue = new Promise<void>((resolve) => {
       releaseDisable = resolve;
     });
-    providerAuthorityStore.faultHooks.beforeProviderAccountDisableUpdate = async () => {
-      signalDisableIntent();
-      await disableMayContinue;
-    };
     const disablePromise = providerAuthorityStore.disableProviderAccount(
       {
         tenantId: TENANT,
@@ -1646,6 +1660,10 @@ describe("connect exchange recovery", () => {
             resourceId: event.resourceId,
             metadata: event.metadata,
           });
+          if (event.action === "provider.account.disable") {
+            signalDisableIntent();
+            await disableMayContinue;
+          }
         },
       },
       accountId,
@@ -1697,7 +1715,6 @@ describe("connect exchange recovery", () => {
       expect(disableActions.map(({ action }) => action)).toEqual(["provider.account.disable"]);
     } finally {
       releaseDisable();
-      providerAuthorityStore.faultHooks = {};
       recovery.restore();
     }
   });

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -30,6 +30,7 @@ import {
   users,
   userTenants,
   workspaces,
+  writeAuditEvent,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { SecretVault } from "@stwd/vault";
@@ -937,6 +938,122 @@ describe("connect exchange recovery", () => {
       .where(eq(providerXCredentialLifecycles.id, staleLifecycle.id));
     expect(revokedLifecycle.state).toBe("revoked");
     expect(revokedLifecycle.credentialSecretId).toBeNull();
+    recovery.restore();
+  });
+
+  test("a staged connect cannot overwrite a newer generic X account without an X adoption anchor", async () => {
+    const store = new MemoryConnectStore();
+    const stagedFake = installFakeX({
+      exchangeToken: {
+        access_token: "access-staged-before-generic",
+        refresh_token: "refresh-staged-before-generic",
+      },
+    });
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store,
+    });
+    __setAfterXCredentialStageForTests(async () => {
+      throw new Error("simulated crash before generic account creation");
+    });
+    await expect(
+      completeXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        callerUserId: ADMIN,
+        code: "auth-code",
+        state: initiated.state,
+        connectToken: initiated.connectToken,
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store,
+        vault,
+      }),
+    ).rejects.toThrow("simulated crash before generic account creation");
+    __setAfterXCredentialStageForTests(null);
+    stagedFake.restore();
+
+    const currentPayload: XCredentialPayload = {
+      schemaVersion: "steward.provider-x.credential.v1",
+      accessToken: "access-current-generic",
+      refreshToken: "refresh-current-generic",
+      scopesGranted: [...X_DEFAULT_SCOPES],
+      xUserId: "1234567890",
+      xUsername: "steward_test",
+      obtainedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 7_200_000).toISOString(),
+    };
+    const currentSecret = await vault.createSecret(
+      TENANT,
+      "provider-x/generic-current-account",
+      JSON.stringify(currentPayload),
+    );
+    const [workspace] = await getDb()
+      .select({ revision: workspaces.revision })
+      .from(workspaces)
+      .where(and(eq(workspaces.tenantId, TENANT), eq(workspaces.id, WORKSPACE)))
+      .limit(1);
+    const genericAccount = await providerAuthorityStore.createProviderAccount(
+      {
+        tenantId: TENANT,
+        actorUserId: ADMIN,
+        tenantRole: "admin",
+        mfaVerifiedAt: Date.now(),
+        idempotencyKey: `generic-x-${crypto.randomUUID()}`,
+        expectedRevision: workspace.revision,
+        reason: "test generic X account interleaving",
+        audit: async (event) => {
+          await writeAuditEvent({
+            tenantId: TENANT,
+            actorType: "user",
+            actorId: ADMIN,
+            action: event.action,
+            resourceType: event.resourceType,
+            resourceId: event.resourceId,
+            metadata: event.metadata,
+          });
+        },
+      },
+      {
+        workspaceId: WORKSPACE,
+        adapterKey: X_ADAPTER_KEY,
+        externalRef: currentPayload.xUserId,
+        displayName: `@${currentPayload.xUsername}`,
+        credentialSecretId: currentSecret.id,
+        credentialVersion: currentSecret.version,
+      },
+    );
+    expect((await readAuditActions(TENANT)).includes("provider.account.create")).toBe(true);
+
+    const recovery = installFakeX({ revokeStatuses: [200] });
+    const swept = await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(Date.now() + 70_000),
+    });
+    expect(swept).toMatchObject({ processed: 1, revoked: 1, adopted: 0, attention: 0 });
+    expect(recovery.counters).toMatchObject({ exchange: 0, identity: 1, revoke: 1 });
+
+    const [accountAfter] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, genericAccount.id));
+    expect(accountAfter).toMatchObject({
+      credentialSecretId: currentSecret.id,
+      credentialVersion: currentSecret.version,
+      revision: genericAccount.revision,
+      status: "active",
+    });
+    expect(await decryptCredential(genericAccount.id)).toEqual(currentPayload);
+    const [stagedLifecycle] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.kind, "connect_exchange"));
+    expect(stagedLifecycle).toMatchObject({ state: "revoked", credentialSecretId: null });
     recovery.restore();
   });
 

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -1226,6 +1226,24 @@ describe("connect exchange recovery", () => {
   test("a staged connect cannot resurrect an account disconnected later", async () => {
     const initial = await connectHappy(new MemoryConnectStore());
     const accountId = initial.completed.providerAccountId;
+    const [connectedAccount] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    const routeId = crypto.randomUUID();
+    await getDb()
+      .insert(secretRoutes)
+      .values({
+        id: routeId,
+        tenantId: TENANT,
+        secretId: connectedAccount.credentialSecretId as string,
+        hostPattern: "api.x.com",
+        pathPattern: "/2/tweets",
+        method: "POST",
+        injectAs: "header",
+        injectKey: "Authorization",
+        injectFormat: "Bearer {value}",
+      });
 
     const staleStore = new MemoryConnectStore();
     const stagedFake = installFakeX({
@@ -1285,6 +1303,19 @@ describe("connect exchange recovery", () => {
       credentialVersion: null,
       status: "revoked",
     });
+    const [secretBeforeRecovery] = await getDb()
+      .select()
+      .from(secrets)
+      .where(eq(secrets.id, connectedAccount.credentialSecretId as string));
+    const [routeBeforeRecovery] = await getDb()
+      .select()
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, routeId));
+    expect(secretBeforeRecovery.deletedAt).not.toBeNull();
+    expect(routeBeforeRecovery).toMatchObject({
+      enabled: false,
+      secretId: connectedAccount.credentialSecretId,
+    });
 
     const recovery = installFakeX({ revokeStatuses: [200] });
     const swept = await runXCredentialLifecycleSweep({
@@ -1305,6 +1336,16 @@ describe("connect exchange recovery", () => {
       revision: accountBeforeRecovery.revision,
       status: accountBeforeRecovery.status,
     });
+    const [secretAfterRecovery] = await getDb()
+      .select()
+      .from(secrets)
+      .where(eq(secrets.id, connectedAccount.credentialSecretId as string));
+    const [routeAfterRecovery] = await getDb()
+      .select()
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, routeId));
+    expect(secretAfterRecovery).toEqual(secretBeforeRecovery);
+    expect(routeAfterRecovery).toEqual(routeBeforeRecovery);
     const liveCredentialLineage = await getDb()
       .select({ id: secrets.id })
       .from(secrets)
@@ -1332,6 +1373,24 @@ describe("connect exchange recovery", () => {
   test("a staged connect cannot re-enable an account disabled by the generic authority path", async () => {
     const initial = await connectHappy(new MemoryConnectStore());
     const accountId = initial.completed.providerAccountId;
+    const [connectedAccount] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    const routeId = crypto.randomUUID();
+    await getDb()
+      .insert(secretRoutes)
+      .values({
+        id: routeId,
+        tenantId: TENANT,
+        secretId: connectedAccount.credentialSecretId as string,
+        hostPattern: "api.x.com",
+        pathPattern: "/2/tweets",
+        method: "POST",
+        injectAs: "header",
+        injectKey: "Authorization",
+        injectFormat: "Bearer {value}",
+      });
 
     const staleStore = new MemoryConnectStore();
     const stagedFake = installFakeX({
@@ -1401,6 +1460,14 @@ describe("connect exchange recovery", () => {
       .from(providerAccounts)
       .where(eq(providerAccounts.id, accountId));
     const credentialBeforeRecovery = await decryptCredential(accountId);
+    const [secretBeforeRecovery] = await getDb()
+      .select()
+      .from(secrets)
+      .where(eq(secrets.id, connectedAccount.credentialSecretId as string));
+    const [routeBeforeRecovery] = await getDb()
+      .select()
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, routeId));
     expect(accountBeforeRecovery).toMatchObject({
       credentialSecretId: accountBeforeDisable.credentialSecretId,
       credentialVersion: accountBeforeDisable.credentialVersion,
@@ -1428,6 +1495,16 @@ describe("connect exchange recovery", () => {
       status: accountBeforeRecovery.status,
     });
     expect(await decryptCredential(accountId)).toEqual(credentialBeforeRecovery);
+    const [secretAfterRecovery] = await getDb()
+      .select()
+      .from(secrets)
+      .where(eq(secrets.id, connectedAccount.credentialSecretId as string));
+    const [routeAfterRecovery] = await getDb()
+      .select()
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, routeId));
+    expect(secretAfterRecovery).toEqual(secretBeforeRecovery);
+    expect(routeAfterRecovery).toEqual(routeBeforeRecovery);
     const [stagedLifecycle] = await getDb()
       .select()
       .from(providerXCredentialLifecycles)

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -1370,6 +1370,89 @@ describe("connect exchange recovery", () => {
     recovery.restore();
   });
 
+  test("recovery ignores a disable intent whose account update never completed", async () => {
+    const initial = await connectHappy(new MemoryConnectStore());
+    const accountId = initial.completed.providerAccountId;
+    const [accountBeforeIntent] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+
+    const staleStore = new MemoryConnectStore();
+    const stagedFake = installFakeX({
+      exchangeToken: {
+        access_token: "access-staged-after-failed-disable",
+        refresh_token: "refresh-staged-after-failed-disable",
+      },
+    });
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store: staleStore,
+    });
+    __setAfterXCredentialStageForTests(async () => {
+      throw new Error("simulated crash before failed generic disable");
+    });
+    await expect(
+      completeXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        callerUserId: ADMIN,
+        code: "auth-code",
+        state: initiated.state,
+        connectToken: initiated.connectToken,
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store: staleStore,
+        vault,
+      }),
+    ).rejects.toThrow("simulated crash before failed generic disable");
+    __setAfterXCredentialStageForTests(null);
+    stagedFake.restore();
+
+    // This is the durable residue left by the old ordering when its separate
+    // account update failed. It is authorization intent, not mutation proof.
+    await writeAuditEvent({
+      tenantId: TENANT,
+      actorType: "user",
+      actorId: ADMIN,
+      action: "provider.account.disable",
+      resourceType: "provider_account",
+      resourceId: accountId,
+      metadata: {
+        workspaceId: WORKSPACE,
+        expectedRevision: accountBeforeIntent.revision,
+        reason: "simulated failed generic disable",
+      },
+    });
+
+    const recovery = installFakeX();
+    const swept = await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(Date.now() + 70_000),
+    });
+    expect(swept).toMatchObject({ processed: 1, adopted: 1, revoked: 0, attention: 0 });
+    const [accountAfterRecovery] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    expect(accountAfterRecovery).toMatchObject({
+      status: "active",
+      revision: accountBeforeIntent.revision + 1,
+      credentialVersion: (accountBeforeIntent.credentialVersion as number) + 1,
+    });
+    expect(await decryptCredential(accountId)).toMatchObject({
+      accessToken: "access-staged-after-failed-disable",
+      refreshToken: "refresh-staged-after-failed-disable",
+    });
+    expect(recovery.counters).toMatchObject({ identity: 1, revoke: 0 });
+    recovery.restore();
+  });
+
   test("a staged connect cannot re-enable an account disabled by the generic authority path", async () => {
     const initial = await connectHappy(new MemoryConnectStore());
     const accountId = initial.completed.providerAccountId;

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -1477,7 +1477,7 @@ describe("connect exchange recovery", () => {
     recovery.restore();
   });
 
-  test("recovery ignores a disable intent whose account update never completed", async () => {
+  test("recovery ignores more than sixteen disable intents whose account updates never completed", async () => {
     const initial = await connectHappy(new MemoryConnectStore());
     const accountId = initial.completed.providerAccountId;
     const [accountBeforeIntent] = await getDb()
@@ -1522,19 +1522,21 @@ describe("connect exchange recovery", () => {
 
     // This is the durable residue left by the old ordering when its separate
     // account update failed. It is authorization intent, not mutation proof.
-    await writeAuditEvent({
-      tenantId: TENANT,
-      actorType: "user",
-      actorId: ADMIN,
-      action: "provider.account.disable",
-      resourceType: "provider_account",
-      resourceId: accountId,
-      metadata: {
-        workspaceId: WORKSPACE,
-        expectedRevision: accountBeforeIntent.revision,
-        reason: "simulated failed generic disable",
-      },
-    });
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      await writeAuditEvent({
+        tenantId: TENANT,
+        actorType: "user",
+        actorId: ADMIN,
+        action: "provider.account.disable",
+        resourceType: "provider_account",
+        resourceId: accountId,
+        metadata: {
+          workspaceId: WORKSPACE,
+          expectedRevision: accountBeforeIntent.revision,
+          reason: `simulated failed generic disable ${attempt}`,
+        },
+      });
+    }
 
     const recovery = installFakeX();
     const swept = await runXCredentialLifecycleSweep({

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -1057,6 +1057,99 @@ describe("connect exchange recovery", () => {
     recovery.restore();
   });
 
+  test("a staged connect cannot overwrite a refresh completed after its exchange intent", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore(), {
+      exchangeToken: {
+        access_token: "access-before-staged-reconnect",
+        refresh_token: "refresh-before-staged-reconnect",
+      },
+    });
+
+    const store = new MemoryConnectStore();
+    const stagedFake = installFakeX({
+      exchangeToken: {
+        access_token: "access-staged-before-refresh",
+        refresh_token: "refresh-staged-before-refresh",
+      },
+    });
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store,
+    });
+    __setAfterXCredentialStageForTests(async () => {
+      throw new Error("simulated crash before concurrent refresh");
+    });
+    await expect(
+      completeXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        callerUserId: ADMIN,
+        code: "auth-code",
+        state: initiated.state,
+        connectToken: initiated.connectToken,
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store,
+        vault,
+      }),
+    ).rejects.toThrow("simulated crash before concurrent refresh");
+    __setAfterXCredentialStageForTests(null);
+    stagedFake.restore();
+
+    const refreshFake = installFakeX({
+      refreshResponses: [
+        {
+          status: 200,
+          body: {
+            access_token: "access-current-refresh",
+            refresh_token: "refresh-current-rotated",
+            scope: "tweet.read tweet.write users.read offline.access",
+            expires_in: 7200,
+          },
+        },
+      ],
+    });
+    const refreshed = await refreshXProviderCredential({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      accountId: completed.providerAccountId,
+      vault,
+      config: CONFIG,
+      force: true,
+    });
+    expect(refreshed.credentialVersion).toBe(2);
+    expect(refreshFake.counters.refresh).toBe(1);
+    refreshFake.restore();
+
+    const recovery = installFakeX({ revokeStatuses: [200] });
+    const swept = await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(Date.now() + 70_000),
+    });
+    expect(swept).toMatchObject({ processed: 1, revoked: 1, adopted: 0, attention: 0 });
+    expect(recovery.counters).toMatchObject({ exchange: 0, identity: 1, revoke: 1 });
+
+    const accountAfter = await decryptCredential(completed.providerAccountId);
+    expect(accountAfter.accessToken).toBe("access-current-refresh");
+    expect(accountAfter.refreshToken).toBe("refresh-current-rotated");
+    const [stagedLifecycle] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.kind, "connect_exchange"),
+          eq(providerXCredentialLifecycles.state, "revoked"),
+        ),
+      );
+    expect(stagedLifecycle.credentialSecretId).toBeNull();
+    recovery.restore();
+  });
+
   test("failed identity revocation is durably retried with backoff and a hard ceiling", async () => {
     const store = new MemoryConnectStore();
     const fake = installFakeX({ identityStatus: 503, revokeStatuses: [503, 503, 503, 503, 503] });

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -34,7 +34,7 @@ import {
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { SecretVault } from "@stwd/vault";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { providerAuthorityStore } from "../services/provider-authority-store";
 import {
   __runDefaultXForwardForTests,
@@ -457,6 +457,58 @@ describe("connect", () => {
     expect(rows.length).toBe(1);
     expect(rows[0].revision).toBe(2);
     expect(rows[0].credentialVersion).toBe(2);
+  });
+
+  test("a fresh connect can re-enable an account disabled before its intent", async () => {
+    const first = await connectHappy(new MemoryConnectStore());
+    const [account] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, first.completed.providerAccountId));
+    await providerAuthorityStore.disableProviderAccount(
+      {
+        tenantId: TENANT,
+        actorUserId: ADMIN,
+        tenantRole: "admin",
+        mfaVerifiedAt: Date.now(),
+        idempotencyKey: `disable-before-connect-${crypto.randomUUID()}`,
+        expectedRevision: account.revision,
+        reason: "test valid reconnect after generic disable",
+        audit: async (event) => {
+          await writeAuditEvent({
+            tenantId: TENANT,
+            actorType: "user",
+            actorId: ADMIN,
+            action: event.action,
+            resourceType: event.resourceType,
+            resourceId: event.resourceId,
+            metadata: event.metadata,
+          });
+        },
+      },
+      account.id,
+    );
+
+    const second = await connectHappy(new MemoryConnectStore(), {
+      exchangeToken: {
+        access_token: "access-after-generic-disable",
+        refresh_token: "refresh-after-generic-disable",
+      },
+    });
+    expect(second.completed).toMatchObject({
+      providerAccountId: account.id,
+      credentialVersion: 2,
+      reconnected: true,
+    });
+    const [reconnected] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, account.id));
+    expect(reconnected).toMatchObject({ status: "active", revision: account.revision + 2 });
+    expect(await decryptCredential(account.id)).toMatchObject({
+      accessToken: "access-after-generic-disable",
+      refreshToken: "refresh-after-generic-disable",
+    });
   });
 });
 
@@ -1057,15 +1109,16 @@ describe("connect exchange recovery", () => {
     recovery.restore();
   });
 
-  test("a staged connect cannot overwrite a refresh completed after its exchange intent", async () => {
-    const { completed } = await connectHappy(new MemoryConnectStore(), {
+  test("a staged connect cannot overwrite a credential rotated by a later refresh", async () => {
+    const initial = await connectHappy(new MemoryConnectStore(), {
       exchangeToken: {
-        access_token: "access-before-staged-reconnect",
-        refresh_token: "refresh-before-staged-reconnect",
+        access_token: "access-before-staged-connect",
+        refresh_token: "refresh-before-staged-connect",
       },
     });
+    const accountId = initial.completed.providerAccountId;
 
-    const store = new MemoryConnectStore();
+    const staleStore = new MemoryConnectStore();
     const stagedFake = installFakeX({
       exchangeToken: {
         access_token: "access-staged-before-refresh",
@@ -1078,10 +1131,10 @@ describe("connect exchange recovery", () => {
       initiatedByUserId: ADMIN,
       redirectUri: REDIRECT,
       config: CONFIG,
-      store,
+      store: staleStore,
     });
     __setAfterXCredentialStageForTests(async () => {
-      throw new Error("simulated crash before concurrent refresh");
+      throw new Error("simulated crash before the newer refresh");
     });
     await expect(
       completeXConnect({
@@ -1093,10 +1146,10 @@ describe("connect exchange recovery", () => {
         connectToken: initiated.connectToken,
         redirectUri: REDIRECT,
         config: CONFIG,
-        store,
+        store: staleStore,
         vault,
       }),
-    ).rejects.toThrow("simulated crash before concurrent refresh");
+    ).rejects.toThrow("simulated crash before the newer refresh");
     __setAfterXCredentialStageForTests(null);
     stagedFake.restore();
 
@@ -1105,25 +1158,37 @@ describe("connect exchange recovery", () => {
         {
           status: 200,
           body: {
-            access_token: "access-current-refresh",
-            refresh_token: "refresh-current-rotated",
+            access_token: "access-current-after-refresh",
+            refresh_token: "refresh-current-after-refresh",
             scope: "tweet.read tweet.write users.read offline.access",
             expires_in: 7200,
           },
         },
       ],
     });
-    const refreshed = await refreshXProviderCredential({
-      tenantId: TENANT,
-      workspaceId: WORKSPACE,
-      accountId: completed.providerAccountId,
-      vault,
-      config: CONFIG,
-      force: true,
-    });
-    expect(refreshed.credentialVersion).toBe(2);
+    await expect(
+      refreshXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId,
+        vault,
+        config: CONFIG,
+        actorId: ADMIN,
+        force: true,
+      }),
+    ).resolves.toMatchObject({ refreshed: true, credentialVersion: 2 });
     expect(refreshFake.counters.refresh).toBe(1);
     refreshFake.restore();
+
+    const [accountBeforeRecovery] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    const credentialBeforeRecovery = await decryptCredential(accountId);
+    expect(credentialBeforeRecovery).toMatchObject({
+      accessToken: "access-current-after-refresh",
+      refreshToken: "refresh-current-after-refresh",
+    });
 
     const recovery = installFakeX({ revokeStatuses: [200] });
     const swept = await runXCredentialLifecycleSweep({
@@ -1132,11 +1197,19 @@ describe("connect exchange recovery", () => {
       now: new Date(Date.now() + 70_000),
     });
     expect(swept).toMatchObject({ processed: 1, revoked: 1, adopted: 0, attention: 0 });
-    expect(recovery.counters).toMatchObject({ exchange: 0, identity: 1, revoke: 1 });
+    expect(recovery.counters).toMatchObject({ exchange: 0, identity: 1, refresh: 0, revoke: 1 });
 
-    const accountAfter = await decryptCredential(completed.providerAccountId);
-    expect(accountAfter.accessToken).toBe("access-current-refresh");
-    expect(accountAfter.refreshToken).toBe("refresh-current-rotated");
+    const [accountAfterRecovery] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    expect(accountAfterRecovery).toMatchObject({
+      credentialSecretId: accountBeforeRecovery.credentialSecretId,
+      credentialVersion: accountBeforeRecovery.credentialVersion,
+      revision: accountBeforeRecovery.revision,
+      status: accountBeforeRecovery.status,
+    });
+    expect(await decryptCredential(accountId)).toEqual(credentialBeforeRecovery);
     const [stagedLifecycle] = await getDb()
       .select()
       .from(providerXCredentialLifecycles)
@@ -1146,7 +1219,225 @@ describe("connect exchange recovery", () => {
           eq(providerXCredentialLifecycles.state, "revoked"),
         ),
       );
-    expect(stagedLifecycle.credentialSecretId).toBeNull();
+    expect(stagedLifecycle).toMatchObject({ providerAccountId: null, credentialSecretId: null });
+    recovery.restore();
+  });
+
+  test("a staged connect cannot resurrect an account disconnected later", async () => {
+    const initial = await connectHappy(new MemoryConnectStore());
+    const accountId = initial.completed.providerAccountId;
+
+    const staleStore = new MemoryConnectStore();
+    const stagedFake = installFakeX({
+      exchangeToken: {
+        access_token: "access-staged-before-disconnect",
+        refresh_token: "refresh-staged-before-disconnect",
+      },
+    });
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store: staleStore,
+    });
+    __setAfterXCredentialStageForTests(async () => {
+      throw new Error("simulated crash before the newer disconnect");
+    });
+    await expect(
+      completeXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        callerUserId: ADMIN,
+        code: "auth-code",
+        state: initiated.state,
+        connectToken: initiated.connectToken,
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store: staleStore,
+        vault,
+      }),
+    ).rejects.toThrow("simulated crash before the newer disconnect");
+    __setAfterXCredentialStageForTests(null);
+    stagedFake.restore();
+
+    const disconnectFake = installFakeX({ revokeStatuses: [200] });
+    await expect(
+      disconnectXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId,
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).resolves.toMatchObject({ providerAccountId: accountId, revoked: true });
+    expect(disconnectFake.counters.revoke).toBe(1);
+    disconnectFake.restore();
+
+    const [accountBeforeRecovery] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    expect(accountBeforeRecovery).toMatchObject({
+      credentialSecretId: null,
+      credentialVersion: null,
+      status: "revoked",
+    });
+
+    const recovery = installFakeX({ revokeStatuses: [200] });
+    const swept = await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(Date.now() + 70_000),
+    });
+    expect(swept).toMatchObject({ processed: 1, revoked: 1, adopted: 0, attention: 0 });
+    expect(recovery.counters).toMatchObject({ exchange: 0, identity: 1, refresh: 0, revoke: 1 });
+
+    const [accountAfterRecovery] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    expect(accountAfterRecovery).toMatchObject({
+      credentialSecretId: accountBeforeRecovery.credentialSecretId,
+      credentialVersion: accountBeforeRecovery.credentialVersion,
+      revision: accountBeforeRecovery.revision,
+      status: accountBeforeRecovery.status,
+    });
+    const liveCredentialLineage = await getDb()
+      .select({ id: secrets.id })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.tenantId, TENANT),
+          eq(secrets.name, xCredentialSecretName(WORKSPACE, "1234567890")),
+          sql`${secrets.deletedAt} IS NULL`,
+        ),
+      );
+    expect(liveCredentialLineage).toEqual([]);
+    const [stagedLifecycle] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.kind, "connect_exchange"),
+          eq(providerXCredentialLifecycles.state, "revoked"),
+        ),
+      );
+    expect(stagedLifecycle).toMatchObject({ providerAccountId: null, credentialSecretId: null });
+    recovery.restore();
+  });
+
+  test("a staged connect cannot re-enable an account disabled by the generic authority path", async () => {
+    const initial = await connectHappy(new MemoryConnectStore());
+    const accountId = initial.completed.providerAccountId;
+
+    const staleStore = new MemoryConnectStore();
+    const stagedFake = installFakeX({
+      exchangeToken: {
+        access_token: "access-staged-before-disable",
+        refresh_token: "refresh-staged-before-disable",
+      },
+    });
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store: staleStore,
+    });
+    __setAfterXCredentialStageForTests(async () => {
+      throw new Error("simulated crash before the generic disable");
+    });
+    await expect(
+      completeXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        callerUserId: ADMIN,
+        code: "auth-code",
+        state: initiated.state,
+        connectToken: initiated.connectToken,
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store: staleStore,
+        vault,
+      }),
+    ).rejects.toThrow("simulated crash before the generic disable");
+    __setAfterXCredentialStageForTests(null);
+    stagedFake.restore();
+
+    const [accountBeforeDisable] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    await providerAuthorityStore.disableProviderAccount(
+      {
+        tenantId: TENANT,
+        actorUserId: ADMIN,
+        tenantRole: "admin",
+        mfaVerifiedAt: Date.now(),
+        idempotencyKey: `disable-x-${crypto.randomUUID()}`,
+        expectedRevision: accountBeforeDisable.revision,
+        reason: "test staged connect and generic disable interleaving",
+        audit: async (event) => {
+          await writeAuditEvent({
+            tenantId: TENANT,
+            actorType: "user",
+            actorId: ADMIN,
+            action: event.action,
+            resourceType: event.resourceType,
+            resourceId: event.resourceId,
+            metadata: event.metadata,
+          });
+        },
+      },
+      accountId,
+    );
+
+    const [accountBeforeRecovery] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    const credentialBeforeRecovery = await decryptCredential(accountId);
+    expect(accountBeforeRecovery).toMatchObject({
+      credentialSecretId: accountBeforeDisable.credentialSecretId,
+      credentialVersion: accountBeforeDisable.credentialVersion,
+      revision: accountBeforeDisable.revision + 1,
+      status: "disabled",
+    });
+
+    const recovery = installFakeX({ revokeStatuses: [200] });
+    const swept = await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(Date.now() + 70_000),
+    });
+    expect(swept).toMatchObject({ processed: 1, revoked: 1, adopted: 0, attention: 0 });
+    expect(recovery.counters).toMatchObject({ exchange: 0, identity: 1, refresh: 0, revoke: 1 });
+
+    const [accountAfterRecovery] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    expect(accountAfterRecovery).toMatchObject({
+      credentialSecretId: accountBeforeRecovery.credentialSecretId,
+      credentialVersion: accountBeforeRecovery.credentialVersion,
+      revision: accountBeforeRecovery.revision,
+      status: accountBeforeRecovery.status,
+    });
+    expect(await decryptCredential(accountId)).toEqual(credentialBeforeRecovery);
+    const [stagedLifecycle] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.kind, "connect_exchange"),
+          eq(providerXCredentialLifecycles.state, "revoked"),
+        ),
+      );
+    expect(stagedLifecycle).toMatchObject({ providerAccountId: null, credentialSecretId: null });
     recovery.restore();
   });
 

--- a/packages/api/src/__tests__/tenant-cors-preflight.test.ts
+++ b/packages/api/src/__tests__/tenant-cors-preflight.test.ts
@@ -27,6 +27,15 @@ describe("tenant CORS preflight", () => {
         tenantId: "cors-patch-tenant",
         allowedOrigins: [ALLOWED_ORIGIN],
       });
+    await getDb().insert(tenants).values({
+      id: "cors-empty-tenant",
+      name: "CORS empty tenant",
+      apiKeyHash: "cors-empty-tenant-hash",
+    });
+    await getDb().insert(tenantConfigs).values({
+      tenantId: "cors-empty-tenant",
+      allowedOrigins: [],
+    });
   });
 
   afterAll(async () => {
@@ -76,6 +85,24 @@ describe("tenant CORS preflight", () => {
     expect(response.status).toBe(403);
     expect(response.headers.get("access-control-allow-origin")).toBeNull();
     expect(response.headers.get("access-control-allow-credentials")).toBeNull();
+    expect(response.headers.get("vary")).toBe("Origin, X-Steward-Tenant");
+  });
+
+  test("keeps an explicitly empty tenant allowlist fail closed", async () => {
+    const app = new Hono();
+    app.use("*", tenantCors);
+
+    const response = await app.request("/resource", {
+      method: "OPTIONS",
+      headers: {
+        Origin: ALLOWED_ORIGIN,
+        "X-Steward-Tenant": "cors-empty-tenant",
+        "Access-Control-Request-Method": "PATCH",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
     expect(response.headers.get("vary")).toBe("Origin, X-Steward-Tenant");
   });
 });

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -390,7 +390,12 @@ export class ProviderAuthorityStore {
   ) {}
   /** Test-only race hooks. Runtime callers never set these. */
   faultHooks: Partial<
-    Record<"afterBudgetPreflight" | "afterOperationRoutePreflight", () => void | Promise<void>>
+    Record<
+      | "afterBudgetPreflight"
+      | "afterOperationRoutePreflight"
+      | "beforeProviderAccountDisableUpdate",
+      () => void | Promise<void>
+    >
   > = {};
 
   private db() {
@@ -843,29 +848,44 @@ export class ProviderAuthorityStore {
         reason: ctx.reason,
       },
     });
-    const [updated] = await this.db()
-      .update(providerAccounts)
-      .set({
-        status: "disabled",
-        revision: row.revision + 1,
-        updatedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(providerAccounts.id, id),
-          eq(providerAccounts.tenantId, ctx.tenantId),
-          eq(providerAccounts.workspaceId, row.workspaceId),
-          eq(providerAccounts.revision, row.revision),
-        ),
-      )
-      .returning();
-    if (!updated)
-      throw new ProviderAuthorityError(
-        "provider account revision conflict",
-        "revision_conflict",
-        409,
-      );
-    return updated;
+    await this.faultHooks.beforeProviderAccountDisableUpdate?.();
+    return this.runAuditedTransaction(ctx.tenantId, async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as DbExecutor;
+      const [updated] = await tx
+        .update(providerAccounts)
+        .set({
+          status: "disabled",
+          revision: row.revision + 1,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(providerAccounts.id, id),
+            eq(providerAccounts.tenantId, ctx.tenantId),
+            eq(providerAccounts.workspaceId, row.workspaceId),
+            eq(providerAccounts.revision, row.revision),
+          ),
+        )
+        .returning();
+      if (!updated)
+        throw new ProviderAuthorityError(
+          "provider account revision conflict",
+          "revision_conflict",
+          409,
+        );
+      await appendAuthorityMutationAudit(ctx, appendRequiredAudit, {
+        action: "provider.account.disable.completed",
+        resourceType: "provider_account",
+        resourceId: id,
+        metadata: {
+          workspaceId: row.workspaceId,
+          expectedRevision: row.revision,
+          resultingRevision: updated.revision,
+          reason: ctx.reason,
+        },
+      });
+      return updated;
+    });
   }
 
   async registerOperation(

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -851,19 +851,34 @@ export class ProviderAuthorityStore {
     await this.faultHooks.beforeProviderAccountDisableUpdate?.();
     return this.runAuditedTransaction(ctx.tenantId, async (txRaw, appendRequiredAudit) => {
       const tx = txRaw as DbExecutor;
+      const [lockedRow] = await tx
+        .select()
+        .from(providerAccounts)
+        .where(and(eq(providerAccounts.id, id), eq(providerAccounts.tenantId, ctx.tenantId)))
+        .limit(1)
+        .for("update");
+      if (!lockedRow) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+      await this.requireWorkspaceAdmin(ctx, lockedRow.workspaceId, true, tx);
+      if (lockedRow.revision !== ctx.expectedRevision) {
+        throw new ProviderAuthorityError(
+          "provider account revision conflict",
+          "revision_conflict",
+          409,
+        );
+      }
       const [updated] = await tx
         .update(providerAccounts)
         .set({
           status: "disabled",
-          revision: row.revision + 1,
+          revision: lockedRow.revision + 1,
           updatedAt: new Date(),
         })
         .where(
           and(
             eq(providerAccounts.id, id),
             eq(providerAccounts.tenantId, ctx.tenantId),
-            eq(providerAccounts.workspaceId, row.workspaceId),
-            eq(providerAccounts.revision, row.revision),
+            eq(providerAccounts.workspaceId, lockedRow.workspaceId),
+            eq(providerAccounts.revision, lockedRow.revision),
           ),
         )
         .returning();
@@ -878,8 +893,8 @@ export class ProviderAuthorityStore {
         resourceType: "provider_account",
         resourceId: id,
         metadata: {
-          workspaceId: row.workspaceId,
-          expectedRevision: row.revision,
+          workspaceId: lockedRow.workspaceId,
+          expectedRevision: lockedRow.revision,
           resultingRevision: updated.revision,
           reason: ctx.reason,
         },

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -390,12 +390,7 @@ export class ProviderAuthorityStore {
   ) {}
   /** Test-only race hooks. Runtime callers never set these. */
   faultHooks: Partial<
-    Record<
-      | "afterBudgetPreflight"
-      | "afterOperationRoutePreflight"
-      | "beforeProviderAccountDisableUpdate",
-      () => void | Promise<void>
-    >
+    Record<"afterBudgetPreflight" | "afterOperationRoutePreflight", () => void | Promise<void>>
   > = {};
 
   private db() {
@@ -848,7 +843,6 @@ export class ProviderAuthorityStore {
         reason: ctx.reason,
       },
     });
-    await this.faultHooks.beforeProviderAccountDisableUpdate?.();
     return this.runAuditedTransaction(ctx.tenantId, async (txRaw, appendRequiredAudit) => {
       const tx = txRaw as DbExecutor;
       const [lockedRow] = await tx

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -1143,7 +1143,7 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
             .orderBy(desc(auditEvents.seq))
             .limit(1)
         : [];
-    const accountMutationCandidates =
+    const [latestAccountMutation] =
       account && connectIntentAudit
         ? await tx
             .select({
@@ -1167,26 +1167,23 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
                   "provider.account.disable",
                   "provider.account.disable.completed",
                 ]),
+                sql`(
+                  ${auditEvents.action} <> 'provider.account.disable'
+                  OR (
+                    ${account.status === "disabled"}
+                    AND ${auditEvents.metadata}->>'expectedRevision' = ${String(account.revision - 1)}
+                  )
+                )`,
               ),
             )
             .orderBy(desc(auditEvents.seq))
-            .limit(16)
+            .limit(1)
         : [];
     // Before provider.account.disable.completed existed, a successful generic
     // disable left only its authorization event. Treat that legacy event as
     // authoritative only when the currently locked row proves the exact CAS
     // landed. A newer orphan intent from an update failure/CAS loss is skipped
     // so it cannot manufacture durable recovery lineage.
-    const latestAccountMutation = accountMutationCandidates.find((event) => {
-      if (event.action !== "provider.account.disable") return true;
-      const expectedRevision = event.metadata.expectedRevision;
-      return (
-        account?.status === "disabled" &&
-        typeof expectedRevision === "number" &&
-        Number.isSafeInteger(expectedRevision) &&
-        account.revision === expectedRevision + 1
-      );
-    });
     // An existing account is only safe to rotate when its current credential
     // has an authoritative X-connect adoption before this intent. A generic
     // provider-account insert (or a selectively missing adoption record) gives

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -1103,7 +1103,7 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
     const [latestConnectAdoption] =
       account && connectIntentAudit
         ? await tx
-            .select({ id: auditEvents.id, seq: auditEvents.seq })
+            .select({ id: auditEvents.id })
             .from(auditEvents)
             .where(
               and(
@@ -1131,10 +1131,38 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
         "current X account adoption lineage cannot be established",
       );
     }
+    const [latestAccountLineageChange] =
+      account && connectIntentAudit
+        ? await tx
+            .select({ seq: auditEvents.seq })
+            .from(auditEvents)
+            .where(
+              and(
+                eq(auditEvents.tenantId, input.tenantId),
+                eq(auditEvents.resourceType, "provider_account"),
+                eq(auditEvents.resourceId, account.id),
+                inArray(auditEvents.action, [
+                  "provider.account.disable",
+                  "provider.x.connect.completed",
+                  "provider.x.connect.reconnected",
+                  "provider.x.disconnect.completed",
+                  "provider.x.refresh.completed",
+                  "provider.x.refresh.needs_attention",
+                  "provider.x.refresh.revoked",
+                ]),
+              ),
+            )
+            .orderBy(desc(auditEvents.seq))
+            .limit(1)
+        : [];
+    // A refresh, disconnect, disable, or second connect can all replace the
+    // credential/status lineage without leaving an unresolved lifecycle. The
+    // staged grant is safe only when no such account mutation follows its
+    // exchange intent on the serialized tenant audit chain.
     if (
-      latestConnectAdoption &&
+      latestAccountLineageChange &&
       connectIntentAudit &&
-      latestConnectAdoption.seq >= connectIntentAudit.seq
+      latestAccountLineageChange.seq >= connectIntentAudit.seq
     ) {
       throw new XConnectError(
         "X_CREDENTIAL_NEEDS_ATTENTION",

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -1143,7 +1143,7 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
             .orderBy(desc(auditEvents.seq))
             .limit(1)
         : [];
-    const [latestAccountMutation] =
+    const accountMutationCandidates =
       account && connectIntentAudit
         ? await tx
             .select({
@@ -1164,13 +1164,29 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
                   "provider.x.refresh.needs_attention",
                   "provider.x.refresh.revoked",
                   "provider.x.disconnect.completed",
+                  "provider.account.disable",
                   "provider.account.disable.completed",
                 ]),
               ),
             )
             .orderBy(desc(auditEvents.seq))
-            .limit(1)
+            .limit(16)
         : [];
+    // Before provider.account.disable.completed existed, a successful generic
+    // disable left only its authorization event. Treat that legacy event as
+    // authoritative only when the currently locked row proves the exact CAS
+    // landed. A newer orphan intent from an update failure/CAS loss is skipped
+    // so it cannot manufacture durable recovery lineage.
+    const latestAccountMutation = accountMutationCandidates.find((event) => {
+      if (event.action !== "provider.account.disable") return true;
+      const expectedRevision = event.metadata.expectedRevision;
+      return (
+        account?.status === "disabled" &&
+        typeof expectedRevision === "number" &&
+        Number.isSafeInteger(expectedRevision) &&
+        account.revision === expectedRevision + 1
+      );
+    });
     // An existing account is only safe to rotate when its current credential
     // has an authoritative X-connect adoption before this intent. A generic
     // provider-account insert (or a selectively missing adoption record) gives
@@ -1223,7 +1239,8 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
         const expectedStatus =
           latestAccountMutation.action === "provider.x.refresh.revoked"
             ? "revoked"
-            : latestAccountMutation.action === "provider.account.disable.completed" ||
+            : latestAccountMutation.action === "provider.account.disable" ||
+                latestAccountMutation.action === "provider.account.disable.completed" ||
                 (latestAccountMutation.action === "provider.x.refresh.needs_attention" &&
                   latestAccountMutation.metadata.accountDisabled === true)
               ? "disabled"
@@ -1264,7 +1281,10 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
             "current X account credential lineage cannot be established",
           );
         }
-        if (latestAccountMutation.action === "provider.account.disable.completed") {
+        if (
+          latestAccountMutation.action === "provider.account.disable" ||
+          latestAccountMutation.action === "provider.account.disable.completed"
+        ) {
           const disabledRevision = latestAccountMutation.metadata.expectedRevision;
           if (
             typeof disabledRevision !== "number" ||

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -1164,7 +1164,7 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
                   "provider.x.refresh.needs_attention",
                   "provider.x.refresh.revoked",
                   "provider.x.disconnect.completed",
-                  "provider.account.disable",
+                  "provider.account.disable.completed",
                 ]),
               ),
             )
@@ -1223,7 +1223,7 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
         const expectedStatus =
           latestAccountMutation.action === "provider.x.refresh.revoked"
             ? "revoked"
-            : latestAccountMutation.action === "provider.account.disable" ||
+            : latestAccountMutation.action === "provider.account.disable.completed" ||
                 (latestAccountMutation.action === "provider.x.refresh.needs_attention" &&
                   latestAccountMutation.metadata.accountDisabled === true)
               ? "disabled"
@@ -1264,7 +1264,7 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
             "current X account credential lineage cannot be established",
           );
         }
-        if (latestAccountMutation.action === "provider.account.disable") {
+        if (latestAccountMutation.action === "provider.account.disable.completed") {
           const disabledRevision = latestAccountMutation.metadata.expectedRevision;
           if (
             typeof disabledRevision !== "number" ||

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -1119,6 +1119,58 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
             .orderBy(desc(auditEvents.seq))
             .limit(1)
         : [];
+    const [latestCredentialAdoption] =
+      account && connectIntentAudit
+        ? await tx
+            .select({
+              action: auditEvents.action,
+              metadata: auditEvents.metadata,
+              seq: auditEvents.seq,
+            })
+            .from(auditEvents)
+            .where(
+              and(
+                eq(auditEvents.tenantId, input.tenantId),
+                eq(auditEvents.resourceType, "provider_account"),
+                eq(auditEvents.resourceId, account.id),
+                inArray(auditEvents.action, [
+                  "provider.x.connect.completed",
+                  "provider.x.connect.reconnected",
+                  "provider.x.refresh.completed",
+                ]),
+              ),
+            )
+            .orderBy(desc(auditEvents.seq))
+            .limit(1)
+        : [];
+    const [latestAccountMutation] =
+      account && connectIntentAudit
+        ? await tx
+            .select({
+              action: auditEvents.action,
+              metadata: auditEvents.metadata,
+              seq: auditEvents.seq,
+            })
+            .from(auditEvents)
+            .where(
+              and(
+                eq(auditEvents.tenantId, input.tenantId),
+                eq(auditEvents.resourceType, "provider_account"),
+                eq(auditEvents.resourceId, account.id),
+                inArray(auditEvents.action, [
+                  "provider.x.connect.completed",
+                  "provider.x.connect.reconnected",
+                  "provider.x.refresh.completed",
+                  "provider.x.refresh.needs_attention",
+                  "provider.x.refresh.revoked",
+                  "provider.x.disconnect.completed",
+                  "provider.account.disable",
+                ]),
+              ),
+            )
+            .orderBy(desc(auditEvents.seq))
+            .limit(1)
+        : [];
     // An existing account is only safe to rotate when its current credential
     // has an authoritative X-connect adoption before this intent. A generic
     // provider-account insert (or a selectively missing adoption record) gives
@@ -1131,44 +1183,102 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
         "current X account adoption lineage cannot be established",
       );
     }
-    const [latestAccountLineageChange] =
-      account && connectIntentAudit
-        ? await tx
-            .select({ seq: auditEvents.seq })
-            .from(auditEvents)
-            .where(
-              and(
-                eq(auditEvents.tenantId, input.tenantId),
-                eq(auditEvents.resourceType, "provider_account"),
-                eq(auditEvents.resourceId, account.id),
-                inArray(auditEvents.action, [
-                  "provider.account.disable",
-                  "provider.x.connect.completed",
-                  "provider.x.connect.reconnected",
-                  "provider.x.disconnect.completed",
-                  "provider.x.refresh.completed",
-                  "provider.x.refresh.needs_attention",
-                  "provider.x.refresh.revoked",
-                ]),
-              ),
-            )
-            .orderBy(desc(auditEvents.seq))
-            .limit(1)
-        : [];
     // A refresh, disconnect, disable, or second connect can all replace the
     // credential/status lineage without leaving an unresolved lifecycle. The
     // staged grant is safe only when no such account mutation follows its
     // exchange intent on the serialized tenant audit chain.
     if (
-      latestAccountLineageChange &&
+      latestAccountMutation &&
       connectIntentAudit &&
-      latestAccountLineageChange.seq >= connectIntentAudit.seq
+      latestAccountMutation.seq >= connectIntentAudit.seq
     ) {
       throw new XConnectError(
         "X_CREDENTIAL_NEEDS_ATTENTION",
         409,
-        "a newer X credential already superseded this staged connect response",
+        "a newer X account mutation already superseded this staged connect response",
       );
+    }
+
+    if (account && latestAccountMutation && latestCredentialAdoption) {
+      const adoptionVersion = latestCredentialAdoption.metadata.credentialVersion;
+      const accountHasCredential =
+        typeof account.credentialSecretId === "string" &&
+        account.credentialSecretId.length > 0 &&
+        Number.isSafeInteger(account.credentialVersion) &&
+        (account.credentialVersion as number) > 0;
+      const disconnected = latestAccountMutation.action === "provider.x.disconnect.completed";
+      if (disconnected) {
+        if (
+          account.status !== "revoked" ||
+          account.credentialSecretId !== null ||
+          account.credentialVersion !== null
+        ) {
+          throw new XConnectError(
+            "X_CREDENTIAL_NEEDS_ATTENTION",
+            409,
+            "current X account state does not match its disconnect lineage",
+          );
+        }
+      } else {
+        const expectedStatus =
+          latestAccountMutation.action === "provider.x.refresh.revoked"
+            ? "revoked"
+            : latestAccountMutation.action === "provider.account.disable" ||
+                (latestAccountMutation.action === "provider.x.refresh.needs_attention" &&
+                  latestAccountMutation.metadata.accountDisabled === true)
+              ? "disabled"
+              : "active";
+        const [currentCredential] = accountHasCredential
+          ? await tx
+              .select({
+                id: secrets.id,
+                name: secrets.name,
+                version: secrets.version,
+              })
+              .from(secrets)
+              .where(
+                and(
+                  eq(secrets.tenantId, input.tenantId),
+                  eq(secrets.id, account.credentialSecretId as string),
+                  eq(secrets.version, account.credentialVersion as number),
+                  sql`${secrets.deletedAt} IS NULL`,
+                ),
+              )
+              .limit(1)
+              .for("update")
+          : [];
+        if (
+          account.status !== expectedStatus ||
+          !currentCredential ||
+          currentCredential.name !== secretName ||
+          typeof adoptionVersion !== "number" ||
+          !Number.isSafeInteger(adoptionVersion) ||
+          adoptionVersion !== account.credentialVersion ||
+          ((latestCredentialAdoption.action === "provider.x.connect.completed" ||
+            latestCredentialAdoption.action === "provider.x.connect.reconnected") &&
+            latestCredentialAdoption.metadata.credentialSecretId !== account.credentialSecretId)
+        ) {
+          throw new XConnectError(
+            "X_CREDENTIAL_NEEDS_ATTENTION",
+            409,
+            "current X account credential lineage cannot be established",
+          );
+        }
+        if (latestAccountMutation.action === "provider.account.disable") {
+          const disabledRevision = latestAccountMutation.metadata.expectedRevision;
+          if (
+            typeof disabledRevision !== "number" ||
+            !Number.isSafeInteger(disabledRevision) ||
+            account.revision < disabledRevision + 1
+          ) {
+            throw new XConnectError(
+              "X_CREDENTIAL_NEEDS_ATTENTION",
+              409,
+              "current X account disable lineage cannot be established",
+            );
+          }
+        }
+      }
     }
 
     const unresolvedLifecycles = account

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -1100,10 +1100,10 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
         "staged X connect lineage cannot be established",
       );
     }
-    const [newerConnectAdoption] =
+    const [latestConnectAdoption] =
       account && connectIntentAudit
         ? await tx
-            .select({ id: auditEvents.id })
+            .select({ id: auditEvents.id, seq: auditEvents.seq })
             .from(auditEvents)
             .where(
               and(
@@ -1114,13 +1114,28 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
                   "provider.x.connect.completed",
                   "provider.x.connect.reconnected",
                 ]),
-                sql`${auditEvents.seq} > ${connectIntentAudit.seq}`,
               ),
             )
             .orderBy(desc(auditEvents.seq))
             .limit(1)
         : [];
-    if (newerConnectAdoption) {
+    // An existing account is only safe to rotate when its current credential
+    // has an authoritative X-connect adoption before this intent. A generic
+    // provider-account insert (or a selectively missing adoption record) gives
+    // us no total-order proof that the staged response is newer, so fail closed
+    // and let the outer reconciler revoke the staged grant.
+    if (account && !latestConnectAdoption) {
+      throw new XConnectError(
+        "X_CREDENTIAL_NEEDS_ATTENTION",
+        409,
+        "current X account adoption lineage cannot be established",
+      );
+    }
+    if (
+      latestConnectAdoption &&
+      connectIntentAudit &&
+      latestConnectAdoption.seq >= connectIntentAudit.seq
+    ) {
       throw new XConnectError(
         "X_CREDENTIAL_NEEDS_ATTENTION",
         409,


### PR DESCRIPTION
Refs #475
Refs #195

## Summary

- require authoritative X connect/reconnect adoption before rotating an existing X provider account
- preserve generic-disable recovery lineage across rolling deployments: new disables commit state plus `provider.account.disable.completed` atomically, while legacy intent counts only when the locked account proves the exact disabled revision landed
- skip arbitrarily long runs of orphan disable intents left by update failure or CAS loss without letting them hide a later authoritative refresh or disconnect
- exercise failure and race paths through the existing audited-transaction and audit dependencies without adding another mutable production test hook
- lock and revalidate the tenant-scoped account, exact revision, and workspace authority inside the audited disable transaction
- order staged recovery against later connect, refresh, disconnect, and generic-disable mutations; fail closed and revoke staged OAuth grants when lineage is stale or inconsistent
- run the deterministic recovery/disable interleaving against real Postgres in both PR and develop CI
- retain the shared behavioral empty-allowlist CORS correction

This closes the post-merge recovery gaps in #475 without breaking legacy successful disables during rolling deployment.

## Exact-head validation

Exact head: `468ca6562dc85c9236a5bb2b32abb007d8ce371d`

Exact tree: `3e734d30b2a5b4e0cc0604f8bec81250ee342cac`

Exact base: `9239a728b9ca28175e00e2825f69d85f3e02856e`

- provider X connect/recovery + provider authority: 84/84 tests, 491 assertions
- real-Postgres disable/recovery concurrency: 1/1 test, 5 assertions
- provider-authority disable subset is hermetic with per-test authority fixtures: isolated 5/5, 14 assertions; full suite 19/19, 66 assertions
- deterministic coverage: completion atomicity; update failure; completion-audit rollback; CAS loss; workspace-authority TOCTOU; legacy landed disable; orphan intent including more than sixteen newer failures; a completed refresh hidden behind seventeen later orphan intents; hermetic isolated disable tests; recovery/disable concurrency
- tenant CORS preflight: 3/3 tests, 13 assertions
- middleware security hardening: 8/8 tests, 68 assertions
- dependency-aware `@stwd/api...` build: 24/24 packages
- Biome on all changed TypeScript files: clean
- actionlint on both changed workflows: clean
- `git diff --check origin/develop`: clean

The PR remains draft pending hosted exact-head CI and independent review.
