### PR TITLE
docs: repair README navigation links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,13 +74,13 @@ docker compose up -d
 
 ## Documentation
 
-- [**Quickstart**](./quickstart.md) — Up and running in 5 minutes
-- [**Architecture**](./architecture.md) — How the pieces fit together
-- [**Authentication**](./auth.md) — Passkeys, magic links, SIWE, JWT, API keys
-- [**Policy Engine**](./policies.md) — Spending limits, whitelists, rate limits, and more
+- [**Quickstart**](./quickstart.mdx) — Up and running in 5 minutes
+- [**Architecture**](./concepts/architecture.mdx) — How the pieces fit together
+- [**Authentication**](./auth/overview.mdx) — Passkeys, magic links, SIWE, JWT, API keys
+- [**Policy Engine**](./concepts/policy-engine.mdx) — Spending limits, whitelists, rate limits, and more
 - [**Monero on Solana**](./guides/monero-on-solana.mdx) — Configure and use the bidirectional wxmr.io bridge handoff
-- [**SDK Reference**](./sdk.md) — `@stwd/sdk` TypeScript client
-- [**React Components**](./react.md) — `@stwd/react` embeddable UI
+- [**SDK Reference**](./sdk/client.mdx) — `@stwd/sdk` TypeScript client
+- [**React Components**](./sdk/react-components.mdx) — `@stwd/react` embeddable UI
 - [**Deployment Guide**](./deployment.md) — Docker, environment variables, database setup
 
 ## Who Uses Steward


### PR DESCRIPTION
Closes #623

## Summary
Repair six broken links in the active documentation README so each points at its current Mintlify source path.

## Exact evidence
- head: `b26b06c299d3e9f761b7ebcdd7bf2290f26c8782`
- base: `9239a728b9ca28175e00e2825f69d85f3e02856e`
- all relative links in non-archive documentation resolve
- `git diff --check`: pass

## Merge posture
Draft pending exact hosted CI and independent approval.
