### PR TITLE
fix(auth): reject malformed platform key scope configuration

### DIFF
--- a/packages/auth/src/__tests__/platform.test.ts
+++ b/packages/auth/src/__tests__/platform.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { getPlatformKeyScopes, isValidPlatformKey } from "../platform";
+import { Hono } from "hono";
+import { getPlatformKeyScopes, isValidPlatformKey, platformAuthMiddleware } from "../platform";
 
 const ORIGINAL_PLATFORM_KEY = process.env.STEWARD_PLATFORM_KEY;
 const ORIGINAL_PLATFORM_KEYS = process.env.STEWARD_PLATFORM_KEYS;
@@ -55,5 +56,49 @@ describe("platform key validation", () => {
       "platform:write",
       "platform:tenant:create",
     ]);
+  });
+
+  it("rejects malformed platform scope JSON instead of hiding the configuration failure", () => {
+    resetPlatformKeyEnv();
+    process.env.STEWARD_PLATFORM_KEY_SCOPES = "{";
+
+    expect(() => getPlatformKeyScopes("platform-key")).toThrow(
+      "STEWARD_PLATFORM_KEY_SCOPES must be valid JSON",
+    );
+  });
+
+  it("fails a mounted platform request when scope configuration is malformed", async () => {
+    resetPlatformKeyEnv();
+    process.env.STEWARD_PLATFORM_KEY = "mounted-platform-key";
+    process.env.STEWARD_PLATFORM_KEY_SCOPES = "{";
+    const app = new Hono();
+    let reachedRoute = false;
+    app.onError((_error, c) => c.json({ ok: false, error: "Internal Server Error" }, 500));
+    app.use("*", platformAuthMiddleware());
+    app.get("/", (c) => {
+      reachedRoute = true;
+      return c.json({ ok: true });
+    });
+
+    const response = await app.request("/", {
+      headers: { "X-Steward-Platform-Key": "mounted-platform-key" },
+    });
+
+    expect(response.status).toBe(500);
+    expect(reachedRoute).toBe(false);
+  });
+
+  it.each([
+    ["an array", ["platform:read"]],
+    ["a scalar", "platform:read"],
+    ["a non-array mapping value", { "platform-key": "platform:read" }],
+    ["a mixed-type scope array", { "platform-key": ["platform:read", 1] }],
+  ])("rejects %s platform scope configuration", (_label, configuredScopes) => {
+    resetPlatformKeyEnv();
+    process.env.STEWARD_PLATFORM_KEY_SCOPES = JSON.stringify(configuredScopes);
+
+    expect(() => getPlatformKeyScopes("platform-key")).toThrow(
+      "STEWARD_PLATFORM_KEY_SCOPES must be a JSON object mapping keys or key hashes to string arrays",
+    );
   });
 });

--- a/packages/auth/src/platform.ts
+++ b/packages/auth/src/platform.ts
@@ -38,17 +38,30 @@ function getValidPlatformKeys(): string[] {
 function parsePlatformKeyScopes(): Record<string, string[]> {
   const raw = process.env.STEWARD_PLATFORM_KEY_SCOPES;
   if (!raw?.trim()) return {};
+
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    const scopes: Record<string, string[]> = {};
-    for (const [keyOrHash, value] of Object.entries(parsed)) {
-      if (!Array.isArray(value)) continue;
-      scopes[keyOrHash] = value.filter((scope): scope is string => typeof scope === "string");
-    }
-    return scopes;
+    parsed = JSON.parse(raw);
   } catch {
-    return {};
+    throw new Error("STEWARD_PLATFORM_KEY_SCOPES must be valid JSON");
   }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      "STEWARD_PLATFORM_KEY_SCOPES must be a JSON object mapping keys or key hashes to string arrays",
+    );
+  }
+
+  const scopes: Record<string, string[]> = {};
+  for (const [keyOrHash, value] of Object.entries(parsed)) {
+    if (!Array.isArray(value) || value.some((scope) => typeof scope !== "string")) {
+      throw new Error(
+        "STEWARD_PLATFORM_KEY_SCOPES must be a JSON object mapping keys or key hashes to string arrays",
+      );
+    }
+    scopes[keyOrHash] = value;
+  }
+  return scopes;
 }
 
 /**


### PR DESCRIPTION
Closes #624

## Summary
- reject malformed `STEWARD_PLATFORM_KEY_SCOPES` JSON instead of silently replacing it with an empty scope map
- validate the complete key-to-string-array shape without filtering malformed entries
- exercise the mounted authentication boundary and prove the route is not reached under invalid configuration

## Exact evidence
- head: `fcc540dc6aabca28086bb3fe246f1e974c60c563`
- base: `9239a728b9ca28175e00e2825f69d85f3e02856e`
- platform auth tests: 9/9 pass
- affected auth build: 4/4 tasks pass
- Biome and `git diff --check`: pass

## Merge posture
Draft pending exact hosted CI, restack after the root CORS repair in #589 if required, and independent approval.
