### PR TITLE
test(api): centralize strict MFA age checks

### DIFF
--- a/packages/api/src/__tests__/mfa-future-timestamp-regression.test.ts
+++ b/packages/api/src/__tests__/mfa-future-timestamp-regression.test.ts
@@ -14,28 +14,27 @@ describe("future-dated MFA timestamps", () => {
     expect(hasRecentSessionMfa(context as never)).toBe(false);
   });
 
-  it("every local recent-MFA helper has a non-negative age bound", async () => {
-    const files = [
-      "middleware/idempotency.ts",
-      "routes/agents.ts",
-      "routes/approvals.ts",
-      "routes/condition-sets.ts",
-      "routes/dashboard.ts",
-      "routes/erc8004.ts",
-      "routes/global-wallet.ts",
-      "routes/intents.ts",
-      "routes/policies-standalone.ts",
-      "routes/secrets.ts",
-      "routes/session-signers.ts",
-      "routes/tenant-config.ts",
-      "routes/tenants.ts",
-      "routes/user.ts",
-      "routes/vault.ts",
-      "routes/webhooks.ts",
-    ];
-    for (const relative of files) {
-      const source = await Bun.file(new URL(`../${relative}`, import.meta.url)).text();
-      expect(source, relative).toMatch(/(?:Date\.now\(\)|\bnow\b) - [\w.]+ >= 0/);
+  it("enforces the exact age and no-future boundaries", async () => {
+    const { isRecentMfaTimestamp } = await import("../services/recent-mfa");
+    const now = 1_800_000_000_000;
+    const maxAgeMs = 5 * 60_000;
+
+    expect(isRecentMfaTimestamp(now, maxAgeMs, now)).toBe(true);
+    expect(isRecentMfaTimestamp(now - maxAgeMs, maxAgeMs, now)).toBe(true);
+    expect(isRecentMfaTimestamp(now - maxAgeMs - 1, maxAgeMs, now)).toBe(false);
+    expect(isRecentMfaTimestamp(now + 1, maxAgeMs, now)).toBe(false);
+    expect(isRecentMfaTimestamp(now + 24 * 60 * 60_000, maxAgeMs, now)).toBe(false);
+  });
+
+  it("rejects malformed timestamps and invalid validation windows", async () => {
+    const { isRecentMfaTimestamp } = await import("../services/recent-mfa");
+    const now = 1_800_000_000_000;
+
+    for (const timestamp of [undefined, null, "recent", Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(isRecentMfaTimestamp(timestamp, 5 * 60_000, now), String(timestamp)).toBe(false);
     }
+    expect(isRecentMfaTimestamp(now, -1, now)).toBe(false);
+    expect(isRecentMfaTimestamp(now, Number.POSITIVE_INFINITY, now)).toBe(false);
+    expect(isRecentMfaTimestamp(now, 5 * 60_000, Number.NaN)).toBe(false);
   });
 });

--- a/packages/api/src/middleware/audit-gate.ts
+++ b/packages/api/src/middleware/audit-gate.ts
@@ -11,6 +11,7 @@
 
 import type { Context, Next } from "hono";
 import { type ApiResponse, type AppVariables, setNoStoreHeaders } from "../services/context";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 
 /** Recent-MFA window for evidence reads (spec §5.2 / audit.ts). */
 export const AUDIT_READ_MFA_MAX_AGE_MS = 5 * 60_000;
@@ -19,13 +20,7 @@ export function hasRecentSessionMfa(
   c: Context<{ Variables: AppVariables }>,
   maxAgeMs = AUDIT_READ_MFA_MAX_AGE_MS,
 ): boolean {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), maxAgeMs);
 }
 
 /**

--- a/packages/api/src/middleware/idempotency.ts
+++ b/packages/api/src/middleware/idempotency.ts
@@ -1,6 +1,7 @@
 import { redactedThrownDiagnostics } from "@stwd/shared";
 import { createMiddleware } from "hono/factory";
 import type { ApiResponse, AppVariables } from "../services/context";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import { getRedisClient } from "./redis";
 
 type IdempotencyStatus = "processing" | "completed";
@@ -611,13 +612,7 @@ function hasReplaySafeAuthenticatedContext(c: { get: (key: keyof AppVariables) =
     return true;
   }
   if (authType !== "session-jwt") return false;
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= 5 * 60_000
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), 5 * 60_000);
 }
 
 function hasReplaySafePublicContext(c: { req: { path: string } }) {

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -50,6 +50,7 @@ import {
   readTenantGasSponsorshipConfig,
 } from "../services/gas-sponsorship";
 import { getPolicyRulesValidationError } from "../services/policy-validation";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import { createSignerCredentialHash } from "../services/signer-credentials";
 import { redactWalletMetadataSecrets } from "../services/wallet-metadata";
 import { dispatchWebhook } from "../services/webhook-dispatch";
@@ -561,13 +562,7 @@ async function validateSignerPolicyIdsForAgent(
 }
 
 function hasRecentSessionMfa(c: Parameters<typeof requireTenantLevel>[0], maxAgeMs = 5 * 60_000) {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), maxAgeMs);
 }
 
 function requireRecentAdminMfa(c: Parameters<typeof requireTenantLevel>[0], reason: string) {

--- a/packages/api/src/routes/approvals.ts
+++ b/packages/api/src/routes/approvals.ts
@@ -20,6 +20,7 @@ import {
   setNoStoreHeaders,
   transactions,
 } from "../services/context";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import { dispatchWebhook } from "../services/webhook-dispatch";
 
 /**
@@ -88,13 +89,7 @@ function requireHumanApprover(c: Context<{ Variables: AppVariables }>): boolean 
 }
 
 function hasRecentSessionMfa(c: Context<{ Variables: AppVariables }>, maxAgeMs = 5 * 60_000) {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), maxAgeMs);
 }
 
 function approvalIntentActionType(actionType: string | null | undefined): string {

--- a/packages/api/src/routes/condition-sets.ts
+++ b/packages/api/src/routes/condition-sets.ts
@@ -20,6 +20,7 @@ import {
   requireTenantLevel,
   safeJsonParse,
 } from "../services/context";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 
 type ConditionSetResponse = {
   id: string;
@@ -286,13 +287,7 @@ function requireTenantAdminSession(c: Parameters<typeof requireTenantLevel>[0]):
 }
 
 function hasRecentSessionMfa(c: Parameters<typeof requireTenantLevel>[0], maxAgeMs = 5 * 60_000) {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), maxAgeMs);
 }
 
 function requireRecentAdminMfa(c: Parameters<typeof requireTenantLevel>[0], reason: string) {

--- a/packages/api/src/routes/dashboard.ts
+++ b/packages/api/src/routes/dashboard.ts
@@ -21,17 +21,12 @@ import {
   transactions,
   vault,
 } from "../services/context";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 
 export const dashboardRoutes = new Hono<{ Variables: AppVariables }>();
 
 function hasRecentSessionMfa(c: Parameters<typeof requireTenantLevel>[0], maxAgeMs = 5 * 60_000) {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), maxAgeMs);
 }
 
 // ─── GET /dashboard/:agentId — aggregated agent dashboard ─────────────────────

--- a/packages/api/src/routes/erc8004.ts
+++ b/packages/api/src/routes/erc8004.ts
@@ -22,6 +22,7 @@ import {
   hasAgentTokenScope,
   requireTenantLevel,
 } from "../services/context";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import { validateWebhookUrlResolved } from "../services/webhook-url";
 
 export const erc8004Routes = new Hono<{ Variables: AppVariables }>();
@@ -65,13 +66,7 @@ function requireTenantAdminSession(c: Parameters<typeof requireTenantLevel>[0]):
 }
 
 function hasRecentSessionMfa(c: Parameters<typeof requireTenantLevel>[0], maxAgeMs = 5 * 60_000) {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), maxAgeMs);
 }
 
 function requireRecentAdminMfa(c: Parameters<typeof requireTenantLevel>[0], reason: string) {

--- a/packages/api/src/routes/global-wallet.ts
+++ b/packages/api/src/routes/global-wallet.ts
@@ -19,6 +19,7 @@ import {
   setNoStoreHeaders,
   verifySessionToken,
 } from "../services/context";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import { getConfiguredVault } from "../services/vault-factory";
 
 type UserSessionPayload = {
@@ -431,13 +432,7 @@ function parseSendTransactionParams(value: unknown):
 }
 
 function hasRecentMfa(c: Context<{ Variables: GlobalWalletVariables }>): boolean {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= MFA_MAX_AGE_MS
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), MFA_MAX_AGE_MS);
 }
 
 async function getEnabledAppClient(

--- a/packages/api/src/routes/intents.ts
+++ b/packages/api/src/routes/intents.ts
@@ -34,6 +34,7 @@ import {
 } from "../services/context";
 import { redactSignedTransactions, toIntentResponse } from "../services/intent-response";
 import { getPolicyRulesValidationError } from "../services/policy-validation";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import { dispatchWebhook } from "../services/webhook-dispatch";
 
 export const intentRoutes = new Hono<{ Variables: AppVariables }>();
@@ -138,13 +139,7 @@ async function hasCurrentTenantReviewerMembership(
 }
 
 function hasRecentSessionMfa(c: Context<{ Variables: AppVariables }>, maxAgeMs = 5 * 60_000) {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), maxAgeMs);
 }
 
 function parseListLimit(value: string | undefined): number | null {

--- a/packages/api/src/routes/policies-standalone.ts
+++ b/packages/api/src/routes/policies-standalone.ts
@@ -28,6 +28,7 @@ import {
   safeJsonParse,
 } from "../services/context";
 import { getPolicyRulesValidationError } from "../services/policy-validation";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 
 type PolicyRow = typeof policies.$inferSelect;
 
@@ -405,13 +406,7 @@ function policyAuditActor(c: Parameters<typeof requireTenantLevel>[0], tenantId:
 }
 
 function hasRecentSessionMfa(c: Parameters<typeof requireTenantLevel>[0], maxAgeMs = 5 * 60_000) {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), maxAgeMs);
 }
 
 function requireRecentAdminMfa(c: Parameters<typeof requireTenantLevel>[0], reason: string) {

--- a/packages/api/src/routes/secrets.ts
+++ b/packages/api/src/routes/secrets.ts
@@ -35,6 +35,7 @@ import {
   sanitizeErrorMessage,
   setNoStoreHeaders,
 } from "../services/context";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import {
   assertGovernedRouteUpdateIsSafe,
   assertNoOppositeAuthorityOverlap,
@@ -312,13 +313,7 @@ function requireTenantAdminSession(c: Context<{ Variables: AppVariables }>): boo
 }
 
 function hasRecentSessionMfa(c: Context<{ Variables: AppVariables }>, maxAgeMs = 5 * 60_000) {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), maxAgeMs);
 }
 
 type TenantMfaPolicyConfig = {

--- a/packages/api/src/routes/session-signers.ts
+++ b/packages/api/src/routes/session-signers.ts
@@ -48,6 +48,7 @@ import {
   safeJsonParse,
   setNoStoreHeaders,
 } from "../services/context";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 
 const MAX_LIFETIME_MS = 30 * 24 * 3600 * 1000;
 const DEFAULT_LIFETIME_MS = 24 * 3600 * 1000;
@@ -77,13 +78,7 @@ function requireTenantAdminSession(c: Parameters<typeof requireTenantLevel>[0]):
 }
 
 function hasRecentSessionMfa(c: Parameters<typeof requireTenantLevel>[0], maxAgeMs = 5 * 60_000) {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), maxAgeMs);
 }
 
 function requireRecentAdminMfa(c: Parameters<typeof requireTenantLevel>[0], reason: string) {

--- a/packages/api/src/routes/tenant-config.ts
+++ b/packages/api/src/routes/tenant-config.ts
@@ -64,6 +64,7 @@ import {
 import { normalizeGasSponsorshipConfig } from "../services/gas-sponsorship";
 import { normalizeOidcProviders } from "../services/oidc-provider-config";
 import { getPolicyRulesValidationError } from "../services/policy-validation";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import { buildSamlServiceProviderUrls, normalizeSamlSsoUpdate } from "../services/saml-sso-config";
 import {
   createTenantTestAccountConfig,
@@ -515,13 +516,7 @@ function requireTenantAdminSession(c: Parameters<typeof requireTenantLevel>[0]):
 }
 
 function hasRecentSessionMfa(c: Parameters<typeof requireTenantLevel>[0], maxAgeMs = 5 * 60_000) {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), maxAgeMs);
 }
 
 type TenantMfaPolicyConfig = {

--- a/packages/api/src/routes/tenants.ts
+++ b/packages/api/src/routes/tenants.ts
@@ -34,6 +34,7 @@ import {
   tenants,
 } from "../services/context";
 import { getPolicyRulesValidationError } from "../services/policy-validation";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 
 export const tenantRoutes = new Hono<{ Variables: AppVariables }>();
 const LEGACY_WEBHOOK_DEPRECATION_ERROR =
@@ -93,13 +94,7 @@ function requireTenantAdminSession(c: Parameters<typeof requireTenantLevel>[0]):
 }
 
 function hasRecentSessionMfa(c: Parameters<typeof requireTenantLevel>[0], maxAgeMs = 5 * 60_000) {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), maxAgeMs);
 }
 
 function requireRecentTenantAdminMfa(

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -106,6 +106,7 @@ import {
   readTenantGasSponsorshipConfig,
 } from "../services/gas-sponsorship";
 import { plaintextKeyExportResponseGateError } from "../services/key-export-plaintext-gate";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import { lockUserSession } from "../services/session-lock";
 import { createSignerCredentialHash, verifySignerCredential } from "../services/signer-credentials";
 import { getConfiguredVault } from "../services/vault-factory";
@@ -1003,12 +1004,7 @@ async function restoreUserAccountUnlinkMutation(
 }
 
 function hasRecentMfaStepUp(session: UserSessionPayload, maxAgeMs = 5 * 60_000): boolean {
-  return (
-    typeof session.mfaVerifiedAt === "number" &&
-    Number.isFinite(session.mfaVerifiedAt) &&
-    Date.now() - session.mfaVerifiedAt >= 0 &&
-    Date.now() - session.mfaVerifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(session.mfaVerifiedAt, maxAgeMs);
 }
 
 async function readPersonalTenantMfaPolicy(tenantId: string): Promise<TenantMfaPolicyConfig> {

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -102,6 +102,7 @@ import {
   resolveGasSponsorshipRequest,
 } from "../services/gas-sponsorship";
 import { plaintextKeyExportResponseGateError } from "../services/key-export-plaintext-gate";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import { verifySignerCredential } from "../services/signer-credentials";
 import { dispatchWebhook } from "../services/webhook-dispatch";
 import {
@@ -1542,13 +1543,7 @@ function hasRecentSessionMfa(
   c: Context<{ Variables: AppVariables }>,
   maxAgeMs = DEFAULT_MFA_MAX_AGE_MS,
 ) {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), maxAgeMs);
 }
 
 function hasTenantAdminSession(c: Context<{ Variables: AppVariables }>): boolean {

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -22,6 +22,7 @@ import {
   webhookConfigs,
   webhookDeliveries,
 } from "../services/context";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import { dispatchReplayWebhook, dispatchTestWebhook } from "../services/webhook-dispatch";
 import {
   acceptsConfiguredWebhookEvent,
@@ -80,13 +81,7 @@ function requireTenantAdminSession(c: Parameters<typeof requireTenantLevel>[0]):
 }
 
 function hasRecentSessionMfa(c: Parameters<typeof requireTenantLevel>[0], maxAgeMs = 5 * 60_000) {
-  const verifiedAt = c.get("sessionMfaVerifiedAt");
-  return (
-    typeof verifiedAt === "number" &&
-    Number.isFinite(verifiedAt) &&
-    Date.now() - verifiedAt >= 0 &&
-    Date.now() - verifiedAt <= maxAgeMs
-  );
+  return isRecentMfaTimestamp(c.get("sessionMfaVerifiedAt"), maxAgeMs);
 }
 
 type TenantMfaPolicyConfig = {

--- a/packages/api/src/services/recent-mfa.ts
+++ b/packages/api/src/services/recent-mfa.ts
@@ -1,0 +1,18 @@
+/** Validate a privileged MFA step-up without accepting any future timestamp. */
+export function isRecentMfaTimestamp(
+  verifiedAt: unknown,
+  maxAgeMs: number,
+  nowMs = Date.now(),
+): boolean {
+  if (
+    typeof verifiedAt !== "number" ||
+    !Number.isFinite(verifiedAt) ||
+    !Number.isFinite(maxAgeMs) ||
+    maxAgeMs < 0 ||
+    !Number.isFinite(nowMs)
+  ) {
+    return false;
+  }
+  const ageMs = nowMs - verifiedAt;
+  return ageMs >= 0 && ageMs <= maxAgeMs;
+}


### PR DESCRIPTION
Closes #637

## Summary
- replace a weak per-file source scan with one strict runtime MFA timestamp validator
- route all 17 covered privileged MFA predicates through the shared no-future boundary
- behaviorally cover exact-now, exact max age, stale, future, hostile future, malformed/non-finite timestamps, and invalid windows

## Exact evidence
- head: `6ba1cf50cb392b55ce7bb0472f8172e144aee8c2`
- base: `9239a728b9ca28175e00e2825f69d85f3e02856e`
- focused behavior: 3/3 tests, 14 assertions
- affected API dependency build: 24/24 tasks successful
- Biome on 19 changed files and `git diff --check`: pass
- frozen dependency hydration used `--ignore-scripts`; no native module was required for these checks

## Merge posture
Draft pending the current API stack, exact conflict-aware restack across affected route files, full hosted CI, and independent approval. The dirty shared checkout contains unrelated work and was not modified.
