### PR TITLE
fix(react): preserve failed approval actions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -405,6 +405,7 @@
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "bs58": "^5.0.0",
+        "happy-dom": "^20.11.6",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "typescript": "^5.8.0",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `@stwd/react` are documented here.
 ## Unreleased
 
 ### Changed
+- Approval confirmations now keep failed mutations actionable while preventing a delayed result from closing or contaminating a newer confirmation.
 - Approval hooks now use stable cursor pagination and pass their agent scope to the server, avoiding offset shifts and client-only filtering of tenant-wide queue pages.
 - Route approval, transaction-history, and spend-stat requests through the credentialed `StewardClient`; remove unauthenticated raw-fetch paths and derive pagination and spend aggregates from authenticated history (SEC-195).
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -130,7 +130,8 @@
     "@solana/wallet-adapter-solflare": "^0.6.33",
     "@solana/wallet-adapter-coinbase": "^0.1.23",
     "@solana/wallet-adapter-trust": "^0.1.17",
-    "@solana/wallet-adapter-coin98": "^0.5.24"
+    "@solana/wallet-adapter-coin98": "^0.5.24",
+    "happy-dom": "^20.11.6"
   },
   "keywords": [
     "steward",

--- a/packages/react/src/__tests__/ApprovalQueue.interaction.test.tsx
+++ b/packages/react/src/__tests__/ApprovalQueue.interaction.test.tsx
@@ -36,6 +36,15 @@ mock.module("../hooks/useApprovals.js", () => ({
         createdAt: new Date().toISOString(),
         policyResults: [],
       },
+      {
+        id: "approval-2",
+        txId: "tx-2",
+        to: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+        value: "2000000000000000000",
+        chainId: 8453,
+        createdAt: new Date().toISOString(),
+        policyResults: [],
+      },
     ],
     isLoading: false,
     error: null,
@@ -58,6 +67,12 @@ function button(name: string, within: ParentNode = container): HTMLButtonElement
     throw new Error(`button not found: ${name}`);
   }
   return match as unknown as HTMLButtonElement;
+}
+
+function approvalItem(index: number): Element {
+  const item = container.querySelectorAll(".stwd-approval-item").item(index);
+  if (!item) throw new Error(`approval item not found: ${index}`);
+  return item;
 }
 
 async function click(target: HTMLButtonElement): Promise<void> {
@@ -171,5 +186,53 @@ describe("<ApprovalQueue /> mutation failures", () => {
 
     expect(container.textContent).toContain("Approve Transaction?");
     expect(container.textContent).not.toContain("We couldn't approve");
+  });
+
+  test("a delayed success cannot close a different confirmation opened after cancellation", async () => {
+    let finishApprove: (() => void) | undefined;
+    approve.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishApprove = resolve;
+        }),
+    );
+
+    await click(button("Approve", approvalItem(0)));
+    await click(button("Approve", container.querySelector(".stwd-modal")!));
+    await click(button("Cancel"));
+    await click(button("Deny", approvalItem(1)));
+
+    await React.act(async () => {
+      finishApprove?.();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Deny Transaction?");
+    expect(container.textContent).not.toContain("Approve Transaction?");
+    expect(onResolve).toHaveBeenCalledWith("tx-1", "approved");
+  });
+
+  test("a delayed failure cannot leak into a different confirmation opened after cancellation", async () => {
+    let failApprove: ((error: Error) => void) | undefined;
+    approve.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, rejectPromise) => {
+          failApprove = rejectPromise;
+        }),
+    );
+
+    await click(button("Approve", approvalItem(0)));
+    await click(button("Approve", container.querySelector(".stwd-modal")!));
+    await click(button("Cancel"));
+    await click(button("Deny", approvalItem(1)));
+
+    await React.act(async () => {
+      failApprove?.(new Error("stale provider failure"));
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Deny Transaction?");
+    expect(container.textContent).not.toContain("We couldn't approve");
+    expect(onResolve).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/src/__tests__/ApprovalQueue.interaction.test.tsx
+++ b/packages/react/src/__tests__/ApprovalQueue.interaction.test.tsx
@@ -9,6 +9,7 @@ Object.assign(globalThis, {
   document: window.document,
   navigator: window.navigator,
   HTMLElement: window.HTMLElement,
+  KeyboardEvent: window.KeyboardEvent,
   MouseEvent: window.MouseEvent,
   IS_REACT_ACT_ENVIRONMENT: true,
 });
@@ -16,6 +17,7 @@ Object.assign(globalThis, {
 const approve = mock(async (_txId: string) => {});
 const reject = mock(async (_txId: string) => {});
 const onResolve = mock((_txId: string, _status: "approved" | "rejected") => {});
+let isResolving = false;
 
 mock.module("../provider.js", () => ({
   useStewardContext: () => ({ features: { showApprovalQueue: true } }),
@@ -50,7 +52,7 @@ mock.module("../hooks/useApprovals.js", () => ({
     error: null,
     approve,
     reject,
-    isResolving: false,
+    isResolving,
   }),
 }));
 
@@ -81,6 +83,20 @@ async function click(target: HTMLButtonElement): Promise<void> {
   });
 }
 
+async function pressKey(key: string, shiftKey = false): Promise<void> {
+  await React.act(async () => {
+    window.document.dispatchEvent(
+      new window.KeyboardEvent("keydown", { key, shiftKey, bubbles: true, cancelable: true }),
+    );
+  });
+}
+
+async function rerenderQueue(): Promise<void> {
+  await React.act(async () => {
+    root?.render(<ApprovalQueue onResolve={onResolve} />);
+  });
+}
+
 async function renderQueue(): Promise<void> {
   container = window.document.createElement("div") as unknown as HTMLDivElement;
   window.document.body.replaceChildren(container);
@@ -100,6 +116,7 @@ beforeEach(async () => {
   reject.mockReset();
   reject.mockImplementation(async () => {});
   onResolve.mockClear();
+  isResolving = false;
   await renderQueue();
 });
 
@@ -111,6 +128,58 @@ afterAll(async () => {
 });
 
 describe("<ApprovalQueue /> mutation failures", () => {
+  test("provides a named modal dialog with bounded keyboard focus and returns focus", async () => {
+    const opener = button("Approve", approvalItem(0));
+    opener.focus();
+    await click(opener);
+
+    const dialog = container.querySelector('[role="dialog"]');
+    if (!(dialog instanceof window.HTMLDivElement)) throw new Error("dialog not found");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    const title = window.document.getElementById(dialog.getAttribute("aria-labelledby") ?? "");
+    const descriptionIds = (dialog.getAttribute("aria-describedby") ?? "").split(" ");
+    expect(title?.textContent).toContain("Approve Transaction?");
+    expect(descriptionIds).toHaveLength(1);
+    expect(window.document.getElementById(descriptionIds[0])?.textContent).toContain(
+      "signed and broadcast",
+    );
+
+    const cancel = button("Cancel", dialog);
+    const confirm = button("Approve", dialog);
+    expect(window.document.activeElement).toBe(cancel);
+
+    await pressKey("Tab", true);
+    expect(window.document.activeElement).toBe(confirm);
+    await pressKey("Tab");
+    expect(window.document.activeElement).toBe(cancel);
+
+    opener.focus();
+    await pressKey("Tab");
+    expect(window.document.activeElement).toBe(cancel);
+
+    await pressKey("Escape");
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(window.document.activeElement).toBe(opener);
+  });
+
+  test("does not dismiss on Escape while a resolution is in progress", async () => {
+    const opener = button("Deny", approvalItem(0));
+    await click(opener);
+    isResolving = true;
+    await rerenderQueue();
+
+    await pressKey("Escape");
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    expect(button("Cancel").disabled).toBe(true);
+    expect(button("Processing...").disabled).toBe(true);
+
+    isResolving = false;
+    await rerenderQueue();
+    await pressKey("Escape");
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(window.document.activeElement).toBe(opener);
+  });
+
   test("keeps an approve confirmation open, reports a safe error, and succeeds on retry", async () => {
     let finishRetry: (() => void) | undefined;
     approve.mockImplementationOnce(async () => {
@@ -132,6 +201,10 @@ describe("<ApprovalQueue /> mutation failures", () => {
     );
     expect(container.textContent).not.toContain("provider secret");
     expect(onResolve).not.toHaveBeenCalled();
+    const dialog = container.querySelector('[role="dialog"]');
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.id).not.toBe("");
+    expect((dialog?.getAttribute("aria-describedby") ?? "").split(" ")).toContain(alert?.id);
 
     await click(button("Approve", container.querySelector(".stwd-modal")!));
 

--- a/packages/react/src/__tests__/ApprovalQueue.interaction.test.tsx
+++ b/packages/react/src/__tests__/ApprovalQueue.interaction.test.tsx
@@ -1,0 +1,175 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import * as React from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+const window = new Window();
+Object.assign(globalThis, {
+  window,
+  document: window.document,
+  navigator: window.navigator,
+  HTMLElement: window.HTMLElement,
+  MouseEvent: window.MouseEvent,
+  IS_REACT_ACT_ENVIRONMENT: true,
+});
+
+const approve = mock(async (_txId: string) => {});
+const reject = mock(async (_txId: string) => {});
+const onResolve = mock((_txId: string, _status: "approved" | "rejected") => {});
+
+mock.module("../provider.js", () => ({
+  useStewardContext: () => ({ features: { showApprovalQueue: true } }),
+  StewardAuthContext: React.createContext(null),
+  StewardProvider: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+mock.module("../hooks/useApprovals.js", () => ({
+  useApprovals: () => ({
+    pending: [
+      {
+        id: "approval-1",
+        txId: "tx-1",
+        to: "0x1234567890abcdef1234567890abcdef12345678",
+        value: "1000000000000000000",
+        chainId: 8453,
+        createdAt: new Date().toISOString(),
+        policyResults: [],
+      },
+    ],
+    isLoading: false,
+    error: null,
+    approve,
+    reject,
+    isResolving: false,
+  }),
+}));
+
+const { ApprovalQueue } = await import("../components/ApprovalQueue.js");
+
+let container: HTMLDivElement;
+let root: Root | null = null;
+
+function button(name: string, within: ParentNode = container): HTMLButtonElement {
+  const match = [...within.querySelectorAll("button")].find(
+    (candidate) => candidate.textContent?.trim() === name,
+  );
+  if (!(match instanceof window.HTMLButtonElement)) {
+    throw new Error(`button not found: ${name}`);
+  }
+  return match as unknown as HTMLButtonElement;
+}
+
+async function click(target: HTMLButtonElement): Promise<void> {
+  await React.act(async () => {
+    target.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+  });
+}
+
+async function renderQueue(): Promise<void> {
+  container = window.document.createElement("div") as unknown as HTMLDivElement;
+  window.document.body.replaceChildren(container);
+  root = createRoot(container);
+  await React.act(async () => {
+    root?.render(<ApprovalQueue onResolve={onResolve} />);
+  });
+}
+
+beforeEach(async () => {
+  if (root) {
+    await React.act(async () => root?.unmount());
+  }
+  root = null;
+  approve.mockReset();
+  approve.mockImplementation(async () => {});
+  reject.mockReset();
+  reject.mockImplementation(async () => {});
+  onResolve.mockClear();
+  await renderQueue();
+});
+
+afterAll(async () => {
+  if (root) {
+    await React.act(async () => root?.unmount());
+  }
+  window.close();
+});
+
+describe("<ApprovalQueue /> mutation failures", () => {
+  test("keeps an approve confirmation open, reports a safe error, and succeeds on retry", async () => {
+    let finishRetry: (() => void) | undefined;
+    approve.mockImplementationOnce(async () => {
+      throw new Error("provider secret: upstream account 0xdead failed");
+    });
+    approve.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRetry = resolve;
+        }),
+    );
+
+    await click(button("Approve"));
+    await click(button("Approve", container.querySelector(".stwd-modal")!));
+
+    expect(container.textContent).toContain("Approve Transaction?");
+    expect(container.textContent).toContain(
+      "We couldn't approve this transaction. Check your connection and try again.",
+    );
+    expect(container.textContent).not.toContain("provider secret");
+    expect(onResolve).not.toHaveBeenCalled();
+
+    await click(button("Approve", container.querySelector(".stwd-modal")!));
+
+    expect(approve).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain("Approve Transaction?");
+    expect(container.textContent).not.toContain("We couldn't approve");
+
+    await React.act(async () => {
+      finishRetry?.();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).not.toContain("Approve Transaction?");
+    expect(container.textContent).not.toContain("We couldn't approve");
+    expect(onResolve).toHaveBeenCalledWith("tx-1", "approved");
+  });
+
+  test("keeps a deny confirmation open, reports a safe error, and succeeds on retry", async () => {
+    reject.mockImplementationOnce(async () => {
+      throw new Error("database host and tenant details");
+    });
+
+    await click(button("Deny"));
+    await click(button("Deny", container.querySelector(".stwd-modal")!));
+
+    expect(container.textContent).toContain("Deny Transaction?");
+    expect(container.textContent).toContain(
+      "We couldn't reject this transaction. Check your connection and try again.",
+    );
+    expect(container.textContent).not.toContain("database host");
+    expect(onResolve).not.toHaveBeenCalled();
+
+    await click(button("Deny", container.querySelector(".stwd-modal")!));
+
+    expect(reject).toHaveBeenCalledTimes(2);
+    expect(container.textContent).not.toContain("Deny Transaction?");
+    expect(container.textContent).not.toContain("We couldn't reject");
+    expect(onResolve).toHaveBeenCalledWith("tx-1", "rejected");
+  });
+
+  test("cancellation clears a stale action error before the modal is reopened", async () => {
+    approve.mockImplementationOnce(async () => {
+      throw new Error("approve failed");
+    });
+
+    await click(button("Approve"));
+    await click(button("Approve", container.querySelector(".stwd-modal")!));
+    expect(container.textContent).toContain("We couldn't approve");
+
+    await click(button("Cancel"));
+    await click(button("Approve"));
+
+    expect(container.textContent).toContain("Approve Transaction?");
+    expect(container.textContent).not.toContain("We couldn't approve");
+  });
+});

--- a/packages/react/src/components/ApprovalQueue.tsx
+++ b/packages/react/src/components/ApprovalQueue.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { useApprovals } from "../hooks/useApprovals.js";
 import { useStewardContext } from "../provider.js";
 import type { ApprovalQueueProps } from "../types.js";
@@ -22,6 +22,65 @@ export function ApprovalQueue({
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
   const confirmActionRef = useRef<ConfirmAction | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement | null>(null);
+  const confirmationOpenerRef = useRef<HTMLButtonElement | null>(null);
+  const dialogTitleId = useId();
+  const dialogDescriptionId = useId();
+  const dialogErrorId = useId();
+
+  useEffect(() => {
+    if (!confirmAction) return;
+    cancelButtonRef.current?.focus();
+    return () => {
+      const opener = confirmationOpenerRef.current;
+      confirmationOpenerRef.current = null;
+      if (opener?.isConnected) opener.focus();
+    };
+  }, [confirmAction]);
+
+  useEffect(() => {
+    if (!confirmAction) return;
+    const handleDialogKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (isResolving) return;
+        closeConfirmation();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusable = [
+        ...dialog.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      ].filter(
+        (element) =>
+          element.getAttribute("aria-hidden") !== "true" &&
+          element.getAttribute("aria-disabled") !== "true",
+      );
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (event.shiftKey && (active === first || !dialog.contains(active))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && (active === last || !dialog.contains(active))) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", handleDialogKeyDown, true);
+    return () => document.removeEventListener("keydown", handleDialogKeyDown, true);
+  }, [confirmAction, isResolving]);
 
   if (!features.showApprovalQueue) return null;
 
@@ -59,8 +118,13 @@ export function ApprovalQueue({
     setConfirmAction(null);
   };
 
-  const openConfirmation = (txId: string, action: "approve" | "reject") => {
+  const openConfirmation = (
+    txId: string,
+    action: "approve" | "reject",
+    opener: HTMLButtonElement,
+  ) => {
     const nextAction = { txId, action };
+    confirmationOpenerRef.current = opener;
     confirmActionRef.current = nextAction;
     setActionError(null);
     setConfirmAction(nextAction);
@@ -128,14 +192,14 @@ export function ApprovalQueue({
                 <button
                   className="stwd-btn stwd-btn-error"
                   disabled={isResolving}
-                  onClick={() => openConfirmation(entry.txId, "reject")}
+                  onClick={(event) => openConfirmation(entry.txId, "reject", event.currentTarget)}
                 >
                   Deny
                 </button>
                 <button
                   className="stwd-btn stwd-btn-success"
                   disabled={isResolving}
-                  onClick={() => openConfirmation(entry.txId, "approve")}
+                  onClick={(event) => openConfirmation(entry.txId, "approve", event.currentTarget)}
                 >
                   Approve
                 </button>
@@ -147,23 +211,44 @@ export function ApprovalQueue({
 
       {/* Confirmation Dialog */}
       {confirmAction && (
-        <div className="stwd-modal-overlay" onClick={closeConfirmation}>
-          <div className="stwd-modal" onClick={(e) => e.stopPropagation()}>
-            <h3 className="stwd-heading">
+        <div
+          className="stwd-modal-overlay"
+          onClick={() => {
+            if (!isResolving) closeConfirmation();
+          }}
+        >
+          <div
+            ref={dialogRef}
+            className="stwd-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={dialogTitleId}
+            aria-describedby={
+              actionError ? `${dialogDescriptionId} ${dialogErrorId}` : dialogDescriptionId
+            }
+            tabIndex={-1}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 id={dialogTitleId} className="stwd-heading">
               {confirmAction.action === "approve" ? "Approve Transaction?" : "Deny Transaction?"}
             </h3>
-            <p className="stwd-muted-text">
+            <p id={dialogDescriptionId} className="stwd-muted-text">
               {confirmAction.action === "approve"
                 ? "This transaction will be signed and broadcast."
                 : "This transaction will be rejected and will not be executed."}
             </p>
             {actionError && (
-              <div className="stwd-error-text" role="alert">
+              <div id={dialogErrorId} className="stwd-error-text" role="alert">
                 {actionError}
               </div>
             )}
             <div className="stwd-modal-actions">
-              <button className="stwd-btn stwd-btn-secondary" onClick={closeConfirmation}>
+              <button
+                ref={cancelButtonRef}
+                className="stwd-btn stwd-btn-secondary"
+                onClick={closeConfirmation}
+                disabled={isResolving}
+              >
                 Cancel
               </button>
               <button

--- a/packages/react/src/components/ApprovalQueue.tsx
+++ b/packages/react/src/components/ApprovalQueue.tsx
@@ -19,22 +19,37 @@ export function ApprovalQueue({
     txId: string;
     action: "approve" | "reject";
   } | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   if (!features.showApprovalQueue) return null;
 
   const handleConfirm = async () => {
     if (!confirmAction) return;
+    setActionError(null);
     try {
       if (confirmAction.action === "approve") {
         await approve(confirmAction.txId);
       } else {
         await reject(confirmAction.txId);
       }
-      onResolve?.(confirmAction.txId, confirmAction.action === "approve" ? "approved" : "rejected");
     } catch {
-      // Error handled by hook
+      setActionError(
+        `We couldn't ${confirmAction.action} this transaction. Check your connection and try again.`,
+      );
+      return;
     }
     setConfirmAction(null);
+    onResolve?.(confirmAction.txId, confirmAction.action === "approve" ? "approved" : "rejected");
+  };
+
+  const closeConfirmation = () => {
+    setActionError(null);
+    setConfirmAction(null);
+  };
+
+  const openConfirmation = (txId: string, action: "approve" | "reject") => {
+    setActionError(null);
+    setConfirmAction({ txId, action });
   };
 
   if (isLoading) {
@@ -99,14 +114,14 @@ export function ApprovalQueue({
                 <button
                   className="stwd-btn stwd-btn-error"
                   disabled={isResolving}
-                  onClick={() => setConfirmAction({ txId: entry.txId, action: "reject" })}
+                  onClick={() => openConfirmation(entry.txId, "reject")}
                 >
                   Deny
                 </button>
                 <button
                   className="stwd-btn stwd-btn-success"
                   disabled={isResolving}
-                  onClick={() => setConfirmAction({ txId: entry.txId, action: "approve" })}
+                  onClick={() => openConfirmation(entry.txId, "approve")}
                 >
                   Approve
                 </button>
@@ -118,7 +133,7 @@ export function ApprovalQueue({
 
       {/* Confirmation Dialog */}
       {confirmAction && (
-        <div className="stwd-modal-overlay" onClick={() => setConfirmAction(null)}>
+        <div className="stwd-modal-overlay" onClick={closeConfirmation}>
           <div className="stwd-modal" onClick={(e) => e.stopPropagation()}>
             <h3 className="stwd-heading">
               {confirmAction.action === "approve" ? "Approve Transaction?" : "Deny Transaction?"}
@@ -128,11 +143,13 @@ export function ApprovalQueue({
                 ? "This transaction will be signed and broadcast."
                 : "This transaction will be rejected and will not be executed."}
             </p>
+            {actionError && (
+              <div className="stwd-error-text" role="alert">
+                {actionError}
+              </div>
+            )}
             <div className="stwd-modal-actions">
-              <button
-                className="stwd-btn stwd-btn-secondary"
-                onClick={() => setConfirmAction(null)}
-              >
+              <button className="stwd-btn stwd-btn-secondary" onClick={closeConfirmation}>
                 Cancel
               </button>
               <button

--- a/packages/react/src/components/ApprovalQueue.tsx
+++ b/packages/react/src/components/ApprovalQueue.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useApprovals } from "../hooks/useApprovals.js";
 import { useStewardContext } from "../provider.js";
 import type { ApprovalQueueProps } from "../types.js";
@@ -15,41 +15,55 @@ export function ApprovalQueue({
 }: ApprovalQueueProps) {
   const { features } = useStewardContext();
   const { pending, isLoading, error, approve, reject, isResolving } = useApprovals(refreshInterval);
-  const [confirmAction, setConfirmAction] = useState<{
+  type ConfirmAction = {
     txId: string;
     action: "approve" | "reject";
-  } | null>(null);
+  };
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
+  const confirmActionRef = useRef<ConfirmAction | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
   if (!features.showApprovalQueue) return null;
 
   const handleConfirm = async () => {
     if (!confirmAction) return;
+    const submittedAction = confirmAction;
     setActionError(null);
     try {
-      if (confirmAction.action === "approve") {
-        await approve(confirmAction.txId);
+      if (submittedAction.action === "approve") {
+        await approve(submittedAction.txId);
       } else {
-        await reject(confirmAction.txId);
+        await reject(submittedAction.txId);
       }
     } catch {
-      setActionError(
-        `We couldn't ${confirmAction.action} this transaction. Check your connection and try again.`,
-      );
+      if (confirmActionRef.current === submittedAction) {
+        setActionError(
+          `We couldn't ${submittedAction.action} this transaction. Check your connection and try again.`,
+        );
+      }
       return;
     }
-    setConfirmAction(null);
-    onResolve?.(confirmAction.txId, confirmAction.action === "approve" ? "approved" : "rejected");
+    if (confirmActionRef.current === submittedAction) {
+      confirmActionRef.current = null;
+      setConfirmAction(null);
+    }
+    onResolve?.(
+      submittedAction.txId,
+      submittedAction.action === "approve" ? "approved" : "rejected",
+    );
   };
 
   const closeConfirmation = () => {
+    confirmActionRef.current = null;
     setActionError(null);
     setConfirmAction(null);
   };
 
   const openConfirmation = (txId: string, action: "approve" | "reject") => {
+    const nextAction = { txId, action };
+    confirmActionRef.current = nextAction;
     setActionError(null);
-    setConfirmAction({ txId, action });
+    setConfirmAction(nextAction);
   };
 
   if (isLoading) {


### PR DESCRIPTION
Closes #630

## Summary
- keep approve/deny confirmation open after mutation failure and show a fixed actionable error without leaking raw details
- clear stale errors on retry/open/cancel and close only after success
- provide a real accessible modal boundary: named/described `role=dialog`, `aria-modal`, initial focus, bounded Tab/Shift+Tab trap, Escape handling, resolution-time dismissal lock, and focus return
- add mounted interaction coverage for approve/deny failure/retry plus keyboard and assistive-technology semantics

## Exact evidence
- head: `b697e078be520ec0e4aaeeca4e84f9ed5354c00d`
- parent: `fd39d760e9c91a58715aa53ea3aafadc9d8e1f07`
- develop base: `9239a728b9ca28175e00e2825f69d85f3e02856e`
- focused interactions: 7/7, 44 assertions
- full `@stwd/react` suite: PASS
- React and SDK builds: PASS
- root typecheck: 36 packages plus web PASS
- Biome and `git diff --check`: PASS

## Merge posture
Keep draft pending exact-head hosted CI, independent approval, and lockfile restack after any dependency-owning PR that lands first.