### PR TITLE
fix(auth): reject malformed platform key scope configuration

### DIFF
--- a/packages/auth/src/__tests__/platform.test.ts
+++ b/packages/auth/src/__tests__/platform.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { getPlatformKeyScopes, isValidPlatformKey } from "../platform";
+import { Hono } from "hono";
+import { getPlatformKeyScopes, isValidPlatformKey, platformAuthMiddleware } from "../platform";
 
 const ORIGINAL_PLATFORM_KEY = process.env.STEWARD_PLATFORM_KEY;
 const ORIGINAL_PLATFORM_KEYS = process.env.STEWARD_PLATFORM_KEYS;
@@ -55,5 +56,48 @@ describe("platform key validation", () => {
       "platform:write",
       "platform:tenant:create",
     ]);
+  });
+
+  it("preserves an empty scope map only when the configuration is absent or blank", () => {
+    resetPlatformKeyEnv();
+    expect(getPlatformKeyScopes("unscoped-platform-key")).toEqual([]);
+
+    process.env.STEWARD_PLATFORM_KEY_SCOPES = "  \n  ";
+    expect(getPlatformKeyScopes("unscoped-platform-key")).toEqual([]);
+  });
+
+  it.each([
+    ["malformed JSON", "{"],
+    ["null JSON", "null"],
+    ["array JSON", '[["platform:read"]]'],
+    ["non-array scope value", '{"platform-key":"platform:read"}'],
+    ["mixed non-string scope array", '{"platform-key":["platform:read",7]}'],
+  ])("rejects %s instead of silently removing authorization", (_name, raw) => {
+    resetPlatformKeyEnv();
+    process.env.STEWARD_PLATFORM_KEY_SCOPES = raw;
+
+    expect(() => getPlatformKeyScopes("platform-key")).toThrow(
+      "Platform key scope configuration is invalid",
+    );
+  });
+
+  it("returns a redacted configuration error for a valid platform key", async () => {
+    resetPlatformKeyEnv();
+    const key = "valid-platform-key-with-enough-entropy";
+    const canary = "raw-scope-config-canary";
+    process.env.STEWARD_PLATFORM_KEY = key;
+    process.env.STEWARD_PLATFORM_KEY_SCOPES = `{"${canary}":["platform:read"]`;
+
+    const app = new Hono();
+    app.use("*", platformAuthMiddleware());
+    app.get("/", (c) => c.json({ ok: true }));
+
+    const response = await app.request("/", {
+      headers: { "X-Steward-Platform-Key": key },
+    });
+    const body = await response.text();
+    expect(response.status).toBe(500);
+    expect(body).toContain("Platform key scope configuration is invalid");
+    expect(body).not.toContain(canary);
   });
 });

--- a/packages/auth/src/platform.ts
+++ b/packages/auth/src/platform.ts
@@ -35,20 +35,40 @@ function getValidPlatformKeys(): string[] {
     .filter(Boolean);
 }
 
+const PLATFORM_SCOPE_CONFIG_ERROR = "Platform key scope configuration is invalid";
+
+class PlatformKeyScopesConfigurationError extends Error {
+  constructor() {
+    super(PLATFORM_SCOPE_CONFIG_ERROR);
+    this.name = "PlatformKeyScopesConfigurationError";
+  }
+}
+
 function parsePlatformKeyScopes(): Record<string, string[]> {
   const raw = process.env.STEWARD_PLATFORM_KEY_SCOPES;
   if (!raw?.trim()) return {};
+
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    const scopes: Record<string, string[]> = {};
-    for (const [keyOrHash, value] of Object.entries(parsed)) {
-      if (!Array.isArray(value)) continue;
-      scopes[keyOrHash] = value.filter((scope): scope is string => typeof scope === "string");
-    }
-    return scopes;
+    parsed = JSON.parse(raw);
   } catch {
-    return {};
+    throw new PlatformKeyScopesConfigurationError();
   }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new PlatformKeyScopesConfigurationError();
+  }
+
+  const entries = Object.entries(parsed);
+  if (
+    entries.some(
+      ([, value]) => !Array.isArray(value) || value.some((scope) => typeof scope !== "string"),
+    )
+  ) {
+    throw new PlatformKeyScopesConfigurationError();
+  }
+
+  return Object.fromEntries(entries) as Record<string, string[]>;
 }
 
 /**
@@ -143,8 +163,18 @@ export function platformAuthMiddleware() {
       return c.json<ApiResponse>({ ok: false, error: "Invalid platform key" }, 403);
     }
 
+    let scopes: string[];
+    try {
+      scopes = getPlatformKeyScopes(key);
+    } catch (error) {
+      if (error instanceof PlatformKeyScopesConfigurationError) {
+        return c.json<ApiResponse>({ ok: false, error: PLATFORM_SCOPE_CONFIG_ERROR }, 500);
+      }
+      throw error;
+    }
+
     c.set("platformKeyHash", hashKey(key).toString("hex"));
-    c.set("platformScopes", getPlatformKeyScopes(key));
+    c.set("platformScopes", scopes);
 
     await next();
   });


### PR DESCRIPTION
Closes #624

## Summary

- fail closed when `STEWARD_PLATFORM_KEY_SCOPES` is present but is not valid JSON object configuration
- require every configured value to be an array containing strings only; reject partial/mixed scope configuration instead of filtering it
- preserve the existing empty scope map only when the environment variable is absent or blank
- return a redacted 500 configuration response to an otherwise valid platform key without reflecting raw configuration

## Validation

- `bun test packages/auth/src/__tests__/platform.test.ts` (10 pass, 16 assertions)
- `bunx turbo run build --filter=@stwd/auth...` (7/7 packages)
- `bunx biome check packages/auth/src/platform.ts packages/auth/src/__tests__/platform.test.ts`
- `git diff --check`

Base: `9239a728b9ca28175e00e2825f69d85f3e02856e`
Head: `cb541602bd0cbc6429f3ccc20414270ac594719e`
