### PR TITLE
fix(api): reject future provider approval MFA

### DIFF
--- a/packages/api/src/__tests__/provider-approval-route.test.ts
+++ b/packages/api/src/__tests__/provider-approval-route.test.ts
@@ -387,6 +387,20 @@ describe("approval-lifecycle approval + execute routes", () => {
     expect(body.error.code).toBe("APPROVAL_MFA_REQUIRED");
   });
 
+  test("GET approval rejects a hostile future MFA timestamp before returning detail", async () => {
+    const { intentId } = await createApprovalRequired();
+    const res = await app.request(`/v2/provider-actions/${intentId}/approval`, {
+      method: "GET",
+      headers: {
+        authorization: `Bearer ${await humanToken(F.APPROVER, Date.now() + 24 * 60 * 60_000)}`,
+        "x-steward-tenant": F.TENANT,
+      },
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("APPROVAL_MFA_STALE");
+  });
+
   test("GET approval returns safe summary to an eligible approver", async () => {
     const { intentId } = await createApprovalRequired();
     const res = await app.request(`/v2/provider-actions/${intentId}/approval`, {

--- a/packages/api/src/routes/provider-approvals.ts
+++ b/packages/api/src/routes/provider-approvals.ts
@@ -18,6 +18,7 @@ import { decodeUtf8Strict, isApprovalReasonCode, strictParseJson } from "@stwd/s
 import type { Context, Hono } from "hono";
 import { type AppVariables, setNoStoreHeaders, tenantAuth } from "../services/context";
 import { providerApprovalService } from "../services/provider-approval";
+import { isRecentMfaTimestamp } from "../services/recent-mfa";
 
 type RouteContext = Context<{ Variables: AppVariables }>;
 
@@ -92,7 +93,7 @@ async function handleGetApproval(c: RouteContext) {
   if (typeof mfa !== "number" || !Number.isFinite(mfa)) {
     return err(c, "APPROVAL_MFA_REQUIRED", 403);
   }
-  if (Date.now() - mfa > 300_000) return err(c, "APPROVAL_MFA_STALE", 403);
+  if (!isRecentMfaTimestamp(mfa, 300_000)) return err(c, "APPROVAL_MFA_STALE", 403);
 
   // Eligibility (exact workspace approver) is enforced by the service via a
   // detail-load that first checks the caller is an eligible approver. For the


### PR DESCRIPTION
Closes #646

## Summary
- route the final provider-approval detail MFA predicate through the shared strict recent-timestamp validator
- reject arbitrarily future session MFA before loading or returning approval detail
- add a mounted provider-action regression for a +24-hour hostile timestamp

## Exact evidence
- head: `f07612c173969c90ec0ab5f80ecad12d8eab1dd1`
- base: `e4237d5d762a15292557640a88108ae2df9898fe`
- exact unique diff: only `provider-approvals.ts` and `provider-approval-route.test.ts`
- byte-identical unique patch mounted provider approval suite before restack: 12/12, 53 assertions
- byte-identical unique patch API dependency build before restack: 24/24 PASS
- current-head Biome changed files and `git diff --check`: PASS

## Merge posture
Keep draft pending fresh exact-head hosted CI and independent review.