### PR TITLE
fix(proxy): support signed broker GET requests

### DIFF
--- a/docs/guides/session-broker-integration.mdx
+++ b/docs/guides/session-broker-integration.mdx
@@ -230,7 +230,11 @@ The envelope is `{ args?, body?, query? }`:
 - `args` drive policy constraints (`argEquals` / `argMatches`) — they are **not**
   forwarded to the broker.
 - `body` is the JSON request body forwarded to the broker (for `POST`/`PUT`/`PATCH`).
-- `query` is appended to the forwarded URL as a query string.
+- `query` is a bounded string map appended to the forwarded URL. Its exact
+  selectors are also merged into the policy `args`; if a selector is repeated in
+  `args`, both values must match. Query maps are limited to 32 entries, 128
+  characters per key, 2,048 characters per value, and 8,192 encoded characters.
+  Unknown envelope fields and non-string selector values are rejected with 400.
 
 On an allowed call the proxy returns the broker's status and body **verbatim** (the
 injected credential already scrubbed). A `403` means denied by policy or missing

--- a/docs/guides/session-broker-integration.mdx
+++ b/docs/guides/session-broker-integration.mdx
@@ -143,7 +143,7 @@ curl -X POST http://localhost:3200/capabilities \
 | `name` | string | Dotted lowercase identifier, e.g. `broker.session.render`. |
 | `secretId` | uuid | The secret ID from Step 2. |
 | `host` | string | The broker host, lower-cased. Must be public https (see Constraints). |
-| `pathPattern` | string | v1 is **exact-path**: the forwarded path is this value verbatim. |
+| `pathPattern` | string | v1 is **exact-path** and path-only: `?` query and `#` fragment delimiters are rejected. Put selectors in the invoke `query` map. |
 | `method` | string | `GET` for list/fetch reads; `POST` for a body-carrying render call. |
 | `injectAs` | string | `header` only. Query/body injection is unsupported (reflection risk). |
 | `injectKey` | string | The header name to set, e.g. `authorization`. |

--- a/docs/guides/session-broker-integration.mdx
+++ b/docs/guides/session-broker-integration.mdx
@@ -103,7 +103,7 @@ The scoped broker token is stored encrypted. It is never returned in any respons
 
 ```bash
 curl -X POST http://localhost:3200/secrets \
-  -H "X-Steward-Key: your-tenant-key" \
+  -H "Authorization: Bearer <owner/admin-session-jwt-with-recent-mfa>" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "session-broker-token",
@@ -124,7 +124,7 @@ headers are blocked).
 
 ```bash
 curl -X POST http://localhost:3200/capabilities \
-  -H "X-Steward-Key: your-tenant-key" \
+  -H "Authorization: Bearer <owner/admin-session-jwt-with-recent-mfa>" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "broker.session.render",
@@ -144,7 +144,7 @@ curl -X POST http://localhost:3200/capabilities \
 | `secretId` | uuid | The secret ID from Step 2. |
 | `host` | string | The broker host, lower-cased. Must be public https (see Constraints). |
 | `pathPattern` | string | v1 is **exact-path**: the forwarded path is this value verbatim. |
-| `method` | string | `POST` for a body-carrying broker call (see the GET note below). |
+| `method` | string | `GET` for list/fetch reads; `POST` for a body-carrying render call. |
 | `injectAs` | string | `header` only. Query/body injection is unsupported (reflection risk). |
 | `injectKey` | string | The header name to set, e.g. `authorization`. |
 | `injectFormat` | string | `{value}` is replaced with the decrypted secret, e.g. `Bearer {value}`. |
@@ -161,7 +161,7 @@ carry an optional expiry.
 
 ```bash
 curl -X POST http://localhost:3200/capabilities/<capabilityId>/grants \
-  -H "X-Steward-Key: your-tenant-key" \
+  -H "Authorization: Bearer <owner/admin-session-jwt-with-recent-mfa>" \
   -H "Content-Type: application/json" \
   -d '{
     "agentId": "my-agent",
@@ -181,7 +181,7 @@ whose patterns govern the capability name. Policies are set with the full-set
 
 ```bash
 curl -X PUT http://localhost:3200/agents/my-agent/policies \
-  -H "X-Steward-Key: your-tenant-key" \
+  -H "Authorization: Bearer <owner/admin-session-jwt-with-recent-mfa>" \
   -H "Content-Type: application/json" \
   -d '[
     {
@@ -252,26 +252,15 @@ Read these before integrating — they are hard limits, not tunables.
   integrated. Put the broker behind a public HTTPS hostname (the proxy forces
   `https://`).
 
-- **Use `POST`, not `GET`, for broker capabilities.** Two things make `GET`
-  capabilities unusable for a credential-injected broker call under production
-  request-signing:
-  1. a `GET` (or `HEAD`) capability does **not** forward a request body — the
-     invoke path omits the body for those verbs, so a render payload in `body`
-     never reaches the broker;
-  2. more importantly, when the proxy runs with request signing enabled
-     (`STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE=true`, the production posture), it
-     requires an `Idempotency-Key` header on **any signed request — including safe
-     `GET` methods**. The proxy client does not auto-attach an idempotency key on
-     `GET`, and the invoke path supplies none, so a **signed `GET` capability
-     invoke fails closed with a `400` before it ever forwards** (`Idempotency-Key
-     header is required for signed proxy requests`).
-
-  `POST` both carries the request body and receives an auto-attached idempotency
-  key, so a `POST` capability works end to end. Do not work around the `GET` block
-  by smuggling the payload into `query` (query strings can reflect into upstream
-  responses and are not the injection surface). Model every broker capability as
-  `POST`. This limitation is pinned by a test in
-  `session-broker-e2e.test.ts`.
+- **Match the broker's real HTTP verb.** Use `GET` for list/fetch endpoints such
+  as `/api/:plugin/items` and `/api/:plugin/items/:id`; put bounded selectors in
+  the invoke envelope's `query` object. Use `POST` for render endpoints that
+  require a request body. The invoke path deliberately omits bodies for
+  `GET`/`HEAD`. Under production request signing, the proxy client attaches a
+  fresh `Idempotency-Key` to every signed method before computing the HMAC, so
+  signed safe requests remain replay-bound and pass the proxy's fail-closed
+  replay guard. `session-broker-e2e.test.ts` pins a signed, queried `GET` through
+  the real invoke + proxy path.
 
 - **Responses are capped at 25 MiB** (`STEWARD_PROXY_RESPONSE_BYTES`). This
   comfortably fits screenshot / rendered-image payloads. Raise it only if a broker
@@ -291,12 +280,8 @@ Read these before integrating — they are hard limits, not tunables.
 
 Everything above is **configuration**: environment variables, secrets, a
 capability, a grant, and a policy rule. No Steward product code is modified to
-integrate a session broker. The one honest caveat is the **signed-`GET`
-limitation** above — a `GET` capability is not usable for a credential-injected
-broker call under production request-signing (it fails closed with a `400` for the
-missing idempotency key, and would not forward a body regardless), so a broker
-integration must be modeled as `POST`. That is a design boundary of the invoke +
-proxy request-signing path, not something the runbook works around.
+integrate a session broker. Use `GET` for bodyless broker reads and `POST` for
+body-carrying operations; both traverse the same signed, replay-bound proxy path.
 
 ## See also
 

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -107,6 +107,9 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "cap-invoke-e2e-jwt-secret-with-enough-bytes-0123456789";
+  // This hermetic in-process fixture deliberately uses the explicit dev-only
+  // replay/rate stores. Production still requires shared Redis and fails closed.
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
   process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.github.com,api.openai.com";

--- a/packages/plugin-capabilities/src/__tests__/invoke.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke.test.ts
@@ -597,6 +597,74 @@ describe("invoke: body parsing", () => {
     });
     expect(res.status).toBe(400);
   });
+
+  test("unknown invoke envelope field => 400 (not silently ignored)", async () => {
+    await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("r1", "allow")];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request(
+      "/capabilities/github.pr.comment/invoke",
+      invokeReq({ queries: { account: "primary" } }),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toContain("unknown field");
+  });
+
+  for (const [label, query] of [
+    ["array", [["account", "primary"]]],
+    ["scalar", "account=primary"],
+    ["non-string selector value", { account: 7 }],
+  ] as const) {
+    test(`query ${label} => 400 (never coerced through URLSearchParams)`, async () => {
+      await seedCapabilityWithGrant();
+      currentPolicySet = [capRule("r1", "allow")];
+      const app = buildApp(harness!.db, { agent: true });
+      const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({ query }));
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { error: string }).error).toContain("query selectors");
+    });
+  }
+
+  for (const [label, query] of [
+    ["overlong key", { ["k".repeat(129)]: "value" }],
+    ["overlong value", { cursor: "x".repeat(2_049) }],
+    [
+      "too many selectors",
+      Object.fromEntries(Array.from({ length: 33 }, (_, index) => [`selector_${index}`, "x"])),
+    ],
+  ] as const) {
+    test(`${label} => 400 before delegation`, async () => {
+      await seedCapabilityWithGrant();
+      currentPolicySet = [capRule("r1", "allow")];
+      const app = buildApp(harness!.db, { agent: true });
+      const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({ query }));
+      expect(res.status).toBe(400);
+    });
+  }
+
+  test("args/query selector mismatch => 400 instead of authorizing one resource and forwarding another", async () => {
+    await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("r1", "allow", { argEquals: { account: "primary" } })];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request(
+      "/capabilities/github.pr.comment/invoke",
+      invokeReq({ args: { account: "primary" }, query: { account: "secondary" } }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("query-only selector is bound into capability-intent args", async () => {
+    await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("r1", "allow", { argEquals: { account: "primary" } })];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request(
+      "/capabilities/github.pr.comment/invoke",
+      invokeReq({ query: { account: "primary" } }),
+    );
+    // The selector satisfied argEquals, so authorization reached the expected
+    // missing-proxy-env boundary instead of default-denying with 403.
+    expect(res.status).toBe(503);
+  });
 });
 
 describe("invoke: allow-rule constraints", () => {

--- a/packages/plugin-capabilities/src/__tests__/routes.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/routes.test.ts
@@ -274,6 +274,16 @@ describe("capability CRUD happy path (authorized)", () => {
     expect(res.status).toBe(400);
   });
 
+  test.each([
+    "/repos/acme/widgets?account=secondary",
+    "/repos/acme/widgets#fragment",
+  ])("create rejects query/fragment-bearing pathPattern: %s", async (pathPattern) => {
+    const app = authedApp(harness!.db);
+    const res = await createCap(app, { pathPattern });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("query or fragment delimiters");
+  });
+
   test("bad capability name -> 400", async () => {
     const app = authedApp(harness!.db);
     const res = await createCap(app, { name: "Bad Name!" });
@@ -355,6 +365,21 @@ describe("grant + patch route behaviors (authorized)", () => {
       body: JSON.stringify({ pathPattern: "/repos/acme/*" }),
     });
     expect(patch.status).toBe(400);
+  });
+
+  test.each([
+    "/repos/acme/widgets?account=secondary",
+    "/repos/acme/widgets#fragment",
+  ])("PATCH rejects query/fragment-bearing pathPattern: %s", async (pathPattern) => {
+    const app = authedApp(harness!.db);
+    const capId = (await (await createCap(app)).json()).data.id as string;
+    const patch = await app.request(`/capabilities/${capId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ pathPattern }),
+    });
+    expect(patch.status).toBe(400);
+    expect((await patch.json()).error).toContain("query or fragment delimiters");
   });
 
   test("grant with a past expiresAt -> 400", async () => {

--- a/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
@@ -87,6 +87,14 @@ interface ForwardedCapture {
   body: string | null;
 }
 let lastForwarded: ForwardedCapture | null = null;
+let forwardCount = 0;
+interface ProxyRequestCapture {
+  path: string;
+  method: string;
+  headers: Headers;
+  body: BodyInit | null;
+}
+let lastProxyRequest: ProxyRequestCapture | null = null;
 // the broker's next response body (a test may seed a fat body).
 let brokerResponseBody: string = JSON.stringify({ ok: true, rendered: "small" });
 let proxyApp: Hono | null = null;
@@ -164,6 +172,7 @@ beforeAll(async () => {
   // forwarder signature is (url, method, headers, body: ReadableStream|null,
   // records); we drain the stream to a string to assert body passthrough.
   setForwardProxyRequestForTests(async (url, method, headers, body) => {
+    forwardCount += 1;
     let capturedBody: string | null = null;
     if (body != null) {
       capturedBody = await new Response(body as ReadableStream<Uint8Array>).text();
@@ -185,6 +194,12 @@ beforeAll(async () => {
     if (url.startsWith(PROXY_URL) && proxyApp) {
       const path = url.slice(PROXY_URL.length) || "/";
       lastProxyRequestHeaders = new Headers(init?.headers);
+      lastProxyRequest = {
+        path,
+        method: (init?.method ?? "GET").toUpperCase(),
+        headers: new Headers(init?.headers),
+        body: init?.body ?? null,
+      };
       return proxyApp.request(path, init as RequestInit);
     }
     return realFetch(input as RequestInfo, init);
@@ -315,6 +330,8 @@ beforeEach(async () => {
   lastForwarded = null;
   proxyRateLimitChecks = 0;
   lastProxyRequestHeaders = null;
+  lastProxyRequest = null;
+  forwardCount = 0;
   brokerResponseBody = JSON.stringify({ ok: true, rendered: "small" });
 });
 
@@ -469,7 +486,11 @@ describe("session-broker e2e: full arc through the real proxy", () => {
 
   it("signed GET reaches a broker-native read endpoint with query, bearer injection, replay binding, and no body", async () => {
     const capId = await seedBrokerCapability("GET", BROKER_READ_PATH);
-    currentPolicySet = [capRule("r1", "allow")];
+    currentPolicySet = [
+      capRule("r1", "allow", {
+        argEquals: { account: "primary", limit: "10", cursor: "next-page" },
+      }),
+    ];
     brokerResponseBody = JSON.stringify({ items: [{ id: "otter-note-1" }] });
     const app = buildInvokeApp();
 
@@ -478,7 +499,7 @@ describe("session-broker e2e: full arc through the real proxy", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         args: { account: "primary" },
-        query: { limit: "10", cursor: "next-page" },
+        query: { account: "primary", limit: "10", cursor: "next-page" },
       }),
     });
 
@@ -490,10 +511,25 @@ describe("session-broker e2e: full arc through the real proxy", () => {
     expect(lastForwarded).not.toBeNull();
     expect(lastForwarded?.method).toBe("GET");
     expect(lastForwarded?.url).toBe(
-      `https://${BROKER_HOST}${BROKER_READ_PATH}?limit=10&cursor=next-page`,
+      `https://${BROKER_HOST}${BROKER_READ_PATH}?account=primary&limit=10&cursor=next-page`,
     );
     expect(lastForwarded?.headers.get("authorization")).toBe(`Bearer ${BROKER_TOKEN}`);
     expect(lastForwarded?.body).toBeNull();
+    expect(forwardCount).toBe(1);
+
+    // Replay the exact signed client request: same signature, timestamp, and
+    // generated idempotency key. The real proxy must reject it before the
+    // broker forwarder runs a second time.
+    expect(lastProxyRequest).not.toBeNull();
+    expect(lastProxyRequest?.headers.get("idempotency-key")).toMatch(/^[0-9a-f-]{36}$/);
+    expect(lastProxyRequest?.headers.get("x-steward-signature")).toMatch(/^v1=[0-9a-f]{64}$/);
+    const replay = await proxyApp!.request(lastProxyRequest!.path, {
+      method: lastProxyRequest!.method,
+      headers: new Headers(lastProxyRequest!.headers),
+      body: lastProxyRequest!.body,
+    });
+    expect(replay.status).toBe(409);
+    expect(forwardCount).toBe(1);
 
     const rows = await agentInvocations(capId);
     expect(rows.length).toBe(1);

--- a/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
@@ -16,9 +16,9 @@
  *      intact and under the 25 MiB response cap.
  *   3. deny-by-default: an ungranted capability => 403, never forwards.
  *   4. an explicit `effect: "deny"` policy rule => 403, never forwards.
- *   5. the GET-signed limitation: a GET capability does NOT forward a request
- *      body (the invoke path omits it for GET/HEAD), which is why the runbook
- *      says "use POST for body-carrying broker calls".
+ *   5. an ALLOWED signed GET reaches a real broker-shaped list endpoint with
+ *      query parameters, replay-bound idempotency, bearer injection, no body,
+ *      no credential reflection, and a durable allow audit.
  *
  * The SSRF guard is prod defense with NO disable flag, so the broker cannot be a
  * localhost mock. We use the shipped in-process test hooks
@@ -53,6 +53,7 @@ const PROXY_URL = "https://proxy.broker-e2e.test";
 // short-circuited by __setResolveProxyHostForTests to a fixed public IP.
 const BROKER_HOST = "broker.cap-e2e.test";
 const CAP_NAME = "broker.session.render";
+const BROKER_READ_PATH = "/api/otter/items";
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
 const TEST_KDF_SALT = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 const TEST_ENV_KEYS = [
@@ -122,6 +123,9 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "broker-e2e-jwt-secret-with-enough-bytes-0123456789ab";
+  // The in-process proxy intentionally uses its explicit dev-only replay/rate
+  // stores. Production remains fail-closed on shared Redis.
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
   process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
   // the broker host must be in the proxy allowlist (SSRF layer 1) AND the
@@ -220,10 +224,13 @@ async function seedTenantAgent(): Promise<void> {
 }
 
 /**
- * Seed the broker capability + a grant for the agent. `method` defaults to POST
- * (the runbook's recommended verb); the GET-limitation test overrides it.
+ * Seed the broker capability + a grant for the agent. POST render calls use the
+ * default `/render`; GET read calls can select a broker-native list path.
  */
-async function seedBrokerCapability(method: "POST" | "GET" = "POST"): Promise<string> {
+async function seedBrokerCapability(
+  method: "POST" | "GET" = "POST",
+  pathPattern = "/render",
+): Promise<string> {
   const vault = new SecretVault(MASTER_PASSWORD);
   const secret = await vault.createSecret(tenantId, "session-broker-token", BROKER_TOKEN);
   const store = new CapabilityStore(getDb());
@@ -233,7 +240,7 @@ async function seedBrokerCapability(method: "POST" | "GET" = "POST"): Promise<st
     spec: {
       secretId: secret.id,
       host: BROKER_HOST,
-      pathPattern: "/render",
+      pathPattern,
       method,
       injectAs: "header",
       injectKey: "authorization",
@@ -460,44 +467,36 @@ describe("session-broker e2e: full arc through the real proxy", () => {
     expect(rows[0].decision).toBe("deny");
   });
 
-  it("documents the GET-signed limitation: a signed GET capability invoke is BLOCKED (400) under production request-signing", async () => {
-    // The runbook's honest caveat, proven. TWO things conspire against a GET
-    // capability when the proxy runs with request signing enabled (production,
-    // STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE=true, set in beforeAll):
-    //
-    //   1. the invoke path computes
-    //        hasBody = method !== "GET" && method !== "HEAD" && body !== undefined,
-    //      so a GET capability NEVER forwards a request body -- a broker needing a
-    //      render payload in the body could not receive it via GET anyway.
-    //   2. MORE IMPORTANTLY: the proxy requires an `Idempotency-Key` header for
-    //      ANY *signed* request -- including safe/GET methods (proxy.ts
-    //      claimUnsafeProxyRequest: `signedRequest` forces the key even for
-    //      SAFE_PROXY_METHODS). But StewardProxyClient does NOT auto-attach an
-    //      idempotency key on GET, and the invoke path supplies none. So a signed
-    //      GET capability invoke fails CLOSED with a 400 before it ever forwards.
-    //
-    // Net: under production request-signing, a GET capability is not usable for a
-    // credential-injected broker call. USE POST (which carries the body AND gets
-    // an auto-attached idempotency key). This test pins that behavior so a future
-    // change that silently "fixes" GET must update the runbook.
-    await seedBrokerCapability("GET");
+  it("signed GET reaches a broker-native read endpoint with query, bearer injection, replay binding, and no body", async () => {
+    const capId = await seedBrokerCapability("GET", BROKER_READ_PATH);
     currentPolicySet = [capRule("r1", "allow")];
+    brokerResponseBody = JSON.stringify({ items: [{ id: "otter-note-1" }] });
     const app = buildInvokeApp();
 
     const res = await app.request(`/capabilities/${CAP_NAME}/invoke`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ body: { url: "https://example.com/dashboard", format: "png" } }),
+      body: JSON.stringify({
+        args: { account: "primary" },
+        query: { limit: "10", cursor: "next-page" },
+      }),
     });
 
-    // policy authorized the invoke, but the proxy rejected the signed GET for the
-    // missing idempotency key. The invoke path forwards the upstream/proxy status
-    // verbatim. The request NEVER reached the broker.
-    expect(res.status).toBe(400);
-    expect(proxyRateLimitChecks).toBe(1);
-    const bodyText = await res.text();
-    expect(bodyText).toContain("Idempotency-Key");
-    // the broker was never called: no credential was ever attached/forwarded.
-    expect(lastForwarded).toBeNull();
+    expect(res.status).toBe(200);
+    const passthrough = await res.text();
+    expect(JSON.parse(passthrough)).toEqual({ items: [{ id: "otter-note-1" }] });
+    expect(passthrough).not.toContain(BROKER_TOKEN);
+
+    expect(lastForwarded).not.toBeNull();
+    expect(lastForwarded?.method).toBe("GET");
+    expect(lastForwarded?.url).toBe(
+      `https://${BROKER_HOST}${BROKER_READ_PATH}?limit=10&cursor=next-page`,
+    );
+    expect(lastForwarded?.headers.get("authorization")).toBe(`Bearer ${BROKER_TOKEN}`);
+    expect(lastForwarded?.body).toBeNull();
+
+    const rows = await agentInvocations(capId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("allow");
   });
 });

--- a/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
@@ -38,7 +38,7 @@ import { migrate as pgliteMigrate } from "drizzle-orm/pglite/migrator";
 import { Hono } from "hono";
 import type { StewardAppContext } from "../context";
 import { createInvokeRoutes } from "../invoke";
-import { capabilityInvocations } from "../schema";
+import { capabilities, capabilityInvocations } from "../schema";
 import { CapabilityStore } from "../store";
 
 setDefaultTimeout(30000);
@@ -481,6 +481,40 @@ describe("session-broker e2e: full arc through the real proxy", () => {
 
     const rows = await agentInvocations(capId);
     expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("deny");
+  });
+
+  it.each([
+    [`${BROKER_READ_PATH}?account=secondary`, "duplicate configured query"],
+    [`${BROKER_READ_PATH}#fragment`, "fragment-swallowed query"],
+  ])("legacy unsafe path fails closed before proxy dispatch: %s (%s)", async (legacyPath) => {
+    const capId = await seedBrokerCapability("GET", BROKER_READ_PATH);
+    // Simulate a row written before path-only validation existed (or by an
+    // out-of-band writer). The runtime boundary must remain authoritative.
+    await getDb()
+      .update(capabilities)
+      .set({ pathPattern: legacyPath })
+      .where(eq(capabilities.id, capId));
+    currentPolicySet = [capRule("r1", "allow", { argEquals: { account: "primary" } })];
+    const app = buildInvokeApp();
+
+    const res = await app.request(`/capabilities/${CAP_NAME}/invoke`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: { account: "primary" } }),
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { error: string }).toEqual({
+      ok: false,
+      error: "invalid capability route",
+    });
+    expect(lastProxyRequest).toBeNull();
+    expect(proxyRateLimitChecks).toBe(0);
+    expect(lastForwarded).toBeNull();
+    expect(forwardCount).toBe(0);
+    const rows = await agentInvocations(capId);
+    expect(rows).toHaveLength(1);
     expect(rows[0].decision).toBe("deny");
   });
 

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -43,8 +43,14 @@ export interface CapabilityInvokeRequest {
   name: string;
   args?: Record<string, unknown>;
   body?: unknown;
-  query?: Record<string, string>;
+  query?: unknown;
 }
+
+const INVOKE_ENVELOPE_KEYS = new Set(["args", "body", "query"]);
+const MAX_QUERY_SELECTORS = 32;
+const MAX_QUERY_SELECTOR_KEY_LENGTH = 128;
+const MAX_QUERY_SELECTOR_VALUE_LENGTH = 2_048;
+const MAX_ENCODED_QUERY_LENGTH = 8_192;
 
 /**
  * Internal marker on Steward-wrapped ({ok:...}) gate responses. The upstream
@@ -218,6 +224,54 @@ async function capabilityMapsToGovernedRoute(
   );
 }
 
+type NormalizedQuerySelectors = {
+  args: Record<string, unknown>;
+  query: Record<string, string> | undefined;
+};
+
+/**
+ * Validate the agent-controlled query surface and make the exact values that
+ * will be forwarded visible to capability-intent policy evaluation. A caller
+ * may describe a selector once in `query`, or repeat it in `args`; a repeated
+ * value must be byte-for-byte identical so authorization and dispatch cannot
+ * disagree about the selected resource.
+ */
+function normalizeQuerySelectors(
+  args: Record<string, unknown>,
+  rawQuery: unknown,
+): NormalizedQuerySelectors | null {
+  if (rawQuery === undefined) return { args, query: undefined };
+  if (rawQuery === null || typeof rawQuery !== "object" || Array.isArray(rawQuery)) return null;
+
+  const entries = Object.entries(rawQuery as Record<string, unknown>);
+  if (entries.length > MAX_QUERY_SELECTORS) return null;
+
+  // Null-prototype records keep special JavaScript property names (notably
+  // `__proto__`) as ordinary data if a provider legitimately uses them.
+  const query: Record<string, string> = Object.create(null) as Record<string, string>;
+  const effectiveArgs: Record<string, unknown> = Object.assign(
+    Object.create(null) as Record<string, unknown>,
+    args,
+  );
+  for (const [key, value] of entries) {
+    if (
+      key.length === 0 ||
+      key.length > MAX_QUERY_SELECTOR_KEY_LENGTH ||
+      typeof value !== "string" ||
+      value.length > MAX_QUERY_SELECTOR_VALUE_LENGTH
+    ) {
+      return null;
+    }
+    if (Object.hasOwn(args, key) && args[key] !== value) return null;
+    query[key] = value;
+    effectiveArgs[key] = value;
+  }
+
+  const encoded = new URLSearchParams(query).toString();
+  if (encoded.length > MAX_ENCODED_QUERY_LENGTH) return null;
+  return { args: effectiveArgs, query: entries.length > 0 ? query : undefined };
+}
+
 function buildProxyPath(cap: Capability, query: Record<string, string> | undefined): string {
   const host = cap.host.toLowerCase();
   const basePath = cap.pathPattern.startsWith("/") ? cap.pathPattern : `/${cap.pathPattern}`;
@@ -282,7 +336,6 @@ export async function invokeCapabilityThroughProxy(
   const store = new CapabilityStore(ctx.db);
   const engine = new PolicyEngine();
   const { tenantId, agentId, name } = request;
-  const invokeArgs = request.args ?? {};
 
   const usable = await store.listUsableCapabilitiesForAgent(tenantId, agentId);
   const match = usable.find((u) => u.capability.name === name);
@@ -297,6 +350,19 @@ export async function invokeCapabilityThroughProxy(
     });
   }
   const cap = match.capability;
+
+  const selectors = normalizeQuerySelectors(request.args ?? {}, request.query);
+  if (!selectors) {
+    return recordAndJson(store, {
+      tenantId,
+      agentId,
+      capabilityId: cap.id,
+      decision: "deny",
+      status: 400,
+      payload: { ok: false, error: "invalid capability query selectors" } satisfies ApiResponse,
+    });
+  }
+  const invokeArgs = selectors.args;
 
   let count1h: number;
   try {
@@ -506,7 +572,7 @@ export async function invokeCapabilityThroughProxy(
     });
 
     const method = cap.method.toUpperCase();
-    const path = buildProxyPath(cap, request.query);
+    const path = buildProxyPath(cap, selectors.query);
     const hasBody = method !== "GET" && method !== "HEAD" && request.body !== undefined;
     const init: RequestInit = { method };
     if (hasBody) {
@@ -579,9 +645,9 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
     }
 
     type InvokeEnvelope = {
-      args?: Record<string, unknown>;
+      args?: unknown;
       body?: unknown;
-      query?: Record<string, string>;
+      query?: unknown;
     };
     let envelope: InvokeEnvelope = {};
     let rawBody = "";
@@ -598,7 +664,13 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
             jsonResponse({ ok: false, error: "invoke body must be a JSON object" }, 400),
           );
         }
-        envelope = parsedBody as InvokeEnvelope;
+        const parsedEnvelope = parsedBody as Record<string, unknown>;
+        if (Object.keys(parsedEnvelope).some((key) => !INVOKE_ENVELOPE_KEYS.has(key))) {
+          return stripGateMarker(
+            jsonResponse({ ok: false, error: "unknown field in capability invoke body" }, 400),
+          );
+        }
+        envelope = parsedEnvelope as InvokeEnvelope;
       } catch {
         return stripGateMarker(
           jsonResponse({ ok: false, error: "invalid JSON in request body" }, 400),
@@ -606,14 +678,15 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
       }
     }
 
-    const args =
-      envelope.args && typeof envelope.args === "object" && !Array.isArray(envelope.args)
-        ? (envelope.args as Record<string, unknown>)
-        : {};
-    const query =
-      envelope.query && typeof envelope.query === "object" && !Array.isArray(envelope.query)
-        ? (envelope.query as Record<string, string>)
-        : undefined;
+    if (
+      envelope.args !== undefined &&
+      (envelope.args === null || typeof envelope.args !== "object" || Array.isArray(envelope.args))
+    ) {
+      return stripGateMarker(
+        jsonResponse({ ok: false, error: "capability invoke args must be a JSON object" }, 400),
+      );
+    }
+    const args = (envelope.args ?? {}) as Record<string, unknown>;
 
     const res = await invokeCapabilityThroughProxy(ctx, {
       tenantId,
@@ -621,7 +694,7 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
       name: c.req.param("name"),
       args,
       body: envelope.body,
-      query,
+      query: envelope.query,
     });
     return stripGateMarker(res);
   });

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -283,6 +283,16 @@ function buildProxyPath(cap: Capability, query: Record<string, string> | undefin
   return path;
 }
 
+/**
+ * New writes reject URL query/fragment delimiters in pathPattern. Keep this
+ * runtime check for legacy or externally-written rows so an old configured
+ * query cannot disagree with the selector map evaluated by policy, and a
+ * fragment cannot swallow an appended query before fetch dispatches it.
+ */
+function hasUnboundPathSelectors(pathPattern: string): boolean {
+  return pathPattern.includes("?") || pathPattern.includes("#");
+}
+
 function syntheticSignRequest(tenantId: string, agentId: string): SignRequest {
   return {
     agentId,
@@ -350,6 +360,17 @@ export async function invokeCapabilityThroughProxy(
     });
   }
   const cap = match.capability;
+
+  if (hasUnboundPathSelectors(cap.pathPattern)) {
+    return recordAndJson(store, {
+      tenantId,
+      agentId,
+      capabilityId: cap.id,
+      decision: "deny",
+      status: 403,
+      payload: { ok: false, error: "invalid capability route" } satisfies ApiResponse,
+    });
+  }
 
   const selectors = normalizeQuerySelectors(request.args ?? {}, request.query);
   if (!selectors) {

--- a/packages/proxy-client/README.md
+++ b/packages/proxy-client/README.md
@@ -39,7 +39,8 @@ const health = await client.proxyHealth();
 
 - attaches `Authorization: Bearer <token>`
 - auto-generates an `Idempotency-Key` (UUID) for `POST`/`PUT`/`PATCH`/`DELETE`
-  when the caller did not supply one
+  and for every signed request (including `GET`/`HEAD`) when the caller did not
+  supply one; the proxy replay-binds signed safe requests to that key
 - when `signingSecret` is set, computes `X-Steward-Signature` +
   `X-Steward-Request-Timestamp` using the proxy's canonical form
 

--- a/packages/proxy-client/src/__tests__/client.test.ts
+++ b/packages/proxy-client/src/__tests__/client.test.ts
@@ -106,6 +106,39 @@ describe("StewardProxyClient.fetch headers", () => {
     expect(calls[0].headers.get("idempotency-key")).toBeNull();
   });
 
+  test("auto-attaches replay-bound Idempotency-Key on signed GET", async () => {
+    const { fetch, calls } = makeCapturingFetch();
+    const client = new StewardProxyClient({
+      proxyUrl: "https://proxy.test",
+      token: "tok",
+      signingSecret: "signing-secret",
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      fetch,
+    });
+    await client.fetch("/proxy/broker.example.com/api/items?limit=10", { method: "GET" });
+    expect(calls[0].headers.get("idempotency-key")).toMatch(/^[0-9a-f-]{36}$/);
+    expect(calls[0].headers.get("x-steward-signature")).toMatch(/^v1=[0-9a-f]{64}$/);
+  });
+
+  test("preserves caller-supplied replay key on signed HEAD", async () => {
+    const { fetch, calls } = makeCapturingFetch();
+    const client = new StewardProxyClient({
+      proxyUrl: "https://proxy.test",
+      token: "tok",
+      signingSecret: "signing-secret",
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      fetch,
+    });
+    await client.fetch("/proxy/broker.example.com/api/items", {
+      method: "HEAD",
+      headers: { "idempotency-key": "caller-safe-request-key" },
+    });
+    expect(calls[0].headers.get("idempotency-key")).toBe("caller-safe-request-key");
+    expect(calls[0].headers.get("x-steward-signature")).toMatch(/^v1=[0-9a-f]{64}$/);
+  });
+
   test("preserves a caller-supplied Idempotency-Key", async () => {
     const { fetch, calls } = makeCapturingFetch();
     const client = new StewardProxyClient({

--- a/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
+++ b/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
@@ -76,6 +76,9 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "proxy-client-e2e-jwt-secret-with-enough-bytes";
+  // This hermetic in-process fixture deliberately uses the explicit dev-only
+  // replay store. Production still requires shared Redis and fails closed.
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   // Force the production-grade request-signature requirement so the e2e also
   // exercises the client's HMAC signer against the proxy verifier.
   process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";

--- a/packages/proxy-client/src/client.ts
+++ b/packages/proxy-client/src/client.ts
@@ -14,7 +14,8 @@
  *     `X-Steward-Signature` + `X-Steward-Request-Timestamp` headers per the
  *     proxy's canonical form (see ./signature.ts)
  *   - auto-generates an `Idempotency-Key` (crypto.randomUUID) for mutating
- *     methods (POST/PUT/PATCH/DELETE) when the caller did not supply one
+ *     methods and for every signed request when the caller did not supply one;
+ *     the proxy binds signed safe requests to that key for replay protection
  *
  * It is intentionally NOT vendor-specific: there is no openaiChat() helper.
  * Callers build the path (e.g. "/openai/v1/chat/completions") and body.
@@ -123,12 +124,19 @@ export class StewardProxyClient {
 
     headers.set("authorization", `Bearer ${this.token}`);
 
-    // Auto idempotency key for mutating methods, if the caller did not set one.
-    if (MUTATING_METHODS.has(method) && !headers.has("idempotency-key")) {
+    // Mutating calls always need an idempotency key. Signed safe calls need one
+    // too: the proxy intentionally replay-binds every proof-of-possession
+    // request, including GET/HEAD. Generate it before signing so the exact key
+    // is covered by the HMAC canonical form.
+    const signingSecret = this.signingSecret;
+    const tenantId = this.tenantId;
+    const agentId = this.agentId;
+    const signed = Boolean(signingSecret && tenantId && agentId);
+    if ((MUTATING_METHODS.has(method) || signed) && !headers.has("idempotency-key")) {
       headers.set("idempotency-key", crypto.randomUUID());
     }
 
-    if (this.signingSecret && this.tenantId && this.agentId) {
+    if (signingSecret && tenantId && agentId) {
       const timestamp = String(Math.floor(Date.now() / 1000));
       headers.set("x-steward-request-timestamp", timestamp);
 
@@ -137,13 +145,13 @@ export class StewardProxyClient {
         {
           method,
           url: joinPath(this.baseUrl, path),
-          tenantId: this.tenantId,
-          agentId: this.agentId,
+          tenantId,
+          agentId,
           timestamp,
           idempotencyKey: headers.get("idempotency-key") ?? undefined,
           body: signable,
         },
-        this.signingSecret,
+        signingSecret,
       );
       headers.set("x-steward-signature", signature);
     }

--- a/packages/vault/src/__tests__/secret-route-validator.test.ts
+++ b/packages/vault/src/__tests__/secret-route-validator.test.ts
@@ -24,6 +24,15 @@ describe("validateSecretRouteConfig — core rules", () => {
     expect(validateSecretRouteConfig(okBase)).toBeNull();
   });
 
+  it.each([
+    "/v1/items?account=secondary",
+    "/v1/items#account=secondary",
+  ])("rejects query and fragment delimiters in pathPattern: %s", (pathPattern) => {
+    expect(validateSecretRouteConfig({ ...okBase, pathPattern })).toContain(
+      "must not contain query or fragment delimiters",
+    );
+  });
+
   it("accepts only an exact EC2 SigV4 endpoint binding", () => {
     const sigv4 = {
       ...okBase,

--- a/packages/vault/src/secret-route-validator.ts
+++ b/packages/vault/src/secret-route-validator.ts
@@ -325,6 +325,13 @@ export function validateSecretRouteConfig(
       return "broad pathPattern requires STEWARD_ALLOW_BROAD_SECRET_ROUTES=true";
     }
     if (/[\u0000-\u001f\u007f\\]/.test(pathPattern)) return "pathPattern is invalid";
+    // Route paths are matched independently from the request query, and URL
+    // fragments are never transmitted. Keeping both delimiters out of stored
+    // route specs prevents policy-visible selectors from diverging from the
+    // exact URL the proxy dispatches.
+    if (pathPattern.includes("?") || pathPattern.includes("#")) {
+      return "pathPattern must not contain query or fragment delimiters";
+    }
     if (
       lowered.includes("%2e") ||
       lowered.includes("%2f") ||


### PR DESCRIPTION
Refs #157

## Summary

- generate an idempotency key before signing every signed request, including GET/HEAD
- strictly validate the capability invoke envelope and bound query selectors to 32 string entries, 128-character keys, 2,048-character values, and an 8,192-character encoded query
- merge effective query selectors into policy-visible arguments and reject any `args`/`query` overlap mismatch, preventing one authorized selector from dispatching another resource
- reject `?` and `#` in authoritative secret-route/capability create and update validation, and fail closed at invoke time for legacy or externally-written unsafe capability rows
- add reachable broker proofs for signed GET replay plus hostile configured-query and fragment cases; unsafe legacy paths record a deny without reaching proxy auth/rate limiting or broker forwarding
- synchronize the proxy-client README and broker runbook with signed safe-request behavior, path-only capability specs, and actual session/MFA setup

## Validation

- vault route validator: 54/54
- capability package isolated runner: all 15 test files green; the long upstream-leases file exceeded the default 180s aggregate wall after 43 passing cases, then passed independently with a 600s wall
- proxy-client: 23/23, 72 assertions
- affected dependency build: 12/12 packages
- Biome and `git diff --check`

## Stack and remaining acceptance

Stacked directly on #591 exact head `29a9ac4443e565b531b0c0f58870f222c39a644f`; its fixture environment restoration, rate-limit/audit-HMAC assertions, hook resets, and production fail-closed coverage are preserved alongside the signed GET tests.

This PR does not claim the live phase-1 demo. Issue #157 still needs a publicly reachable broker and proxy deployment, scoped token/capability/grant/policy setup, and live audit evidence.

Base: `29a9ac4443e565b531b0c0f58870f222c39a644f`
Head: `2f3daa9949f8177fb0bd479e88d700f19dd87359`