### PR TITLE
fix(vault): preserve transaction ownership atomically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,7 +505,7 @@ jobs:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
       - name: Vault custody transition race proof (real Postgres)
-        run: bun test ./packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts
+        run: bun test ./packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts ./packages/vault/src/__tests__/transaction-id-race.real-pg.test.ts
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -595,7 +595,7 @@ jobs:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
       - name: Vault custody transition race proof (real Postgres)
-        run: bun test ./packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts
+        run: bun test ./packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts ./packages/vault/src/__tests__/transaction-id-race.real-pg.test.ts
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 

--- a/packages/vault/src/__tests__/transaction-id-hardening.test.ts
+++ b/packages/vault/src/__tests__/transaction-id-hardening.test.ts
@@ -1,19 +1,95 @@
-import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { agents, closeDb, getDb, tenants, transactions } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import type { SignRequest } from "@stwd/shared";
+import { eq } from "drizzle-orm";
+import { Vault } from "../vault";
 
-const vaultSource = readFileSync(join(import.meta.dir, "..", "vault.ts"), "utf8");
+const tenantId = `transaction-owner-${crypto.randomUUID()}`;
+const firstAgentId = `transaction-owner-first-${crypto.randomUUID()}`;
+const secondAgentId = `transaction-owner-second-${crypto.randomUUID()}`;
+const txId = `transaction-owner-tx-${crypto.randomUUID()}`;
+
+type TransactionRecorder = {
+  recordSignedTransaction(
+    request: SignRequest,
+    chainId: number,
+    shouldBroadcast: boolean,
+    hash: string,
+    options: { txId: string; status?: "signed" | "broadcast" | "outcome_unknown" },
+  ): Promise<void>;
+};
+
+function requestFor(agentId: string, value: string): SignRequest {
+  return {
+    tenantId,
+    agentId,
+    to: "0x0000000000000000000000000000000000000001",
+    value,
+    chainId: 1,
+    broadcast: true,
+  };
+}
 
 describe("transaction id hardening", () => {
-  it("rejects reusing a transaction id across agents before upsert", () => {
-    const helperStart = vaultSource.indexOf("private async recordSignedTransaction");
-    expect(helperStart).toBeGreaterThanOrEqual(0);
-    const guard = vaultSource.indexOf(
-      "Transaction id already belongs to a different agent",
-      helperStart,
-    );
-    const upsert = vaultSource.indexOf(".onConflictDoUpdate", helperStart);
-    expect(guard).toBeGreaterThan(helperStart);
-    expect(upsert).toBeGreaterThan(guard);
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db as never, async () => client.close());
+    await getDb()
+      .insert(tenants)
+      .values({
+        id: tenantId,
+        name: "Transaction ownership tenant",
+        apiKeyHash: `hash-${tenantId}`,
+      });
+    await getDb()
+      .insert(agents)
+      .values([
+        {
+          id: firstAgentId,
+          tenantId,
+          name: "First transaction owner",
+          walletAddress: "0x0000000000000000000000000000000000000011",
+        },
+        {
+          id: secondAgentId,
+          tenantId,
+          name: "Second transaction owner",
+          walletAddress: "0x0000000000000000000000000000000000000022",
+        },
+      ]);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+  });
+
+  test("updates a transaction only for its existing agent", async () => {
+    const recorder = new Vault({
+      masterPassword: "transaction-owner-test",
+    }) as unknown as TransactionRecorder;
+    await recorder.recordSignedTransaction(requestFor(firstAgentId, "1"), 1, true, "0xfirst", {
+      txId,
+      status: "outcome_unknown",
+    });
+    await recorder.recordSignedTransaction(requestFor(firstAgentId, "2"), 1, true, "0xupdated", {
+      txId,
+      status: "broadcast",
+    });
+
+    await expect(
+      recorder.recordSignedTransaction(requestFor(secondAgentId, "3"), 1, true, "0xhostile", {
+        txId,
+        status: "broadcast",
+      }),
+    ).rejects.toThrow("Transaction id already belongs to a different agent");
+
+    const [recorded] = await getDb().select().from(transactions).where(eq(transactions.id, txId));
+    expect(recorded?.agentId).toBe(firstAgentId);
+    expect(recorded?.value).toBe("2");
+    expect(recorded?.txHash).toBe("0xupdated");
+    expect(recorded?.status).toBe("broadcast");
   });
 });

--- a/packages/vault/src/__tests__/transaction-id-race.real-pg.test.ts
+++ b/packages/vault/src/__tests__/transaction-id-race.real-pg.test.ts
@@ -1,0 +1,171 @@
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { agents, closeDb, createPostgresClient, eq, getDb, tenants, transactions } from "@stwd/db";
+import type { SignRequest } from "@stwd/shared";
+import { Vault } from "../vault";
+
+setDefaultTimeout(120_000);
+
+const databaseUrl = process.env.DATABASE_URL;
+const suite =
+  databaseUrl && !databaseUrl.startsWith("file:") && !process.env.STEWARD_PGLITE_MEMORY
+    ? describe
+    : describe.skip;
+const suffix = crypto.randomUUID().replaceAll("-", "");
+const tenantId = `tx-owner-race-tenant-${suffix}`;
+const firstAgentId = `tx-owner-race-first-${suffix}`;
+const secondAgentId = `tx-owner-race-second-${suffix}`;
+const txId = `tx-owner-race-${suffix}`;
+const lockKey = `transaction-owner-race:${suffix}`;
+const triggerFunction = `tx_owner_race_fn_${suffix}`;
+const triggerName = `tx_owner_race_trigger_${suffix}`;
+const blocker = databaseUrl ? createPostgresClient(databaseUrl) : null;
+const inspector = databaseUrl ? createPostgresClient(databaseUrl) : null;
+
+type TransactionRecorder = {
+  recordSignedTransaction(
+    request: SignRequest,
+    chainId: number,
+    shouldBroadcast: boolean,
+    hash: string,
+    options: { txId: string; status: "broadcast" },
+  ): Promise<void>;
+};
+
+function requestFor(agentId: string, value: string): SignRequest {
+  return {
+    tenantId,
+    agentId,
+    to: "0x0000000000000000000000000000000000000001",
+    value,
+    chainId: 1,
+    broadcast: true,
+  };
+}
+
+async function waitForBlockedRecorders(expected: number): Promise<number[]> {
+  if (!inspector) throw new Error("real PostgreSQL inspector is unavailable");
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    const rows = await inspector<{ pid: number }[]>`
+      with target as (
+        select hashtextextended(${lockKey}, 0)::bigint as key
+      )
+      select distinct locks.pid
+      from pg_locks as locks
+      cross join target
+      where locks.locktype = 'advisory'
+        and locks.granted = false
+        and locks.database = (select oid from pg_database where datname = current_database())
+        and locks.classid::bigint = ((target.key >> 32) & 4294967295)
+        and locks.objid::bigint = (target.key & 4294967295)
+        and locks.objsubid = 1
+    `;
+    if (rows.length >= expected) return rows.map((row) => row.pid);
+    await Bun.sleep(10);
+  }
+  throw new Error(`timed out waiting for ${expected} blocked transaction recorders`);
+}
+
+suite("transaction id ownership across real PostgreSQL connections", () => {
+  beforeAll(async () => {
+    if (!inspector) throw new Error("real PostgreSQL inspector is unavailable");
+    delete process.env.STEWARD_DB_MODE;
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    await getDb()
+      .insert(tenants)
+      .values({
+        id: tenantId,
+        name: "Transaction ownership race tenant",
+        apiKeyHash: `hash-${tenantId}`,
+      });
+    await getDb()
+      .insert(agents)
+      .values([
+        {
+          id: firstAgentId,
+          tenantId,
+          name: "First transaction owner",
+          walletAddress: "0x0000000000000000000000000000000000000011",
+        },
+        {
+          id: secondAgentId,
+          tenantId,
+          name: "Second transaction owner",
+          walletAddress: "0x0000000000000000000000000000000000000022",
+        },
+      ]);
+    await inspector.unsafe(`
+      create function ${triggerFunction}() returns trigger
+      language plpgsql
+      as $$
+      begin
+        perform pg_advisory_xact_lock(hashtextextended('${lockKey}', 0));
+        return new;
+      end
+      $$
+    `);
+    await inspector.unsafe(`
+      create trigger ${triggerName}
+      before insert on transactions
+      for each row when (new.id = '${txId}')
+      execute function ${triggerFunction}()
+    `);
+  });
+
+  afterAll(async () => {
+    await inspector
+      ?.unsafe(`drop trigger if exists ${triggerName} on transactions`)
+      .catch(() => {});
+    await inspector?.unsafe(`drop function if exists ${triggerFunction}()`).catch(() => {});
+    await getDb()
+      .delete(tenants)
+      .where(eq(tenants.id, tenantId))
+      .catch(() => {});
+    await closeDb();
+    await Promise.all([blocker?.end(), inspector?.end()]);
+  });
+
+  test("only one agent can create a shared transaction id", async () => {
+    if (!blocker) throw new Error("real PostgreSQL blocker is unavailable");
+    const recorder = new Vault({
+      masterPassword: "transaction-owner-race-test",
+    }) as unknown as TransactionRecorder;
+    await blocker`select pg_advisory_lock(hashtextextended(${lockKey}, 0))`;
+
+    const first = recorder.recordSignedTransaction(
+      requestFor(firstAgentId, "1"),
+      1,
+      true,
+      "0xfirst",
+      { txId, status: "broadcast" },
+    );
+    const second = recorder.recordSignedTransaction(
+      requestFor(secondAgentId, "2"),
+      1,
+      true,
+      "0xsecond",
+      { txId, status: "broadcast" },
+    );
+    const resultsPromise = Promise.allSettled([first, second]);
+    let blockedPids: number[] = [];
+    try {
+      blockedPids = await waitForBlockedRecorders(2);
+    } finally {
+      await blocker`select pg_advisory_unlock(hashtextextended(${lockKey}, 0))`;
+    }
+
+    const results = await resultsPromise;
+    expect(new Set(blockedPids).size).toBe(2);
+    expect(results.map((result) => result.status).sort()).toEqual(["fulfilled", "rejected"]);
+    const rejected = results.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    expect(String(rejected?.reason)).toContain(
+      "Transaction id already belongs to a different agent",
+    );
+
+    const [recorded] = await getDb().select().from(transactions).where(eq(transactions.id, txId));
+    const winningAgent = results[0]?.status === "fulfilled" ? firstAgentId : secondAgentId;
+    expect(recorded?.agentId).toBe(winningAgent);
+    expect(recorded?.value).toBe(winningAgent === firstAgentId ? "1" : "2");
+  });
+});

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -865,15 +865,7 @@ export class Vault {
     const db = getDb();
     const txId = options.txId ?? crypto.randomUUID();
     const signedAt = new Date();
-    const [existingTransaction] = await db
-      .select({ agentId: transactions.agentId })
-      .from(transactions)
-      .where(eq(transactions.id, txId));
-    if (existingTransaction && existingTransaction.agentId !== request.agentId) {
-      throw new Error("Transaction id already belongs to a different agent");
-    }
-
-    await db
+    const recordedTransactions = await db
       .insert(transactions)
       .values({
         id: txId,
@@ -893,7 +885,6 @@ export class Vault {
       .onConflictDoUpdate({
         target: transactions.id,
         set: {
-          agentId: request.agentId,
           status: shouldBroadcast ? (options.status ?? "signed") : "signed",
           toAddress: request.to,
           value: request.value,
@@ -905,7 +896,12 @@ export class Vault {
           policyResults: options.policyResults ?? [],
           signedAt,
         },
-      });
+        setWhere: eq(transactions.agentId, request.agentId),
+      })
+      .returning({ agentId: transactions.agentId });
+    if (recordedTransactions.length !== 1) {
+      throw new Error("Transaction id already belongs to a different agent");
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #602

## Summary
- replace the read-then-upsert transaction ownership check with one conditional conflict update
- never rewrite the stored agent owner; reject a conflict when the existing row belongs to another agent
- replace the source-order assertion with PGLite persistence behavior
- add and CI-wire a deterministic PostgreSQL two-writer race for an initially absent shared transaction ID

## Exact evidence
- base: `9239a728b9ca28175e00e2825f69d85f3e02856e`
- head: `4ef0478e1b925159e1081337f4d72c5b51a4135f`
- fresh PostgreSQL 16 migration + PGLite/real-PG focused tests: 2/2, 10 assertions
- affected dependency build: 6/6
- Biome, actionlint, diff-check: pass

Keep draft until exact hosted PostgreSQL/full CI and independent review are green.