### PR TITLE
ci: bootstrap trusted wallet E2E dispatcher

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,6 +74,7 @@ jobs:
           # consumes NUL-delimited filenames so hostile names cannot bypass the
           # package check.
           bun test scripts/__tests__/check-public-package-metadata.test.ts
+          bun test scripts/__tests__/wallet-e2e-authorization.test.ts
           bun scripts/check-public-package-metadata.ts "$BASE_SHA" "$HEAD_SHA"
 
       - name: Check PR title

--- a/.github/workflows/wallet-e2e.yml
+++ b/.github/workflows/wallet-e2e.yml
@@ -146,10 +146,11 @@ jobs:
                     (.started_at | type) == "string" and
                     (.started_at | length) > 0) and
                   (($matches | map(.id) | unique | length) == ($matches | length)) and
-                  ($matches |
-                    max_by([.started_at, (.completed_at // ""), .id])) as $latest |
-                  $latest.status == "completed" and
-                  $latest.conclusion == "success") and
+                  ($matches | map(.started_at) | max) as $latest_started_at |
+                  ([$matches[] | select(.started_at == $latest_started_at)]) as $latest |
+                  ($latest | length) == 1 and
+                  $latest[0].status == "completed" and
+                  $latest[0].conclusion == "success") and
                 all($status_contexts[];
                   . as $context |
                   ([$commit_statuses[] | select(.context == $context)]) as $matches |

--- a/.github/workflows/wallet-e2e.yml
+++ b/.github/workflows/wallet-e2e.yml
@@ -1,0 +1,95 @@
+name: Wallet E2E (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Exact reviewed Steward commit to exercise
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wallet-e2e-manual
+  cancel-in-progress: false
+
+jobs:
+  authorize-target:
+    name: Validate exact target
+    runs-on: ubuntu-latest
+    outputs:
+      target_sha: ${{ steps.target.outputs.target_sha }}
+    steps:
+      - name: Require the trusted default-branch dispatcher
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+        id: target
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/develop" ]; then
+            echo "Wallet E2E must be dispatched from develop" >&2
+            exit 1
+          fi
+          if [[ ! "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "target_sha must be a full lowercase commit SHA" >&2
+            exit 1
+          fi
+          echo "target_sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
+
+  wallet-e2e:
+    name: MetaMask SIWE + Phantom SIWS (${{ needs.authorize-target.outputs.target_sha }})
+    if: github.ref == 'refs/heads/develop'
+    needs: authorize-target
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    environment: wallet-e2e
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          ref: ${{ needs.authorize-target.outputs.target_sha }}
+
+      - name: Verify exact checkout
+        env:
+          TARGET_SHA: ${{ needs.authorize-target.outputs.target_sha }}
+        run: test "$(git rev-parse HEAD)" = "$TARGET_SHA"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build embedded API runtime dependencies
+        run: bunx turbo run build --filter=@stwd/api...
+
+      - name: Install Chromium and Linux browser dependencies
+        run: bunx playwright install --with-deps chromium
+
+      - name: Fail closed when wallet credentials are not provisioned
+        env: &wallet-credentials
+          E2E_METAMASK_SEED_PHRASE: ${{ secrets.E2E_METAMASK_SEED_PHRASE }}
+          E2E_METAMASK_PASSWORD: ${{ secrets.E2E_METAMASK_PASSWORD }}
+          E2E_PHANTOM_SEED_PHRASE: ${{ secrets.E2E_PHANTOM_SEED_PHRASE }}
+          E2E_PHANTOM_PASSWORD: ${{ secrets.E2E_PHANTOM_PASSWORD }}
+        run: bun run test:e2e:wallets:preflight
+
+      - name: Verify wallet spec collection
+        run: bun run test:e2e:wallets:list
+
+      - name: Build isolated wallet-extension profiles
+        env: *wallet-credentials
+        run: xvfb-run -a bun run test:e2e:wallets:cache
+
+      - name: Run real wallet authentication flows
+        env: *wallet-credentials
+        run: xvfb-run -a bun run test:e2e:wallets
+
+      - name: Remove wallet profiles and test artifacts
+        if: always()
+        run: bun run test:e2e:wallets:cleanup

--- a/.github/workflows/wallet-e2e.yml
+++ b/.github/workflows/wallet-e2e.yml
@@ -39,9 +39,11 @@ jobs:
           fi
           target_pr="$({
             gh api \
+              --paginate \
+              --slurp \
               -H "Accept: application/vnd.github+json" \
               "repos/$GITHUB_REPOSITORY/commits/$TARGET_SHA/pulls"
-          } | jq -r \
+          } | jq -r 'add' | jq -r \
             --arg repository "$GITHUB_REPOSITORY" \
             --arg sha "$TARGET_SHA" \
             '[.[] | select(
@@ -56,20 +58,71 @@ jobs:
             exit 1
           fi
           IFS=$'\t' read -r pr_number pr_author <<< "$target_pr"
-          approved_by="$({
+
+          readiness="$({
+            gh pr view "$pr_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json headRefOid,isDraft,state,mergeStateStatus,reviewDecision,statusCheckRollup
+          })"
+          if ! jq -e \
+            --arg sha "$TARGET_SHA" \
+            '.headRefOid == $sha and
+             .state == "OPEN" and
+             .isDraft == false and
+             .mergeStateStatus == "CLEAN" and
+             .reviewDecision == "APPROVED" and
+             (.statusCheckRollup | length > 0) and
+             all(.statusCheckRollup[];
+               if .__typename == "CheckRun" then
+                 .status == "COMPLETED" and
+                 (.conclusion == "SUCCESS" or .conclusion == "NEUTRAL" or .conclusion == "SKIPPED")
+               elif .__typename == "StatusContext" then
+                 .state == "SUCCESS"
+               else
+                 false
+               end)' <<< "$readiness" >/dev/null; then
+            echo "target PR must be approved, conflict-free, and green at the exact target SHA" >&2
+            exit 1
+          fi
+
+          latest_reviews="$({
             gh api \
+              --paginate \
+              --slurp \
               -H "Accept: application/vnd.github+json" \
               "repos/$GITHUB_REPOSITORY/pulls/$pr_number/reviews"
-          } | jq -r \
+          } | jq -r 'add' | jq -r \
             --arg author "$pr_author" \
             --arg sha "$TARGET_SHA" \
-            '[.[] | select(
-              .state == "APPROVED" and
-              .commit_id == $sha and
-              .user.login != $author
-            )] | last | .user.login // empty')"
+            '[.[] | select(.commit_id == $sha)] |
+             sort_by(.submitted_at, .id) |
+             group_by(.user.login | ascii_downcase) |
+             map(last) |
+             .[] |
+             select(
+               .state == "APPROVED" and
+               .user.type == "User" and
+               (.user.login | ascii_downcase) != ($author | ascii_downcase)
+             ) |
+             .user.login')"
+          approved_by=""
+          while IFS= read -r reviewer; do
+            [ -n "$reviewer" ] || continue
+            permission="$(
+              gh api \
+                -H "Accept: application/vnd.github+json" \
+                "repos/$GITHUB_REPOSITORY/collaborators/$reviewer/permission" \
+                --jq '.permission' 2>/dev/null || true
+            )"
+            case "$permission" in
+              admin|maintain|write)
+                approved_by="$reviewer"
+                break
+                ;;
+            esac
+          done <<< "$latest_reviews"
           if [ -z "$approved_by" ]; then
-            echo "target PR must have an independent APPROVED review" >&2
+            echo "target PR must have a current approval from an independent write-capable reviewer" >&2
             exit 1
           fi
           echo "target_sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/wallet-e2e.yml
+++ b/.github/workflows/wallet-e2e.yml
@@ -65,7 +65,7 @@ jobs:
           readiness="$({
             gh pr view "$pr_number" \
               --repo "$GITHUB_REPOSITORY" \
-              --json headRefOid,isDraft,state,mergeStateStatus,reviewDecision,statusCheckRollup
+              --json headRefOid,isDraft,state,mergeStateStatus,reviewDecision
           })"
           if ! jq -e \
             --arg sha "$TARGET_SHA" \
@@ -73,18 +73,98 @@ jobs:
              .state == "OPEN" and
              .isDraft == false and
              .mergeStateStatus == "CLEAN" and
-             .reviewDecision == "APPROVED" and
-             (.statusCheckRollup | length > 0) and
-             all(.statusCheckRollup[];
-               if .__typename == "CheckRun" then
-                 .status == "COMPLETED" and
-                 (.conclusion == "SUCCESS" or .conclusion == "NEUTRAL" or .conclusion == "SKIPPED")
-               elif .__typename == "StatusContext" then
-                 .state == "SUCCESS"
-               else
-                 false
-               end)' <<< "$readiness" >/dev/null; then
-            echo "target PR must be approved, conflict-free, and green at the exact target SHA" >&2
+             .reviewDecision == "APPROVED"' <<< "$readiness" >/dev/null; then
+            echo "target PR must be approved and conflict-free at the exact target SHA" >&2
+            exit 1
+          fi
+
+          required_file="$(mktemp)"
+          check_runs_file="$(mktemp)"
+          statuses_file="$(mktemp)"
+          trap 'rm -f "$required_file" "$check_runs_file" "$statuses_file"' EXIT
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/$GITHUB_REPOSITORY/branches/develop/protection/required_status_checks" \
+            > "$required_file"
+          gh api \
+            --paginate \
+            --slurp \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/$GITHUB_REPOSITORY/commits/$TARGET_SHA/check-runs?filter=latest&per_page=100" \
+            | jq '[.[] | .check_runs[]]' > "$check_runs_file"
+          gh api \
+            --paginate \
+            --slurp \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/$GITHUB_REPOSITORY/commits/$TARGET_SHA/statuses?per_page=100" \
+            | jq 'add // []' > "$statuses_file"
+          if ! jq -n -e \
+            --arg sha "$TARGET_SHA" \
+            --slurpfile protection "$required_file" \
+            --slurpfile check_runs "$check_runs_file" \
+            --slurpfile statuses "$statuses_file" \
+            '
+              ($protection[0]) as $policy |
+              if
+                ($policy | type) != "object" or
+                (($policy.checks // []) | type) != "array" or
+                (($policy.contexts // []) | type) != "array" or
+                (($check_runs[0]) | type) != "array" or
+                (($statuses[0]) | type) != "array"
+              then false
+              else
+                ($policy.checks // []) as $required_checks |
+                ($policy.contexts // []) as $required_contexts |
+                ($required_checks | map(.context)) as $pinned_contexts |
+                ($required_contexts |
+                  map(. as $context |
+                    select(($pinned_contexts | index($context)) == null))) as $status_contexts |
+                ($check_runs[0]) as $runs |
+                ($statuses[0]) as $commit_statuses |
+                (($required_checks | length) + ($status_contexts | length) > 0) and
+                all($required_checks[];
+                  (.context | type) == "string" and
+                  (.context | length) > 0 and
+                  (.app_id | type) == "number") and
+                all($required_contexts[];
+                  type == "string" and length > 0) and
+                (($pinned_contexts | unique | length) == ($pinned_contexts | length)) and
+                (($required_contexts | unique | length) == ($required_contexts | length)) and
+                all($required_checks[];
+                  . as $required |
+                  ([$runs[] | select(
+                    .head_sha == $sha and
+                    .name == $required.context and
+                    .app.id == $required.app_id
+                  )]) as $matches |
+                  ($matches | length) > 0 and
+                  all($matches[];
+                    (.id | type) == "number" and
+                    (.started_at | type) == "string" and
+                    (.started_at | length) > 0) and
+                  (($matches | map(.id) | unique | length) == ($matches | length)) and
+                  ($matches |
+                    max_by([.started_at, (.completed_at // ""), .id])) as $latest |
+                  $latest.status == "completed" and
+                  $latest.conclusion == "success") and
+                all($status_contexts[];
+                  . as $context |
+                  ([$commit_statuses[] | select(.context == $context)]) as $matches |
+                  ($matches | length) > 0 and
+                  all($matches[];
+                    (.id | type) == "number" and
+                    (.created_at | type) == "string" and
+                    (.created_at | length) > 0) and
+                  (($matches | map(.id) | unique | length) == ($matches | length)) and
+                  ($matches |
+                    max_by([.created_at, (.updated_at // ""), .id]) |
+                    .state) == "success")
+              end
+            ' >/dev/null; then
+            echo "every required develop check must have a latest exact successful result from its configured app" >&2
             exit 1
           fi
 
@@ -127,6 +207,9 @@ jobs:
             echo "target PR must have a current approval from an independent write-capable reviewer" >&2
             exit 1
           fi
+          # The configured app authenticates the check producer, not the workflow definition.
+          # Exact-head approval by an independent write-capable reviewer is the trust gate for
+          # target-controlled workflow changes that could reuse a required job name.
           echo "target_sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
           echo "Authorized PR #$pr_number at $TARGET_SHA after approval by $approved_by"
 

--- a/.github/workflows/wallet-e2e.yml
+++ b/.github/workflows/wallet-e2e.yml
@@ -85,7 +85,7 @@ jobs:
           gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "repos/$GITHUB_REPOSITORY/branches/develop/protection/required_status_checks" \
+            "repos/$GITHUB_REPOSITORY/branches/develop" \
             > "$required_file"
           gh api \
             --paginate \
@@ -107,7 +107,7 @@ jobs:
             --slurpfile check_runs "$check_runs_file" \
             --slurpfile statuses "$statuses_file" \
             '
-              ($protection[0]) as $policy |
+              ($protection[0].protection.required_status_checks) as $policy |
               if
                 ($policy | type) != "object" or
                 (($policy.checks // []) | type) != "array" or

--- a/.github/workflows/wallet-e2e.yml
+++ b/.github/workflows/wallet-e2e.yml
@@ -9,8 +9,10 @@ on:
         type: string
 
 permissions:
+  checks: read
   contents: read
   pull-requests: read
+  statuses: read
 
 concurrency:
   group: wallet-e2e-manual
@@ -95,9 +97,8 @@ jobs:
             --arg author "$pr_author" \
             --arg sha "$TARGET_SHA" \
             '[.[] | select(.commit_id == $sha)] |
-             sort_by(.submitted_at, .id) |
              group_by(.user.login | ascii_downcase) |
-             map(last) |
+             map(sort_by(.submitted_at, .id) | last) |
              .[] |
              select(
                .state == "APPROVED" and

--- a/.github/workflows/wallet-e2e.yml
+++ b/.github/workflows/wallet-e2e.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: wallet-e2e-manual
@@ -24,6 +25,7 @@ jobs:
     steps:
       - name: Require the trusted default-branch dispatcher
         env:
+          GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ inputs.target_sha }}
         id: target
         run: |
@@ -35,7 +37,43 @@ jobs:
             echo "target_sha must be a full lowercase commit SHA" >&2
             exit 1
           fi
+          target_pr="$({
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/$GITHUB_REPOSITORY/commits/$TARGET_SHA/pulls"
+          } | jq -r \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg sha "$TARGET_SHA" \
+            '[.[] | select(
+              .state == "open" and
+              .draft == false and
+              .base.ref == "develop" and
+              .head.repo.full_name == $repository and
+              .head.sha == $sha
+            )] | if length == 1 then .[0] else empty end | [.number, .user.login] | @tsv')"
+          if [ -z "$target_pr" ]; then
+            echo "target_sha must be the exact head of one ready same-repository PR targeting develop" >&2
+            exit 1
+          fi
+          IFS=$'\t' read -r pr_number pr_author <<< "$target_pr"
+          approved_by="$({
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/$GITHUB_REPOSITORY/pulls/$pr_number/reviews"
+          } | jq -r \
+            --arg author "$pr_author" \
+            --arg sha "$TARGET_SHA" \
+            '[.[] | select(
+              .state == "APPROVED" and
+              .commit_id == $sha and
+              .user.login != $author
+            )] | last | .user.login // empty')"
+          if [ -z "$approved_by" ]; then
+            echo "target PR must have an independent APPROVED review" >&2
+            exit 1
+          fi
           echo "target_sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
+          echo "Authorized PR #$pr_number at $TARGET_SHA after approval by $approved_by"
 
   wallet-e2e:
     name: MetaMask SIWE + Phantom SIWS (${{ needs.authorize-target.outputs.target_sha }})
@@ -92,4 +130,4 @@ jobs:
 
       - name: Remove wallet profiles and test artifacts
         if: always()
-        run: bun run test:e2e:wallets:cleanup
+        run: cd web && bun run e2e:wallets:cleanup

--- a/.github/workflows/wallet-e2e.yml
+++ b/.github/workflows/wallet-e2e.yml
@@ -266,7 +266,9 @@ jobs:
         run: xvfb-run -a bun run test:e2e:wallets:cache
 
       - name: Run real wallet authentication flows
-        env: *wallet-credentials
+        env:
+          E2E_METAMASK_PASSWORD: ${{ secrets.E2E_METAMASK_PASSWORD }}
+          E2E_PHANTOM_PASSWORD: ${{ secrets.E2E_PHANTOM_PASSWORD }}
         run: xvfb-run -a bun run test:e2e:wallets
 
       - name: Remove wallet profiles and test artifacts

--- a/.github/workflows/wallet-e2e.yml
+++ b/.github/workflows/wallet-e2e.yml
@@ -8,11 +8,7 @@ on:
         required: true
         type: string
 
-permissions:
-  checks: read
-  contents: read
-  pull-requests: read
-  statuses: read
+permissions: {}
 
 concurrency:
   group: wallet-e2e-manual
@@ -22,6 +18,11 @@ jobs:
   authorize-target:
     name: Validate exact target
     runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+      pull-requests: read
+      statuses: read
     outputs:
       target_sha: ${{ steps.target.outputs.target_sha }}
     steps:
@@ -136,6 +137,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
     environment: wallet-e2e
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/packages/api/src/__tests__/middleware-security-hardening.test.ts
+++ b/packages/api/src/__tests__/middleware-security-hardening.test.ts
@@ -56,7 +56,6 @@ describe("middleware security hardening", () => {
     // an unset NODE_ENV must fail closed like production.
     expect(tenantCorsSource).toContain("function devWildcardAllowed()");
     expect(tenantCorsSource).toContain('env === "development" || env === "test"');
-    expect(tenantCorsSource).toContain("origins.length === 0");
     expect(tenantCorsSource).toContain("return c.newResponse(null, 403)");
     expect(tenantCorsSource).toContain("TENANT_ID_RE.test(tenantId)");
     expect(tenantCorsSource).toContain("MAX_CORS_CACHE_ENTRIES");

--- a/packages/api/src/__tests__/tenant-cors-preflight.test.ts
+++ b/packages/api/src/__tests__/tenant-cors-preflight.test.ts
@@ -27,6 +27,15 @@ describe("tenant CORS preflight", () => {
         tenantId: "cors-patch-tenant",
         allowedOrigins: [ALLOWED_ORIGIN],
       });
+    await getDb().insert(tenants).values({
+      id: "cors-empty-tenant",
+      name: "CORS empty tenant",
+      apiKeyHash: "cors-empty-tenant-hash",
+    });
+    await getDb().insert(tenantConfigs).values({
+      tenantId: "cors-empty-tenant",
+      allowedOrigins: [],
+    });
   });
 
   afterAll(async () => {
@@ -76,6 +85,24 @@ describe("tenant CORS preflight", () => {
     expect(response.status).toBe(403);
     expect(response.headers.get("access-control-allow-origin")).toBeNull();
     expect(response.headers.get("access-control-allow-credentials")).toBeNull();
+    expect(response.headers.get("vary")).toBe("Origin, X-Steward-Tenant");
+  });
+
+  test("keeps an explicitly empty tenant allowlist fail closed", async () => {
+    const app = new Hono();
+    app.use("*", tenantCors);
+
+    const response = await app.request("/resource", {
+      method: "OPTIONS",
+      headers: {
+        Origin: ALLOWED_ORIGIN,
+        "X-Steward-Tenant": "cors-empty-tenant",
+        "Access-Control-Request-Method": "PATCH",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
     expect(response.headers.get("vary")).toBe("Origin, X-Steward-Tenant");
   });
 });

--- a/packages/api/src/__tests__/worker-boot-validation.test.ts
+++ b/packages/api/src/__tests__/worker-boot-validation.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { afterEach, describe, expect, it } from "bun:test";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import worker from "../worker";
 
 /**
@@ -23,6 +24,7 @@ const MANAGED_KEYS = [
   "STEWARD_DB_MODE",
   "STEWARD_PGLITE_MEMORY",
   "AGENT_TOKEN_EXPIRY",
+  "STEWARD_OIDC_JWKS_MAX_AGE_MS",
 ] as const;
 
 describe("workers boot JWT env validation (SEC-134)", () => {
@@ -91,25 +93,75 @@ describe("workers boot JWT env validation (SEC-134)", () => {
 
   it("validates concurrent request bindings before either database selection", async () => {
     snapshotEnv();
-    const shortSecret = worker.fetch(
-      new Request("https://workers.test/short-secret"),
-      { NODE_ENV: "production", STEWARD_JWT_SECRET: "short", DATABASE_DRIVER: "bogus" },
-      {},
-    );
-    const malformedExpiry = worker.fetch(
-      new Request("https://workers.test/malformed-expiry"),
-      {
-        STEWARD_JWT_SECRET: "workers-boot-test-secret-32-chars-long!!",
-        AGENT_TOKEN_EXPIRY: "not-a-duration",
-        DATABASE_DRIVER: "bogus",
-      },
-      {},
-    );
+    const shortSecret = expect(
+      worker.fetch(
+        new Request("https://workers.test/short-secret"),
+        { NODE_ENV: "production", STEWARD_JWT_SECRET: "short", DATABASE_DRIVER: "bogus" },
+        {},
+      ),
+    ).rejects.toThrow("at least 32 characters in production");
+    const malformedExpiry = expect(
+      worker.fetch(
+        new Request("https://workers.test/malformed-expiry"),
+        {
+          STEWARD_JWT_SECRET: "workers-boot-test-secret-32-chars-long!!",
+          AGENT_TOKEN_EXPIRY: "not-a-duration",
+          DATABASE_DRIVER: "bogus",
+        },
+        {},
+      ),
+    ).rejects.toThrow('AGENT_TOKEN_EXPIRY "not-a-duration" is not a valid positive duration');
 
-    await expect(shortSecret).rejects.toThrow("at least 32 characters in production");
-    await expect(malformedExpiry).rejects.toThrow(
-      'AGENT_TOKEN_EXPIRY "not-a-duration" is not a valid positive duration',
-    );
+    await Promise.all([shortSecret, malformedExpiry]);
+  });
+
+  it("keeps nested Worker request snapshots isolated from missing global values", async () => {
+    snapshotEnv();
+    process.env.STEWARD_OIDC_JWKS_MAX_AGE_MS = "global-poison";
+    const secret = "workers-runtime-snapshot-secret-at-least-32-chars";
+    let nestedRejection: Promise<void> | undefined;
+    const nestedContext = Object.defineProperty({}, "waitUntil", {
+      get() {
+        throw new Error(
+          `nested snapshot: ${String(runtimeEnvironmentValue("STEWARD_OIDC_JWKS_MAX_AGE_MS"))}`,
+        );
+      },
+    });
+    const firstContext = Object.defineProperty({}, "waitUntil", {
+      get() {
+        const nestedRequest = worker.fetch(
+          new Request("https://workers.test/runtime-snapshot-missing"),
+          { STEWARD_JWT_SECRET: secret, DATABASE_DRIVER: "bogus" },
+          nestedContext,
+        );
+        nestedRejection = nestedRequest.then(
+          () => {
+            throw new Error("nested Worker request unexpectedly succeeded");
+          },
+          (error) => {
+            expect(String(error)).toContain("nested snapshot: undefined");
+          },
+        );
+        throw new Error(
+          `first snapshot: ${String(runtimeEnvironmentValue("STEWARD_OIDC_JWKS_MAX_AGE_MS"))}`,
+        );
+      },
+    });
+
+    const firstRejection = expect(
+      worker.fetch(
+        new Request("https://workers.test/runtime-snapshot-first"),
+        {
+          STEWARD_JWT_SECRET: secret,
+          STEWARD_OIDC_JWKS_MAX_AGE_MS: "60000",
+          DATABASE_DRIVER: "bogus",
+        },
+        firstContext,
+      ),
+    ).rejects.toThrow("first snapshot: 60000");
+    await firstRejection;
+    if (!nestedRejection) throw new Error("nested Worker request did not run");
+    await nestedRejection;
   });
 
   it("validates scheduled security bindings before opening any database handle", async () => {

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -47,6 +47,7 @@ import {
   type NeonTransactionDbHandle,
   withRequestDatabase,
 } from "@stwd/db";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { initRedis } from "./middleware/redis";
 
 export interface Env {
@@ -378,39 +379,43 @@ async function getComposedApp() {
 
 export default {
   async fetch(request: Request, env: Env, ctx: unknown): Promise<Response> {
-    // SEC-148: refresh process.env from the CURRENT request's bindings on every
-    // request (not once per isolate) so rotated bindings take effect promptly;
-    // the once-per-isolate init below only bootstraps stores/imports.
-    hydrateProcessEnv(env);
-    validateWorkerSecurityEnv();
-    const executionCtx = ctx as { waitUntil?: (promise: Promise<unknown>) => void };
-    const waitUntil =
-      typeof executionCtx?.waitUntil === "function"
-        ? executionCtx.waitUntil.bind(executionCtx)
-        : undefined;
-    return withWorkerRequestDatabase(
-      env,
-      async () => {
-        await ensureWorkerInit(env);
-        const app = await getComposedApp();
-        return app.fetch(request, env, ctx as never);
-      },
-      waitUntil ? { waitUntil } : undefined,
-    );
+    return withRuntimeEnvironment({ ...env, STEWARD_RUNTIME: "workers" }, async () => {
+      // Keep the legacy bridge for modules not yet migrated to request-local
+      // configuration. Security-sensitive OIDC settings use the immutable
+      // snapshot above and cannot be replaced by an overlapping request.
+      hydrateProcessEnv(env);
+      validateWorkerSecurityEnv();
+      const executionCtx = ctx as { waitUntil?: (promise: Promise<unknown>) => void };
+      const waitUntil =
+        typeof executionCtx?.waitUntil === "function"
+          ? executionCtx.waitUntil.bind(executionCtx)
+          : undefined;
+      return withWorkerRequestDatabase(
+        env,
+        async () => {
+          await ensureWorkerInit(env);
+          const app = await getComposedApp();
+          return app.fetch(request, env, ctx as never);
+        },
+        waitUntil ? { waitUntil } : undefined,
+      );
+    });
   },
   async scheduled(
     _controller: unknown,
     env: Env,
     ctx: { waitUntil(promise: Promise<unknown>): void },
   ) {
-    hydrateProcessEnv(env);
-    validateWorkerSecurityEnv();
-    ctx.waitUntil(
-      Promise.all([
-        withWorkerRequestDatabase(env, () => runWorkerUpstreamCredentialLeaseSweep(env)),
-        withWorkerRequestDatabase(env, () => runWorkerGoogleCredentialLifecycleSweep(env)),
-        withWorkerRequestDatabase(env, () => runWorkerXCredentialLifecycleSweep(env)),
-      ]),
-    );
+    withRuntimeEnvironment({ ...env, STEWARD_RUNTIME: "workers" }, () => {
+      hydrateProcessEnv(env);
+      validateWorkerSecurityEnv();
+      ctx.waitUntil(
+        Promise.all([
+          withWorkerRequestDatabase(env, () => runWorkerUpstreamCredentialLeaseSweep(env)),
+          withWorkerRequestDatabase(env, () => runWorkerGoogleCredentialLifecycleSweep(env)),
+          withWorkerRequestDatabase(env, () => runWorkerXCredentialLifecycleSweep(env)),
+        ]),
+      );
+    });
   },
 };

--- a/packages/auth/src/__tests__/oidc.test.ts
+++ b/packages/auth/src/__tests__/oidc.test.ts
@@ -19,8 +19,11 @@ class JwksTransportHarness {
   requestDestroyed = false;
   requestEnded = false;
   responseResumed = false;
+  responseDestroyed = false;
   timeoutMs: number | undefined;
   lookupCalls = 0;
+  requestLookup: LookupFunction | undefined;
+  readonly lookup = (() => {}) as LookupFunction;
   private responseHandler: ((response: IncomingMessage) => void) | undefined;
   private deadlineCallbacks = new Map<ReturnType<typeof setTimeout>, () => void>();
 
@@ -43,12 +46,13 @@ class JwksTransportHarness {
     ) => {
       this.requestCalls += 1;
       this.timeoutMs = options.timeout as number | undefined;
+      this.requestLookup = options.lookup;
       this.responseHandler = handler;
       return this.request;
     }) as PublicJwksTransportDependencies["request"],
     createLookup: ((_resource: string) => {
       this.lookupCalls += 1;
-      return (() => {}) as LookupFunction;
+      return this.lookup;
     }) as PublicJwksTransportDependencies["createLookup"],
     setDeadline: (callback, _timeoutMs) => {
       const deadline = Object.create(null) as ReturnType<typeof setTimeout>;
@@ -71,6 +75,10 @@ class JwksTransportHarness {
       this.responseResumed = true;
       return response;
     }) as IncomingMessage["resume"];
+    response.destroy = (() => {
+      this.responseDestroyed = true;
+      return response;
+    }) as IncomingMessage["destroy"];
     this.responseHandler(response);
     return response;
   }
@@ -101,10 +109,28 @@ describe("assertPublicJwksDestination SSRF guard", () => {
     expect(await result.text()).toBe('{"error":"unauthorized"}');
     expect(harness.timeoutMs).toBe(1234);
     expect(harness.lookupCalls).toBe(1);
+    expect(harness.requestLookup).toBe(harness.lookup);
     expect(harness.requestEnded).toBe(true);
     expect(harness.deadlines.size).toBe(0);
     controller.abort();
     expect(harness.requestDestroyed).toBe(false);
+  });
+
+  it("drops non-conforming upstream bytes for bodyless success statuses", async () => {
+    for (const status of [204, 205]) {
+      const harness = new JwksTransportHarness();
+      const pending = createPublicJwksTransport(harness.dependencies)(
+        "https://idp.example.com/jwks",
+      );
+      const response = harness.respond(status);
+      response.emit("data", Buffer.from("hostile-body"));
+      response.emit("end");
+
+      const result = await pending;
+      expect(result.status).toBe(status);
+      expect(await result.text()).toBe("");
+      expect(harness.deadlines.size).toBe(0);
+    }
   });
 
   it("rejects redirects and oversized declared or streamed bodies", async () => {
@@ -132,10 +158,10 @@ describe("assertPublicJwksDestination SSRF guard", () => {
       response.emit("data", Buffer.alloc(1024));
       response.emit("end");
       expect(harness.deadlines.size).toBe(0);
+      expect(harness.requestDestroyed).toBe(true);
       if (testCase.status === 302 || "content-length" in testCase.headers) {
-        expect(harness.responseResumed).toBe(true);
-      } else {
-        expect(harness.requestDestroyed).toBe(true);
+        expect(harness.responseDestroyed).toBe(true);
+        expect(harness.responseResumed).toBe(false);
       }
     }
   });

--- a/packages/auth/src/__tests__/oidc.test.ts
+++ b/packages/auth/src/__tests__/oidc.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import { EventEmitter } from "node:events";
 import type { ClientRequest, IncomingMessage, RequestOptions } from "node:http";
 import type { RequestOptions as HttpsRequestOptions } from "node:https";
 import type { LookupFunction } from "node:net";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 
 import {
   assertPublicJwksDestination,
@@ -20,6 +21,7 @@ class JwksTransportHarness {
   requestEnded = false;
   responseResumed = false;
   responseDestroyed = false;
+  destroyError: Error | undefined;
   timeoutMs: number | undefined;
   lookupCalls = 0;
   requestLookup: LookupFunction | undefined;
@@ -30,6 +32,7 @@ class JwksTransportHarness {
   constructor() {
     this.request.destroy = (() => {
       this.requestDestroyed = true;
+      if (this.destroyError) throw this.destroyError;
       return this.request;
     }) as ClientRequest["destroy"];
     this.request.end = (() => {
@@ -77,6 +80,7 @@ class JwksTransportHarness {
     }) as IncomingMessage["resume"];
     response.destroy = (() => {
       this.responseDestroyed = true;
+      if (this.destroyError) throw this.destroyError;
       return response;
     }) as IncomingMessage["destroy"];
     this.responseHandler(response);
@@ -164,6 +168,16 @@ describe("assertPublicJwksDestination SSRF guard", () => {
         expect(harness.responseResumed).toBe(false);
       }
     }
+  });
+
+  it("preserves fixed terminal errors when best-effort socket destruction throws", async () => {
+    const harness = new JwksTransportHarness();
+    harness.destroyError = new Error("injected destroy detail");
+    const pending = createPublicJwksTransport(harness.dependencies)("https://idp.example.com/jwks");
+    expect(() => harness.respond(302)).not.toThrow();
+    await expect(pending).rejects.toThrow("OIDC jwksUri redirects are not allowed");
+    expect(harness.responseDestroyed).toBe(true);
+    expect(harness.requestDestroyed).toBe(true);
   });
 
   it("rejects deadline, request timeout, and request failure", async () => {
@@ -313,5 +327,30 @@ describe("assertPublicJwksDestination SSRF guard", () => {
     const reloaded = await getPublicRemoteJWKSet("https://idp.example.com/jwks", "tenant:first");
     expect(reloaded).not.toBe(first);
     clearOidcJwksCacheForTests();
+  });
+
+  it("applies the request-local JWKS maximum age to each cache decision", async () => {
+    clearOidcJwksCacheForTests();
+    let now = 1_000_000;
+    const nowSpy = spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      const first = await withRuntimeEnvironment({ STEWARD_OIDC_JWKS_MAX_AGE_MS: "60000" }, () =>
+        getPublicRemoteJWKSet("https://idp.example.com/jwks", "tenant:runtime-age"),
+      );
+      now += 60_001;
+      const retained = await withRuntimeEnvironment(
+        { STEWARD_OIDC_JWKS_MAX_AGE_MS: "120000" },
+        () => getPublicRemoteJWKSet("https://idp.example.com/jwks", "tenant:runtime-age"),
+      );
+      expect(retained).toBe(first);
+
+      const rebuilt = await withRuntimeEnvironment({ STEWARD_OIDC_JWKS_MAX_AGE_MS: "60000" }, () =>
+        getPublicRemoteJWKSet("https://idp.example.com/jwks", "tenant:runtime-age"),
+      );
+      expect(rebuilt).not.toBe(first);
+    } finally {
+      nowSpy.mockRestore();
+      clearOidcJwksCacheForTests();
+    }
   });
 });

--- a/packages/auth/src/__tests__/oidc.test.ts
+++ b/packages/auth/src/__tests__/oidc.test.ts
@@ -1,21 +1,217 @@
 import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
+import { EventEmitter } from "node:events";
+import type { ClientRequest, IncomingMessage, RequestOptions } from "node:http";
+import type { RequestOptions as HttpsRequestOptions } from "node:https";
+import type { LookupFunction } from "node:net";
 
 import {
   assertPublicJwksDestination,
   clearOidcJwksCacheForTests,
+  createPublicJwksTransport,
   getPublicRemoteJWKSet,
+  type PublicJwksTransportDependencies,
 } from "../oidc";
 
+class JwksTransportHarness {
+  readonly request = new EventEmitter() as ClientRequest;
+  readonly deadlines = new Set<ReturnType<typeof setTimeout>>();
+  requestCalls = 0;
+  requestDestroyed = false;
+  requestEnded = false;
+  responseResumed = false;
+  timeoutMs: number | undefined;
+  lookupCalls = 0;
+  private responseHandler: ((response: IncomingMessage) => void) | undefined;
+  private deadlineCallbacks = new Map<ReturnType<typeof setTimeout>, () => void>();
+
+  constructor() {
+    this.request.destroy = (() => {
+      this.requestDestroyed = true;
+      return this.request;
+    }) as ClientRequest["destroy"];
+    this.request.end = (() => {
+      this.requestEnded = true;
+      return this.request;
+    }) as ClientRequest["end"];
+  }
+
+  readonly dependencies: Readonly<PublicJwksTransportDependencies> = Object.freeze({
+    request: ((
+      _url: URL,
+      options: RequestOptions | HttpsRequestOptions,
+      handler: (response: IncomingMessage) => void,
+    ) => {
+      this.requestCalls += 1;
+      this.timeoutMs = options.timeout as number | undefined;
+      this.responseHandler = handler;
+      return this.request;
+    }) as PublicJwksTransportDependencies["request"],
+    createLookup: ((_resource: string) => {
+      this.lookupCalls += 1;
+      return (() => {}) as LookupFunction;
+    }) as PublicJwksTransportDependencies["createLookup"],
+    setDeadline: (callback, _timeoutMs) => {
+      const deadline = Object.create(null) as ReturnType<typeof setTimeout>;
+      this.deadlines.add(deadline);
+      this.deadlineCallbacks.set(deadline, callback);
+      return deadline;
+    },
+    clearDeadline: (deadline) => {
+      this.deadlines.delete(deadline);
+      this.deadlineCallbacks.delete(deadline);
+    },
+  });
+
+  respond(statusCode: number, headers: IncomingMessage["headers"] = {}): EventEmitter {
+    if (!this.responseHandler) throw new Error("request was not created");
+    const response = new EventEmitter() as EventEmitter & IncomingMessage;
+    response.statusCode = statusCode;
+    response.headers = headers;
+    response.resume = (() => {
+      this.responseResumed = true;
+      return response;
+    }) as IncomingMessage["resume"];
+    this.responseHandler(response);
+    return response;
+  }
+
+  fireDeadline(): void {
+    const callback = this.deadlineCallbacks.values().next().value;
+    if (!callback) throw new Error("deadline was not scheduled");
+    callback();
+  }
+}
+
 describe("assertPublicJwksDestination SSRF guard", () => {
-  it("preserves HTTP status and bounds all production JWKS I/O", () => {
-    const source = readFileSync(new URL("../oidc.ts", import.meta.url), "utf8");
-    expect(source).toContain("status: result.status");
-    expect(source).toContain('res.headers["content-length"]');
-    expect(source).toContain("size > JWKS_MAX_BYTES");
-    expect(source).toContain("init?.signal?.addEventListener");
-    expect(source).toContain("JWKS_FETCH_TIMEOUT_MS");
-    expect(source).toContain("OIDC jwksUri redirects are not allowed");
+  it("preserves upstream status, headers, and body and cleans up request resources", async () => {
+    const harness = new JwksTransportHarness();
+    const transport = createPublicJwksTransport(harness.dependencies, {
+      timeoutMs: 1234,
+      maxBytes: 32,
+    });
+    const controller = new AbortController();
+    const pending = transport("https://idp.example.com/jwks", { signal: controller.signal });
+    const response = harness.respond(401, { "content-type": "application/json" });
+    response.emit("data", Buffer.from('{"error":"unauthorized"}'));
+    response.emit("end");
+
+    const result = await pending;
+    expect(result.status).toBe(401);
+    expect(result.headers.get("content-type")).toBe("application/json");
+    expect(await result.text()).toBe('{"error":"unauthorized"}');
+    expect(harness.timeoutMs).toBe(1234);
+    expect(harness.lookupCalls).toBe(1);
+    expect(harness.requestEnded).toBe(true);
+    expect(harness.deadlines.size).toBe(0);
+    controller.abort();
+    expect(harness.requestDestroyed).toBe(false);
+  });
+
+  it("rejects redirects and oversized declared or streamed bodies", async () => {
+    const cases = [
+      { status: 302, headers: {}, body: Buffer.alloc(0), error: "redirects are not allowed" },
+      {
+        status: 200,
+        headers: { "content-length": "9" },
+        body: Buffer.alloc(0),
+        error: "response is too large",
+      },
+      { status: 200, headers: {}, body: Buffer.alloc(9), error: "response is too large" },
+    ] as const;
+
+    for (const testCase of cases) {
+      const harness = new JwksTransportHarness();
+      const transport = createPublicJwksTransport(harness.dependencies, {
+        timeoutMs: 5000,
+        maxBytes: 8,
+      });
+      const pending = transport("https://idp.example.com/jwks");
+      const response = harness.respond(testCase.status, testCase.headers);
+      if (testCase.body.byteLength > 0) response.emit("data", testCase.body);
+      await expect(pending).rejects.toThrow(testCase.error);
+      response.emit("data", Buffer.alloc(1024));
+      response.emit("end");
+      expect(harness.deadlines.size).toBe(0);
+      if (testCase.status === 302 || "content-length" in testCase.headers) {
+        expect(harness.responseResumed).toBe(true);
+      } else {
+        expect(harness.requestDestroyed).toBe(true);
+      }
+    }
+  });
+
+  it("rejects deadline, request timeout, and request failure", async () => {
+    for (const event of ["deadline", "timeout", "error"] as const) {
+      const harness = new JwksTransportHarness();
+      const transport = createPublicJwksTransport(harness.dependencies);
+      const pending = transport("https://idp.example.com/jwks");
+      if (event === "deadline") harness.fireDeadline();
+      else harness.request.emit(event, event === "error" ? new Error("socket detail") : undefined);
+      await expect(pending).rejects.toThrow(
+        event === "error" ? "OIDC JWKS request failed" : "OIDC JWKS request timed out",
+      );
+      expect(harness.deadlines.size).toBe(0);
+      if (event !== "error") expect(harness.requestDestroyed).toBe(true);
+    }
+  });
+
+  it("cleans up when pinned request construction fails synchronously", async () => {
+    const harness = new JwksTransportHarness();
+    const controller = new AbortController();
+    const dependencies: Readonly<PublicJwksTransportDependencies> = Object.freeze({
+      ...harness.dependencies,
+      request: (() => {
+        throw new Error("request-construction-secret");
+      }) as PublicJwksTransportDependencies["request"],
+    });
+
+    await expect(
+      createPublicJwksTransport(dependencies)("https://idp.example.com/jwks", {
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("OIDC JWKS request failed");
+    expect(harness.deadlines.size).toBe(0);
+    controller.abort();
+    expect(harness.requestDestroyed).toBe(false);
+  });
+
+  it("rejects preflight and mid-flight aborts without retaining listeners", async () => {
+    const preflightHarness = new JwksTransportHarness();
+    const preflightController = new AbortController();
+    preflightController.abort();
+    await expect(
+      createPublicJwksTransport(preflightHarness.dependencies)("https://idp.example.com/jwks", {
+        signal: preflightController.signal,
+      }),
+    ).rejects.toThrow("OIDC JWKS request was aborted");
+    expect(preflightHarness.requestCalls).toBe(0);
+    expect(preflightHarness.deadlines.size).toBe(0);
+
+    const activeHarness = new JwksTransportHarness();
+    const activeController = new AbortController();
+    const pending = createPublicJwksTransport(activeHarness.dependencies)(
+      "https://idp.example.com/jwks",
+      { signal: activeController.signal },
+    );
+    activeController.abort();
+    await expect(pending).rejects.toThrow("OIDC JWKS request was aborted");
+    expect(activeHarness.requestDestroyed).toBe(true);
+    expect(activeHarness.deadlines.size).toBe(0);
+  });
+
+  it("rejects interrupted and failed response streams", async () => {
+    for (const event of ["aborted", "error"] as const) {
+      const harness = new JwksTransportHarness();
+      const pending = createPublicJwksTransport(harness.dependencies)(
+        "https://idp.example.com/jwks",
+      );
+      const response = harness.respond(200);
+      response.emit(event, event === "error" ? new Error("upstream detail") : undefined);
+      await expect(pending).rejects.toThrow(
+        event === "aborted" ? "OIDC JWKS response was interrupted" : "OIDC JWKS response failed",
+      );
+      expect(harness.deadlines.size).toBe(0);
+    }
   });
   it("rejects IPv4-mapped IPv6 literals that embed private IPv4 targets", async () => {
     await expect(assertPublicJwksDestination("https://[::ffff:10.0.0.1]/jwks")).rejects.toThrow();

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -10,7 +10,13 @@ export * from "./farcaster";
 export * from "./jwt";
 export * from "./middleware";
 export * from "./oauth";
-export * from "./oidc";
+export {
+  assertPublicJwksDestination,
+  clearOidcJwksCacheForTests,
+  getPublicRemoteJWKSet,
+  type VerifiedOidcToken,
+  verifyOidcJwt,
+} from "./oidc";
 export * from "./passkey";
 export * from "./phone";
 export * from "./platform";

--- a/packages/auth/src/oidc.ts
+++ b/packages/auth/src/oidc.ts
@@ -222,14 +222,16 @@ export function createPublicJwksTransport(
           },
           (res) => {
             if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+              req?.destroy();
+              res.destroy();
               finish(reject, new Error("OIDC jwksUri redirects are not allowed"));
-              res.resume();
               return;
             }
             const declaredLength = Number(res.headers["content-length"]);
             if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+              req?.destroy();
+              res.destroy();
               finish(reject, new Error("OIDC JWKS response is too large"));
-              res.resume();
               return;
             }
             const chunks: Uint8Array[] = [];
@@ -285,10 +287,11 @@ export function createPublicJwksTransport(
       }
     });
 
+    // Fetch forbids response bodies for 204/205. Ignore an upstream's hostile
+    // or non-conforming bytes rather than letting Response construction throw
+    // a runtime TypeError after the bounded transport has otherwise settled.
     const responseBody =
-      result.body.byteLength === 0 && (result.status === 204 || result.status === 205)
-        ? null
-        : new Uint8Array(result.body);
+      result.status === 204 || result.status === 205 ? null : new Uint8Array(result.body);
     return new Response(responseBody, { headers: result.headers, status: result.status });
   };
 }

--- a/packages/auth/src/oidc.ts
+++ b/packages/auth/src/oidc.ts
@@ -2,6 +2,7 @@ import { lookup as dnsLookup } from "node:dns";
 import { request as httpsRequest } from "node:https";
 import { isIP } from "node:net";
 import type { TenantOidcProviderConfig } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   createRemoteJWKSet,
   customFetch,
@@ -28,15 +29,18 @@ const JWKS_CACHE_MAX_ENTRIES = 256;
 // jose's internal cooldown only limits how *often* it refetches on unknown-kid;
 // it never evicts known keys, so a process-lifetime cache would not pick up an
 // IdP emergency key revocation. Rebuilding the set after this TTL guarantees a
-// rotated/revoked key stops verifying within the window. Configurable via env.
-const JWKS_MAX_AGE_MS = (() => {
-  const raw = Number(process.env.STEWARD_OIDC_JWKS_MAX_AGE_MS);
+// rotated/revoked key stops verifying within the window. Resolve the binding
+// for each cache decision so a long-lived Worker observes a tightened window.
+const DEFAULT_JWKS_MAX_AGE_MS = 60 * 60 * 1000;
+function jwksMaxAgeMs(): number {
+  const raw = Number(runtimeEnvironmentValue("STEWARD_OIDC_JWKS_MAX_AGE_MS"));
   if (Number.isFinite(raw) && raw >= 60_000) return raw;
-  return 60 * 60 * 1000; // 1 hour default
-})();
+  return DEFAULT_JWKS_MAX_AGE_MS;
+}
 function allowTestJwksFetch(): boolean {
   return (
-    process.env.NODE_ENV === "test" && process.env.STEWARD_ALLOW_INSECURE_OIDC_JWKS_FETCH === "true"
+    runtimeEnvironmentValue("NODE_ENV") === "test" &&
+    runtimeEnvironmentValue("STEWARD_ALLOW_INSECURE_OIDC_JWKS_FETCH") === "true"
   );
 }
 
@@ -114,7 +118,7 @@ export async function assertPublicJwksDestination(jwksUri: string): Promise<void
 /**
  * Builds (or returns a cached) remote JWKS set whose key fetches are routed
  * through the SSRF-guarded {@link fetchPublicJwks} transport. The set is
- * rebuilt once it exceeds {@link JWKS_MAX_AGE_MS} so rotated or emergency-
+ * rebuilt once it exceeds the configured maximum age so rotated or emergency-
  * revoked IdP keys stop verifying within the window.
  *
  * Reused by both the tenant OIDC path ({@link verifyOidcJwt}) and the
@@ -130,7 +134,7 @@ export async function getPublicRemoteJWKSet(
 ): Promise<ReturnType<typeof createRemoteJWKSet>> {
   assertPinnedDnsTransportSupported("OIDC jwksUri");
   const cached = JWKS_CACHE.get(cacheKey);
-  if (cached && Date.now() - cached.createdAt <= JWKS_MAX_AGE_MS) {
+  if (cached && Date.now() - cached.createdAt <= jwksMaxAgeMs()) {
     // Refresh insertion order so the bounded map acts as an LRU cache.
     JWKS_CACHE.delete(cacheKey);
     JWKS_CACHE.set(cacheKey, cached);
@@ -179,6 +183,13 @@ export function createPublicJwksTransport(
 ): (url: string | URL, init?: RequestInit) => Promise<Response> {
   const { request, createLookup, setDeadline, clearDeadline } = dependencies;
   const { timeoutMs, maxBytes } = limits;
+  const destroySafely = (stream: { destroy(): unknown } | undefined) => {
+    try {
+      stream?.destroy();
+    } catch {
+      // The fixed transport classification already settled the public promise.
+    }
+  };
   return async (url: string | URL, init?: RequestInit): Promise<Response> => {
     const jwksUrl = assertSafeJwksUri(url.toString());
     assertPinnedDnsTransportSupported("OIDC jwksUri");
@@ -197,12 +208,12 @@ export function createPublicJwksTransport(
         fn(value);
       };
       const abortRequest = () => {
-        req?.destroy();
         finish(reject, new Error("OIDC JWKS request was aborted"));
+        destroySafely(req);
       };
       const deadline = setDeadline(() => {
-        req?.destroy();
         finish(reject, new Error("OIDC JWKS request timed out"));
+        destroySafely(req);
       }, timeoutMs);
 
       if (init?.signal?.aborted) {
@@ -222,16 +233,16 @@ export function createPublicJwksTransport(
           },
           (res) => {
             if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
-              req?.destroy();
-              res.destroy();
               finish(reject, new Error("OIDC jwksUri redirects are not allowed"));
+              destroySafely(res);
+              destroySafely(req);
               return;
             }
             const declaredLength = Number(res.headers["content-length"]);
             if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
-              req?.destroy();
-              res.destroy();
               finish(reject, new Error("OIDC JWKS response is too large"));
+              destroySafely(res);
+              destroySafely(req);
               return;
             }
             const chunks: Uint8Array[] = [];
@@ -240,8 +251,9 @@ export function createPublicJwksTransport(
               if (settled) return;
               size += chunk.byteLength;
               if (size > maxBytes) {
-                req?.destroy();
                 finish(reject, new Error("OIDC JWKS response is too large"));
+                destroySafely(res);
+                destroySafely(req);
                 return;
               }
               chunks.push(chunk);
@@ -276,14 +288,14 @@ export function createPublicJwksTransport(
         );
 
         req.on("timeout", () => {
-          req?.destroy();
           finish(reject, new Error("OIDC JWKS request timed out"));
+          destroySafely(req);
         });
         req.on("error", () => finish(reject, new Error("OIDC JWKS request failed")));
         req.end();
       } catch {
-        req?.destroy();
         finish(reject, new Error("OIDC JWKS request failed"));
+        destroySafely(req);
       }
     });
 

--- a/packages/auth/src/oidc.ts
+++ b/packages/auth/src/oidc.ts
@@ -150,110 +150,163 @@ export async function getPublicRemoteJWKSet(
   return jwks;
 }
 
+type JwksHttpsRequest = typeof httpsRequest;
+type JwksDeadline = ReturnType<typeof setTimeout>;
+
+export interface PublicJwksTransportDependencies {
+  readonly request: JwksHttpsRequest;
+  readonly createLookup: typeof createPublicInternetLookup;
+  readonly setDeadline: (callback: () => void, timeoutMs: number) => JwksDeadline;
+  readonly clearDeadline: (deadline: JwksDeadline) => void;
+}
+
+export interface PublicJwksTransportLimits {
+  readonly timeoutMs: number;
+  readonly maxBytes: number;
+}
+
+/**
+ * Construct the production JWKS byte transport from immutable dependencies.
+ * Callers can inject isolated request/scheduler implementations for behavioral
+ * verification without mutating the process-wide HTTPS module.
+ */
+export function createPublicJwksTransport(
+  dependencies: Readonly<PublicJwksTransportDependencies>,
+  limits: Readonly<PublicJwksTransportLimits> = {
+    timeoutMs: JWKS_FETCH_TIMEOUT_MS,
+    maxBytes: JWKS_MAX_BYTES,
+  },
+): (url: string | URL, init?: RequestInit) => Promise<Response> {
+  const { request, createLookup, setDeadline, clearDeadline } = dependencies;
+  const { timeoutMs, maxBytes } = limits;
+  return async (url: string | URL, init?: RequestInit): Promise<Response> => {
+    const jwksUrl = assertSafeJwksUri(url.toString());
+    assertPinnedDnsTransportSupported("OIDC jwksUri");
+    const result = await new Promise<{
+      body: Uint8Array;
+      headers: Headers;
+      status: number;
+    }>((resolve, reject) => {
+      let settled = false;
+      let req: ReturnType<JwksHttpsRequest> | undefined;
+      const finish = <T>(fn: (value: T) => void, value: T) => {
+        if (settled) return;
+        settled = true;
+        clearDeadline(deadline);
+        init?.signal?.removeEventListener("abort", abortRequest);
+        fn(value);
+      };
+      const abortRequest = () => {
+        req?.destroy();
+        finish(reject, new Error("OIDC JWKS request was aborted"));
+      };
+      const deadline = setDeadline(() => {
+        req?.destroy();
+        finish(reject, new Error("OIDC JWKS request timed out"));
+      }, timeoutMs);
+
+      if (init?.signal?.aborted) {
+        abortRequest();
+        return;
+      }
+      init?.signal?.addEventListener("abort", abortRequest, { once: true });
+
+      try {
+        req = request(
+          jwksUrl,
+          {
+            headers: Object.fromEntries(new Headers(init?.headers).entries()),
+            method: init?.method ?? "GET",
+            timeout: timeoutMs,
+            lookup: createLookup("OIDC jwksUri"),
+          },
+          (res) => {
+            if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+              finish(reject, new Error("OIDC jwksUri redirects are not allowed"));
+              res.resume();
+              return;
+            }
+            const declaredLength = Number(res.headers["content-length"]);
+            if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+              finish(reject, new Error("OIDC JWKS response is too large"));
+              res.resume();
+              return;
+            }
+            const chunks: Uint8Array[] = [];
+            let size = 0;
+            res.on("data", (chunk: Uint8Array) => {
+              if (settled) return;
+              size += chunk.byteLength;
+              if (size > maxBytes) {
+                req?.destroy();
+                finish(reject, new Error("OIDC JWKS response is too large"));
+                return;
+              }
+              chunks.push(chunk);
+            });
+            res.on("end", () => {
+              if (settled) return;
+              const body = new Uint8Array(size);
+              let offset = 0;
+              for (const chunk of chunks) {
+                body.set(chunk, offset);
+                offset += chunk.byteLength;
+              }
+              const headers = new Headers();
+              for (const [name, value] of Object.entries(res.headers)) {
+                if (Array.isArray(value)) {
+                  for (const item of value) headers.append(name, item);
+                } else if (value !== undefined) {
+                  headers.set(name, value);
+                }
+              }
+              const status =
+                res.statusCode && res.statusCode >= 200 && res.statusCode <= 599
+                  ? res.statusCode
+                  : 502;
+              finish(resolve, { body, headers, status });
+            });
+            res.on("aborted", () =>
+              finish(reject, new Error("OIDC JWKS response was interrupted")),
+            );
+            res.on("error", () => finish(reject, new Error("OIDC JWKS response failed")));
+          },
+        );
+
+        req.on("timeout", () => {
+          req?.destroy();
+          finish(reject, new Error("OIDC JWKS request timed out"));
+        });
+        req.on("error", () => finish(reject, new Error("OIDC JWKS request failed")));
+        req.end();
+      } catch {
+        req?.destroy();
+        finish(reject, new Error("OIDC JWKS request failed"));
+      }
+    });
+
+    const responseBody =
+      result.body.byteLength === 0 && (result.status === 204 || result.status === 205)
+        ? null
+        : new Uint8Array(result.body);
+    return new Response(responseBody, { headers: result.headers, status: result.status });
+  };
+}
+
+const productionPublicJwksTransport = createPublicJwksTransport(
+  Object.freeze<PublicJwksTransportDependencies>({
+    request: httpsRequest,
+    createLookup: createPublicInternetLookup,
+    setDeadline: (callback, timeoutMs) => setTimeout(callback, timeoutMs),
+    clearDeadline: (deadline) => clearTimeout(deadline),
+  }),
+);
+
 async function fetchPublicJwks(url: string | URL, init?: RequestInit): Promise<Response> {
+  if (!allowTestJwksFetch()) return productionPublicJwksTransport(url, init);
   const jwksUrl = assertSafeJwksUri(url.toString());
   assertPinnedDnsTransportSupported("OIDC jwksUri");
-  if (allowTestJwksFetch()) {
-    return fetch(jwksUrl, init);
-  }
-
-  const result = await new Promise<{
-    body: Uint8Array;
-    headers: Headers;
-    status: number;
-  }>((resolve, reject) => {
-    let settled = false;
-    let req: ReturnType<typeof httpsRequest> | undefined;
-    const finish = <T>(fn: (value: T) => void, value: T) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(deadline);
-      init?.signal?.removeEventListener("abort", abortRequest);
-      fn(value);
-    };
-    const abortRequest = () => {
-      req?.destroy();
-      finish(reject, new Error("OIDC JWKS request was aborted"));
-    };
-    const deadline = setTimeout(() => {
-      req?.destroy();
-      finish(reject, new Error("OIDC JWKS request timed out"));
-    }, JWKS_FETCH_TIMEOUT_MS);
-
-    if (init?.signal?.aborted) {
-      abortRequest();
-      return;
-    }
-    init?.signal?.addEventListener("abort", abortRequest, { once: true });
-
-    req = httpsRequest(
-      jwksUrl,
-      {
-        headers: Object.fromEntries(new Headers(init?.headers).entries()),
-        method: init?.method ?? "GET",
-        timeout: JWKS_FETCH_TIMEOUT_MS,
-        lookup: createPublicInternetLookup("OIDC jwksUri"),
-      },
-      (res) => {
-        if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
-          finish(reject, new Error("OIDC jwksUri redirects are not allowed"));
-          res.resume();
-          return;
-        }
-        const declaredLength = Number(res.headers["content-length"]);
-        if (Number.isFinite(declaredLength) && declaredLength > JWKS_MAX_BYTES) {
-          finish(reject, new Error("OIDC JWKS response is too large"));
-          res.resume();
-          return;
-        }
-        const chunks: Uint8Array[] = [];
-        let size = 0;
-        res.on("data", (chunk: Uint8Array) => {
-          size += chunk.byteLength;
-          if (size > JWKS_MAX_BYTES) {
-            req?.destroy();
-            finish(reject, new Error("OIDC JWKS response is too large"));
-            return;
-          }
-          chunks.push(chunk);
-        });
-        res.on("end", () => {
-          const body = new Uint8Array(size);
-          let offset = 0;
-          for (const chunk of chunks) {
-            body.set(chunk, offset);
-            offset += chunk.byteLength;
-          }
-          const headers = new Headers();
-          for (const [name, value] of Object.entries(res.headers)) {
-            if (Array.isArray(value)) {
-              for (const item of value) headers.append(name, item);
-            } else if (value !== undefined) {
-              headers.set(name, value);
-            }
-          }
-          const status =
-            res.statusCode && res.statusCode >= 200 && res.statusCode <= 599 ? res.statusCode : 502;
-          finish(resolve, { body, headers, status });
-        });
-        res.on("aborted", () => finish(reject, new Error("OIDC JWKS response was interrupted")));
-        res.on("error", () => finish(reject, new Error("OIDC JWKS response failed")));
-      },
-    );
-
-    req.on("timeout", () => {
-      req?.destroy();
-      finish(reject, new Error("OIDC JWKS request timed out"));
-    });
-    req.on("error", () => finish(reject, new Error("OIDC JWKS request failed")));
-    req.end();
-  });
-
-  const responseBody =
-    result.body.byteLength === 0 && (result.status === 204 || result.status === 205)
-      ? null
-      : new Uint8Array(result.body);
-  return new Response(responseBody, { headers: result.headers, status: result.status });
+  return fetch(jwksUrl, init);
 }
 
 export async function verifyOidcJwt(

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,6 +17,10 @@
     "./sensitive-keys": {
       "types": "./dist/sensitive-keys.d.ts",
       "import": "./dist/sensitive-keys.js"
+    },
+    "./runtime-env": {
+      "types": "./dist/runtime-env.d.ts",
+      "import": "./dist/runtime-env.js"
     }
   },
   "files": [

--- a/packages/shared/src/__tests__/runtime-env.test.ts
+++ b/packages/shared/src/__tests__/runtime-env.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { runtimeEnvironmentValue, withRuntimeEnvironment } from "../runtime-env";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("request-local runtime environment", () => {
+  test("keeps overlapping Worker binding snapshots isolated", async () => {
+    const firstEntered = deferred();
+    const releaseFirst = deferred();
+
+    const first = withRuntimeEnvironment(
+      {
+        NODE_ENV: "test",
+        STEWARD_OIDC_JWKS_MAX_AGE_MS: "60000",
+        STEWARD_ALLOW_INSECURE_OIDC_JWKS_FETCH: "false",
+      },
+      async () => {
+        firstEntered.resolve();
+        await releaseFirst.promise;
+        return {
+          age: runtimeEnvironmentValue("STEWARD_OIDC_JWKS_MAX_AGE_MS"),
+          override: runtimeEnvironmentValue("STEWARD_ALLOW_INSECURE_OIDC_JWKS_FETCH"),
+        };
+      },
+    );
+
+    await firstEntered.promise;
+    const second = await withRuntimeEnvironment(
+      {
+        NODE_ENV: "test",
+        STEWARD_OIDC_JWKS_MAX_AGE_MS: "120000",
+        STEWARD_ALLOW_INSECURE_OIDC_JWKS_FETCH: "true",
+      },
+      async () => ({
+        age: runtimeEnvironmentValue("STEWARD_OIDC_JWKS_MAX_AGE_MS"),
+        override: runtimeEnvironmentValue("STEWARD_ALLOW_INSECURE_OIDC_JWKS_FETCH"),
+      }),
+    );
+    releaseFirst.resolve();
+
+    expect(second).toEqual({ age: "120000", override: "true" });
+    expect(await first).toEqual({ age: "60000", override: "false" });
+  });
+});

--- a/packages/shared/src/runtime-env.ts
+++ b/packages/shared/src/runtime-env.ts
@@ -1,0 +1,27 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type RuntimeEnvironment = Readonly<Record<string, string | undefined>>;
+
+const runtimeEnvironmentStorage = new AsyncLocalStorage<RuntimeEnvironment>();
+
+function snapshotRuntimeEnvironment(environment: Record<string, unknown>): RuntimeEnvironment {
+  const snapshot: Record<string, string | undefined> = {};
+  for (const [name, value] of Object.entries(environment)) {
+    if (typeof value === "string") snapshot[name] = value;
+  }
+  return Object.freeze(snapshot);
+}
+
+/** Bind an immutable environment snapshot to one asynchronous request. */
+export function withRuntimeEnvironment<T>(
+  environment: Record<string, unknown>,
+  callback: () => T,
+): T {
+  return runtimeEnvironmentStorage.run(snapshotRuntimeEnvironment(environment), callback);
+}
+
+/** Resolve one setting from the current request snapshot or Bun process. */
+export function runtimeEnvironmentValue(name: string): string | undefined {
+  const requestEnvironment = runtimeEnvironmentStorage.getStore();
+  return requestEnvironment ? requestEnvironment[name] : process.env[name];
+}

--- a/scripts/__tests__/wallet-e2e-authorization.test.ts
+++ b/scripts/__tests__/wallet-e2e-authorization.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPOSITORY = "Steward-Fi/steward";
+const TARGET_SHA = "a".repeat(40);
+const workflowPath = join(import.meta.dir, "..", "..", ".github", "workflows", "wallet-e2e.yml");
+const temporaryDirectories: string[] = [];
+
+interface ReviewFixture {
+  commit_id: string;
+  id: number;
+  state: string;
+  submitted_at: string;
+  user: { login: string; type: string };
+}
+
+interface Fixtures {
+  branch: Record<string, unknown>;
+  checkRuns: Record<string, unknown>[];
+  permission: string;
+  pulls: Record<string, unknown>[];
+  readiness: Record<string, unknown>;
+  reviews: ReviewFixture[];
+  statuses: Record<string, unknown>[];
+}
+
+function authorizationScript(): string {
+  const source = readFileSync(workflowPath, "utf8");
+  const step = source.indexOf("      - name: Require the trusted default-branch dispatcher");
+  const marker = "        run: |\n";
+  const start = source.indexOf(marker, step);
+  if (step < 0 || start < 0) throw new Error("wallet authorization step is missing");
+  const block: string[] = [];
+  for (const line of source.slice(start + marker.length).split("\n")) {
+    if (line.startsWith("          ")) {
+      block.push(line.slice(10));
+      continue;
+    }
+    if (line.length === 0) {
+      block.push("");
+      continue;
+    }
+    break;
+  }
+  if (block.length === 0) throw new Error("wallet authorization script is empty");
+  return block.join("\n");
+}
+
+function baselineFixtures(): Fixtures {
+  return {
+    pulls: [
+      {
+        base: { ref: "develop" },
+        draft: false,
+        head: { repo: { full_name: REPOSITORY }, sha: TARGET_SHA },
+        number: 42,
+        state: "open",
+        user: { login: "pr-author" },
+      },
+    ],
+    readiness: {
+      headRefOid: TARGET_SHA,
+      isDraft: false,
+      mergeStateStatus: "CLEAN",
+      reviewDecision: "APPROVED",
+      state: "OPEN",
+    },
+    branch: {
+      protection: {
+        required_status_checks: {
+          checks: [{ app_id: 15368, context: "Required Check" }],
+          contexts: ["Required Check"],
+        },
+      },
+    },
+    checkRuns: [
+      {
+        app: { id: 15368 },
+        completed_at: "2026-08-19T20:00:10Z",
+        conclusion: "success",
+        head_sha: TARGET_SHA,
+        id: 100,
+        name: "Required Check",
+        started_at: "2026-08-19T20:00:00Z",
+        status: "completed",
+      },
+    ],
+    statuses: [],
+    reviews: [
+      {
+        commit_id: TARGET_SHA,
+        id: 200,
+        state: "APPROVED",
+        submitted_at: "2026-08-19T20:01:00Z",
+        user: { login: "trusted-reviewer", type: "User" },
+      },
+    ],
+    permission: "write",
+  };
+}
+
+function writeJson(directory: string, name: string, value: unknown): void {
+  writeFileSync(join(directory, `${name}.json`), `${JSON.stringify(value)}\n`);
+}
+
+function installMockGh(directory: string, fixtures: Fixtures): void {
+  writeJson(directory, "pulls", [fixtures.pulls]);
+  writeJson(directory, "readiness", fixtures.readiness);
+  writeJson(directory, "branch", fixtures.branch);
+  writeJson(directory, "check-runs", [{ check_runs: fixtures.checkRuns }]);
+  writeJson(directory, "statuses", [fixtures.statuses]);
+  writeJson(directory, "reviews", [fixtures.reviews]);
+  writeJson(directory, "permission", { permission: fixtures.permission });
+  const mock = `#!/usr/bin/env bash
+set -euo pipefail
+args="$*"
+if [[ "$args" == "pr view "* ]]; then file="readiness";
+elif [[ "$args" == *"/commits/"*"/pulls"* ]]; then file="pulls";
+elif [[ "$args" == *"/branches/develop"* ]]; then file="branch";
+elif [[ "$args" == *"/check-runs"* ]]; then file="check-runs";
+elif [[ "$args" == *"/statuses"* ]]; then file="statuses";
+elif [[ "$args" == *"/reviews"* ]]; then file="reviews";
+elif [[ "$args" == *"/collaborators/"*"/permission"* ]]; then
+  if [[ "$args" == *"--jq"* ]]; then bun -e 'console.log(JSON.parse(await Bun.file(process.env.MOCK_DIR + "/permission.json").text()).permission)'; exit 0; fi
+  file="permission";
+else echo "unexpected gh invocation: $args" >&2; exit 97; fi
+exec bun -e 'process.stdout.write(await Bun.file(process.env.MOCK_DIR + "/" + process.argv[1] + ".json").text())' "$file"
+`;
+  const executable = join(directory, "gh");
+  writeFileSync(executable, mock, { mode: 0o700 });
+  chmodSync(executable, 0o700);
+}
+
+async function execute(fixtures: Fixtures): Promise<{ exitCode: number; output: string; stderr: string }> {
+  const directory = mkdtempSync(join(tmpdir(), "steward-wallet-auth-"));
+  temporaryDirectories.push(directory);
+  installMockGh(directory, fixtures);
+  const outputPath = join(directory, "github-output");
+  writeFileSync(outputPath, "");
+  const child = Bun.spawn(["bash", "-euo", "pipefail", "-c", authorizationScript()], {
+    cwd: join(import.meta.dir, "..", ".."),
+    env: {
+      ...process.env,
+      GITHUB_OUTPUT: outputPath,
+      GITHUB_REF: "refs/heads/develop",
+      GITHUB_REPOSITORY: REPOSITORY,
+      MOCK_DIR: directory,
+      PATH: `${directory}:${process.env.PATH ?? ""}`,
+      TARGET_SHA,
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  return {
+    exitCode,
+    output: readFileSync(outputPath, "utf8"),
+    stderr: `${stdout}${stderr}`,
+  };
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("wallet E2E target authorization", () => {
+  test("accepts an exact green head with a current write-capable approval", async () => {
+    const result = await execute(baselineFixtures());
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain(`target_sha=${TARGET_SHA}`);
+  });
+
+  test("rejects a required check from the wrong GitHub App", async () => {
+    const fixtures = baselineFixtures();
+    fixtures.checkRuns[0] = { ...fixtures.checkRuns[0], app: { id: 999 } };
+    const result = await execute(fixtures);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("every required develop check");
+  });
+
+  test("rejects a later changes-requested review", async () => {
+    const fixtures = baselineFixtures();
+    fixtures.reviews.push({
+      commit_id: TARGET_SHA,
+      id: 201,
+      state: "CHANGES_REQUESTED",
+      submitted_at: "2026-08-19T20:02:00Z",
+      user: { login: "trusted-reviewer", type: "User" },
+    });
+    const result = await execute(fixtures);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("current approval from an independent write-capable reviewer");
+  });
+
+  test("uses the contents-readable branch endpoint", () => {
+    const script = authorizationScript();
+    expect(script).toContain('"repos/$GITHUB_REPOSITORY/branches/develop"');
+    expect(script).not.toContain("/protection/required_status_checks");
+  });
+});

--- a/scripts/__tests__/wallet-e2e-authorization.test.ts
+++ b/scripts/__tests__/wallet-e2e-authorization.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,6 +7,8 @@ const REPOSITORY = "Steward-Fi/steward";
 const TARGET_SHA = "a".repeat(40);
 const workflowPath = join(import.meta.dir, "..", "..", ".github", "workflows", "wallet-e2e.yml");
 const temporaryDirectories: string[] = [];
+
+setDefaultTimeout(15_000);
 
 interface ReviewFixture {
   commit_id: string;
@@ -133,7 +135,9 @@ exec bun -e 'process.stdout.write(await Bun.file(process.env.MOCK_DIR + "/" + pr
   chmodSync(executable, 0o700);
 }
 
-async function execute(fixtures: Fixtures): Promise<{ exitCode: number; output: string; stderr: string }> {
+async function execute(
+  fixtures: Fixtures,
+): Promise<{ exitCode: number; output: string; stderr: string }> {
   const directory = mkdtempSync(join(tmpdir(), "steward-wallet-auth-"));
   temporaryDirectories.push(directory);
   installMockGh(directory, fixtures);

--- a/scripts/__tests__/wallet-e2e-authorization.test.ts
+++ b/scripts/__tests__/wallet-e2e-authorization.test.ts
@@ -186,6 +186,25 @@ describe("wallet E2E target authorization", () => {
     expect(result.stderr).toContain("every required develop check");
   });
 
+  for (const latest of [
+    { conclusion: null, status: "in_progress" },
+    { conclusion: "failure", status: "completed" },
+  ] as const) {
+    test(`rejects an ambiguous same-second ${latest.status} required-check rerun`, async () => {
+      const fixtures = baselineFixtures();
+      fixtures.checkRuns.push({
+        ...fixtures.checkRuns[0],
+        completed_at: latest.status === "completed" ? "2026-08-19T20:00:20Z" : null,
+        conclusion: latest.conclusion,
+        id: 101,
+        status: latest.status,
+      });
+      const result = await execute(fixtures);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("every required develop check");
+    });
+  }
+
   test("rejects a later changes-requested review", async () => {
     const fixtures = baselineFixtures();
     fixtures.reviews.push({


### PR DESCRIPTION
## Purpose

Install only the reviewed manual wallet-E2E dispatcher on the default branch so GitHub can expose `workflow_dispatch` without first merging the larger wallet implementation.

## Security boundary

- this PR adds the dispatcher, its executable authorization contract test, and one PR-matrix invocation; it contains no wallet implementation, credentials, generated profiles, or artifacts
- dispatch is accepted only from `refs/heads/develop` and requires a full lowercase 40-character `target_sha`
- before any secret-bearing job, the dispatcher requires that SHA to be the exact head of one ready, open, same-repository PR targeting `develop`
- the target must be conflict-free and have a current aggregate `APPROVED` review decision
- authorization reads the contents-readable `develop` branch payload and its nested protection policy at dispatch time, then fails closed when the policy is unreadable, malformed, empty, duplicated, or ambiguous
- every app-pinned required check must have a latest exact-head `completed`/`success` result from the configured app; latest pending, skipped, neutral, cancelled, or failed results reject authorization
- matching reruns are ordered by documented `started_at`; a same-second latest-start ambiguity fails closed instead of allowing completion metadata or IDs to choose an older result; missing start timestamps and duplicate identities also fail closed
- legacy required status contexts, if configured without an app-pinned check, must have a latest exact-head `success` status
- optional checks do not affect authorization, so optional Mintlify `skipped`/`neutral` results do not block while required checks cannot use those conclusions
- the app pin authenticates GitHub Actions as the producer, not a specific workflow definition; exact-head approval from an independent write-capable reviewer is the trust gate for target-controlled workflow changes that could reuse a required job name
- at least one latest-per-reviewer exact-head approval must come from an independent write-capable human reviewer; superseded approvals and later changes-requested reviews do not authorize the run
- the secret-free authorization job has only contents, pull-request, check, and status read permissions; the secret-bearing job has contents-read only
- the protected `wallet-e2e` job checks out and verifies exactly the authorized SHA with persisted checkout credentials disabled
- all four wallet credentials are confined to preflight and cache construction; the real-flow step receives only the two passwords it consumes
- cleanup invokes the actual web package command under `always()`

## Required external configuration

The live `wallet-e2e` environment is currently absent (API `404` on 2026-08-19). Do not mark ready or merge until a repository administrator creates it, adds the four dedicated empty-wallet secrets, requires an independent reviewer, enables prevent-self-review, and constrains deployment branches to `develop`. After this bootstrap merges, dispatch it from `develop` with PR #597's independently approved exact head.

## Validation

Head: `dd104b6d4a39a5c402ca540136b12192a81656b2`

Base: `f6e7b114f15f888198652f5307a09c16faf67fc0` (`#589`)

- Actionlint: passed at exact head
- live `GET /branches/develop` succeeds with contents-read authority and exposes both app-pinned checks and legacy contexts; the Administration-only `/protection/required_status_checks` endpoint is not used
- live protection contract: `strict=true`, 62 unique required contexts/checks, all pinned to GitHub Actions app `15368`
- live known-green target `f6e7b114f15f888198652f5307a09c16faf67fc0`: all 62 required app-pinned checks accepted; optional successful CodeQL app `57789` and skipped Mintlify app `222410` ignored
- hostile synthetic contract: accepts a latest required success and ignores optional skipped checks; rejects empty/duplicate policy, wrong app, duplicate result identity, missing timestamps, required pending/skipped/neutral/cancelled, later retry failure/pending, and later legacy-status failure
- retry contract: timestamp ordering lets a later successful rerun supersede an older failure; a newer queued run rejects even when its numeric ID is smaller than the older success
- hostile review-history selector: an approval followed by changes-requested is rejected; a current exact approval is accepted
- checked-in executable authorization contract: 6/6 tests, 12 assertions, including the contents-readable branch endpoint, wrong-app rejection, latest-review rejection, and same-second pending/failing rerun rejection
- `git diff --check`: passed at exact head
- scope: `.github/workflows/wallet-e2e.yml`, one PR-matrix test invocation, and its authorization regression suite

Keep draft pending independent workflow review, the external environment configuration above, exact hosted CI, and #589's merge followed by a patch-identical restack onto `develop`.

