### PR TITLE
fix(sandbox): require live vault KDF salt

### DIFF
--- a/deploy/enterprise-reference/provider-github-sandbox.env.example
+++ b/deploy/enterprise-reference/provider-github-sandbox.env.example
@@ -64,6 +64,11 @@ STEWARD_SANDBOX_SECRET_ID=
 # dispatch endpoint and no caller-forgeable dispatch context.
 DATABASE_URL=
 STEWARD_MASTER_PASSWORD=
+# The exact per-deployment salt used by the live vault. It must be valid hex
+# encoding at least 16 bytes (generate a new deployment salt with
+# `openssl rand -hex 32`). Supply the existing deployment value out-of-band;
+# using a different value cannot decrypt the pre-provisioned sandbox secret.
+STEWARD_KDF_SALT=
 STEWARD_EXECUTION_AUTH_SECRET=
 STEWARD_AUDIT_HMAC_KEY=
 STEWARD_AUDIT_SIGNING_KEY=

--- a/docs/guides/provider-authority-golden-path.mdx
+++ b/docs/guides/provider-authority-golden-path.mdx
@@ -169,7 +169,16 @@ Requirements:
   The committed artifact is a `*.example` with placeholders and presence guards.
 - Pre-provisioned sandbox-only workspace, provider account, governed secret
   route, provider-agent JWT, recent-MFA approver session, and the database/vault/
-  execution/audit environment used by that same Steward deployment.
+  execution/audit environment used by that same Steward deployment. This
+  includes the exact `STEWARD_KDF_SALT` used to encrypt the pre-provisioned
+  secret; preflight rejects a missing or malformed salt, but operators must
+  supply the matching live value out-of-band.
+
+No real sandbox artifact is committed yet. Producing the artifact bundle still
+requires the external throwaway GitHub App/repository and pre-provisioned live
+Steward authority graph above. A naturally observed GitHub 403/429 with
+`Retry-After` also remains an external observation: the harness does not induce
+or manufacture rate limiting.
 
 `--preflight` performs no network request. The live command rotates the minted
 installation token through the MFA-gated secret API, drives create → approve →

--- a/docs/security/provider-authority-threat-model.mdx
+++ b/docs/security/provider-authority-threat-model.mdx
@@ -60,6 +60,9 @@ recorded, the following are explicitly **not** claimed:
 
 - The real GitHub sandbox run is documented but not yet recorded here; the
   golden-path manifest keeps the pre-real-proof wording until it is.
+- A live GitHub 403/429 with `Retry-After` has not been recorded. The harness
+  leaves that matrix row `not_observed` and Gate D at STOP rather than inducing
+  rate limiting or substituting the hermetic classifier proof.
 - A render-based accessibility (axe) scan of the two trust surfaces is deferred
   until the web package adopts a component-render test harness; the current
   guard is a structural source scan.

--- a/packages/vault/src/__tests__/kdf-domain-separation.test.ts
+++ b/packages/vault/src/__tests__/kdf-domain-separation.test.ts
@@ -15,9 +15,19 @@ const altDomainRoot = new KeyStore(MASTER, SALT, "signing-vault");
 const TIMEOUT = 30_000;
 
 describe("KDF domain separation (#11)", () => {
-  test("rejects odd-length or partially decoded KDF salts", () => {
+  test("accepts compatible full-string hexadecimal KDF salts", () => {
+    const uppercase = new KeyStore(MASTER, "AB".repeat(16));
+    const lowercase = new KeyStore(MASTER, "ab".repeat(16));
+    const ciphertext = uppercase.encrypt("compatible-existing-root");
+    expect(lowercase.decrypt(ciphertext)).toBe("compatible-existing-root");
+  });
+
+  test("rejects odd-length, partially decoded, or whitespace-padded KDF salts", () => {
     expect(() => new KeyStore(MASTER, "a".repeat(33))).toThrow("even-length hexadecimal string");
     expect(() => new KeyStore(MASTER, `${"a".repeat(32)}zz`)).toThrow(
+      "even-length hexadecimal string",
+    );
+    expect(() => new KeyStore(MASTER, `${"a".repeat(32)} `)).toThrow(
       "even-length hexadecimal string",
     );
   });

--- a/packages/vault/src/__tests__/kdf-domain-separation.test.ts
+++ b/packages/vault/src/__tests__/kdf-domain-separation.test.ts
@@ -15,6 +15,13 @@ const altDomainRoot = new KeyStore(MASTER, SALT, "signing-vault");
 const TIMEOUT = 30_000;
 
 describe("KDF domain separation (#11)", () => {
+  test("rejects odd-length or partially decoded KDF salts", () => {
+    expect(() => new KeyStore(MASTER, "a".repeat(33))).toThrow("even-length hexadecimal string");
+    expect(() => new KeyStore(MASTER, `${"a".repeat(32)}zz`)).toThrow(
+      "even-length hexadecimal string",
+    );
+  });
+
   test(
     "secret-vault and signing-vault roots are cryptographically distinct",
     () => {

--- a/packages/vault/src/kdf-salt.d.mts
+++ b/packages/vault/src/kdf-salt.d.mts
@@ -1,0 +1,4 @@
+import type { Buffer } from "node:buffer";
+
+export declare const KDF_SALT_MIN_BYTES: 16;
+export declare function decodeKdfSalt(value: string, variableName?: string): Buffer;

--- a/packages/vault/src/kdf-salt.mjs
+++ b/packages/vault/src/kdf-salt.mjs
@@ -1,0 +1,34 @@
+import { Buffer } from "node:buffer";
+
+export const KDF_SALT_MIN_BYTES = 16;
+
+const KDF_SALT_REQUIREMENT =
+  "must be an even-length hexadecimal string of at least 32 characters (16 bytes). Generate with: openssl rand -hex 32";
+
+/**
+ * Decode a deployment KDF salt without Node's permissive partial-hex parsing.
+ *
+ * `Buffer.from(value, "hex")` silently stops at an invalid nibble. Validate the
+ * complete string first so operator preflight and the production KeyStore use
+ * exactly the same fail-closed contract and derive from exactly the bytes the
+ * operator supplied.
+ */
+export function decodeKdfSalt(value, variableName = "STEWARD_KDF_SALT") {
+  if (
+    typeof value !== "string" ||
+    value.length < KDF_SALT_MIN_BYTES * 2 ||
+    value.length % 2 !== 0 ||
+    !/^[0-9a-fA-F]+$/.test(value)
+  ) {
+    throw new Error(`${variableName} ${KDF_SALT_REQUIREMENT}`);
+  }
+
+  const decoded = Buffer.from(value, "hex");
+  // Defensive parity check: the full-string/even-length validation above should
+  // make these conditions impossible, but never trust a decoder to consume less
+  // input than expected at a cryptographic configuration boundary.
+  if (decoded.length < KDF_SALT_MIN_BYTES || decoded.length * 2 !== value.length) {
+    throw new Error(`${variableName} ${KDF_SALT_REQUIREMENT}`);
+  }
+  return decoded;
+}

--- a/packages/vault/src/kdf-salt.mjs
+++ b/packages/vault/src/kdf-salt.mjs
@@ -23,12 +23,5 @@ export function decodeKdfSalt(value, variableName = "STEWARD_KDF_SALT") {
     throw new Error(`${variableName} ${KDF_SALT_REQUIREMENT}`);
   }
 
-  const decoded = Buffer.from(value, "hex");
-  // Defensive parity check: the full-string/even-length validation above should
-  // make these conditions impossible, but never trust a decoder to consume less
-  // input than expected at a cryptographic configuration boundary.
-  if (decoded.length < KDF_SALT_MIN_BYTES || decoded.length * 2 !== value.length) {
-    throw new Error(`${variableName} ${KDF_SALT_REQUIREMENT}`);
-  }
-  return decoded;
+  return Buffer.from(value, "hex");
 }

--- a/packages/vault/src/keystore.ts
+++ b/packages/vault/src/keystore.ts
@@ -8,6 +8,7 @@
 //     alternative - note that switching KDFs invalidates existing encrypted
 //     records (operator decision, not a transparent migration).
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:crypto";
+import { decodeKdfSalt } from "./kdf-salt.mjs";
 import type { KeystoreContext } from "./keystore-backend";
 
 /**
@@ -64,15 +65,7 @@ export class KeyStore {
     const envSalt = masterSalt ?? process.env.STEWARD_KDF_SALT;
     let salt: Buffer;
     if (envSalt) {
-      if (envSalt.length < 32 || envSalt.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(envSalt)) {
-        throw new Error(
-          "STEWARD_KDF_SALT must be an even-length hexadecimal string of at least 32 characters (16 bytes). Generate with: openssl rand -hex 32",
-        );
-      }
-      salt = Buffer.from(envSalt, "hex");
-      if (salt.length < 16) {
-        throw new Error("STEWARD_KDF_SALT must decode to at least 16 bytes of randomness.");
-      }
+      salt = decodeKdfSalt(envSalt);
     } else {
       if (process.env.NODE_ENV === "production") {
         throw new Error(

--- a/packages/vault/src/keystore.ts
+++ b/packages/vault/src/keystore.ts
@@ -64,9 +64,9 @@ export class KeyStore {
     const envSalt = masterSalt ?? process.env.STEWARD_KDF_SALT;
     let salt: Buffer;
     if (envSalt) {
-      if (envSalt.length < 32) {
+      if (envSalt.length < 32 || envSalt.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(envSalt)) {
         throw new Error(
-          "STEWARD_KDF_SALT must be at least 32 hex characters (16 bytes). Generate with: openssl rand -hex 32",
+          "STEWARD_KDF_SALT must be an even-length hexadecimal string of at least 32 characters (16 bytes). Generate with: openssl rand -hex 32",
         );
       }
       salt = Buffer.from(envSalt, "hex");

--- a/scripts/__tests__/provider-authority-sandbox.test.ts
+++ b/scripts/__tests__/provider-authority-sandbox.test.ts
@@ -58,6 +58,7 @@ function envFixture() {
       "STEWARD_AUDIT_SIGNING_KEY_FINGERPRINT",
       "DATABASE_URL",
       "STEWARD_MASTER_PASSWORD",
+      "STEWARD_KDF_SALT",
       "STEWARD_EXECUTION_AUTH_SECRET",
       "STEWARD_AUDIT_HMAC_KEY",
     ]
@@ -71,6 +72,7 @@ function envFixture() {
       ]),
   );
   env.STEWARD_API_URL = "https://steward.sandbox.test";
+  env.STEWARD_KDF_SALT = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
   return env;
 }
 
@@ -100,6 +102,20 @@ describe("provider authority sandbox operator primitives", () => {
       globalThis.fetch = original;
     }
     expect(calls).toBe(0);
+  });
+
+  it("fails closed when the live vault KDF salt is missing or malformed", () => {
+    const missing = envFixture();
+    delete missing.STEWARD_KDF_SALT;
+    expect(() => validateEnvironment(missing)).toThrow("STEWARD_KDF_SALT");
+
+    const short = envFixture();
+    short.STEWARD_KDF_SALT = "abcd";
+    expect(() => validateEnvironment(short)).toThrow("at least 32 hex characters");
+
+    const nonHex = envFixture();
+    nonHex.STEWARD_KDF_SALT = "z".repeat(64);
+    expect(() => validateEnvironment(nonHex)).toThrow("decode to at least 16 bytes");
   });
 
   it("rejects credential-bearing and public plaintext service URLs", async () => {

--- a/scripts/__tests__/provider-authority-sandbox.test.ts
+++ b/scripts/__tests__/provider-authority-sandbox.test.ts
@@ -105,28 +105,28 @@ describe("provider authority sandbox operator primitives", () => {
   });
 
   it("fails closed when the live vault KDF salt is missing or malformed", () => {
-    const missing = envFixture();
+    // RSA fixture generation is intentionally expensive. Generate it once so
+    // this validation table stays within Bun's default per-test timeout (the
+    // official scripts/__tests__ CI command does not raise that timeout).
+    const valid = envFixture();
+
+    const missing = { ...valid };
     delete missing.STEWARD_KDF_SALT;
     expect(() => validateEnvironment(missing)).toThrow("STEWARD_KDF_SALT");
 
-    const short = envFixture();
-    short.STEWARD_KDF_SALT = "abcd";
+    const short = { ...valid, STEWARD_KDF_SALT: "abcd" };
     expect(() => validateEnvironment(short)).toThrow("at least 32 characters");
 
-    const nonHex = envFixture();
-    nonHex.STEWARD_KDF_SALT = `${"a".repeat(32)}zz`;
+    const nonHex = { ...valid, STEWARD_KDF_SALT: `${"a".repeat(32)}zz` };
     expect(() => validateEnvironment(nonHex)).toThrow("even-length hexadecimal string");
 
-    const oddLength = envFixture();
-    oddLength.STEWARD_KDF_SALT = "a".repeat(33);
+    const oddLength = { ...valid, STEWARD_KDF_SALT: "a".repeat(33) };
     expect(() => validateEnvironment(oddLength)).toThrow("even-length hexadecimal string");
 
-    const trailingSpace = envFixture();
-    trailingSpace.STEWARD_KDF_SALT = `${"a".repeat(32)} `;
+    const trailingSpace = { ...valid, STEWARD_KDF_SALT: `${"a".repeat(32)} ` };
     expect(() => validateEnvironment(trailingSpace)).toThrow("even-length hexadecimal string");
 
-    const uppercase = envFixture();
-    uppercase.STEWARD_KDF_SALT = "AB".repeat(16);
+    const uppercase = { ...valid, STEWARD_KDF_SALT: "AB".repeat(16) };
     expect(() => validateEnvironment(uppercase)).not.toThrow();
   });
 

--- a/scripts/__tests__/provider-authority-sandbox.test.ts
+++ b/scripts/__tests__/provider-authority-sandbox.test.ts
@@ -120,6 +120,14 @@ describe("provider authority sandbox operator primitives", () => {
     const oddLength = envFixture();
     oddLength.STEWARD_KDF_SALT = "a".repeat(33);
     expect(() => validateEnvironment(oddLength)).toThrow("even-length hexadecimal string");
+
+    const trailingSpace = envFixture();
+    trailingSpace.STEWARD_KDF_SALT = `${"a".repeat(32)} `;
+    expect(() => validateEnvironment(trailingSpace)).toThrow("even-length hexadecimal string");
+
+    const uppercase = envFixture();
+    uppercase.STEWARD_KDF_SALT = "AB".repeat(16);
+    expect(() => validateEnvironment(uppercase)).not.toThrow();
   });
 
   it("rejects credential-bearing and public plaintext service URLs", async () => {

--- a/scripts/__tests__/provider-authority-sandbox.test.ts
+++ b/scripts/__tests__/provider-authority-sandbox.test.ts
@@ -111,11 +111,15 @@ describe("provider authority sandbox operator primitives", () => {
 
     const short = envFixture();
     short.STEWARD_KDF_SALT = "abcd";
-    expect(() => validateEnvironment(short)).toThrow("at least 32 hex characters");
+    expect(() => validateEnvironment(short)).toThrow("at least 32 characters");
 
     const nonHex = envFixture();
-    nonHex.STEWARD_KDF_SALT = "z".repeat(64);
-    expect(() => validateEnvironment(nonHex)).toThrow("decode to at least 16 bytes");
+    nonHex.STEWARD_KDF_SALT = `${"a".repeat(32)}zz`;
+    expect(() => validateEnvironment(nonHex)).toThrow("even-length hexadecimal string");
+
+    const oddLength = envFixture();
+    oddLength.STEWARD_KDF_SALT = "a".repeat(33);
+    expect(() => validateEnvironment(oddLength)).toThrow("even-length hexadecimal string");
   });
 
   it("rejects credential-bearing and public plaintext service URLs", async () => {

--- a/scripts/lib/provider-authority-sandbox-lib.mjs
+++ b/scripts/lib/provider-authority-sandbox-lib.mjs
@@ -19,6 +19,7 @@ export const REQUIRED_ENV = [
   "STEWARD_AUDIT_SIGNING_KEY_FINGERPRINT",
   "DATABASE_URL",
   "STEWARD_MASTER_PASSWORD",
+  "STEWARD_KDF_SALT",
   "STEWARD_EXECUTION_AUTH_SECRET",
   "STEWARD_AUDIT_HMAC_KEY",
   "STEWARD_AUDIT_SIGNING_KEY",
@@ -138,6 +139,20 @@ export function validateEnvironment(env) {
     if (missing.length) parts.push(`missing required env: ${missing.join(", ")}`);
     if (placeholders.length) parts.push(`placeholder value(s): ${placeholders.join(", ")}`);
     throw new Error(parts.join("; "));
+  }
+  // Match the production vault's KeyStore contract. The live dispatch child
+  // must derive the same root key as the deployment that encrypted the seeded
+  // credential; accepting a missing, short, or non-hex salt would make a
+  // successful preflight meaningless and defer the failure until dispatch.
+  const kdfSalt = env.STEWARD_KDF_SALT;
+  if (kdfSalt.length < 32) {
+    throw new Error(
+      "STEWARD_KDF_SALT must be at least 32 hex characters (16 bytes). Generate with: openssl rand -hex 32",
+    );
+  }
+  const decodedKdfSalt = Buffer.from(kdfSalt, "hex");
+  if (decodedKdfSalt.length < 16) {
+    throw new Error("STEWARD_KDF_SALT must decode to at least 16 bytes of randomness.");
   }
   const stewardBase = validateServiceUrl("STEWARD_API_URL", env.STEWARD_API_URL);
   const stewardUrl = new URL(stewardBase);

--- a/scripts/lib/provider-authority-sandbox-lib.mjs
+++ b/scripts/lib/provider-authority-sandbox-lib.mjs
@@ -145,9 +145,9 @@ export function validateEnvironment(env) {
   // credential; accepting a missing, short, or non-hex salt would make a
   // successful preflight meaningless and defer the failure until dispatch.
   const kdfSalt = env.STEWARD_KDF_SALT;
-  if (kdfSalt.length < 32) {
+  if (kdfSalt.length < 32 || kdfSalt.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(kdfSalt)) {
     throw new Error(
-      "STEWARD_KDF_SALT must be at least 32 hex characters (16 bytes). Generate with: openssl rand -hex 32",
+      "STEWARD_KDF_SALT must be an even-length hexadecimal string of at least 32 characters (16 bytes). Generate with: openssl rand -hex 32",
     );
   }
   const decodedKdfSalt = Buffer.from(kdfSalt, "hex");

--- a/scripts/lib/provider-authority-sandbox-lib.mjs
+++ b/scripts/lib/provider-authority-sandbox-lib.mjs
@@ -1,6 +1,7 @@
 import { createSign } from "node:crypto";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { decodeKdfSalt } from "../../packages/vault/src/kdf-salt.mjs";
 
 export const REQUIRED_ENV = [
   "GITHUB_APP_ID",
@@ -144,16 +145,7 @@ export function validateEnvironment(env) {
   // must derive the same root key as the deployment that encrypted the seeded
   // credential; accepting a missing, short, or non-hex salt would make a
   // successful preflight meaningless and defer the failure until dispatch.
-  const kdfSalt = env.STEWARD_KDF_SALT;
-  if (kdfSalt.length < 32 || kdfSalt.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(kdfSalt)) {
-    throw new Error(
-      "STEWARD_KDF_SALT must be an even-length hexadecimal string of at least 32 characters (16 bytes). Generate with: openssl rand -hex 32",
-    );
-  }
-  const decodedKdfSalt = Buffer.from(kdfSalt, "hex");
-  if (decodedKdfSalt.length < 16) {
-    throw new Error("STEWARD_KDF_SALT must decode to at least 16 bytes of randomness.");
-  }
+  decodeKdfSalt(env.STEWARD_KDF_SALT);
   const stewardBase = validateServiceUrl("STEWARD_API_URL", env.STEWARD_API_URL);
   const stewardUrl = new URL(stewardBase);
   if (stewardUrl.search || stewardUrl.hash) {


### PR DESCRIPTION
Refs #230

## Summary

- require `STEWARD_KDF_SALT` during provider-authority sandbox preflight so the isolated dispatch worker uses the same vault root derivation as the live deployment
- share one strict decoder between the production `KeyStore` and sandbox preflight, rejecting short, odd-length, non-hex, whitespace-padded, or partially decoded salts
- document the variable name only in the placeholder env template, with the existing value supplied out-of-band
- keep acceptance claims honest: real sandbox artifacts and a naturally observed GitHub 403/429 with `Retry-After` remain external and Gate D stays STOP without them

## Validation

- `bun test scripts/__tests__/provider-authority-sandbox.test.ts packages/vault/src/__tests__/kdf-domain-separation.test.ts` (26 pass, 82 assertions)
- affected dependency build: 9/9 packages at the preceding strict-decoder tree; the final commit only removes a logically redundant post-validation decoder parity branch
- Biome on the changed source and tests
- `git diff --check`

Node's hex decoder silently truncates odd nibbles and trailing non-hex input. The shared validator checks the complete even-length string before decoding. Valid generated deployment salts remain unchanged, and the now-provably redundant decoded-length recheck was removed rather than retained as defensive duplication.

No provider calls were made, no credentials were created or used, and no real-proof artifact is claimed.

Base: `9239a728b9ca28175e00e2825f69d85f3e02856e`
Head: `766900afadc55e260040e5fd18acbbad9b82159d`
