### PR TITLE
test(agent-trader): exercise oracle boundary behavior

### DIFF
--- a/packages/agent-trader/src/__tests__/state-security.test.ts
+++ b/packages/agent-trader/src/__tests__/state-security.test.ts
@@ -1,12 +1,66 @@
 import { expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import type { StewardClient } from "@stwd/sdk";
+import type { AgentTraderConfig } from "../config.js";
+import { fetchAgentState } from "../state.js";
 
-test("agent state never fetches an operator-controlled price-oracle URL", () => {
-  const source = readFileSync(join(import.meta.dir, "../state.ts"), "utf8");
-  expect(source).not.toContain("PRICE_ORACLE_URL");
-  expect(source).not.toContain("PRICE_ORACLE_");
-  expect(source).not.toContain("await fetch(");
-  expect(source).not.toContain("globalThis.fetch");
-  expect(source).toContain("getHardenedOracleQuote(tokenAddress, chainId)");
+const TEST_CHAIN_ID = 31_337;
+const RPC_URL = "https://rpc.example.test/";
+const OPERATOR_ORACLE_URL = "https://operator.example.test/private-price";
+
+test("agent state ignores an operator-controlled price-oracle URL at runtime", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalRpcUrl = process.env[`RPC_URL_${TEST_CHAIN_ID}`];
+  const originalOracleUrl = process.env.PRICE_ORACLE_URL;
+  const requestedUrls: string[] = [];
+
+  process.env[`RPC_URL_${TEST_CHAIN_ID}`] = RPC_URL;
+  process.env.PRICE_ORACLE_URL = OPERATOR_ORACLE_URL;
+  globalThis.fetch = (async (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    requestedUrls.push(url);
+
+    const request = JSON.parse(String(init?.body)) as { id: number; method: string };
+    const result = request.method === "eth_getBalance" ? "0x2a" : `0x${"0".repeat(63)}7`;
+    return new Response(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }), {
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  const config: AgentTraderConfig = {
+    agentId: "agent-oracle-boundary",
+    tokenAddress: "0x1111111111111111111111111111111111111111",
+    strategy: "manual",
+    intervalSeconds: 60,
+    enabled: true,
+    chainId: TEST_CHAIN_ID,
+    params: {},
+  };
+  const steward = {
+    getHistory: async () => [],
+  } as unknown as StewardClient;
+
+  try {
+    const state = await fetchAgentState(
+      config,
+      "0x2222222222222222222222222222222222222222",
+      steward,
+    );
+
+    expect(requestedUrls.length).toBe(2);
+    expect(requestedUrls).toEqual([RPC_URL, RPC_URL]);
+    expect(requestedUrls).not.toContain(OPERATOR_ORACLE_URL);
+    expect(state).toMatchObject({
+      nativeBalance: 42n,
+      tokenBalance: 7n,
+      tokenPrice: 0n,
+      priceConfidence: "none",
+      treasuryValue: 42n,
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalRpcUrl === undefined) delete process.env[`RPC_URL_${TEST_CHAIN_ID}`];
+    else process.env[`RPC_URL_${TEST_CHAIN_ID}`] = originalRpcUrl;
+    if (originalOracleUrl === undefined) delete process.env.PRICE_ORACLE_URL;
+    else process.env.PRICE_ORACLE_URL = originalOracleUrl;
+  }
 });


### PR DESCRIPTION
Closes #640

## Summary
- replace the agent-state price-oracle source-text scan with reachable `fetchAgentState` behavior
- poison the legacy operator-controlled `PRICE_ORACLE_URL` and assert runtime traffic goes only to the configured chain RPC
- assert balance/state results remain fail-closed when no hardened oracle quote is available

## Exact evidence
- head: `821a39bc4fd86720117c94e4e6ed770c4834ad96`
- base: `9239a728b9ca28175e00e2825f69d85f3e02856e`
- focused test: 1/1 PASS
- full `agent-trader` suite: 55/55, 134 assertions PASS
- package TypeScript: PASS
- Biome and `git diff --check`: PASS

## Merge posture
Keep draft pending exact-head hosted CI and independent approval.