### PR TITLE
test(auth): exercise passkey enumeration route

### DIFF
--- a/packages/api/src/__tests__/auth-passkey-enumeration.test.ts
+++ b/packages/api/src/__tests__/auth-passkey-enumeration.test.ts
@@ -1,17 +1,143 @@
-import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { authenticators, closeDb, getDb, tenantConfigs, tenants, users } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Hono } from "hono";
 
-const authSource = readFileSync(join(import.meta.dir, "..", "routes", "auth.ts"), "utf8");
+setDefaultTimeout(120_000);
+
+const ENABLED_TENANT_ID = "passkey-enumeration-enabled";
+const DISABLED_TENANT_ID = "passkey-enumeration-disabled";
+const KNOWN_EMAIL = "passkey-known@example.test";
+const UNKNOWN_EMAIL = "passkey-unknown@example.test";
+const SECRET_CREDENTIAL_ID = "credential-id-must-never-leave-options-route";
+
+type LoginOptions = {
+  challenge: string;
+  challengeId: string;
+  rpId: string;
+  timeout: number;
+  userVerification: string;
+  allowCredentials: Array<{ id: string }>;
+  [key: string]: unknown;
+};
 
 describe("passkey login options privacy", () => {
-  it("does not expose stored credential ids before authentication", () => {
-    const routeStart = authSource.indexOf('auth.post("/passkey/login/options"');
-    const routeEnd = authSource.indexOf('auth.post("/passkey/login/verify"', routeStart);
-    const routeBody = authSource.slice(routeStart, routeEnd);
+  let app: Hono;
+  let getAuthChallengeStore: Awaited<typeof import("../routes/auth")>["getAuthChallengeStore"];
+  let knownUserId = "";
 
-    expect(routeBody).not.toContain("authenticators.credentialId");
-    expect(routeBody).not.toContain("authenticators.userId");
-    expect(routeBody).toContain("allowCredentials: []");
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_ALLOW_DEV_SECRETS = "true";
+    process.env.STEWARD_JWT_SECRET = "passkey-enumeration-jwt-secret-with-enough-entropy";
+    process.env.STEWARD_MASTER_PASSWORD = "passkey-enumeration-master-password";
+    process.env.STEWARD_KDF_SALT = "dGVzdC1zYWx0LXRlc3Qtc2FsdA==";
+    process.env.PASSKEY_RP_ID = "steward.fi";
+    process.env.PASSKEY_ORIGIN = "https://steward.fi";
+
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+
+    await getDb()
+      .insert(tenants)
+      .values([
+        { id: ENABLED_TENANT_ID, name: "Passkey enabled", apiKeyHash: "passkey-enabled" },
+        { id: DISABLED_TENANT_ID, name: "Passkey disabled", apiKeyHash: "passkey-disabled" },
+      ]);
+    await getDb()
+      .insert(tenantConfigs)
+      .values({
+        tenantId: DISABLED_TENANT_ID,
+        authAbuseConfig: { loginMethods: { passkey: false } },
+      });
+    const [knownUser] = await getDb()
+      .insert(users)
+      .values({ email: KNOWN_EMAIL, emailVerified: true })
+      .returning({ id: users.id });
+    knownUserId = knownUser.id;
+    await getDb()
+      .insert(authenticators)
+      .values({
+        userId: knownUserId,
+        credentialId: SECRET_CREDENTIAL_ID,
+        credentialPublicKey: "credential-public-key-must-also-remain-private",
+        counter: 7,
+        credentialDeviceType: "singleDevice",
+        credentialBackedUp: false,
+        transports: ["internal"],
+      });
+
+    const auth = await import("../routes/auth");
+    getAuthChallengeStore = auth.getAuthChallengeStore;
+    app = new Hono().route("/auth", auth.authRoutes);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_ALLOW_DEV_SECRETS;
+    delete process.env.STEWARD_JWT_SECRET;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+    delete process.env.STEWARD_KDF_SALT;
+    delete process.env.PASSKEY_RP_ID;
+    delete process.env.PASSKEY_ORIGIN;
+  });
+
+  async function requestOptions(email: string, tenantId = ENABLED_TENANT_ID) {
+    return app.request("/auth/passkey/login/options", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, tenantId }),
+    });
+  }
+
+  function assertDiscoverableCredentialShape(options: LoginOptions) {
+    expect(options.challenge).toMatch(/^[A-Za-z0-9_-]{32,}$/);
+    expect(options.challengeId).toBe(options.challenge);
+    expect(options.rpId).toBe("steward.fi");
+    expect(options.timeout).toBeGreaterThan(0);
+    expect(options.userVerification).toBe("required");
+    expect(options.allowCredentials).toEqual([]);
+  }
+
+  it("returns the same non-enumerating shape for known and unknown emails", async () => {
+    const [knownResponse, unknownResponse] = await Promise.all([
+      requestOptions(`  ${KNOWN_EMAIL.toUpperCase()}  `),
+      requestOptions(UNKNOWN_EMAIL),
+    ]);
+    expect(knownResponse.status).toBe(200);
+    expect(unknownResponse.status).toBe(200);
+
+    const known = (await knownResponse.json()) as LoginOptions;
+    const unknown = (await unknownResponse.json()) as LoginOptions;
+    assertDiscoverableCredentialShape(known);
+    assertDiscoverableCredentialShape(unknown);
+    expect(Object.keys(known).sort()).toEqual(Object.keys(unknown).sort());
+
+    for (const payload of [known, unknown]) {
+      const serialized = JSON.stringify(payload);
+      expect(serialized).not.toContain(SECRET_CREDENTIAL_ID);
+      expect(serialized).not.toContain("credential-public-key-must-also-remain-private");
+      expect(serialized).not.toContain(knownUserId);
+    }
+
+    expect(
+      await getAuthChallengeStore().get(`passkey-login:${KNOWN_EMAIL}:${known.challengeId}`),
+    ).toBe(known.challenge);
+    expect(
+      await getAuthChallengeStore().get(`passkey-login:${UNKNOWN_EMAIL}:${unknown.challengeId}`),
+    ).toBe(unknown.challenge);
+  });
+
+  it("honors explicit tenant existence and passkey login-method boundaries", async () => {
+    const missingTenant = await requestOptions(KNOWN_EMAIL, "passkey-enumeration-missing");
+    expect(missingTenant.status).toBe(404);
+
+    const disabled = await requestOptions(KNOWN_EMAIL, DISABLED_TENANT_ID);
+    expect(disabled.status).toBe(403);
+    expect(await disabled.json()).toMatchObject({
+      ok: false,
+      error: "passkey login is disabled for this tenant",
+    });
   });
 });

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -8194,7 +8194,9 @@ auth.post("/passkey/register/verify", async (c) => {
 /**
  * POST /passkey/login/options
  * Body: { email }
- * Returns WebAuthn authentication options with allowed credentials.
+ * Returns privacy-preserving discoverable-credential options. `allowCredentials`
+ * is intentionally empty for every email so this pre-auth route cannot reveal
+ * whether an account or passkey exists.
  */
 auth.post("/passkey/login/options", async (c) => {
   const rl = await checkAuthRateLimit(c, "passkey-options", 60_000, 20);


### PR DESCRIPTION
Closes #613

## Summary

- replace the passkey enumeration source-text scan with a mounted Hono route test against migrated PGLite
- prove known and unknown identities receive the same non-enumerating response shape with empty `allowCredentials`
- prove no stored credential ID, public key, or user ID leaks while the normalized-email challenge is stored correctly
- cover missing-tenant and passkey-disabled tenant boundaries
- correct the route comment to describe discoverable-credential privacy behavior

## Validation

- focused route suite: 2/2, 26 assertions
- API TypeScript build passed
- Biome on both changed files
- `git show --check`

Base: `9239a728b9ca28175e00e2825f69d85f3e02856e`
Head: `5f2da3db8adf971fc74646e6539e8a68b5f194c7`
