### PR TITLE
fix(api): persist Solana recovery anchor before broadcast

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -556,6 +556,7 @@
         "@solana/web3.js": "^1",
         "@stwd/db": "workspace:*",
         "@stwd/shared": "workspace:*",
+        "bs58": "^6.0.0",
         "drizzle-orm": "^0.45.2",
         "viem": "^2.30.0",
       },

--- a/packages/api/src/__tests__/solana-recovery-anchor.test.ts
+++ b/packages/api/src/__tests__/solana-recovery-anchor.test.ts
@@ -1,0 +1,251 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  agents,
+  closeDb,
+  getDb,
+  policies,
+  tenants,
+  transactions,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { ExternalBroadcastOutcomeUnknownError } from "@stwd/vault";
+import { eq, sql } from "drizzle-orm";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
+
+const TENANT_ID = `solana-recovery-tenant-${Date.now()}`;
+const AGENT_ID = `solana-recovery-agent-${Date.now()}`;
+const FROM = "7v54NWdBtkjuAFJrLGsS2SXnuk8nKam81mZJeeYxVFi9";
+const RECIPIENT = "6TcyBfPdBt1kjsvDZLzmBFnuMaLWiTaAt4RjUr9VA5YD";
+const SIGNATURE =
+  "4oL4p7QvN3UH7V5wMGZgW5PuzEk4A9LXLHk9RxAoKjDKuLbQBsfXN8kEvKfj5K1oEJa8wFF6RVp2h7pP9w2f51ZV";
+const WITHIN_CAP_V0_TRANSFER =
+  "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQACBGa+fjMsekUzMr2dCn99sFX1xe8aBq2mbZizn7aBDEc6URw0oaLLUh3xa7JGuN6OeZfOI1x+drIqPXUDokgZ3YoDBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcDAgAFAkANAwACAAkD6AMAAAAAAAADAgABDAIAAAB7AAAAAAAAAAA=";
+
+async function makeApp() {
+  const { vaultRoutes } = await import("../routes/vault");
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("tenantId", TENANT_ID);
+    c.set("authType", "session-jwt");
+    c.set("tenantRole", "admin");
+    c.set("userId", "solana-recovery-admin");
+    c.set("sessionMfaVerifiedAt", Date.now());
+    c.set("requestId", crypto.randomUUID());
+    await next();
+  });
+  app.route("/vault", vaultRoutes);
+  return app;
+}
+
+async function onlyRecoveryRow() {
+  const rows = await getDb().select().from(transactions).where(eq(transactions.agentId, AGENT_ID));
+  expect(rows).toHaveLength(1);
+  return rows[0];
+}
+
+describe("Solana durable recovery anchors", () => {
+  let app: Awaited<ReturnType<typeof makeApp>>;
+
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_MASTER_PASSWORD = "solana-recovery-anchor-master-password";
+    process.env.STEWARD_AUDIT_HMAC_KEY =
+      "solana-recovery-anchor-audit-hmac-key-with-more-than-32-bytes";
+    process.env.STEWARD_ALLOW_DEV_SECRETS = "true";
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => {
+      await client.close();
+    });
+    await getDb()
+      .insert(tenants)
+      .values({
+        id: TENANT_ID,
+        name: "Solana Recovery Tenant",
+        apiKeyHash: `hash-${TENANT_ID}`,
+      });
+    await getDb().insert(agents).values({
+      id: AGENT_ID,
+      tenantId: TENANT_ID,
+      name: "Solana Recovery Agent",
+      walletAddress: FROM,
+    });
+    await getDb()
+      .insert(policies)
+      .values([
+        {
+          id: `${AGENT_ID}-approved-recipient`,
+          agentId: AGENT_ID,
+          type: "approved-addresses",
+          enabled: true,
+          config: { addresses: [RECIPIENT], mode: "whitelist" },
+        },
+        {
+          id: `${AGENT_ID}-auto-approve-threshold`,
+          agentId: AGENT_ID,
+          type: "auto-approve-threshold",
+          enabled: true,
+          config: { threshold: "999" },
+        },
+      ]);
+    app = await makeApp();
+  });
+
+  beforeEach(async () => {
+    process.env.STEWARD_AUDIT_HMAC_KEY =
+      "solana-recovery-anchor-audit-hmac-key-with-more-than-32-bytes";
+    __resetAuditHmacKeyCacheForTests();
+    delete process.env.STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING;
+    await getDb().delete(transactions).where(eq(transactions.agentId, AGENT_ID));
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_MASTER_PASSWORD;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    delete process.env.STEWARD_ALLOW_DEV_SECRETS;
+    delete process.env.STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING;
+    __resetAuditHmacKeyCacheForTests();
+  });
+
+  it("keeps the parsed-route anchor and submitted signature when final bookkeeping fails", async () => {
+    const context = await import("../services/context");
+    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
+    context.vault.signSolanaTransaction = async (request) => {
+      const staged = await onlyRecoveryRow();
+      expect(staged.status).toBe("approved");
+      expect(staged.data).toBe(WITHIN_CAP_V0_TRANSFER);
+      expect(staged.txHash).toBeNull();
+
+      await request.onBroadcastPrepared?.(SIGNATURE);
+      const checkpoint = await onlyRecoveryRow();
+      expect(checkpoint.status).toBe("outcome_unknown");
+      expect(checkpoint.txHash).toBe(SIGNATURE);
+      return { signature: SIGNATURE, broadcast: true, chainId: request.chainId ?? 101 };
+    };
+
+    await getDb().execute(
+      sql.raw(`
+      ALTER TABLE transactions
+      ADD CONSTRAINT test_reject_solana_finalization
+      CHECK (status <> 'broadcast' OR action_type <> 'solana_transaction')
+    `),
+    );
+    try {
+      const response = await app.request(`/vault/${AGENT_ID}/sign-solana`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "solana-recovery-final-write-failure",
+        },
+        body: JSON.stringify({ transaction: WITHIN_CAP_V0_TRANSFER, broadcast: true }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        data: { signature: SIGNATURE, broadcast: true },
+      });
+      const surviving = await onlyRecoveryRow();
+      expect(surviving.status).toBe("outcome_unknown");
+      expect(surviving.txHash).toBe(SIGNATURE);
+      expect(surviving.data).toBe(WITHIN_CAP_V0_TRANSFER);
+    } finally {
+      context.vault.signSolanaTransaction = originalSign;
+      await getDb().execute(
+        sql.raw("ALTER TABLE transactions DROP CONSTRAINT test_reject_solana_finalization"),
+      );
+    }
+  });
+
+  it("keeps the blind-route broadcast row and success response when final audit fails", async () => {
+    process.env.STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING = "true";
+    const context = await import("../services/context");
+    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
+    context.vault.signSolanaTransaction = async (request) => {
+      const staged = await onlyRecoveryRow();
+      expect(staged.status).toBe("approved");
+      expect(staged.data).toBe("not-a-solana-transaction");
+      expect(staged.actionPayload).toMatchObject({ blindSigned: true, recoveryAnchor: true });
+
+      await request.onBroadcastPrepared?.(SIGNATURE);
+      const checkpoint = await onlyRecoveryRow();
+      expect(checkpoint.status).toBe("outcome_unknown");
+      expect(checkpoint.txHash).toBe(SIGNATURE);
+
+      process.env.STEWARD_AUDIT_HMAC_KEY = "too-weak";
+      __resetAuditHmacKeyCacheForTests();
+      return { signature: SIGNATURE, broadcast: true, chainId: request.chainId ?? 101 };
+    };
+
+    try {
+      const response = await app.request(`/vault/${AGENT_ID}/sign-solana`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "solana-recovery-audit-failure",
+        },
+        body: JSON.stringify({
+          transaction: "not-a-solana-transaction",
+          broadcast: true,
+          to: RECIPIENT,
+          value: "123",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        data: { signature: SIGNATURE, broadcast: true },
+      });
+      const surviving = await onlyRecoveryRow();
+      expect(surviving.status).toBe("broadcast");
+      expect(surviving.txHash).toBe(SIGNATURE);
+      expect(surviving.data).toBe("not-a-solana-transaction");
+    } finally {
+      context.vault.signSolanaTransaction = originalSign;
+      process.env.STEWARD_AUDIT_HMAC_KEY =
+        "solana-recovery-anchor-audit-hmac-key-with-more-than-32-bytes";
+      __resetAuditHmacKeyCacheForTests();
+    }
+  });
+
+  it("returns a non-retryable 202 with the durable hash when confirmation is ambiguous", async () => {
+    const context = await import("../services/context");
+    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
+    context.vault.signSolanaTransaction = async (request) => {
+      expect((await onlyRecoveryRow()).status).toBe("approved");
+      await request.onBroadcastPrepared?.(SIGNATURE);
+      throw new ExternalBroadcastOutcomeUnknownError(SIGNATURE, {
+        cause: new Error("injected confirmation timeout"),
+      });
+    };
+
+    try {
+      const response = await app.request(`/vault/${AGENT_ID}/sign-solana`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "solana-recovery-confirmation-unknown",
+        },
+        body: JSON.stringify({ transaction: WITHIN_CAP_V0_TRANSFER, broadcast: true }),
+      });
+
+      expect(response.status).toBe(202);
+      expect(await response.json()).toMatchObject({
+        ok: false,
+        data: {
+          code: "external_broadcast_outcome_unknown",
+          txHash: SIGNATURE,
+          reconciliationRequired: true,
+        },
+      });
+      const surviving = await onlyRecoveryRow();
+      expect(surviving.status).toBe("outcome_unknown");
+      expect(surviving.txHash).toBe(SIGNATURE);
+    } finally {
+      context.vault.signSolanaTransaction = originalSign;
+    }
+  });
+});

--- a/packages/api/src/__tests__/solana-recovery-anchor.test.ts
+++ b/packages/api/src/__tests__/solana-recovery-anchor.test.ts
@@ -1,10 +1,11 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import {
   __resetAuditHmacKeyCacheForTests,
   agents,
   closeDb,
   getDb,
   policies,
+  tenantConfigs,
   tenants,
   transactions,
 } from "@stwd/db";
@@ -12,6 +13,7 @@ import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { ExternalBroadcastOutcomeUnknownError } from "@stwd/vault";
 import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
+import { idempotencyMiddleware, MemoryIdempotencyStore } from "../middleware/idempotency";
 import type { AppVariables } from "../services/context";
 
 const TENANT_ID = `solana-recovery-tenant-${Date.now()}`;
@@ -20,8 +22,11 @@ const FROM = "7v54NWdBtkjuAFJrLGsS2SXnuk8nKam81mZJeeYxVFi9";
 const RECIPIENT = "6TcyBfPdBt1kjsvDZLzmBFnuMaLWiTaAt4RjUr9VA5YD";
 const SIGNATURE =
   "4oL4p7QvN3UH7V5wMGZgW5PuzEk4A9LXLHk9RxAoKjDKuLbQBsfXN8kEvKfj5K1oEJa8wFF6RVp2h7pP9w2f51ZV";
+const RECENT_BLOCKHASH = "11111111111111111111111111111111";
 const WITHIN_CAP_V0_TRANSFER =
   "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQACBGa+fjMsekUzMr2dCn99sFX1xe8aBq2mbZizn7aBDEc6URw0oaLLUh3xa7JGuN6OeZfOI1x+drIqPXUDokgZ3YoDBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcDAgAFAkANAwACAAkD6AMAAAAAAAADAgABDAIAAAB7AAAAAAAAAAA=";
+
+setDefaultTimeout(30_000);
 
 async function makeApp() {
   const { vaultRoutes } = await import("../routes/vault");
@@ -31,10 +36,13 @@ async function makeApp() {
     c.set("authType", "session-jwt");
     c.set("tenantRole", "admin");
     c.set("userId", "solana-recovery-admin");
-    c.set("sessionMfaVerifiedAt", Date.now());
+    if (c.req.header("x-test-recent-mfa") === "true") {
+      c.set("sessionMfaVerifiedAt", Date.now());
+    }
     c.set("requestId", crypto.randomUUID());
     await next();
   });
+  app.use("*", idempotencyMiddleware({ store: new MemoryIdempotencyStore(), ttlMs: 60_000 }));
   app.route("/vault", vaultRoutes);
   return app;
 }
@@ -71,6 +79,12 @@ describe("Solana durable recovery anchors", () => {
       name: "Solana Recovery Agent",
       walletAddress: FROM,
     });
+    await getDb()
+      .insert(tenantConfigs)
+      .values({
+        tenantId: TENANT_ID,
+        authAbuseConfig: { mfa: { requireFor: { vaultSigning: false } } },
+      });
     await getDb()
       .insert(policies)
       .values([
@@ -118,11 +132,19 @@ describe("Solana durable recovery anchors", () => {
       expect(staged.data).toBe(WITHIN_CAP_V0_TRANSFER);
       expect(staged.txHash).toBeNull();
 
-      await request.onBroadcastPrepared?.(SIGNATURE);
+      await request.onBroadcastPrepared?.({
+        signature: SIGNATURE,
+        recentBlockhash: RECENT_BLOCKHASH,
+      });
       const checkpoint = await onlyRecoveryRow();
       expect(checkpoint.status).toBe("outcome_unknown");
       expect(checkpoint.txHash).toBe(SIGNATURE);
-      return { signature: SIGNATURE, broadcast: true, chainId: request.chainId ?? 101 };
+      return {
+        signature: SIGNATURE,
+        broadcast: true,
+        chainId: request.chainId ?? 101,
+        caip2: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      };
     };
 
     await getDb().execute(
@@ -169,7 +191,10 @@ describe("Solana durable recovery anchors", () => {
       expect(staged.data).toBe("not-a-solana-transaction");
       expect(staged.actionPayload).toMatchObject({ blindSigned: true, recoveryAnchor: true });
 
-      await request.onBroadcastPrepared?.(SIGNATURE);
+      await request.onBroadcastPrepared?.({
+        signature: SIGNATURE,
+        recentBlockhash: RECENT_BLOCKHASH,
+      });
       const checkpoint = await onlyRecoveryRow();
       expect(checkpoint.status).toBe("outcome_unknown");
       expect(checkpoint.txHash).toBe(SIGNATURE);
@@ -216,7 +241,10 @@ describe("Solana durable recovery anchors", () => {
     const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
     context.vault.signSolanaTransaction = async (request) => {
       expect((await onlyRecoveryRow()).status).toBe("approved");
-      await request.onBroadcastPrepared?.(SIGNATURE);
+      await request.onBroadcastPrepared?.({
+        signature: SIGNATURE,
+        recentBlockhash: RECENT_BLOCKHASH,
+      });
       throw new ExternalBroadcastOutcomeUnknownError(SIGNATURE, {
         cause: new Error("injected confirmation timeout"),
       });
@@ -248,4 +276,227 @@ describe("Solana durable recovery anchors", () => {
       context.vault.signSolanaTransaction = originalSign;
     }
   });
+
+  it("durably replays across both cache-unsafe and cache-safe session auth", async () => {
+    const context = await import("../services/context");
+    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
+    let signCalls = 0;
+    let releaseAttempt!: () => void;
+    const attemptBarrier = new Promise<void>((resolve) => {
+      releaseAttempt = resolve;
+    });
+    let signalAttemptStarted!: () => void;
+    const attemptStarted = new Promise<void>((resolve) => {
+      signalAttemptStarted = resolve;
+    });
+    context.vault.signSolanaTransaction = async (request) => {
+      signCalls += 1;
+      signalAttemptStarted();
+      await attemptBarrier;
+      await request.onBroadcastPrepared?.({
+        signature: SIGNATURE,
+        recentBlockhash: RECENT_BLOCKHASH,
+      });
+      return {
+        signature: SIGNATURE,
+        broadcast: true,
+        chainId: request.chainId ?? 101,
+        caip2: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      };
+    };
+    const request = (recentMfa = false) =>
+      app.request(`/vault/${AGENT_ID}/sign-solana`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "session-admin-durable-solana-replay",
+          ...(recentMfa ? { "x-test-recent-mfa": "true" } : {}),
+        },
+        body: JSON.stringify({ transaction: WITHIN_CAP_V0_TRANSFER, broadcast: true }),
+      });
+
+    try {
+      const firstPromise = request();
+      await attemptStarted;
+      const concurrent = await request(true);
+      expect(concurrent.status).toBe(409);
+      expect(await concurrent.json()).toMatchObject({
+        ok: false,
+        data: { status: "processing" },
+      });
+      expect(signCalls).toBe(1);
+
+      releaseAttempt();
+      const first = await firstPromise;
+      const replay = await request(true);
+      expect(first.status).toBe(200);
+      expect(replay.status).toBe(200);
+      expect(replay.headers.get("Idempotency-Replayed")).toBeNull();
+      expect(await replay.json()).toEqual(await first.json());
+      expect(signCalls).toBe(1);
+      const row = await onlyRecoveryRow();
+      expect(row.status).toBe("broadcast");
+      expect(readPayload(row.actionPayload).recentBlockhash).toBe(RECENT_BLOCKHASH);
+      expect((await context.getTransactionStats(AGENT_ID, 101)).recentTxCount24h).toBe(1);
+
+      const mismatch = await app.request(`/vault/${AGENT_ID}/sign-solana`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "session-admin-durable-solana-replay",
+        },
+        body: JSON.stringify({
+          transaction: WITHIN_CAP_V0_TRANSFER,
+          broadcast: true,
+          chainId: 102,
+        }),
+      });
+      expect(mismatch.status).toBe(409);
+      expect(signCalls).toBe(1);
+    } finally {
+      context.vault.signSolanaTransaction = originalSign;
+    }
+  });
+
+  it("fences a stale callback after an expired signing lease is taken over", async () => {
+    const context = await import("../services/context");
+    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
+    let signCalls = 0;
+    let submittedCalls = 0;
+    let releaseStale!: () => void;
+    const staleBarrier = new Promise<void>((resolve) => {
+      releaseStale = resolve;
+    });
+    let signalStaleStarted!: () => void;
+    const staleStarted = new Promise<void>((resolve) => {
+      signalStaleStarted = resolve;
+    });
+    let releaseWinner!: () => void;
+    const winnerBarrier = new Promise<void>((resolve) => {
+      releaseWinner = resolve;
+    });
+    let signalWinnerStarted!: () => void;
+    const winnerStarted = new Promise<void>((resolve) => {
+      signalWinnerStarted = resolve;
+    });
+    context.vault.signSolanaTransaction = async (request) => {
+      signCalls += 1;
+      if (signCalls === 1) {
+        signalStaleStarted();
+        await staleBarrier;
+      } else {
+        signalWinnerStarted();
+        await winnerBarrier;
+      }
+      await request.onBroadcastPrepared?.({
+        signature: SIGNATURE,
+        recentBlockhash: RECENT_BLOCKHASH,
+      });
+      submittedCalls += 1;
+      return {
+        signature: SIGNATURE,
+        broadcast: true,
+        chainId: request.chainId ?? 101,
+        caip2: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      };
+    };
+    const request = () =>
+      app.request(`/vault/${AGENT_ID}/sign-solana`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "expired-solana-attempt-takeover",
+        },
+        body: JSON.stringify({ transaction: WITHIN_CAP_V0_TRANSFER, broadcast: true }),
+      });
+
+    try {
+      const staleResponse = request();
+      await staleStarted;
+      const staged = await onlyRecoveryRow();
+      await getDb()
+        .update(transactions)
+        .set({
+          actionPayload: {
+            ...readPayload(staged.actionPayload),
+            attemptLeaseUntil: new Date(Date.now() - 1_000).toISOString(),
+          },
+        })
+        .where(eq(transactions.id, staged.id));
+
+      const takeoverResponse = request();
+      await winnerStarted;
+      expect(signCalls).toBe(2);
+      expect(submittedCalls).toBe(0);
+
+      releaseStale();
+      expect((await staleResponse).status).toBe(500);
+      expect((await onlyRecoveryRow()).status).toBe("approved");
+      expect(submittedCalls).toBe(0);
+
+      releaseWinner();
+      expect((await takeoverResponse).status).toBe(200);
+      expect(submittedCalls).toBe(1);
+      expect((await onlyRecoveryRow()).status).toBe("broadcast");
+    } finally {
+      releaseStale();
+      releaseWinner();
+      context.vault.signSolanaTransaction = originalSign;
+    }
+  });
+
+  it("reconciles only the stored signature and blockhash through guarded transitions", async () => {
+    const context = await import("../services/context");
+    const originalReconcile = context.vault.reconcileSolanaBroadcast.bind(context.vault);
+    const cases = [
+      { outcome: "confirmed" as const, status: 200 },
+      { outcome: "broadcast" as const, status: 200 },
+      { outcome: "failed" as const, status: 200 },
+      { outcome: "outcome_unknown" as const, status: 202 },
+    ];
+    try {
+      for (const [index, testCase] of cases.entries()) {
+        await getDb().delete(transactions).where(eq(transactions.agentId, AGENT_ID));
+        const txId = `solana-reconcile-${index}`;
+        await getDb()
+          .insert(transactions)
+          .values({
+            id: txId,
+            agentId: AGENT_ID,
+            status: "outcome_unknown",
+            toAddress: RECIPIENT,
+            value: "123",
+            chainId: 101,
+            txHash: SIGNATURE,
+            actionType: "solana_transaction",
+            actionPayload: {
+              type: "solana_transaction",
+              recoveryAnchor: true,
+              recentBlockhash: RECENT_BLOCKHASH,
+            },
+          });
+        context.vault.reconcileSolanaBroadcast = async (input) => {
+          expect(input).toEqual({
+            signature: SIGNATURE,
+            recentBlockhash: RECENT_BLOCKHASH,
+            chainId: 101,
+          });
+          return testCase.outcome;
+        };
+        const response = await app.request(
+          `/vault/${AGENT_ID}/transactions/${txId}/reconcile-solana`,
+          { method: "POST" },
+        );
+        expect(response.status).toBe(testCase.status);
+        const [row] = await getDb().select().from(transactions).where(eq(transactions.id, txId));
+        expect(row?.status).toBe(testCase.outcome);
+      }
+    } finally {
+      context.vault.reconcileSolanaBroadcast = originalReconcile;
+    }
+  });
 });
+
+function readPayload(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}

--- a/packages/api/src/middleware/idempotency.ts
+++ b/packages/api/src/middleware/idempotency.ts
@@ -653,6 +653,22 @@ export function idempotencyMiddleware(options?: { store?: IdempotencyStore; ttlM
       recordIdempotencyMetric(metricsTenantId, "invalidKeys");
       return c.json<ApiResponse>({ ok: false, error: "Invalid Idempotency-Key header" }, 400);
     }
+    // Solana broadcast requests bind this key to their durable transaction row.
+    // Let that database state machine serve every auth mode consistently,
+    // including recovery after a process dies while this cache says processing.
+    if (/^\/vault\/[^/]+\/sign-solana$/.test(c.req.path)) {
+      const body = await c.req.raw
+        .clone()
+        .json()
+        .catch(() => null);
+      if (
+        body &&
+        typeof body === "object" &&
+        (body as { broadcast?: unknown }).broadcast !== false
+      ) {
+        return next();
+      }
+    }
 
     const [fingerprint, storageKey] = await Promise.all([
       buildFingerprint(c.req.raw),

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -7,6 +7,7 @@
 
 import {
   createDecipheriv,
+  createHash,
   createPrivateKey,
   createPublicKey,
   diffieHellman,
@@ -20,9 +21,11 @@ import {
   tenantConfigs as tenantConfigsTable,
   users,
   userTenants,
+  withTenantAuditedTransaction,
 } from "@stwd/db";
 import { recordAggregationEvent } from "@stwd/redis";
 import {
+  canonicalJsonStringify,
   ExecutionPayloadNormalizationError,
   type PolicyResult,
   rawSigningChainSupport,
@@ -49,6 +52,7 @@ import {
   parseMoneroWalletScope,
   parseSolanaTransaction,
   readEip7702Delegation,
+  SolanaBroadcastNotSubmittedError,
   type UnpackedUserOperationFields,
 } from "@stwd/vault";
 import { and, desc, eq, type SQL, sql } from "drizzle-orm";
@@ -863,9 +867,16 @@ function requireBroadcastActionIdempotency(
   broadcast: boolean,
   actionLabel: string,
 ): Response | null {
-  if (!broadcast || isNonEmptyString(c.req.header("Idempotency-Key"))) return null;
+  if (!broadcast) return null;
+  const key = c.req.header("Idempotency-Key");
+  if (isNonEmptyString(key) && /^[\x21-\x7e]{8,255}$/.test(key)) return null;
   return c.json<ApiResponse>(
-    { ok: false, error: `${actionLabel} require an Idempotency-Key header` },
+    {
+      ok: false,
+      error: key
+        ? "Invalid Idempotency-Key header"
+        : `${actionLabel} require an Idempotency-Key header`,
+    },
     400,
   );
 }
@@ -7834,7 +7845,18 @@ async function signSolanaBlind(
       );
     }
 
-    const txId = crypto.randomUUID();
+    const binding = createSolanaRecoveryBinding(c, {
+      tenantId,
+      agentId,
+      transaction: args.transaction,
+      chainId,
+      toAddress,
+      value: txValue,
+      broadcastRequested: shouldBroadcast,
+      blindSigned: true,
+    });
+    const { txId } = binding;
+    let executionToken: string | null = null;
     let completedResult: {
       txId: string;
       signature: string;
@@ -7843,8 +7865,7 @@ async function signSolanaBlind(
       caip2?: string;
     } | null = null;
     try {
-      await stageSolanaRecoveryAnchor({
-        txId,
+      const staged = await stageSolanaRecoveryAnchor({
         agentId,
         transaction: args.transaction,
         chainId,
@@ -7853,7 +7874,11 @@ async function signSolanaBlind(
         broadcastRequested: shouldBroadcast,
         blindSigned: true,
         policyResults: evaluation.results,
+        binding,
       });
+      if (!staged.executionToken) return solanaReplayResponse(c, staged.row);
+      const ownerToken = staged.executionToken;
+      executionToken = ownerToken;
       const result = await vault.signSolanaTransaction({
         agentId,
         tenantId,
@@ -7862,11 +7887,11 @@ async function signSolanaBlind(
         broadcast: args.broadcast,
         expectedTo: toAddress,
         expectedValue: txValue,
-        onBroadcastPrepared: (signature) =>
-          checkpointSolanaBroadcastSubmission(txId, agentId, signature),
+        onBroadcastPrepared: (checkpoint) =>
+          checkpointSolanaBroadcastSubmission(txId, agentId, ownerToken, checkpoint),
       });
       completedResult = { txId, ...result };
-      await finalizeSolanaRecoveryAnchor(txId, agentId, result);
+      await finalizeSolanaRecoveryAnchor(txId, agentId, ownerToken, result);
       recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
         console.error("[vault] Failed to record Solana spend", redactedThrownDiagnostics(err)),
       );
@@ -7922,8 +7947,24 @@ async function signSolanaBlind(
           }>
         >({ ok: true, data: completedResult });
       }
+      if (e instanceof SolanaIdempotencyConflictError) {
+        return c.json<ApiResponse>({ ok: false, error: e.message }, 409);
+      }
+      if (e instanceof SolanaBroadcastNotSubmittedError) {
+        await markSolanaBroadcastNotSubmitted(
+          tenantId,
+          txId,
+          agentId,
+          executionToken,
+          e.transactionHash,
+        );
+        return c.json<ApiResponse>(
+          { ok: false, error: "Solana RPC preflight rejected the transaction", data: { txId } },
+          502,
+        );
+      }
       if (e instanceof ExternalBroadcastOutcomeUnknownError) {
-        await preserveUnknownSolanaOutcome(txId, agentId, e.transactionHash);
+        await preserveUnknownSolanaOutcome(txId, agentId, executionToken, e.transactionHash);
         recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
           console.error(
             "[vault] Failed to record ambiguous Solana spend",
@@ -7947,7 +7988,7 @@ async function signSolanaBlind(
         });
         return externalBroadcastOutcomeUnknownResponse(c, e, txId) as Response;
       }
-      await markSolanaRecoveryAnchorFailed(txId, agentId);
+      await markSolanaRecoveryAnchorFailed(txId, agentId, executionToken);
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
       dispatchWebhook(tenantId, agentId, "tx_failed", {
@@ -7970,8 +8011,117 @@ type SolanaSigningResult = {
   caip2?: string;
 };
 
-async function stageSolanaRecoveryAnchor(input: {
+type SolanaRecoveryBinding = {
   txId: string;
+  idempotencyKeyDigest?: string;
+  requestDigest?: string;
+};
+
+const SOLANA_SIGNING_ATTEMPT_LEASE_MS = 2 * 60 * 1000;
+
+class SolanaIdempotencyConflictError extends Error {
+  constructor() {
+    super("Idempotency-Key was already used for a different Solana transaction");
+    this.name = "SolanaIdempotencyConflictError";
+  }
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function createSolanaRecoveryBinding(
+  c: Context<{ Variables: AppVariables }>,
+  input: {
+    tenantId: string;
+    agentId: string;
+    transaction: string;
+    chainId: number;
+    toAddress: string;
+    value: string;
+    broadcastRequested: boolean;
+    blindSigned: boolean;
+  },
+): SolanaRecoveryBinding {
+  if (!input.broadcastRequested) return { txId: crypto.randomUUID() };
+  const key = c.req.header("Idempotency-Key");
+  if (!key) throw new Error("Idempotency-Key is required for Solana broadcast");
+  const scope = `${input.tenantId}\0${input.agentId}\0${key}`;
+  return {
+    txId: `solana_${sha256(scope).slice(0, 56)}`,
+    idempotencyKeyDigest: sha256(scope),
+    requestDigest: sha256(
+      canonicalJsonStringify({
+        agentId: input.agentId,
+        blindSigned: input.blindSigned,
+        broadcast: true,
+        chainId: input.chainId,
+        tenantId: input.tenantId,
+        toAddress: input.toAddress,
+        transaction: input.transaction,
+        value: input.value,
+      }),
+    ),
+  };
+}
+
+type SolanaRecoveryRow = {
+  id: string;
+  agentId: string;
+  status: string;
+  txHash: string | null;
+  chainId: number;
+  actionPayload: unknown;
+};
+
+function readSolanaRecoveryMetadata(payload: unknown): Record<string, unknown> {
+  return payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+}
+
+function solanaReplayResponse(
+  c: Context<{ Variables: AppVariables }>,
+  row: SolanaRecoveryRow,
+): Response {
+  if (row.status === "approved") {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "A matching Solana signing attempt is already in progress",
+        data: { txId: row.id, status: "processing" },
+      },
+      409,
+    );
+  }
+  if (row.status === "outcome_unknown" && row.txHash) {
+    return externalBroadcastOutcomeUnknownResponse(
+      c,
+      new ExternalBroadcastOutcomeUnknownError(row.txHash),
+      row.id,
+    ) as Response;
+  }
+  if ((row.status === "broadcast" || row.status === "confirmed") && row.txHash) {
+    return c.json<ApiResponse<SolanaSigningResult & { txId: string }>>({
+      ok: true,
+      data: {
+        txId: row.id,
+        signature: row.txHash,
+        broadcast: true,
+        chainId: row.chainId,
+        caip2: toCaip2(row.chainId),
+      },
+    });
+  }
+  return c.json<ApiResponse>(
+    {
+      ok: false,
+      error: "The prior Solana request did not complete; use a new Idempotency-Key",
+      data: { txId: row.id, status: row.status },
+    },
+    409,
+  );
+}
+
+async function stageSolanaRecoveryAnchor(input: {
   agentId: string;
   transaction: string;
   chainId: number;
@@ -7980,39 +8130,120 @@ async function stageSolanaRecoveryAnchor(input: {
   broadcastRequested: boolean;
   blindSigned: boolean;
   policyResults: PolicyResult[];
-}): Promise<void> {
-  await db.insert(transactions).values({
-    id: input.txId,
-    agentId: input.agentId,
-    status: "approved",
-    toAddress: input.toAddress,
-    value: input.value,
-    data: input.transaction,
-    chainId: input.chainId,
-    actionType: "solana_transaction",
-    actionPayload: {
-      type: "solana_transaction",
-      broadcast: input.broadcastRequested,
-      blindSigned: input.blindSigned,
-      recoveryAnchor: true,
-    },
-    policyResults: input.policyResults,
-  });
+  binding: SolanaRecoveryBinding;
+}): Promise<{ row: SolanaRecoveryRow; executionToken: string | null }> {
+  const executionToken = crypto.randomUUID();
+  const attemptLeaseUntil = new Date(Date.now() + SOLANA_SIGNING_ATTEMPT_LEASE_MS).toISOString();
+  const inserted = await db
+    .insert(transactions)
+    .values({
+      id: input.binding.txId,
+      agentId: input.agentId,
+      status: "approved",
+      toAddress: input.toAddress,
+      value: input.value,
+      data: input.transaction,
+      chainId: input.chainId,
+      actionType: "solana_transaction",
+      actionPayload: {
+        type: "solana_transaction",
+        broadcast: input.broadcastRequested,
+        blindSigned: input.blindSigned,
+        recoveryAnchor: true,
+        idempotencyKeyDigest: input.binding.idempotencyKeyDigest,
+        requestDigest: input.binding.requestDigest,
+        executionToken,
+        attemptLeaseUntil,
+      },
+      policyResults: input.policyResults,
+    })
+    .onConflictDoNothing()
+    .returning();
+  if (inserted[0]) return { row: inserted[0] as SolanaRecoveryRow, executionToken };
+
+  const [existing] = await db
+    .select()
+    .from(transactions)
+    .where(eq(transactions.id, input.binding.txId))
+    .limit(1);
+  const metadata = readSolanaRecoveryMetadata(existing?.actionPayload);
+  if (
+    !existing ||
+    existing.agentId !== input.agentId ||
+    metadata.type !== "solana_transaction" ||
+    metadata.idempotencyKeyDigest !== input.binding.idempotencyKeyDigest ||
+    metadata.requestDigest !== input.binding.requestDigest
+  ) {
+    throw new SolanaIdempotencyConflictError();
+  }
+  if (existing.status !== "approved") {
+    return { row: existing as SolanaRecoveryRow, executionToken: null };
+  }
+
+  const priorLeaseUntil =
+    typeof metadata.attemptLeaseUntil === "string"
+      ? Date.parse(metadata.attemptLeaseUntil)
+      : Number.NaN;
+  if (Number.isFinite(priorLeaseUntil) && priorLeaseUntil > Date.now()) {
+    return { row: existing as SolanaRecoveryRow, executionToken: null };
+  }
+
+  const priorToken = typeof metadata.executionToken === "string" ? metadata.executionToken : null;
+  const tokenPredicate = priorToken
+    ? sql`${transactions.actionPayload}->>'executionToken' = ${priorToken}`
+    : sql`${transactions.actionPayload}->>'executionToken' is null`;
+  const [takenOver] = await db
+    .update(transactions)
+    .set({
+      actionPayload: { ...metadata, executionToken, attemptLeaseUntil },
+    })
+    .where(
+      and(
+        eq(transactions.id, input.binding.txId),
+        eq(transactions.agentId, input.agentId),
+        eq(transactions.status, "approved"),
+        tokenPredicate,
+      ),
+    )
+    .returning();
+  if (takenOver) return { row: takenOver as SolanaRecoveryRow, executionToken };
+
+  const [winner] = await db
+    .select()
+    .from(transactions)
+    .where(eq(transactions.id, input.binding.txId))
+    .limit(1);
+  return { row: (winner ?? existing) as SolanaRecoveryRow, executionToken: null };
 }
 
 async function checkpointSolanaBroadcastSubmission(
   txId: string,
   agentId: string,
-  signature: string,
+  executionToken: string,
+  checkpoint: { signature: string; recentBlockhash: string },
 ): Promise<void> {
+  const [existing] = await db
+    .select({ actionPayload: transactions.actionPayload })
+    .from(transactions)
+    .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)))
+    .limit(1);
   const rows = await db
     .update(transactions)
-    .set({ status: "outcome_unknown", txHash: signature, signedAt: new Date() })
+    .set({
+      status: "outcome_unknown",
+      txHash: checkpoint.signature,
+      signedAt: new Date(),
+      actionPayload: {
+        ...readSolanaRecoveryMetadata(existing?.actionPayload),
+        recentBlockhash: checkpoint.recentBlockhash,
+      },
+    })
     .where(
       and(
         eq(transactions.id, txId),
         eq(transactions.agentId, agentId),
         eq(transactions.status, "approved"),
+        sql`${transactions.actionPayload}->>'executionToken' = ${executionToken}`,
       ),
     )
     .returning({ id: transactions.id });
@@ -8024,6 +8255,7 @@ async function checkpointSolanaBroadcastSubmission(
 async function finalizeSolanaRecoveryAnchor(
   txId: string,
   agentId: string,
+  executionToken: string,
   result: SolanaSigningResult,
 ): Promise<void> {
   const rows = await db
@@ -8037,7 +8269,13 @@ async function finalizeSolanaRecoveryAnchor(
       and(
         eq(transactions.id, txId),
         eq(transactions.agentId, agentId),
-        sql`${transactions.status} in ('approved', 'outcome_unknown')`,
+        result.broadcast
+          ? and(
+              eq(transactions.status, "outcome_unknown"),
+              eq(transactions.txHash, result.signature),
+            )
+          : eq(transactions.status, "approved"),
+        sql`${transactions.actionPayload}->>'executionToken' = ${executionToken}`,
       ),
     )
     .returning({ id: transactions.id });
@@ -8049,13 +8287,22 @@ async function finalizeSolanaRecoveryAnchor(
 async function preserveUnknownSolanaOutcome(
   txId: string,
   agentId: string,
+  executionToken: string | null,
   signature: string,
 ): Promise<void> {
+  if (!executionToken) return;
   try {
     await db
       .update(transactions)
       .set({ status: "outcome_unknown", txHash: signature, signedAt: new Date() })
-      .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)));
+      .where(
+        and(
+          eq(transactions.id, txId),
+          eq(transactions.agentId, agentId),
+          sql`${transactions.status} in ('approved', 'outcome_unknown')`,
+          sql`${transactions.actionPayload}->>'executionToken' = ${executionToken}`,
+        ),
+      );
   } catch (error) {
     // The pre-sign approved row is already durable. Preserve the typed 202
     // response even when the database cannot enrich it with the known hash.
@@ -8066,7 +8313,12 @@ async function preserveUnknownSolanaOutcome(
   }
 }
 
-async function markSolanaRecoveryAnchorFailed(txId: string, agentId: string): Promise<void> {
+async function markSolanaRecoveryAnchorFailed(
+  txId: string,
+  agentId: string,
+  executionToken: string | null,
+): Promise<void> {
+  if (!executionToken) return;
   try {
     await db
       .update(transactions)
@@ -8076,6 +8328,7 @@ async function markSolanaRecoveryAnchorFailed(txId: string, agentId: string): Pr
           eq(transactions.id, txId),
           eq(transactions.agentId, agentId),
           eq(transactions.status, "approved"),
+          sql`${transactions.actionPayload}->>'executionToken' = ${executionToken}`,
         ),
       );
   } catch (error) {
@@ -8084,6 +8337,42 @@ async function markSolanaRecoveryAnchorFailed(txId: string, agentId: string): Pr
       redactedThrownDiagnostics(error),
     );
   }
+}
+
+async function markSolanaBroadcastNotSubmitted(
+  tenantId: string,
+  txId: string,
+  agentId: string,
+  executionToken: string | null,
+  signature: string,
+): Promise<void> {
+  if (!executionToken) return;
+  await withTenantAuditedTransaction(tenantId, async (rawTx, appendRequiredAudit) => {
+    const tx = rawTx as typeof db;
+    const [updated] = await tx
+      .update(transactions)
+      .set({ status: "failed" })
+      .where(
+        and(
+          eq(transactions.id, txId),
+          eq(transactions.agentId, agentId),
+          eq(transactions.status, "outcome_unknown"),
+          eq(transactions.txHash, signature),
+          sql`${transactions.actionPayload}->>'executionToken' = ${executionToken}`,
+        ),
+      )
+      .returning({ id: transactions.id });
+    if (!updated) return;
+    await appendRequiredAudit({
+      tenantId,
+      actorType: "system",
+      actorId: "solana-rpc-preflight",
+      action: "vault.sign.solana.not_submitted",
+      resourceType: "transaction",
+      resourceId: txId,
+      metadata: { previousStatus: "outcome_unknown", status: "failed", signature },
+    });
+  });
 }
 
 vaultRoutes.post("/:agentId/sign-solana", async (c) => {
@@ -8446,7 +8735,18 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
       );
     }
 
-    const txId = crypto.randomUUID();
+    const binding = createSolanaRecoveryBinding(c, {
+      tenantId,
+      agentId,
+      transaction: body.transaction,
+      chainId,
+      toAddress,
+      value: txValue,
+      broadcastRequested: shouldBroadcast,
+      blindSigned: false,
+    });
+    const { txId } = binding;
+    let executionToken: string | null = null;
     let completedResult: {
       txId: string;
       signature: string;
@@ -8468,8 +8768,7 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         derived.summary.instructions[0].instructionType === "system:Transfer" &&
         derived.to !== undefined;
 
-      await stageSolanaRecoveryAnchor({
-        txId,
+      const staged = await stageSolanaRecoveryAnchor({
         agentId,
         transaction: body.transaction,
         chainId,
@@ -8478,7 +8777,11 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         broadcastRequested: shouldBroadcast,
         blindSigned: false,
         policyResults: evaluation.results,
+        binding,
       });
+      if (!staged.executionToken) return solanaReplayResponse(c, staged.row);
+      const ownerToken = staged.executionToken;
+      executionToken = ownerToken;
       const result = await vault.signSolanaTransaction({
         agentId,
         tenantId,
@@ -8491,12 +8794,12 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         ...(isSingleNativeTransfer
           ? { expectedTo: toAddress, expectedValue: txValue }
           : { allowBlindSign: true }),
-        onBroadcastPrepared: (signature) =>
-          checkpointSolanaBroadcastSubmission(txId, agentId, signature),
+        onBroadcastPrepared: (checkpoint) =>
+          checkpointSolanaBroadcastSubmission(txId, agentId, ownerToken, checkpoint),
       });
       completedResult = { txId, ...result };
 
-      await finalizeSolanaRecoveryAnchor(txId, agentId, result);
+      await finalizeSolanaRecoveryAnchor(txId, agentId, ownerToken, result);
 
       // ── Record spend in Redis (fire-and-forget) ──────────────────────────────
       recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
@@ -8569,8 +8872,24 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         >({ ok: true, data: completedResult });
       }
 
+      if (e instanceof SolanaIdempotencyConflictError) {
+        return c.json<ApiResponse>({ ok: false, error: e.message }, 409);
+      }
+      if (e instanceof SolanaBroadcastNotSubmittedError) {
+        await markSolanaBroadcastNotSubmitted(
+          tenantId,
+          txId,
+          agentId,
+          executionToken,
+          e.transactionHash,
+        );
+        return c.json<ApiResponse>(
+          { ok: false, error: "Solana RPC preflight rejected the transaction", data: { txId } },
+          502,
+        );
+      }
       if (e instanceof ExternalBroadcastOutcomeUnknownError) {
-        await preserveUnknownSolanaOutcome(txId, agentId, e.transactionHash);
+        await preserveUnknownSolanaOutcome(txId, agentId, executionToken, e.transactionHash);
         recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
           console.error(
             "[vault] Failed to record ambiguous Solana spend",
@@ -8594,7 +8913,7 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         });
         return externalBroadcastOutcomeUnknownResponse(c, e, txId) as Response;
       }
-      await markSolanaRecoveryAnchorFailed(txId, agentId);
+      await markSolanaRecoveryAnchorFailed(txId, agentId, executionToken);
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
 
@@ -8609,6 +8928,119 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
       }
       return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
     }
+  });
+});
+
+vaultRoutes.post("/:agentId/transactions/:txId/reconcile-solana", async (c) => {
+  if (!requireAgentAccess(c)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Forbidden: token scope does not match agent" },
+      403,
+    );
+  }
+  const tenantId = c.get("tenantId");
+  const agentId = c.req.param("agentId");
+  const txId = c.req.param("txId");
+  if (!(await ensureAgentForTenant(tenantId, agentId))) {
+    return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
+  }
+  const signerAuthorization = await requireSignerPermission(
+    c,
+    tenantId,
+    agentId,
+    "sign_transaction",
+  );
+  if (!signerAuthorization.ok) return signerAuthorization.response;
+
+  const [row] = await db
+    .select()
+    .from(transactions)
+    .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)))
+    .limit(1);
+  const metadata = readSolanaRecoveryMetadata(row?.actionPayload);
+  if (!row || row.actionType !== "solana_transaction") {
+    return c.json<ApiResponse>({ ok: false, error: "Solana transaction not found" }, 404);
+  }
+  if (row.status !== "outcome_unknown") {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Only outcome_unknown Solana transactions can be reconciled" },
+      409,
+    );
+  }
+  if (!isNonEmptyString(row.txHash) || !isNonEmptyString(metadata.recentBlockhash)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Solana recovery checkpoint is incomplete" },
+      409,
+    );
+  }
+  const signature = row.txHash;
+  const recentBlockhash = metadata.recentBlockhash;
+
+  const nextStatus = await vault.reconcileSolanaBroadcast({
+    signature,
+    recentBlockhash,
+    chainId: row.chainId,
+  });
+  if (nextStatus === "outcome_unknown") {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "Solana broadcast outcome is still unknown",
+        data: { txId, signature: row.txHash, status: nextStatus },
+      },
+      202,
+    );
+  }
+
+  const transitioned = await withTenantAuditedTransaction(
+    tenantId,
+    async (rawTx, appendRequiredAudit) => {
+      const tx = rawTx as typeof db;
+      const [updated] = await tx
+        .update(transactions)
+        .set({
+          status: nextStatus,
+          confirmedAt: nextStatus === "confirmed" ? new Date() : row.confirmedAt,
+          actionPayload: {
+            ...metadata,
+            reconciledAt: new Date().toISOString(),
+            reconciliationResult: nextStatus,
+          },
+        })
+        .where(
+          and(
+            eq(transactions.id, txId),
+            eq(transactions.agentId, agentId),
+            eq(transactions.status, "outcome_unknown"),
+            eq(transactions.txHash, signature),
+          ),
+        )
+        .returning({ id: transactions.id });
+      if (!updated) return false;
+      await appendRequiredAudit({
+        tenantId,
+        actorType: "agent",
+        actorId: agentId,
+        action: "vault.sign.solana.reconciled",
+        resourceType: "transaction",
+        resourceId: txId,
+        metadata: {
+          previousStatus: "outcome_unknown",
+          status: nextStatus,
+          signature: row.txHash,
+          evidence: "solana_signature_status",
+          ...signerAuthAuditMetadata(signerAuthorization.auth),
+        },
+      });
+      return true;
+    },
+  );
+  if (!transitioned) {
+    return c.json<ApiResponse>({ ok: false, error: "Transaction state changed; retry" }, 409);
+  }
+  return c.json<ApiResponse>({
+    ok: true,
+    data: { txId, signature: row.txHash, status: nextStatus },
   });
 });
 

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -7843,6 +7843,17 @@ async function signSolanaBlind(
       caip2?: string;
     } | null = null;
     try {
+      await stageSolanaRecoveryAnchor({
+        txId,
+        agentId,
+        transaction: args.transaction,
+        chainId,
+        toAddress,
+        value: txValue,
+        broadcastRequested: shouldBroadcast,
+        blindSigned: true,
+        policyResults: evaluation.results,
+      });
       const result = await vault.signSolanaTransaction({
         agentId,
         tenantId,
@@ -7851,19 +7862,11 @@ async function signSolanaBlind(
         broadcast: args.broadcast,
         expectedTo: toAddress,
         expectedValue: txValue,
+        onBroadcastPrepared: (signature) =>
+          checkpointSolanaBroadcastSubmission(txId, agentId, signature),
       });
       completedResult = { txId, ...result };
-      await db.insert(transactions).values({
-        id: txId,
-        agentId,
-        status: result.broadcast ? "broadcast" : "signed",
-        toAddress,
-        value: txValue,
-        chainId,
-        txHash: result.broadcast ? result.signature : undefined,
-        policyResults: evaluation.results,
-        signedAt: new Date(),
-      });
+      await finalizeSolanaRecoveryAnchor(txId, agentId, result);
       recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
         console.error("[vault] Failed to record Solana spend", redactedThrownDiagnostics(err)),
       );
@@ -7899,8 +7902,6 @@ async function signSolanaBlind(
         }>
       >({ ok: true, data: { txId, ...result } });
     } catch (e: unknown) {
-      const frozen = frozenSigningResponse(c, e);
-      if (frozen) return frozen;
       const requestId = c.get("requestId") || "unknown";
       console.error(
         `[${requestId}] Solana blind sign failed for agent ${agentId}`,
@@ -7921,6 +7922,34 @@ async function signSolanaBlind(
           }>
         >({ ok: true, data: completedResult });
       }
+      if (e instanceof ExternalBroadcastOutcomeUnknownError) {
+        await preserveUnknownSolanaOutcome(txId, agentId, e.transactionHash);
+        recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
+          console.error(
+            "[vault] Failed to record ambiguous Solana spend",
+            redactedThrownDiagnostics(err),
+          ),
+        );
+        await writeOutcomeUnknownAudit(c, {
+          tenantId,
+          actorType: "agent",
+          actorId: agentId,
+          action: "vault.sign.solana.blind.outcome_unknown",
+          resourceType: "transaction",
+          resourceId: txId,
+          metadata: {
+            chainId,
+            to: toAddress,
+            value: txValue,
+            blindSigned: true,
+            signature: e.transactionHash,
+          },
+        });
+        return externalBroadcastOutcomeUnknownResponse(c, e, txId) as Response;
+      }
+      await markSolanaRecoveryAnchorFailed(txId, agentId);
+      const frozen = frozenSigningResponse(c, e);
+      if (frozen) return frozen;
       dispatchWebhook(tenantId, agentId, "tx_failed", {
         error: "Transaction failed",
         ...redactedThrownDiagnostics(e),
@@ -7932,6 +7961,129 @@ async function signSolanaBlind(
       return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
     }
   });
+}
+
+type SolanaSigningResult = {
+  signature: string;
+  broadcast: boolean;
+  chainId: number;
+  caip2?: string;
+};
+
+async function stageSolanaRecoveryAnchor(input: {
+  txId: string;
+  agentId: string;
+  transaction: string;
+  chainId: number;
+  toAddress: string;
+  value: string;
+  broadcastRequested: boolean;
+  blindSigned: boolean;
+  policyResults: PolicyResult[];
+}): Promise<void> {
+  await db.insert(transactions).values({
+    id: input.txId,
+    agentId: input.agentId,
+    status: "approved",
+    toAddress: input.toAddress,
+    value: input.value,
+    data: input.transaction,
+    chainId: input.chainId,
+    actionType: "solana_transaction",
+    actionPayload: {
+      type: "solana_transaction",
+      broadcast: input.broadcastRequested,
+      blindSigned: input.blindSigned,
+      recoveryAnchor: true,
+    },
+    policyResults: input.policyResults,
+  });
+}
+
+async function checkpointSolanaBroadcastSubmission(
+  txId: string,
+  agentId: string,
+  signature: string,
+): Promise<void> {
+  const rows = await db
+    .update(transactions)
+    .set({ status: "outcome_unknown", txHash: signature, signedAt: new Date() })
+    .where(
+      and(
+        eq(transactions.id, txId),
+        eq(transactions.agentId, agentId),
+        eq(transactions.status, "approved"),
+      ),
+    )
+    .returning({ id: transactions.id });
+  if (rows.length !== 1) {
+    throw new Error("Solana recovery anchor was not available for broadcast checkpoint");
+  }
+}
+
+async function finalizeSolanaRecoveryAnchor(
+  txId: string,
+  agentId: string,
+  result: SolanaSigningResult,
+): Promise<void> {
+  const rows = await db
+    .update(transactions)
+    .set({
+      status: result.broadcast ? "broadcast" : "signed",
+      txHash: result.broadcast ? result.signature : null,
+      signedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(transactions.id, txId),
+        eq(transactions.agentId, agentId),
+        sql`${transactions.status} in ('approved', 'outcome_unknown')`,
+      ),
+    )
+    .returning({ id: transactions.id });
+  if (rows.length !== 1) {
+    throw new Error("Solana recovery anchor was not available for finalization");
+  }
+}
+
+async function preserveUnknownSolanaOutcome(
+  txId: string,
+  agentId: string,
+  signature: string,
+): Promise<void> {
+  try {
+    await db
+      .update(transactions)
+      .set({ status: "outcome_unknown", txHash: signature, signedAt: new Date() })
+      .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)));
+  } catch (error) {
+    // The pre-sign approved row is already durable. Preserve the typed 202
+    // response even when the database cannot enrich it with the known hash.
+    console.error(
+      "[vault] Failed to persist ambiguous Solana broadcast hash",
+      redactedThrownDiagnostics(error),
+    );
+  }
+}
+
+async function markSolanaRecoveryAnchorFailed(txId: string, agentId: string): Promise<void> {
+  try {
+    await db
+      .update(transactions)
+      .set({ status: "failed" })
+      .where(
+        and(
+          eq(transactions.id, txId),
+          eq(transactions.agentId, agentId),
+          eq(transactions.status, "approved"),
+        ),
+      );
+  } catch (error) {
+    console.error(
+      "[vault] Failed to mark Solana recovery anchor as failed",
+      redactedThrownDiagnostics(error),
+    );
+  }
 }
 
 vaultRoutes.post("/:agentId/sign-solana", async (c) => {
@@ -8316,6 +8468,17 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         derived.summary.instructions[0].instructionType === "system:Transfer" &&
         derived.to !== undefined;
 
+      await stageSolanaRecoveryAnchor({
+        txId,
+        agentId,
+        transaction: body.transaction,
+        chainId,
+        toAddress,
+        value: txValue,
+        broadcastRequested: shouldBroadcast,
+        blindSigned: false,
+        policyResults: evaluation.results,
+      });
       const result = await vault.signSolanaTransaction({
         agentId,
         tenantId,
@@ -8328,20 +8491,12 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         ...(isSingleNativeTransfer
           ? { expectedTo: toAddress, expectedValue: txValue }
           : { allowBlindSign: true }),
+        onBroadcastPrepared: (signature) =>
+          checkpointSolanaBroadcastSubmission(txId, agentId, signature),
       });
       completedResult = { txId, ...result };
 
-      await db.insert(transactions).values({
-        id: txId,
-        agentId,
-        status: result.broadcast ? "broadcast" : "signed",
-        toAddress,
-        value: txValue,
-        chainId,
-        txHash: result.broadcast ? result.signature : undefined,
-        policyResults: evaluation.results,
-        signedAt: new Date(),
-      });
+      await finalizeSolanaRecoveryAnchor(txId, agentId, result);
 
       // ── Record spend in Redis (fire-and-forget) ──────────────────────────────
       recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
@@ -8393,8 +8548,6 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         data: { txId, ...result },
       });
     } catch (e: unknown) {
-      const frozen = frozenSigningResponse(c, e);
-      if (frozen) return frozen;
       const requestId = c.get("requestId") || "unknown";
       console.error(
         `[${requestId}] Solana sign failed for agent ${agentId}`,
@@ -8415,6 +8568,35 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
           }>
         >({ ok: true, data: completedResult });
       }
+
+      if (e instanceof ExternalBroadcastOutcomeUnknownError) {
+        await preserveUnknownSolanaOutcome(txId, agentId, e.transactionHash);
+        recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
+          console.error(
+            "[vault] Failed to record ambiguous Solana spend",
+            redactedThrownDiagnostics(err),
+          ),
+        );
+        await writeOutcomeUnknownAudit(c, {
+          tenantId,
+          actorType: "agent",
+          actorId: agentId,
+          action: "vault.sign.solana.outcome_unknown",
+          resourceType: "transaction",
+          resourceId: txId,
+          metadata: {
+            chainId,
+            to: toAddress,
+            value: txValue,
+            signature: e.transactionHash,
+            derivedFromTransaction: true,
+          },
+        });
+        return externalBroadcastOutcomeUnknownResponse(c, e, txId) as Response;
+      }
+      await markSolanaRecoveryAnchorFailed(txId, agentId);
+      const frozen = frozenSigningResponse(c, e);
+      if (frozen) return frozen;
 
       dispatchWebhook(tenantId, agentId, "tx_failed", {
         error: "Transaction failed",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -679,6 +679,14 @@ export interface SignSolanaTransactionRequest {
    * sign. Never forward client-controlled input into this flag.
    */
   allowBlindSign?: boolean;
+  /**
+   * Durable recovery checkpoint invoked after signing has produced the
+   * deterministic transaction signature, but before any broadcast I/O. API
+   * callers use this to persist the signature as outcome_unknown so a crash,
+   * lost RPC response, or confirmation failure cannot make a potentially
+   * submitted transaction indistinguishable from one that was never sent.
+   */
+  onBroadcastPrepared?: (signature: string) => Promise<void>;
 }
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -686,7 +686,10 @@ export interface SignSolanaTransactionRequest {
    * lost RPC response, or confirmation failure cannot make a potentially
    * submitted transaction indistinguishable from one that was never sent.
    */
-  onBroadcastPrepared?: (signature: string) => Promise<void>;
+  onBroadcastPrepared?: (checkpoint: {
+    signature: string;
+    recentBlockhash: string;
+  }) => Promise<void>;
 }
 
 /**

--- a/packages/vault/package.json
+++ b/packages/vault/package.json
@@ -20,6 +20,7 @@
     "@solana/web3.js": "^1",
     "@stwd/db": "workspace:*",
     "@stwd/shared": "workspace:*",
+    "bs58": "^6.0.0",
     "drizzle-orm": "^0.45.2",
     "viem": "^2.30.0"
   },

--- a/packages/vault/src/__tests__/solana-vault-priority-fee.test.ts
+++ b/packages/vault/src/__tests__/solana-vault-priority-fee.test.ts
@@ -1,6 +1,7 @@
-import { afterAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, setDefaultTimeout, spyOn, test } from "bun:test";
 import {
   ComputeBudgetProgram,
+  Connection,
   PublicKey,
   SystemProgram,
   Transaction,
@@ -9,12 +10,15 @@ import {
 } from "@solana/web3.js";
 import { getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { ExternalBroadcastOutcomeUnknownError } from "../external-key-custody";
 import { Vault } from "../vault";
 
 const MASTER_PASSWORD = "test-vault-solana-priority-fee";
 const TENANT_ID = "vault-solana-priority-fee-tenant";
 const AGENT_ID = "vault-solana-priority-fee-agent";
 const RECENT_BLOCKHASH = new PublicKey(new Uint8Array(32).fill(11)).toBase58();
+const SUBMITTED_SIGNATURE =
+  "4oL4p7QvN3UH7V5wMGZgW5PuzEk4A9LXLHk9RxAoKjDKuLbQBsfXN8kEvKfj5K1oEJa8wFF6RVp2h7pP9w2f51ZV";
 
 setDefaultTimeout(30000);
 
@@ -146,5 +150,142 @@ describe("Vault.signSolanaTransaction priority fee cap", () => {
     const signed = Transaction.from(fromBase64(result.signature));
     expect(result.broadcast).toBe(false);
     expect(signed.signatures.some(({ signature }) => signature?.some((b) => b !== 0))).toBe(true);
+  });
+
+  test("aborts before network I/O when the durable pre-broadcast checkpoint fails", async () => {
+    const feePayer = await createSolanaAgent(vault);
+    let sendCalls = 0;
+    let blockhashCalls = 0;
+    let confirmCalls = 0;
+    const send = spyOn(Connection.prototype, "sendRawTransaction").mockImplementation(async () => {
+      sendCalls += 1;
+      return SUBMITTED_SIGNATURE;
+    });
+    const getBlockhash = spyOn(Connection.prototype, "getLatestBlockhash").mockImplementation(
+      async () => {
+        blockhashCalls += 1;
+        return { blockhash: RECENT_BLOCKHASH, lastValidBlockHeight: 100 };
+      },
+    );
+    const confirm = spyOn(Connection.prototype, "confirmTransaction").mockImplementation(
+      async () => {
+        confirmCalls += 1;
+        return { context: { slot: 1 }, value: { err: null } };
+      },
+    );
+    let error: unknown;
+    try {
+      await vault.signSolanaTransaction({
+        tenantId: TENANT_ID,
+        agentId: AGENT_ID,
+        transaction: legacyTransferWithPriorityFee(feePayer, 1_000),
+        broadcast: true,
+        allowBlindSign: true,
+        onBroadcastPrepared: async (signature) => {
+          expect(signature).toBeString();
+          throw new Error("injected durable checkpoint failure");
+        },
+      });
+    } catch (caught) {
+      error = caught;
+    } finally {
+      send.mockRestore();
+      getBlockhash.mockRestore();
+      confirm.mockRestore();
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(ExternalBroadcastOutcomeUnknownError);
+    expect((error as Error).message).toBe("injected durable checkpoint failure");
+    expect(sendCalls).toBe(0);
+    expect(blockhashCalls).toBe(0);
+    expect(confirmCalls).toBe(0);
+  });
+
+  test("checkpoints before confirmation and retains the hash when confirmation fails", async () => {
+    const feePayer = await createSolanaAgent(vault);
+    const order: string[] = [];
+    let preparedSignature = "";
+    const send = spyOn(Connection.prototype, "sendRawTransaction").mockImplementation(async () => {
+      order.push("submitted");
+      return preparedSignature;
+    });
+    const getBlockhash = spyOn(Connection.prototype, "getLatestBlockhash").mockResolvedValue({
+      blockhash: RECENT_BLOCKHASH,
+      lastValidBlockHeight: 100,
+    });
+    const confirm = spyOn(Connection.prototype, "confirmTransaction").mockImplementation(
+      async () => {
+        order.push("confirmation");
+        throw new Error("injected confirmation failure");
+      },
+    );
+    let error: unknown;
+    try {
+      await vault.signSolanaTransaction({
+        tenantId: TENANT_ID,
+        agentId: AGENT_ID,
+        transaction: legacyTransferWithPriorityFee(feePayer, 1_000),
+        broadcast: true,
+        allowBlindSign: true,
+        onBroadcastPrepared: async (signature) => {
+          preparedSignature = signature;
+          order.push("checkpoint");
+        },
+      });
+    } catch (caught) {
+      error = caught;
+    } finally {
+      send.mockRestore();
+      getBlockhash.mockRestore();
+      confirm.mockRestore();
+    }
+
+    expect(error).toBeInstanceOf(ExternalBroadcastOutcomeUnknownError);
+    expect((error as ExternalBroadcastOutcomeUnknownError).transactionHash).toBe(preparedSignature);
+    expect(preparedSignature).not.toBe("");
+    expect(order).toEqual(["checkpoint", "submitted", "confirmation"]);
+  });
+
+  test("retains the prepared hash when sendRawTransaction may have accepted but loses its response", async () => {
+    const feePayer = await createSolanaAgent(vault);
+    let preparedSignature = "";
+    let sendCalls = 0;
+    const send = spyOn(Connection.prototype, "sendRawTransaction").mockImplementation(async () => {
+      sendCalls += 1;
+      throw new Error("injected transport loss after submission");
+    });
+    const getBlockhash = spyOn(Connection.prototype, "getLatestBlockhash").mockResolvedValue({
+      blockhash: RECENT_BLOCKHASH,
+      lastValidBlockHeight: 100,
+    });
+    const confirm = spyOn(Connection.prototype, "confirmTransaction").mockResolvedValue({
+      context: { slot: 1 },
+      value: { err: null },
+    });
+    let error: unknown;
+    try {
+      await vault.signSolanaTransaction({
+        tenantId: TENANT_ID,
+        agentId: AGENT_ID,
+        transaction: legacyTransferWithPriorityFee(feePayer, 1_000),
+        broadcast: true,
+        allowBlindSign: true,
+        onBroadcastPrepared: async (signature) => {
+          preparedSignature = signature;
+        },
+      });
+    } catch (caught) {
+      error = caught;
+    } finally {
+      send.mockRestore();
+      getBlockhash.mockRestore();
+      confirm.mockRestore();
+    }
+
+    expect(sendCalls).toBe(1);
+    expect(preparedSignature).not.toBe("");
+    expect(error).toBeInstanceOf(ExternalBroadcastOutcomeUnknownError);
+    expect((error as ExternalBroadcastOutcomeUnknownError).transactionHash).toBe(preparedSignature);
   });
 });

--- a/packages/vault/src/__tests__/solana-vault-priority-fee.test.ts
+++ b/packages/vault/src/__tests__/solana-vault-priority-fee.test.ts
@@ -3,6 +3,7 @@ import {
   ComputeBudgetProgram,
   Connection,
   PublicKey,
+  SendTransactionError,
   SystemProgram,
   Transaction,
   TransactionMessage,
@@ -10,7 +11,10 @@ import {
 } from "@solana/web3.js";
 import { getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { ExternalBroadcastOutcomeUnknownError } from "../external-key-custody";
+import {
+  ExternalBroadcastOutcomeUnknownError,
+  SolanaBroadcastNotSubmittedError,
+} from "../external-key-custody";
 import { Vault } from "../vault";
 
 const MASTER_PASSWORD = "test-vault-solana-priority-fee";
@@ -181,8 +185,9 @@ describe("Vault.signSolanaTransaction priority fee cap", () => {
         transaction: legacyTransferWithPriorityFee(feePayer, 1_000),
         broadcast: true,
         allowBlindSign: true,
-        onBroadcastPrepared: async (signature) => {
-          expect(signature).toBeString();
+        onBroadcastPrepared: async (checkpoint) => {
+          expect(checkpoint.signature).toBeString();
+          expect(checkpoint.recentBlockhash).toBe(RECENT_BLOCKHASH);
           throw new Error("injected durable checkpoint failure");
         },
       });
@@ -228,8 +233,9 @@ describe("Vault.signSolanaTransaction priority fee cap", () => {
         transaction: legacyTransferWithPriorityFee(feePayer, 1_000),
         broadcast: true,
         allowBlindSign: true,
-        onBroadcastPrepared: async (signature) => {
-          preparedSignature = signature;
+        onBroadcastPrepared: async (checkpoint) => {
+          preparedSignature = checkpoint.signature;
+          expect(checkpoint.recentBlockhash).toBe(RECENT_BLOCKHASH);
           order.push("checkpoint");
         },
       });
@@ -271,8 +277,9 @@ describe("Vault.signSolanaTransaction priority fee cap", () => {
         transaction: legacyTransferWithPriorityFee(feePayer, 1_000),
         broadcast: true,
         allowBlindSign: true,
-        onBroadcastPrepared: async (signature) => {
-          preparedSignature = signature;
+        onBroadcastPrepared: async (checkpoint) => {
+          preparedSignature = checkpoint.signature;
+          expect(checkpoint.recentBlockhash).toBe(RECENT_BLOCKHASH);
         },
       });
     } catch (caught) {
@@ -287,5 +294,110 @@ describe("Vault.signSolanaTransaction priority fee cap", () => {
     expect(preparedSignature).not.toBe("");
     expect(error).toBeInstanceOf(ExternalBroadcastOutcomeUnknownError);
     expect((error as ExternalBroadcastOutcomeUnknownError).transactionHash).toBe(preparedSignature);
+  });
+
+  for (const version of ["legacy", "v0"] as const) {
+    test(`checkpoints the deterministic ${version} signature and original blockhash`, async () => {
+      const feePayer = await createSolanaAgent(vault);
+      let checkpoint: { signature: string; recentBlockhash: string } | undefined;
+      const send = spyOn(Connection.prototype, "sendRawTransaction").mockImplementation(
+        async () => {
+          if (!checkpoint) throw new Error("checkpoint did not run before send");
+          return checkpoint.signature;
+        },
+      );
+      const confirm = spyOn(Connection.prototype, "confirmTransaction").mockResolvedValue({
+        context: { slot: 1 },
+        value: { err: null },
+      });
+      try {
+        const result = await vault.signSolanaTransaction({
+          tenantId: TENANT_ID,
+          agentId: AGENT_ID,
+          transaction:
+            version === "legacy"
+              ? legacyTransferWithPriorityFee(feePayer, 1_000)
+              : v0TransferWithPriorityFee(feePayer, 1_000),
+          broadcast: true,
+          allowBlindSign: true,
+          onBroadcastPrepared: async (value) => {
+            checkpoint = value;
+          },
+        });
+        expect(checkpoint?.recentBlockhash).toBe(RECENT_BLOCKHASH);
+        expect(result.signature).toBe(checkpoint?.signature);
+      } finally {
+        send.mockRestore();
+        confirm.mockRestore();
+      }
+    });
+  }
+
+  test("classifies an SDK simulation rejection as definitively not submitted", async () => {
+    const feePayer = await createSolanaAgent(vault);
+    let preparedSignature = "";
+    const send = spyOn(Connection.prototype, "sendRawTransaction").mockRejectedValue(
+      new SendTransactionError({
+        action: "simulate",
+        signature: "",
+        transactionMessage: "custom program error",
+      }),
+    );
+    try {
+      await vault.signSolanaTransaction({
+        tenantId: TENANT_ID,
+        agentId: AGENT_ID,
+        transaction: legacyTransferWithPriorityFee(feePayer, 1_000),
+        broadcast: true,
+        allowBlindSign: true,
+        onBroadcastPrepared: async (checkpoint) => {
+          preparedSignature = checkpoint.signature;
+        },
+      });
+      throw new Error("expected preflight rejection");
+    } catch (error) {
+      expect(error).toBeInstanceOf(SolanaBroadcastNotSubmittedError);
+      expect((error as SolanaBroadcastNotSubmittedError).transactionHash).toBe(preparedSignature);
+    } finally {
+      send.mockRestore();
+    }
+  });
+
+  test("distinguishes signature evidence, live blockhash ambiguity, and expiry", async () => {
+    const statuses = spyOn(Connection.prototype, "getSignatureStatuses");
+    const validity = spyOn(Connection.prototype, "isBlockhashValid");
+    try {
+      statuses.mockResolvedValueOnce({
+        context: { slot: 1 },
+        value: [{ slot: 1, confirmations: 1, err: null, confirmationStatus: "confirmed" }],
+      });
+      expect(
+        await vault.reconcileSolanaBroadcast({
+          signature: SUBMITTED_SIGNATURE,
+          recentBlockhash: RECENT_BLOCKHASH,
+        }),
+      ).toBe("confirmed");
+
+      statuses.mockResolvedValueOnce({ context: { slot: 1 }, value: [null] });
+      validity.mockResolvedValueOnce({ context: { slot: 1 }, value: true });
+      expect(
+        await vault.reconcileSolanaBroadcast({
+          signature: SUBMITTED_SIGNATURE,
+          recentBlockhash: RECENT_BLOCKHASH,
+        }),
+      ).toBe("outcome_unknown");
+
+      statuses.mockResolvedValueOnce({ context: { slot: 1 }, value: [null] });
+      validity.mockResolvedValueOnce({ context: { slot: 1 }, value: false });
+      expect(
+        await vault.reconcileSolanaBroadcast({
+          signature: SUBMITTED_SIGNATURE,
+          recentBlockhash: RECENT_BLOCKHASH,
+        }),
+      ).toBe("failed");
+    } finally {
+      statuses.mockRestore();
+      validity.mockRestore();
+    }
   });
 });

--- a/packages/vault/src/external-key-custody.ts
+++ b/packages/vault/src/external-key-custody.ts
@@ -79,6 +79,17 @@ export class ExternalBroadcastOutcomeUnknownError extends Error {
   }
 }
 
+/** A Solana RPC preflight rejection proves the signed bytes were not submitted. */
+export class SolanaBroadcastNotSubmittedError extends Error {
+  readonly transactionHash: string;
+
+  constructor(transactionHash: string, options?: { cause?: unknown }) {
+    super("Solana transaction was rejected before submission", options);
+    this.name = "SolanaBroadcastNotSubmittedError";
+    this.transactionHash = transactionHash;
+  }
+}
+
 export interface ExternalKeyHandleRegistration {
   custody: "external";
   tenantId: string;

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -54,6 +54,7 @@ export {
   FailClosedExternalKeyCustodyProvider,
   InMemoryExternalKeyCustodyProvider,
   normalizeExternalKeyHandleRegistration,
+  SolanaBroadcastNotSubmittedError,
 } from "./external-key-custody";
 export type {
   ExternalKeyCustodyV1ConformanceResult,

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -66,6 +66,7 @@ import {
   externalKeyPrivateExportUnavailableError,
   externalKeySigningUnavailableError,
   normalizeExternalKeyHandleRegistration,
+  SolanaBroadcastNotSubmittedError,
 } from "./external-key-custody";
 import { deriveBitcoinKey, deriveEvmKey, deriveSolanaKey, generateMnemonic } from "./hd-wallet";
 import { type EncryptedKey, KeyStore } from "./keystore";
@@ -3141,6 +3142,7 @@ export class Vault {
       Transaction: SolTransaction,
       VersionedTransaction,
       Connection,
+      SendTransactionError,
     } = await import("@solana/web3.js");
     const txBytes = Uint8Array.from(atob(request.transaction), (c) => c.charCodeAt(0));
 
@@ -3158,6 +3160,7 @@ export class Vault {
 
     let signedBytes: Uint8Array;
     let preparedSignature: string;
+    let recentBlockhash: string;
     if (isVersionedTransactionBytes(txBytes)) {
       const vtx = VersionedTransaction.deserialize(txBytes);
       assertSolanaPriorityFeeWithinCap(parseSolanaTransaction(request.transaction));
@@ -3174,6 +3177,7 @@ export class Vault {
         throw new Error("Solana versioned transaction did not produce a signer signature");
       }
       preparedSignature = bs58.encode(signature);
+      recentBlockhash = vtx.message.recentBlockhash;
     } else {
       const tx = SolTransaction.from(txBytes);
       assertSolanaPriorityFeeWithinCap(parseSolanaTransaction(request.transaction));
@@ -3191,12 +3195,16 @@ export class Vault {
         throw new Error("Solana transaction did not produce a signer signature");
       }
       preparedSignature = bs58.encode(tx.signature);
+      if (!tx.recentBlockhash) {
+        throw new Error("Solana transaction is missing a recent blockhash");
+      }
+      recentBlockhash = tx.recentBlockhash;
     }
 
     if (shouldBroadcast) {
       // Persist the deterministic signature before the first external write.
       // A checkpoint failure aborts safely before sendRawTransaction.
-      await request.onBroadcastPrepared?.(preparedSignature);
+      await request.onBroadcastPrepared?.({ signature: preparedSignature, recentBlockhash });
       const connection = new Connection(rpcUrl, "confirmed");
       try {
         const sig = await connection.sendRawTransaction(signedBytes, {
@@ -3206,18 +3214,19 @@ export class Vault {
         if (sig !== preparedSignature) {
           throw new Error("Solana RPC returned a signature that does not match the signed bytes");
         }
-        const { blockhash, lastValidBlockHeight } =
-          await connection.getLatestBlockhash("confirmed");
-        await connection.confirmTransaction(
-          { signature: sig, blockhash, lastValidBlockHeight },
-          "confirmed",
-        );
+        await connection.confirmTransaction(sig, "confirmed");
       } catch (error) {
         // The signed bytes and their deterministic signature were durably
         // checkpointed before sendRawTransaction. Its rejection may represent
         // a preflight denial, an accepted submission with a lost response, or
         // a later confirmation failure, so every case is conservatively
         // non-retryable until the signature is reconciled.
+        if (
+          error instanceof SendTransactionError &&
+          error.message.startsWith("Simulation failed.")
+        ) {
+          throw new SolanaBroadcastNotSubmittedError(preparedSignature, { cause: error });
+        }
         throw new ExternalBroadcastOutcomeUnknownError(preparedSignature, { cause: error });
       }
 
@@ -3237,6 +3246,31 @@ export class Vault {
       chainId,
       caip2: toCaip2(chainId),
     };
+  }
+
+  async reconcileSolanaBroadcast(input: {
+    signature: string;
+    recentBlockhash: string;
+    chainId?: number;
+  }): Promise<"confirmed" | "broadcast" | "failed" | "outcome_unknown"> {
+    const { Connection } = await import("@solana/web3.js");
+    const rpcUrl = this.config.rpcUrl ?? resolveSolanaRpc(input.chainId ?? 101);
+    const connection = new Connection(rpcUrl, "confirmed");
+    const response = await connection.getSignatureStatuses([input.signature], {
+      searchTransactionHistory: true,
+    });
+    const status = response.value[0];
+    if (status) {
+      if (status.err !== null) return "failed";
+      if (status.confirmationStatus === "confirmed" || status.confirmationStatus === "finalized") {
+        return "confirmed";
+      }
+      return "broadcast";
+    }
+    const validity = await connection.isBlockhashValid(input.recentBlockhash, {
+      commitment: "confirmed",
+    });
+    return validity.value ? "outcome_unknown" : "failed";
   }
 
   /**

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -25,6 +25,7 @@ import type {
   WalletAddressMetadata,
 } from "@stwd/shared";
 import { canonicalJsonStringify, toCaip2 } from "@stwd/shared";
+import bs58 from "bs58";
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import {
   type Chain,
@@ -3156,6 +3157,7 @@ export class Vault {
     };
 
     let signedBytes: Uint8Array;
+    let preparedSignature: string;
     if (isVersionedTransactionBytes(txBytes)) {
       const vtx = VersionedTransaction.deserialize(txBytes);
       assertSolanaPriorityFeeWithinCap(parseSolanaTransaction(request.transaction));
@@ -3167,6 +3169,11 @@ export class Vault {
       }
       vtx.sign([keypair]);
       signedBytes = vtx.serialize();
+      const signature = vtx.signatures[0];
+      if (!signature?.some((byte) => byte !== 0)) {
+        throw new Error("Solana versioned transaction did not produce a signer signature");
+      }
+      preparedSignature = bs58.encode(signature);
     } else {
       const tx = SolTransaction.from(txBytes);
       assertSolanaPriorityFeeWithinCap(parseSolanaTransaction(request.transaction));
@@ -3180,23 +3187,42 @@ export class Vault {
       }
       tx.partialSign(keypair);
       signedBytes = tx.serialize();
+      if (!tx.signature) {
+        throw new Error("Solana transaction did not produce a signer signature");
+      }
+      preparedSignature = bs58.encode(tx.signature);
     }
 
     if (shouldBroadcast) {
+      // Persist the deterministic signature before the first external write.
+      // A checkpoint failure aborts safely before sendRawTransaction.
+      await request.onBroadcastPrepared?.(preparedSignature);
       const connection = new Connection(rpcUrl, "confirmed");
-      const sig = await connection.sendRawTransaction(signedBytes, {
-        skipPreflight: false,
-        preflightCommitment: "confirmed",
-      });
-
-      const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash("confirmed");
-      await connection.confirmTransaction(
-        { signature: sig, blockhash, lastValidBlockHeight },
-        "confirmed",
-      );
+      try {
+        const sig = await connection.sendRawTransaction(signedBytes, {
+          skipPreflight: false,
+          preflightCommitment: "confirmed",
+        });
+        if (sig !== preparedSignature) {
+          throw new Error("Solana RPC returned a signature that does not match the signed bytes");
+        }
+        const { blockhash, lastValidBlockHeight } =
+          await connection.getLatestBlockhash("confirmed");
+        await connection.confirmTransaction(
+          { signature: sig, blockhash, lastValidBlockHeight },
+          "confirmed",
+        );
+      } catch (error) {
+        // The signed bytes and their deterministic signature were durably
+        // checkpointed before sendRawTransaction. Its rejection may represent
+        // a preflight denial, an accepted submission with a lost response, or
+        // a later confirmation failure, so every case is conservatively
+        // non-retryable until the signature is reconciled.
+        throw new ExternalBroadcastOutcomeUnknownError(preparedSignature, { cause: error });
+      }
 
       return {
-        signature: sig,
+        signature: preparedSignature,
         broadcast: true,
         chainId,
         caip2: toCaip2(chainId),


### PR DESCRIPTION
Closes #615

## Summary
- persist a canonical database-bound Idempotency-Key/request binding for every broadcast Solana auth mode
- use a token-owned execution lease so concurrent/retried requests cannot sign, submit, or account twice; expired takeover is CAS-fenced and stale callbacks cannot mutate the winner
- checkpoint the exact legacy/v0 signature and original recent blockhash before network submission
- distinguish proven preflight rejection from ambiguous submission, and provide authenticated evidence-bound Solana reconciliation with atomic audited transitions
- preserve durable recovery and successful/ambiguous responses through post-broadcast bookkeeping failures

## Exact evidence
- head: `51936a802297ffe2def031084ab70c4d7e8a3d16`
- parent/base PR head: `3b9e406ddd6e089bb41ace3a2e1ca9de111d7efd`
- develop base: `9239a728b9ca28175e00e2825f69d85f3e02856e`
- mounted API recovery/idempotency/reconciliation: 6/6, 70 assertions
- idempotency middleware: 18/18
- Vault Solana behavior: 10/10
- full workspace typecheck: 36-package graph plus web PASS
- API dependency build: 24/24 PASS
- Biome changed files and `git diff --check`: PASS

## Merge posture
Keep draft pending replacement exact-head hosted CI, independent approval, and restack after #603 if that transaction-owner change lands first.