### PR TITLE
fix(web): decouple webhook list and delivery refreshes

### DIFF
--- a/web/e2e/webhooks-page.spec.ts
+++ b/web/e2e/webhooks-page.spec.ts
@@ -78,6 +78,8 @@ test.describe("Dashboard webhook delivery history", () => {
       },
     ];
     let lastDeliveryQuery = "";
+    let webhookListRequestCount = 0;
+    const deliveryRequestCounts = new Map<string, number>();
     let createPayload: { url: string; events: string[]; description?: string } | null = null;
     let deletedEndpointId = "";
 
@@ -106,6 +108,7 @@ test.describe("Dashboard webhook delivery history", () => {
         await route.fulfill({ json: { ok: true, data: created } });
         return;
       }
+      if (route.request().method() === "GET") webhookListRequestCount += 1;
       await route.fulfill({
         json: {
           ok: true,
@@ -142,6 +145,9 @@ test.describe("Dashboard webhook delivery history", () => {
         });
         return;
       }
+      if (route.request().method() === "GET") {
+        deliveryRequestCounts.set("webhook-1", (deliveryRequestCounts.get("webhook-1") ?? 0) + 1);
+      }
       lastDeliveryQuery = params.toString();
       const status = params.get("status");
       const eventType = params.get("eventType");
@@ -156,6 +162,12 @@ test.describe("Dashboard webhook delivery history", () => {
       await route.fulfill({ json: { ok: true, data: filtered } });
     });
     await page.route(`${API}/webhooks/webhook-created/deliveries**`, async (route) => {
+      if (route.request().method() === "GET") {
+        deliveryRequestCounts.set(
+          "webhook-created",
+          (deliveryRequestCounts.get("webhook-created") ?? 0) + 1,
+        );
+      }
       await route.fulfill({ json: { ok: true, data: [] } });
     });
 
@@ -212,6 +224,8 @@ test.describe("Dashboard webhook delivery history", () => {
     await expect(page.getByText("https://example.test/steward-webhooks").first()).toBeVisible();
     await expect(page.getByText("user.created").first()).toBeVisible();
     await expect(page.getByText("transaction.confirmed").first()).toBeVisible();
+    expect(webhookListRequestCount).toBe(1);
+    expect(deliveryRequestCounts.get("webhook-1")).toBe(1);
 
     await page
       .getByPlaceholder("https://api.example.com/webhooks/steward")
@@ -227,16 +241,24 @@ test.describe("Dashboard webhook delivery history", () => {
     await expect(page.getByText("whsec_created_once")).toBeVisible();
     await expect(page.getByText("https://hooks.example.test/steward").first()).toBeVisible();
     await expect(page.getByText("wallet.recovery_setup, mfa.enabled")).toBeVisible();
+    await expect.poll(() => deliveryRequestCounts.get("webhook-created")).toBe(1);
+    expect(webhookListRequestCount).toBe(1);
     await page.getByRole("button", { name: "Disable" }).first().click();
     await expect(page.getByText("disabled").first()).toBeVisible();
     await page.getByText("https://example.test/steward-webhooks").first().click();
+    await expect.poll(() => deliveryRequestCounts.get("webhook-1")).toBe(2);
+    expect(webhookListRequestCount).toBe(1);
 
     await page.getByLabel("Delivery status").selectOption("failed");
+    await expect.poll(() => deliveryRequestCounts.get("webhook-1") ?? 0).toBe(3);
     await expect.poll(() => lastDeliveryQuery).toContain("status=failed");
     await page.getByLabel("Delivery event type").fill("user.created");
+    await expect.poll(() => deliveryRequestCounts.get("webhook-1") ?? 0).toBe(4);
     await expect.poll(() => lastDeliveryQuery).toContain("eventType=user.created");
     await page.getByLabel("Delivery error state").selectOption("with_error");
+    await expect.poll(() => deliveryRequestCounts.get("webhook-1") ?? 0).toBe(5);
     await expect.poll(() => lastDeliveryQuery).toContain("hasError=true");
+    expect(webhookListRequestCount).toBe(1);
     await expect(page.getByRole("button", { name: /user\.created failed/ })).toBeVisible();
     await expect(page.getByRole("button", { name: /transaction\.confirmed/ })).toHaveCount(0);
 
@@ -274,10 +296,19 @@ test.describe("Dashboard webhook delivery history", () => {
       expect(dialog.message()).toContain("Delete webhook endpoint");
       await dialog.accept();
     });
+    const createdRequestsBeforeDelete = deliveryRequestCounts.get("webhook-created") ?? 0;
     await page.getByText("https://hooks.example.test/steward").first().click();
+    await expect
+      .poll(() => deliveryRequestCounts.get("webhook-created") ?? 0)
+      .toBe(createdRequestsBeforeDelete + 1);
+    const firstWebhookRequestsBeforeDelete = deliveryRequestCounts.get("webhook-1") ?? 0;
     await page.getByRole("button", { name: "Delete" }).first().click();
     expect(deletedEndpointId).toBe("webhook-created");
     await expect(page.getByText("https://hooks.example.test/steward")).toHaveCount(0);
+    await expect
+      .poll(() => deliveryRequestCounts.get("webhook-1") ?? 0)
+      .toBe(firstWebhookRequestsBeforeDelete + 1);
+    expect(webhookListRequestCount).toBe(1);
 
     await page.screenshot({
       path: testInfo.outputPath("dashboard-webhook-delivery-history.png"),

--- a/web/e2e/webhooks-page.spec.ts
+++ b/web/e2e/webhooks-page.spec.ts
@@ -310,4 +310,135 @@ test.describe("Dashboard webhook delivery history", () => {
       fullPage: true,
     });
   });
+
+  test("summary counters never retain rows owned by an old endpoint or filter", async ({
+    page,
+    request,
+  }) => {
+    const email = `webhook-summary-ownership-${Date.now()}@example.test`;
+    const now = "2026-05-28T12:00:00.000Z";
+    const webhooks: WebhookConfig[] = [
+      {
+        id: "webhook-a",
+        tenantId: "e2e-tenant",
+        url: "https://a.example.test/webhooks",
+        events: ["user.created"],
+        enabled: true,
+        maxRetries: 5,
+        retryBackoffMs: 60000,
+        description: "Endpoint A",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "webhook-b",
+        tenantId: "e2e-tenant",
+        url: "https://b.example.test/webhooks",
+        events: ["transaction.confirmed"],
+        enabled: true,
+        maxRetries: 5,
+        retryBackoffMs: 60000,
+        description: "Endpoint B",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ];
+    const delivered = (id: string): WebhookDelivery => ({
+      id,
+      eventType: "transaction.confirmed",
+      status: "delivered",
+      attempts: 1,
+      maxAttempts: 6,
+      nextRetryAt: null,
+      hasError: false,
+      createdAt: now,
+      deliveredAt: now,
+    });
+    const failed = (id: string): WebhookDelivery => ({
+      id,
+      eventType: "user.created",
+      status: "failed",
+      attempts: 1,
+      maxAttempts: 6,
+      nextRetryAt: now,
+      hasError: true,
+      createdAt: now,
+      deliveredAt: null,
+    });
+    const endpointARows = [
+      delivered("a-delivered-1"),
+      delivered("a-delivered-2"),
+      failed("a-failed"),
+    ];
+    const endpointBRows = [delivered("b-delivered"), failed("b-failed")];
+
+    let releaseEndpointB: (() => void) | undefined;
+    const endpointBGate = new Promise<void>((resolve) => {
+      releaseEndpointB = resolve;
+    });
+    let markEndpointBStarted: (() => void) | undefined;
+    const endpointBStarted = new Promise<void>((resolve) => {
+      markEndpointBStarted = resolve;
+    });
+    let releaseFailedFilter: (() => void) | undefined;
+    const failedFilterGate = new Promise<void>((resolve) => {
+      releaseFailedFilter = resolve;
+    });
+    let markFailedFilterStarted: (() => void) | undefined;
+    const failedFilterStarted = new Promise<void>((resolve) => {
+      markFailedFilterStarted = resolve;
+    });
+
+    await page.route(`${API}/webhooks`, async (route) => {
+      await route.fulfill({ json: { ok: true, data: webhooks } });
+    });
+    await page.route(`${API}/webhooks/webhook-a/deliveries**`, async (route) => {
+      await route.fulfill({ json: { ok: true, data: endpointARows } });
+    });
+    await page.route(`${API}/webhooks/webhook-b/deliveries**`, async (route) => {
+      const status = new URL(route.request().url()).searchParams.get("status");
+      if (status === "failed") {
+        markFailedFilterStarted?.();
+        await failedFilterGate;
+        await route.fulfill({
+          json: { ok: true, data: endpointBRows.filter((row) => row.status === status) },
+        });
+        return;
+      }
+      markEndpointBStarted?.();
+      await endpointBGate;
+      await route.fulfill({ json: { ok: true, data: endpointBRows } });
+    });
+
+    await loginWithMagicLink(page, request, email);
+    await page.goto(`${WEB}/dashboard/webhooks`);
+
+    const deliveredSummary = page.getByTestId("webhook-delivery-summary-delivered");
+    const failedSummary = page.getByTestId("webhook-delivery-summary-failed");
+    const retryableSummary = page.getByTestId("webhook-delivery-summary-retryable");
+    await expect(deliveredSummary).toHaveText("2");
+    await expect(failedSummary).toHaveText("1");
+    await expect(retryableSummary).toHaveText("1");
+
+    await page.getByText("https://b.example.test/webhooks").first().click();
+    await endpointBStarted;
+    await expect(page.getByText("https://b.example.test/webhooks").last()).toBeVisible();
+    await expect(deliveredSummary).toHaveText("0");
+    await expect(failedSummary).toHaveText("0");
+    await expect(retryableSummary).toHaveText("0");
+    releaseEndpointB?.();
+    await expect(deliveredSummary).toHaveText("1");
+    await expect(failedSummary).toHaveText("1");
+    await expect(retryableSummary).toHaveText("1");
+
+    await page.getByLabel("Delivery status").selectOption("failed");
+    await failedFilterStarted;
+    await expect(deliveredSummary).toHaveText("0");
+    await expect(failedSummary).toHaveText("0");
+    await expect(retryableSummary).toHaveText("0");
+    releaseFailedFilter?.();
+    await expect(deliveredSummary).toHaveText("0");
+    await expect(failedSummary).toHaveText("1");
+    await expect(retryableSummary).toHaveText("1");
+  });
 });

--- a/web/e2e/webhooks-page.spec.ts
+++ b/web/e2e/webhooks-page.spec.ts
@@ -296,18 +296,13 @@ test.describe("Dashboard webhook delivery history", () => {
       expect(dialog.message()).toContain("Delete webhook endpoint");
       await dialog.accept();
     });
-    const createdRequestsBeforeDelete = deliveryRequestCounts.get("webhook-created") ?? 0;
-    await page.getByText("https://hooks.example.test/steward").first().click();
-    await expect
-      .poll(() => deliveryRequestCounts.get("webhook-created") ?? 0)
-      .toBe(createdRequestsBeforeDelete + 1);
     const firstWebhookRequestsBeforeDelete = deliveryRequestCounts.get("webhook-1") ?? 0;
     await page.getByRole("button", { name: "Delete" }).first().click();
     expect(deletedEndpointId).toBe("webhook-created");
     await expect(page.getByText("https://hooks.example.test/steward")).toHaveCount(0);
-    await expect
-      .poll(() => deliveryRequestCounts.get("webhook-1") ?? 0)
-      .toBe(firstWebhookRequestsBeforeDelete + 1);
+    await expect(page.getByText("https://example.test/steward-webhooks").first()).toBeVisible();
+    await expect(page.getByRole("button", { name: /user\.created pending/ })).toBeVisible();
+    expect(deliveryRequestCounts.get("webhook-1") ?? 0).toBe(firstWebhookRequestsBeforeDelete);
     expect(webhookListRequestCount).toBe(1);
 
     await page.screenshot({

--- a/web/src/app/dashboard/webhooks/page.tsx
+++ b/web/src/app/dashboard/webhooks/page.tsx
@@ -276,9 +276,10 @@ export default function WebhooksPage() {
       await steward.deleteWebhook(webhook.id);
       const remaining = webhooks.filter((row) => row.id !== webhook.id);
       setWebhooks(remaining);
-      const nextSelected = remaining[0]?.id ?? "";
-      setSelectedId(nextSelected);
-      setDeliveries([]);
+      if (selectedId === webhook.id) {
+        setSelectedId(remaining[0]?.id ?? "");
+        setDeliveries([]);
+      }
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to delete webhook endpoint");
     } finally {

--- a/web/src/app/dashboard/webhooks/page.tsx
+++ b/web/src/app/dashboard/webhooks/page.tsx
@@ -82,52 +82,61 @@ export default function WebhooksPage() {
     [selectedId, webhooks],
   );
 
-  const loadDeliveries = useCallback(
-    async (webhookId: string) => {
-      setDeliveryLoading(true);
-      try {
-        const rows = await steward.getWebhookDeliveries(webhookId, deliveryQuery);
-        setDeliveries(rows);
-      } finally {
-        setDeliveryLoading(false);
-      }
-    },
-    [deliveryQuery],
-  );
-
-  const loadData = useCallback(async () => {
+  const loadWebhooks = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const configs = await steward.listWebhooks();
       setWebhooks(configs);
-      const nextSelectedId = selectedId || configs[0]?.id || "";
-      setSelectedId(nextSelectedId);
-      if (nextSelectedId) {
-        await loadDeliveries(nextSelectedId);
-      } else {
-        setDeliveries([]);
-      }
+      setSelectedId((current) =>
+        current && configs.some((webhook) => webhook.id === current)
+          ? current
+          : (configs[0]?.id ?? ""),
+      );
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to load webhooks");
     } finally {
       setLoading(false);
     }
-  }, [loadDeliveries, selectedId]);
+  }, []);
 
   useEffect(() => {
-    loadData();
-  }, [loadData]);
+    void loadWebhooks();
+  }, [loadWebhooks]);
 
-  async function selectWebhook(webhookId: string) {
+  useEffect(() => {
+    if (!selectedId) {
+      setDeliveries([]);
+      setDeliveryLoading(false);
+      return;
+    }
+
+    let active = true;
+    setDeliveryLoading(true);
+    setError(null);
+    void steward
+      .getWebhookDeliveries(selectedId, deliveryQuery)
+      .then((rows) => {
+        if (active) setDeliveries(rows);
+      })
+      .catch((e: unknown) => {
+        if (active) {
+          setError(e instanceof Error ? e.message : "Failed to load webhook deliveries");
+        }
+      })
+      .finally(() => {
+        if (active) setDeliveryLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [deliveryQuery, selectedId]);
+
+  function selectWebhook(webhookId: string) {
     setSelectedId(webhookId);
     setExpanded(null);
     setError(null);
-    try {
-      await loadDeliveries(webhookId);
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Failed to load webhook deliveries");
-    }
   }
 
   async function retryDelivery(deliveryId: string) {
@@ -270,7 +279,6 @@ export default function WebhooksPage() {
       const nextSelected = remaining[0]?.id ?? "";
       setSelectedId(nextSelected);
       setDeliveries([]);
-      if (nextSelected) await loadDeliveries(nextSelected);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to delete webhook endpoint");
     } finally {
@@ -300,7 +308,7 @@ export default function WebhooksPage() {
         </div>
         <button
           type="button"
-          onClick={loadData}
+          onClick={loadWebhooks}
           className="px-4 py-2 text-sm border border-border text-text-tertiary hover:text-text hover:border-accent transition-colors"
         >
           Refresh

--- a/web/src/app/dashboard/webhooks/page.tsx
+++ b/web/src/app/dashboard/webhooks/page.tsx
@@ -44,6 +44,7 @@ export default function WebhooksPage() {
   const [webhooks, setWebhooks] = useState<WebhookConfig[]>([]);
   const [selectedId, setSelectedId] = useState<string>("");
   const [deliveries, setDeliveries] = useState<WebhookDelivery[]>([]);
+  const [deliveryOwnerKey, setDeliveryOwnerKey] = useState("");
   const [loading, setLoading] = useState(true);
   const [deliveryLoading, setDeliveryLoading] = useState(false);
   const [creating, setCreating] = useState(false);
@@ -76,6 +77,14 @@ export default function WebhooksPage() {
     }),
     [deliveryErrorFilter, deliveryEventFilter, deliveryStatusFilter],
   );
+  const deliveryQueryKey = useMemo(
+    () => JSON.stringify([selectedId, deliveryQuery]),
+    [deliveryQuery, selectedId],
+  );
+  const visibleDeliveries =
+    deliveryOwnerKey === deliveryQueryKey ? deliveries : ([] as WebhookDelivery[]);
+  const deliveryQueryLoading =
+    Boolean(selectedId) && (deliveryLoading || deliveryOwnerKey !== deliveryQueryKey);
 
   const selectedWebhook = useMemo(
     () => webhooks.find((webhook) => webhook.id === selectedId),
@@ -107,6 +116,7 @@ export default function WebhooksPage() {
   useEffect(() => {
     if (!selectedId) {
       setDeliveries([]);
+      setDeliveryOwnerKey(deliveryQueryKey);
       setDeliveryLoading(false);
       return;
     }
@@ -117,7 +127,10 @@ export default function WebhooksPage() {
     void steward
       .getWebhookDeliveries(selectedId, deliveryQuery)
       .then((rows) => {
-        if (active) setDeliveries(rows);
+        if (active) {
+          setDeliveries(rows);
+          setDeliveryOwnerKey(deliveryQueryKey);
+        }
       })
       .catch((e: unknown) => {
         if (active) {
@@ -131,7 +144,7 @@ export default function WebhooksPage() {
     return () => {
       active = false;
     };
-  }, [deliveryQuery, selectedId]);
+  }, [deliveryQuery, deliveryQueryKey, selectedId]);
 
   function selectWebhook(webhookId: string) {
     setSelectedId(webhookId);
@@ -287,11 +300,13 @@ export default function WebhooksPage() {
     }
   }
 
-  const deliveredCount = deliveries.filter((delivery) => delivery.status === "delivered").length;
-  const failedCount = deliveries.filter(
+  const deliveredCount = visibleDeliveries.filter(
+    (delivery) => delivery.status === "delivered",
+  ).length;
+  const failedCount = visibleDeliveries.filter(
     (delivery) => delivery.status === "failed" || delivery.status === "dead",
   ).length;
-  const retryableCount = deliveries.filter(canRetry).length;
+  const retryableCount = visibleDeliveries.filter(canRetry).length;
 
   return (
     <motion.div
@@ -477,7 +492,10 @@ export default function WebhooksPage() {
               ].map((item) => (
                 <div key={item.label} className="border border-border bg-bg-elevated p-4">
                   <div className="text-xs text-text-tertiary">{item.label}</div>
-                  <div className={`font-display text-xl font-700 ${item.className}`}>
+                  <div
+                    data-testid={`webhook-delivery-summary-${item.label.toLowerCase()}`}
+                    className={`font-display text-xl font-700 ${item.className}`}
+                  >
                     {item.value.toLocaleString()}
                   </div>
                 </div>
@@ -555,13 +573,13 @@ export default function WebhooksPage() {
                   </select>
                 </div>
               </div>
-              {deliveryLoading ? (
+              {deliveryQueryLoading ? (
                 <div className="space-y-px bg-border">
                   {[...Array(4)].map((_, i) => (
                     <div key={i} className="bg-bg h-14 animate-pulse" />
                   ))}
                 </div>
-              ) : deliveries.length === 0 ? (
+              ) : visibleDeliveries.length === 0 ? (
                 <div className="py-16 text-center border border-border-subtle">
                   <p className="text-sm text-text-secondary">No deliveries yet</p>
                   <p className="text-xs text-text-tertiary mt-1">
@@ -577,7 +595,7 @@ export default function WebhooksPage() {
                     <span>Time</span>
                   </div>
                   <AnimatePresence initial={false}>
-                    {deliveries.map((delivery, i) => (
+                    {visibleDeliveries.map((delivery, i) => (
                       <motion.div
                         key={delivery.id}
                         initial={{ opacity: 0, y: 4 }}

--- a/web/src/components/providers.tsx
+++ b/web/src/components/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { StewardProvider, useAuth } from "@stwd/react";
+import { usePathname } from "next/navigation";
 import { createElement, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { clearAuthToken, setAuthToken, steward } from "@/lib/api";
 import { STEWARD_API_URL } from "@/lib/steward-api-url";
@@ -93,6 +94,7 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
  * page until the wallet bundle loaded.
  */
 function WalletProviderTree({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
   const [Mounted, setMounted] = useState<{
     EVMWalletProvider: React.ComponentType<{ config: unknown; children: ReactNode }>;
     SolanaWalletProvider: React.ComponentType<{ endpoint: string; children: ReactNode }>;
@@ -115,6 +117,13 @@ function WalletProviderTree({ children }: { children: ReactNode }) {
       cancelled = true;
     };
   }, []);
+
+  if (pathname === "/dashboard/webhooks" || pathname?.startsWith("/dashboard/webhooks/")) {
+    // Webhook administration does not use wallet capabilities. Keep it outside
+    // the optional wallet wrappers so their late load cannot remount the page
+    // and repeat configuration or delivery requests.
+    return children;
+  }
 
   if (!Mounted) {
     // Server render and pre-hydration client render: pass children


### PR DESCRIPTION
Closes #622

## Summary
- decouple webhook configuration loading from endpoint and delivery-filter changes
- fetch deliveries once per selection/filter epoch and fence stale responses
- hide stale delivery rows and summary counters synchronously until the active query owns the response
- preserve valid selection when unrelated endpoints are refreshed or deleted
- add deterministic delayed-response browser coverage for endpoint and filter transitions

## Exact evidence
- head: `0c348722620b32a48b65fa96ce4338d241b8d496`
- parent: `f6a37f792921d088f7d1509ab1757812c16c8959`
- base: `9239a728b9ca28175e00e2825f69d85f3e02856e`
- web TypeScript: PASS
- Biome changed files: PASS
- `git diff --check`: PASS
- focused browser assertions were not completed locally because the host reached full disk and reused dependency links had unrelated Solana export skew; hosted exact-head browser/CI remains required

## Merge posture
Keep draft until the replacement exact-head matrix is green and an independent approval lands.