### PR TITLE
fix(web): fence webhook mutation and refresh ownership

### DIFF
--- a/web/e2e/webhooks-page.spec.ts
+++ b/web/e2e/webhooks-page.spec.ts
@@ -441,4 +441,165 @@ test.describe("Dashboard webhook delivery history", () => {
     await expect(failedSummary).toHaveText("1");
     await expect(retryableSummary).toHaveText("1");
   });
+
+  test("delayed delivery mutations cannot overwrite a newer endpoint selection", async ({
+    page,
+    request,
+  }) => {
+    const email = `webhook-mutation-ownership-${Date.now()}@example.test`;
+    const now = "2026-05-28T12:00:00.000Z";
+    const webhooks: WebhookConfig[] = ["a", "b", "c"].map((suffix) => ({
+      id: `webhook-${suffix}`,
+      tenantId: "e2e-tenant",
+      url: `https://${suffix}.example.test/webhooks`,
+      events: ["user.created"],
+      enabled: true,
+      maxRetries: 5,
+      retryBackoffMs: 60000,
+      description: `Endpoint ${suffix.toUpperCase()}`,
+      createdAt: now,
+      updatedAt: now,
+    }));
+    const delivery = (
+      id: string,
+      status: WebhookDelivery["status"] = "delivered",
+      eventType = "user.created",
+    ): WebhookDelivery => ({
+      id,
+      eventType,
+      status,
+      attempts: 1,
+      maxAttempts: 6,
+      nextRetryAt: status === "failed" ? now : null,
+      hasError: status === "failed",
+      createdAt: now,
+      deliveredAt: status === "delivered" ? now : null,
+    });
+    const rows = new Map<string, WebhookDelivery[]>([
+      ["webhook-a", [delivery("a-failed", "failed")]],
+      ["webhook-b", [delivery("b-delivered", "delivered", "transaction.confirmed")]],
+      ["webhook-c", [delivery("c-delivered", "delivered", "wallet.created")]],
+    ]);
+
+    let releaseReplay: (() => void) | undefined;
+    const replayGate = new Promise<void>((resolve) => {
+      releaseReplay = resolve;
+    });
+    let markReplayStarted: (() => void) | undefined;
+    const replayStarted = new Promise<void>((resolve) => {
+      markReplayStarted = resolve;
+    });
+    let releaseTest: (() => void) | undefined;
+    const testGate = new Promise<void>((resolve) => {
+      releaseTest = resolve;
+    });
+    let markTestStarted: (() => void) | undefined;
+    const testStarted = new Promise<void>((resolve) => {
+      markTestStarted = resolve;
+    });
+    let releaseDelete: (() => void) | undefined;
+    const deleteGate = new Promise<void>((resolve) => {
+      releaseDelete = resolve;
+    });
+    let markDeleteStarted: (() => void) | undefined;
+    const deleteStarted = new Promise<void>((resolve) => {
+      markDeleteStarted = resolve;
+    });
+    let markDeleteResponded: (() => void) | undefined;
+    const deleteResponded = new Promise<void>((resolve) => {
+      markDeleteResponded = resolve;
+    });
+    let releaseStaleList: (() => void) | undefined;
+    const staleListGate = new Promise<void>((resolve) => {
+      releaseStaleList = resolve;
+    });
+    let markStaleListStarted: (() => void) | undefined;
+    const staleListStarted = new Promise<void>((resolve) => {
+      markStaleListStarted = resolve;
+    });
+    let listRequestCount = 0;
+
+    await page.route(`${API}/webhooks`, async (route) => {
+      listRequestCount += 1;
+      if (listRequestCount === 2) {
+        const staleSnapshot = [...webhooks];
+        markStaleListStarted?.();
+        await staleListGate;
+        await route.fulfill({ json: { ok: true, data: staleSnapshot } });
+        return;
+      }
+      await route.fulfill({ json: { ok: true, data: webhooks } });
+    });
+    for (const webhookId of ["webhook-a", "webhook-b", "webhook-c"]) {
+      await page.route(`${API}/webhooks/${webhookId}/deliveries**`, async (route) => {
+        await route.fulfill({ json: { ok: true, data: rows.get(webhookId) ?? [] } });
+      });
+    }
+    await page.route(`${API}/webhooks/deliveries/a-failed/replay`, async (route) => {
+      markReplayStarted?.();
+      await replayGate;
+      const replayed = delivery("a-replayed");
+      rows.set("webhook-a", [replayed, ...(rows.get("webhook-a") ?? [])]);
+      await route.fulfill({ status: 202, json: { ok: true, data: replayed } });
+    });
+    await page.route(`${API}/webhooks/webhook-a/test`, async (route) => {
+      markTestStarted?.();
+      await testGate;
+      const tested = { ...delivery("a-test"), eventType: "webhook.test" };
+      rows.set("webhook-a", [tested, ...(rows.get("webhook-a") ?? [])]);
+      await route.fulfill({ status: 202, json: { ok: true, data: tested } });
+    });
+    await page.route(`${API}/webhooks/webhook-a`, async (route) => {
+      markDeleteStarted?.();
+      await deleteGate;
+      const index = webhooks.findIndex((webhook) => webhook.id === "webhook-a");
+      if (index >= 0) webhooks.splice(index, 1);
+      await route.fulfill({ json: { ok: true } });
+      markDeleteResponded?.();
+    });
+
+    await loginWithMagicLink(page, request, email);
+    await page.goto(`${WEB}/dashboard/webhooks`);
+    await expect(page.getByRole("button", { name: /user\.created failed/ })).toBeVisible();
+    await page.getByRole("button", { name: /user\.created failed/ }).click();
+    page.once("dialog", async (dialog) => dialog.accept());
+    await page.getByRole("button", { name: "Replay Delivery" }).click();
+    await replayStarted;
+
+    await page.getByText("https://b.example.test/webhooks").first().click();
+    await expect(
+      page.getByRole("button", { name: /transaction\.confirmed delivered/ }),
+    ).toBeVisible();
+    releaseReplay?.();
+    await expect(page.getByText("a-replayed")).toHaveCount(0);
+    await expect(page.getByTestId("webhook-delivery-summary-delivered")).toHaveText("1");
+
+    await page.getByRole("button", { name: "Send Test" }).first().click();
+    await testStarted;
+    await page.getByText("https://c.example.test/webhooks").first().click();
+    await expect(page.getByRole("button", { name: /wallet\.created delivered/ })).toBeVisible();
+    releaseTest?.();
+    await expect(page.getByText("a-test")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /wallet\.created delivered/ })).toBeVisible();
+
+    await page.getByText("https://a.example.test/webhooks").first().click();
+    await expect(page.getByRole("button", { name: /user\.created failed/ })).toBeVisible();
+    page.once("dialog", async (dialog) => dialog.accept());
+    await page.getByRole("button", { name: "Delete" }).first().click();
+    await deleteStarted;
+    await page.getByText("https://c.example.test/webhooks").first().click();
+    await expect(page.getByRole("button", { name: /wallet\.created delivered/ })).toBeVisible();
+    await page.getByRole("button", { name: "Refresh" }).click();
+    await staleListStarted;
+    releaseDelete?.();
+    await deleteResponded;
+    await expect(page.getByText("https://a.example.test/webhooks")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /wallet\.created delivered/ })).toBeVisible();
+    releaseStaleList?.();
+    await expect(page.getByText("https://a.example.test/webhooks")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /wallet\.created delivered/ })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /transaction\.confirmed delivered/ }),
+    ).toHaveCount(0);
+  });
 });

--- a/web/src/app/dashboard/webhooks/page.tsx
+++ b/web/src/app/dashboard/webhooks/page.tsx
@@ -3,7 +3,7 @@
 import { WEBHOOK_EVENT_TYPES, type WebhookConfig, type WebhookDelivery } from "@stwd/sdk";
 import { AnimatePresence, motion } from "framer-motion";
 import type { FormEvent } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { steward } from "@/lib/api";
 import { formatDate } from "@/lib/utils";
 
@@ -60,6 +60,15 @@ export default function WebhooksPage() {
   const [deliveryStatusFilter, setDeliveryStatusFilter] = useState<string>("all");
   const [deliveryEventFilter, setDeliveryEventFilter] = useState("");
   const [deliveryErrorFilter, setDeliveryErrorFilter] = useState<string>("all");
+  const webhooksRef = useRef(webhooks);
+  const selectedIdRef = useRef(selectedId);
+  const selectionEpochRef = useRef(0);
+  const deliveryQueryKeyRef = useRef("");
+  const retryOperationRef = useRef<object | null>(null);
+  const replayOperationRef = useRef<object | null>(null);
+  const testOperationRef = useRef<object | null>(null);
+  const deleteOperationRef = useRef<object | null>(null);
+  const webhookListEpochRef = useRef(0);
   const [newWebhook, setNewWebhook] = useState({
     url: "",
     description: "",
@@ -81,6 +90,9 @@ export default function WebhooksPage() {
     () => JSON.stringify([selectedId, deliveryQuery]),
     [deliveryQuery, selectedId],
   );
+  webhooksRef.current = webhooks;
+  selectedIdRef.current = selectedId;
+  deliveryQueryKeyRef.current = deliveryQueryKey;
   const visibleDeliveries =
     deliveryOwnerKey === deliveryQueryKey ? deliveries : ([] as WebhookDelivery[]);
   const deliveryQueryLoading =
@@ -92,20 +104,31 @@ export default function WebhooksPage() {
   );
 
   const loadWebhooks = useCallback(async () => {
+    const epoch = ++webhookListEpochRef.current;
     setLoading(true);
     setError(null);
     try {
       const configs = await steward.listWebhooks();
+      if (webhookListEpochRef.current !== epoch) return;
+      webhooksRef.current = configs;
       setWebhooks(configs);
-      setSelectedId((current) =>
-        current && configs.some((webhook) => webhook.id === current)
-          ? current
-          : (configs[0]?.id ?? ""),
-      );
+      const currentSelectedId = selectedIdRef.current;
+      const nextSelectedId =
+        currentSelectedId && configs.some((webhook) => webhook.id === currentSelectedId)
+          ? currentSelectedId
+          : (configs[0]?.id ?? "");
+      if (nextSelectedId !== currentSelectedId) {
+        selectionEpochRef.current += 1;
+        selectedIdRef.current = nextSelectedId;
+        setExpanded(null);
+      }
+      setSelectedId(nextSelectedId);
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Failed to load webhooks");
+      if (webhookListEpochRef.current === epoch) {
+        setError(e instanceof Error ? e.message : "Failed to load webhooks");
+      }
     } finally {
-      setLoading(false);
+      if (webhookListEpochRef.current === epoch) setLoading(false);
     }
   }, []);
 
@@ -147,6 +170,8 @@ export default function WebhooksPage() {
   }, [deliveryQuery, deliveryQueryKey, selectedId]);
 
   function selectWebhook(webhookId: string) {
+    selectionEpochRef.current += 1;
+    selectedIdRef.current = webhookId;
     setSelectedId(webhookId);
     setExpanded(null);
     setError(null);
@@ -154,24 +179,41 @@ export default function WebhooksPage() {
 
   async function retryDelivery(deliveryId: string) {
     if (!selectedId) return;
+    const operation = {};
+    const ownerKey = deliveryQueryKey;
+    retryOperationRef.current = operation;
     setRetryingId(deliveryId);
     setError(null);
     try {
       const updated = await steward.retryDelivery(deliveryId);
+      if (retryOperationRef.current !== operation || deliveryQueryKeyRef.current !== ownerKey) {
+        return;
+      }
       setDeliveries((rows) => rows.map((row) => (row.id === updated.id ? updated : row)));
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Failed to retry webhook delivery");
+      if (retryOperationRef.current === operation && deliveryQueryKeyRef.current === ownerKey) {
+        setError(e instanceof Error ? e.message : "Failed to retry webhook delivery");
+      }
     } finally {
-      setRetryingId(null);
+      if (retryOperationRef.current === operation) {
+        retryOperationRef.current = null;
+        setRetryingId(null);
+      }
     }
   }
 
   async function replayDelivery(delivery: WebhookDelivery) {
     if (!window.confirm("Replay this event as a new signed webhook delivery?")) return;
+    const operation = {};
+    const ownerKey = deliveryQueryKey;
+    replayOperationRef.current = operation;
     setReplayingId(delivery.id);
     setError(null);
     try {
       const replayed = await steward.replayDelivery(delivery.id);
+      if (replayOperationRef.current !== operation || deliveryQueryKeyRef.current !== ownerKey) {
+        return;
+      }
       const matchesFilters =
         (deliveryStatusFilter === "all" || replayed.status === deliveryStatusFilter) &&
         (!deliveryEventFilter.trim() || replayed.eventType === deliveryEventFilter.trim()) &&
@@ -184,19 +226,41 @@ export default function WebhooksPage() {
       );
       setExpanded(matchesFilters ? replayed.id : null);
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Failed to replay webhook delivery");
+      if (replayOperationRef.current === operation && deliveryQueryKeyRef.current === ownerKey) {
+        setError(e instanceof Error ? e.message : "Failed to replay webhook delivery");
+      }
     } finally {
-      setReplayingId(null);
+      if (replayOperationRef.current === operation) {
+        replayOperationRef.current = null;
+        setReplayingId(null);
+      }
     }
   }
 
   async function sendTest(webhook: WebhookConfig) {
+    const operation = {};
+    const ownerKey = deliveryQueryKey;
+    const selectionAtStart = selectedId;
+    const selectionEpochAtStart = selectionEpochRef.current;
+    testOperationRef.current = operation;
     setTestingId(webhook.id);
     setError(null);
     try {
       const delivery = await steward.testWebhook(webhook.id);
-      if (selectedId !== webhook.id) {
+      if (
+        testOperationRef.current !== operation ||
+        deliveryQueryKeyRef.current !== ownerKey ||
+        selectedIdRef.current !== selectionAtStart ||
+        selectionEpochRef.current !== selectionEpochAtStart
+      ) {
+        return;
+      }
+      if (selectionAtStart !== webhook.id) {
+        selectionEpochRef.current += 1;
+        selectedIdRef.current = webhook.id;
         setSelectedId(webhook.id);
+        setExpanded(null);
+        return;
       }
       const matchesFilters =
         (deliveryStatusFilter === "all" || delivery.status === deliveryStatusFilter) &&
@@ -210,9 +274,14 @@ export default function WebhooksPage() {
       );
       setExpanded(matchesFilters ? delivery.id : null);
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Failed to send test webhook");
+      if (testOperationRef.current === operation && deliveryQueryKeyRef.current === ownerKey) {
+        setError(e instanceof Error ? e.message : "Failed to send test webhook");
+      }
     } finally {
-      setTestingId(null);
+      if (testOperationRef.current === operation) {
+        testOperationRef.current = null;
+        setTestingId(null);
+      }
     }
   }
 
@@ -252,7 +321,13 @@ export default function WebhooksPage() {
         description: newWebhook.description.trim() || undefined,
         events: parseEventList(newWebhook.events),
       });
-      setWebhooks((rows) => [created, ...rows.filter((row) => row.id !== created.id)]);
+      webhookListEpochRef.current += 1;
+      setLoading(false);
+      const nextWebhooks = [created, ...webhooksRef.current.filter((row) => row.id !== created.id)];
+      webhooksRef.current = nextWebhooks;
+      setWebhooks(nextWebhooks);
+      selectionEpochRef.current += 1;
+      selectedIdRef.current = created.id;
       setSelectedId(created.id);
       setDeliveries([]);
       setNewWebhook({
@@ -273,7 +348,13 @@ export default function WebhooksPage() {
     setError(null);
     try {
       const updated = await steward.updateWebhook(webhook.id, { enabled });
-      setWebhooks((rows) => rows.map((row) => (row.id === updated.id ? updated : row)));
+      webhookListEpochRef.current += 1;
+      setLoading(false);
+      const nextWebhooks = webhooksRef.current.map((row) =>
+        row.id === updated.id ? updated : row,
+      );
+      webhooksRef.current = nextWebhooks;
+      setWebhooks(nextWebhooks);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to update webhook endpoint");
     } finally {
@@ -283,20 +364,34 @@ export default function WebhooksPage() {
 
   async function deleteEndpoint(webhook: WebhookConfig) {
     if (!window.confirm(`Delete webhook endpoint ${webhook.url}?`)) return;
+    const operation = {};
+    deleteOperationRef.current = operation;
     setDeletingId(webhook.id);
     setError(null);
     try {
       await steward.deleteWebhook(webhook.id);
-      const remaining = webhooks.filter((row) => row.id !== webhook.id);
+      webhookListEpochRef.current += 1;
+      setLoading(false);
+      const remaining = webhooksRef.current.filter((row) => row.id !== webhook.id);
+      webhooksRef.current = remaining;
       setWebhooks(remaining);
-      if (selectedId === webhook.id) {
-        setSelectedId(remaining[0]?.id ?? "");
+      if (selectedIdRef.current === webhook.id) {
+        const nextSelectedId = remaining[0]?.id ?? "";
+        selectionEpochRef.current += 1;
+        selectedIdRef.current = nextSelectedId;
+        setSelectedId(nextSelectedId);
         setDeliveries([]);
+        setExpanded(null);
       }
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Failed to delete webhook endpoint");
+      if (deleteOperationRef.current === operation) {
+        setError(e instanceof Error ? e.message : "Failed to delete webhook endpoint");
+      }
     } finally {
-      setDeletingId(null);
+      if (deleteOperationRef.current === operation) {
+        deleteOperationRef.current = null;
+        setDeletingId(null);
+      }
     }
   }
 


### PR DESCRIPTION
Closes #647

## Summary

Follow up the merged #632 endpoint/filter GET fence by binding every webhook delivery mutation to the exact endpoint/filter owner and operation identity that initiated it.

- retry/replay completions and errors are ignored after ownership changes;
- test delivery cannot override a newer endpoint selection;
- delete removes the committed endpoint but only changes selection if that endpoint is still selected;
- webhook list loads are ordered and invalidated after successful create/update/delete, preventing stale refresh resurrection;
- endpoint configuration refs and selection epochs update synchronously with committed local mutations.

The mounted browser regression deterministically delays replay, test, delete, and a pre-delete refresh while switching among three endpoints. It proves endpoint-A completions never pollute endpoint B/C rows or counters and stale configuration data cannot resurrect endpoint A.

## Exact evidence

- head: `b3b43c1124486f2434e6e36b8ace9285d1c560d3`
- tree: `a207d22d21df19a4a783ae8b9e0f854261832959`
- base: `72a26d8d5dbcc7689b358c771adcd539fb1a91db`
- exact frozen install after final restack: PASS
- changed-file Biome and `git diff --check`: PASS
- focused production Chromium race: 1/1 PASS in 6.3 minutes on byte-identical changed files
- web production dependency build: 8/8 PASS on byte-identical changed files
- API dependency build: 24/24 PASS
- three Chromium tests collect from the exact final source
- a full dev rerun was inconclusive before assertions because a concurrent fixed-port E2E run killed the API; the successful production run used the normal full harness

## Merge posture

Keep draft until the exact develop-target hosted matrix is terminal green and independent review confirms the post-merge ownership boundary.