### PR TITLE
fix(api): serialize capability authority deletion

### DIFF
--- a/packages/api/src/__tests__/agent-deletion-lifecycle.test.ts
+++ b/packages/api/src/__tests__/agent-deletion-lifecycle.test.ts
@@ -5,8 +5,10 @@ import { revocationStore } from "@stwd/auth";
 import {
   __resetAuditHmacKeyCacheForTests,
   agents,
+  auditEvents,
   getDb,
   intents,
+  pendingProxyRequests,
   providerAccounts,
   providerActionBindings,
   providerOperations,
@@ -19,7 +21,7 @@ import {
   users,
   workspaces,
 } from "@stwd/db";
-import { capabilities, capabilityGrants } from "@stwd/plugin-capabilities";
+import { capabilities, capabilityGrants, capabilityInvocations } from "@stwd/plugin-capabilities";
 import { and, eq } from "drizzle-orm";
 import { migrate as pgliteMigrate } from "drizzle-orm/pglite/migrator";
 import { Hono } from "hono";
@@ -622,6 +624,164 @@ describe("agent deletion upstream credential boundary", () => {
     ).toEqual([{ status: "revoked" }]);
   });
 
+  it("deletes active and terminal tenant capability authority while retaining invocation evidence", async () => {
+    const tenantId = `tenant-capability-delete-${crypto.randomUUID()}`;
+    const activeAgentId = `active-${crypto.randomUUID()}`;
+    const terminalAgentId = `terminal-${crypto.randomUUID()}`;
+    await getDb()
+      .insert(tenants)
+      .values({
+        id: tenantId,
+        name: tenantId,
+        apiKeyHash: `hash-${tenantId}`,
+      });
+    await getDb()
+      .insert(agents)
+      .values([
+        {
+          id: activeAgentId,
+          tenantId,
+          name: activeAgentId,
+          walletAddress: "0x1234567890123456789012345678901234567890",
+        },
+        {
+          id: terminalAgentId,
+          tenantId,
+          name: terminalAgentId,
+          walletAddress: "0x2234567890123456789012345678901234567890",
+        },
+      ]);
+    const activeCapabilityId = crypto.randomUUID();
+    const terminalCapabilityId = crypto.randomUUID();
+    const activeGrantId = crypto.randomUUID();
+    const terminalGrantId = crypto.randomUUID();
+    const activeRouteId = crypto.randomUUID();
+    const terminalRouteId = crypto.randomUUID();
+    const invocationId = crypto.randomUUID();
+    await getDb()
+      .insert(capabilities)
+      .values([
+        {
+          id: activeCapabilityId,
+          tenantId,
+          name: `active-${activeCapabilityId}`,
+          secretId: crypto.randomUUID(),
+          host: "active.example.test",
+          pathPattern: "/v1/*",
+          method: "POST",
+          injectKey: "Authorization",
+        },
+        {
+          id: terminalCapabilityId,
+          tenantId,
+          name: `terminal-${terminalCapabilityId}`,
+          secretId: crypto.randomUUID(),
+          host: "terminal.example.test",
+          pathPattern: "/v1/*",
+          method: "POST",
+          injectKey: "Authorization",
+        },
+      ]);
+    await getDb()
+      .insert(secretRoutes)
+      .values([
+        {
+          id: activeRouteId,
+          tenantId,
+          agentId: activeAgentId,
+          secretId: crypto.randomUUID(),
+          hostPattern: "active.example.test",
+          pathPattern: "/v1/*",
+          method: "POST",
+          injectAs: "header",
+          injectKey: "Authorization",
+        },
+        {
+          id: terminalRouteId,
+          tenantId,
+          agentId: terminalAgentId,
+          secretId: crypto.randomUUID(),
+          hostPattern: "terminal.example.test",
+          pathPattern: "/v1/*",
+          method: "POST",
+          injectAs: "header",
+          injectKey: "Authorization",
+          enabled: false,
+        },
+      ]);
+    await getDb()
+      .insert(capabilityGrants)
+      .values([
+        {
+          id: activeGrantId,
+          tenantId,
+          agentId: activeAgentId,
+          capabilityId: activeCapabilityId,
+          secretRouteId: activeRouteId,
+          status: "active",
+        },
+        {
+          id: terminalGrantId,
+          tenantId,
+          agentId: terminalAgentId,
+          capabilityId: terminalCapabilityId,
+          secretRouteId: terminalRouteId,
+          status: "revoked",
+        },
+      ]);
+    await getDb().insert(capabilityInvocations).values({
+      id: invocationId,
+      tenantId,
+      agentId: activeAgentId,
+      capabilityId: activeCapabilityId,
+      decision: "allow",
+    });
+
+    const response = await platformTenantDelete(tenantId);
+    expect(response.status).toBe(200);
+    expect(await getDb().select().from(tenants).where(eq(tenants.id, tenantId))).toHaveLength(0);
+    expect(
+      await getDb().select().from(capabilityGrants).where(eq(capabilityGrants.tenantId, tenantId)),
+    ).toHaveLength(0);
+    expect(
+      await getDb().select().from(capabilities).where(eq(capabilities.tenantId, tenantId)),
+    ).toHaveLength(0);
+    expect(
+      await getDb().select().from(secretRoutes).where(eq(secretRoutes.tenantId, tenantId)),
+    ).toHaveLength(0);
+    expect(
+      await getDb()
+        .select({ id: capabilityInvocations.id })
+        .from(capabilityInvocations)
+        .where(eq(capabilityInvocations.id, invocationId)),
+    ).toEqual([{ id: invocationId }]);
+    const deletionEvents = await getDb()
+      .select({ action: auditEvents.action, metadata: auditEvents.metadata })
+      .from(auditEvents)
+      .where(eq(auditEvents.tenantId, tenantId));
+    expect(deletionEvents).toContainEqual({
+      action: "tenant.delete",
+      metadata: {
+        agentTokenRevocationTargets: 2,
+        userTokenRevocationTargets: 0,
+        capabilityCleanup: {
+          activeGrantsRetired: 1,
+          terminalGrantsRemoved: 1,
+          capabilitiesRemoved: 2,
+          invocationEvidenceRetained: 1,
+        },
+      },
+    });
+    expect(deletionEvents).toContainEqual({
+      action: "tenant.delete.token_revocation_completed",
+      metadata: {
+        agentRevocationCutoffsEstablished: 2,
+        userRevocationCutoffsEstablished: 0,
+      },
+    });
+    await getDb().delete(capabilityInvocations).where(eq(capabilityInvocations.id, invocationId));
+  });
+
   it("refuses both routed and direct deletion while signed execution is unresolved", async () => {
     const agentId = `signed-execution-${crypto.randomUUID()}`;
     const transactionId = crypto.randomUUID();
@@ -746,6 +906,95 @@ describe("agent deletion upstream credential boundary", () => {
         .where(eq(intents.id, intentId)),
     ).toEqual([{ agentId: null }]);
   });
+
+  it.skipIf(!USING_REAL_POSTGRES)(
+    "orders agent deletion before a pending proxy authority writer without deadlock",
+    async () => {
+      const agentId = `proxy-authority-race-${crypto.randomUUID()}`;
+      const routeId = crypto.randomUUID();
+      const requestId = crypto.randomUUID();
+      await createAgent(agentId);
+      await getDb().insert(secretRoutes).values({
+        id: routeId,
+        tenantId: TENANT_ID,
+        agentId,
+        secretId: crypto.randomUUID(),
+        hostPattern: "pending-race.example.test",
+        pathPattern: "/mutation",
+        method: "POST",
+        injectAs: "header",
+        injectKey: "Authorization",
+      });
+      await getDb()
+        .insert(pendingProxyRequests)
+        .values({
+          id: requestId,
+          tenantId: TENANT_ID,
+          agentId,
+          routeId,
+          method: "POST",
+          targetHost: "pending-race.example.test",
+          targetPath: "/mutation",
+          requestDigest: "d".repeat(64),
+          bodyCiphertext: "body",
+          bodyIv: "iv",
+          bodyAuthTag: "tag",
+          bodySalt: "salt",
+          status: "pending",
+          expiresAt: new Date(Date.now() + 60_000),
+        });
+
+      const writer = postgres(process.env.DATABASE_URL as string, { max: 1 });
+      const observer = postgres(process.env.DATABASE_URL as string, { max: 1 });
+      const [writerBackend] = await writer<{ pid: number }[]>`
+        SELECT pg_backend_pid()::int AS pid
+      `;
+      const writerPid = writerBackend?.pid ?? 0;
+      let beginWriterUpdate!: () => void;
+      const updateRequested = new Promise<void>((resolve) => {
+        beginWriterUpdate = resolve;
+      });
+      let writerReady!: () => void;
+      const ready = new Promise<void>((resolve) => {
+        writerReady = resolve;
+      });
+      const writerTransaction = writer.begin(async (tx) => {
+        await tx`SELECT public.steward_lock_tenant_deletion(${TENANT_ID})`;
+        writerReady();
+        await updateRequested;
+        await tx`
+          UPDATE pending_proxy_requests
+          SET status = 'approved', approved_at = now(), approved_by = 'race-writer'
+          WHERE id = ${requestId}
+        `;
+      });
+      await ready;
+
+      let deletion: Promise<Response> | undefined;
+      try {
+        deletion = tenantDelete(agentId);
+        expect(await waitUntilBackendBlockedBy(observer, writerPid)).toBe(true);
+        beginWriterUpdate();
+        await writerTransaction;
+
+        expect((await deletion).status).toBe(200);
+        expect(await getDb().select().from(agents).where(eq(agents.id, agentId))).toHaveLength(0);
+        expect(
+          await getDb()
+            .select({
+              status: pendingProxyRequests.status,
+              deniedBy: pendingProxyRequests.deniedBy,
+            })
+            .from(pendingProxyRequests)
+            .where(eq(pendingProxyRequests.id, requestId)),
+        ).toEqual([{ status: "denied", deniedBy: "system:agent-delete" }]);
+      } finally {
+        beginWriterUpdate();
+        await Promise.allSettled([writerTransaction, deletion ?? Promise.resolve(new Response())]);
+        await Promise.all([writer.end(), observer.end()]);
+      }
+    },
+  );
 
   it.skipIf(!USING_REAL_POSTGRES)(
     "blocks agent deletion when intent-only provider evidence commits first",

--- a/packages/api/src/__tests__/platform-security-hardening.test.ts
+++ b/packages/api/src/__tests__/platform-security-hardening.test.ts
@@ -450,9 +450,17 @@ describe("platform security hardening", () => {
     expect(platformSource.indexOf("tenantMembers", tenantDeleteStart)).toBeGreaterThan(
       tenantDeleteStart,
     );
-    expect(
-      platformSource.indexOf("revocationStore.revokeUserTokens(member.userId)", tenantDeleteStart),
-    ).toBeLessThan(platformSource.indexOf("tx.delete(refreshTokens)", tenantDeleteStart));
+    const tenantDeleteRoute = platformSource.slice(
+      tenantDeleteStart,
+      platformSource.indexOf('platform.put("/tenants/:id/policies"', tenantDeleteStart),
+    );
+    expect(tenantDeleteRoute.indexOf("tx.delete(tenants)")).toBeLessThan(
+      tenantDeleteRoute.indexOf("revocationStore.revokeAgentTokens(agentId)"),
+    );
+    expect(tenantDeleteRoute.indexOf("tx.delete(tenants)")).toBeLessThan(
+      tenantDeleteRoute.indexOf("revocationStore.revokeUserTokens(userId)"),
+    );
+    expect(tenantDeleteRoute).toContain('action: "tenant.delete.token_revocation_completed"');
   });
 
   it("removes non-cascading tenant credential state during tenant deletion", () => {
@@ -465,6 +473,7 @@ describe("platform security hardening", () => {
     expect(tenantDeleteRoute).toContain("tx.delete(secretRoutes)");
     expect(tenantDeleteRoute).toContain("tx.delete(secrets)");
     expect(tenantDeleteRoute).toContain("tx.delete(proxyAuditLog)");
+    expect(tenantDeleteRoute).toContain("cleanupOptionalTenantCapabilities(tx, tenantId)");
     expect(tenantDeleteRoute.indexOf("tx.delete(secretRoutes)")).toBeLessThan(
       tenantDeleteRoute.indexOf("tx.delete(secrets)"),
     );

--- a/packages/api/src/routes/approvals.ts
+++ b/packages/api/src/routes/approvals.ts
@@ -542,6 +542,12 @@ approvalRoutes.post("/proxy/:id/approve", async (c) => {
   // an already-approved row returns 409 without a second transition or audit.
   const row = await withTenantAuditedTransaction(tenantId, async (tx, appendRequiredAudit) => {
     const dbTx = tx as typeof db;
+    // Agent deletion takes the tenant fence before the parent agent and pending
+    // request rows. Approval is an authority reactivation, so acquire the same
+    // fence before UPDATE takes the pending-request row lock. Relying only on
+    // the row trigger would acquire the advisory lock after PostgreSQL has
+    // already locked the row, which can deadlock with deletion.
+    await dbTx.execute(sql`SELECT public.steward_lock_tenant_deletion(${tenantId})`);
     const [updated] = await dbTx
       .update(pendingProxyRequests)
       .set({

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -110,6 +110,100 @@ const WALLET_EXTERNAL_ID_PROVIDER = "wallet_external_id";
 const MAX_WALLET_EXTERNAL_ID_LENGTH = 180;
 type PlatformTenantConfigRow = typeof tenantConfigs.$inferSelect;
 
+interface TenantCapabilityCleanup {
+  activeGrantsRetired: number;
+  terminalGrantsRemoved: number;
+  capabilitiesRemoved: number;
+  invocationEvidenceRetained: number;
+}
+
+function resultRows<T>(result: unknown): T[] {
+  return (Array.isArray(result) ? result : ((result as { rows?: T[] } | null)?.rows ?? [])) as T[];
+}
+
+async function cleanupOptionalTenantCapabilities(
+  tx: ReturnType<typeof getDb>,
+  tenantId: string,
+): Promise<TenantCapabilityCleanup | null> {
+  const [relations] = resultRows<{
+    capabilities: string | null;
+    grants: string | null;
+    invocations: string | null;
+  }>(
+    await tx.execute(sql`
+      SELECT
+        to_regclass('public.capabilities')::text AS capabilities,
+        to_regclass('public.capability_grants')::text AS grants,
+        to_regclass('public.capability_invocations')::text AS invocations
+    `),
+  );
+  const cleanup: TenantCapabilityCleanup = {
+    activeGrantsRetired: 0,
+    terminalGrantsRemoved: 0,
+    capabilitiesRemoved: 0,
+    invocationEvidenceRetained: 0,
+  };
+
+  let tenantCapabilityIds: string[] = [];
+  if (relations?.capabilities) {
+    tenantCapabilityIds = resultRows<{ id: string }>(
+      await tx.execute(sql`
+        SELECT id::text AS id
+        FROM public.capabilities
+        WHERE tenant_id = ${tenantId}
+        FOR UPDATE
+      `),
+    ).map((row) => row.id);
+  }
+  if (relations?.grants) {
+    const grants = resultRows<{ status: string }>(
+      await tx.execute(sql`
+        SELECT status
+        FROM public.capability_grants
+        WHERE tenant_id = ${tenantId}
+        FOR UPDATE
+      `),
+    );
+    cleanup.activeGrantsRetired = grants.filter((grant) => grant.status === "active").length;
+    cleanup.terminalGrantsRemoved = grants.length - cleanup.activeGrantsRetired;
+    if (relations.capabilities) {
+      const crossTenantGrants = resultRows<{ id: string }>(
+        await tx.execute(sql`
+          SELECT capability_grant.id::text AS id
+          FROM public.capability_grants AS capability_grant
+          INNER JOIN public.capabilities AS capability
+            ON capability.id = capability_grant.capability_id
+          WHERE capability.tenant_id = ${tenantId}
+            AND capability_grant.tenant_id <> ${tenantId}
+          FOR UPDATE OF capability_grant
+        `),
+      );
+      if (crossTenantGrants.length > 0) return null;
+    }
+    await tx.execute(sql`
+      UPDATE public.capability_grants
+      SET status = 'revoked'
+      WHERE tenant_id = ${tenantId} AND status = 'active'
+    `);
+    await tx.execute(sql`DELETE FROM public.capability_grants WHERE tenant_id = ${tenantId}`);
+  }
+  if (relations?.capabilities) {
+    await tx.execute(sql`DELETE FROM public.capabilities WHERE tenant_id = ${tenantId}`);
+    cleanup.capabilitiesRemoved = tenantCapabilityIds.length;
+  }
+  if (relations?.invocations) {
+    const [countRow] = resultRows<{ count: number }>(
+      await tx.execute(sql`
+        SELECT count(*)::int AS count
+        FROM public.capability_invocations
+        WHERE tenant_id = ${tenantId}
+      `),
+    );
+    cleanup.invocationEvidenceRetained = countRow?.count ?? 0;
+  }
+  return cleanup;
+}
+
 function parseDurationSeconds(value: string): number | null {
   const match = value.trim().match(/^(\d+)([smhd])$/i);
   if (!match) return null;
@@ -1972,19 +2066,22 @@ platform.delete("/tenants/:id", async (c) => {
         return { status: "blocked_by_provider" as const };
       }
 
+      const capabilityCleanup = await cleanupOptionalTenantCapabilities(tx, tenantId);
+      if (!capabilityCleanup) return { status: "blocked_by_capability_integrity" as const };
+
       await appendRequiredAudit({
         tenantId,
         actorType: "platform",
         action: "tenant.delete.authorized",
         resourceType: "tenant",
         resourceId: tenantId,
-        metadata: { agentTokenCount: tenantAgents.length, userTokenCount: tenantMembers.length },
+        metadata: {
+          agentTokenRevocationTargets: tenantAgents.length,
+          userTokenRevocationTargets: tenantMembers.length,
+          capabilityCleanup,
+        },
         ...auditCtx(c),
       });
-      await Promise.all([
-        ...tenantAgents.map((agent) => revocationStore.revokeAgentTokens(agent.id)),
-        ...tenantMembers.map((member) => revocationStore.revokeUserTokens(member.userId)),
-      ]);
       await appendRequiredAudit({
         tenantId,
         actorType: "platform",
@@ -1992,8 +2089,9 @@ platform.delete("/tenants/:id", async (c) => {
         resourceType: "tenant",
         resourceId: tenantId,
         metadata: {
-          revokedAgentTokenCount: tenantAgents.length,
-          revokedUserTokenCount: tenantMembers.length,
+          agentTokenRevocationTargets: tenantAgents.length,
+          userTokenRevocationTargets: tenantMembers.length,
+          capabilityCleanup,
         },
         ...auditCtx(c),
       });
@@ -2003,7 +2101,11 @@ platform.delete("/tenants/:id", async (c) => {
       await tx.delete(secrets).where(eq(secrets.tenantId, tenantId));
       await tx.delete(proxyAuditLog).where(eq(proxyAuditLog.tenantId, tenantId));
       await tx.delete(tenants).where(eq(tenants.id, tenantId));
-      return { status: "deleted" as const };
+      return {
+        status: "deleted" as const,
+        agentIds: tenantAgents.map((agent) => agent.id),
+        userIds: tenantMembers.map((member) => member.userId),
+      };
     },
   );
 
@@ -2022,6 +2124,29 @@ platform.delete("/tenants/:id", async (c) => {
       409,
     );
   }
+  if (result.status === "blocked_by_capability_integrity") {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Tenant capability authority has cross-tenant references" },
+      409,
+    );
+  }
+
+  const [agentRevocationCutoffs, userRevocationCutoffs] = await Promise.all([
+    Promise.all(result.agentIds.map((agentId) => revocationStore.revokeAgentTokens(agentId))),
+    Promise.all(result.userIds.map((userId) => revocationStore.revokeUserTokens(userId))),
+  ]);
+  await writeAuditEvent({
+    tenantId,
+    actorType: "platform",
+    action: "tenant.delete.token_revocation_completed",
+    resourceType: "tenant",
+    resourceId: tenantId,
+    metadata: {
+      agentRevocationCutoffsEstablished: agentRevocationCutoffs.length,
+      userRevocationCutoffsEstablished: userRevocationCutoffs.length,
+    },
+    ...auditCtx(c),
+  });
 
   return c.json<ApiResponse>({ ok: true });
 });

--- a/packages/api/src/services/agent-deletion.ts
+++ b/packages/api/src/services/agent-deletion.ts
@@ -70,6 +70,11 @@ export async function deleteAgentAuthority(
   const { tenantId, agentId } = input;
   return withTenantAuditedTransaction(tenantId, async (txRaw, appendRequiredAudit) => {
     const tx = txRaw as ReturnType<typeof getDb>;
+    // Every authority writer takes this tenant-scoped advisory fence before it
+    // takes a parent-agent key-share lock. Deletion must use the same order:
+    // taking the agent row first can deadlock with a writer that already owns
+    // the advisory lock and is waiting to validate the agent parent.
+    await tx.execute(sql`SELECT public.steward_lock_tenant_deletion(${tenantId})`);
     const [lockedAgent] = await tx
       .select({ id: agents.id })
       .from(agents)

--- a/packages/plugin-capabilities/src/store.ts
+++ b/packages/plugin-capabilities/src/store.ts
@@ -128,12 +128,20 @@ export class CapabilityStore {
     audit: AuditFactory<T> | undefined,
     mutate: (tx: Db) => Promise<T>,
   ): Promise<T> {
-    if (!audit) return this.db.transaction(mutate);
+    const mutateBehindTenantFence = async (tx: Db): Promise<T> => {
+      // Core deletion takes this fence before parent-agent and capability row
+      // locks. Every capability mutation must use the same order so a
+      // capability update cannot hold its row while waiting on a deletion that
+      // is itself waiting to inventory or remove that capability.
+      await tx.execute(sql`SELECT public.steward_lock_tenant_deletion(${tenantId})`);
+      return mutate(tx);
+    };
+    if (!audit) return this.db.transaction(mutateBehindTenantFence);
     if (!this.auditedTransaction) {
       throw new Error("audited transaction runner is required for capability mutations");
     }
     return this.auditedTransaction(tenantId, async (tx, appendRequiredAudit) => {
-      const result = await mutate(tx as Db);
+      const result = await mutateBehindTenantFence(tx as Db);
       const event = audit(result);
       if (event) await appendRequiredAudit(event);
       return result;


### PR DESCRIPTION
Closes #649

## Summary
- acquire the tenant deletion fence before agent and capability authority locks across deletion, pending-proxy mutation, and capability-store mutation paths
- dynamically preflight optional capability plugin relations, reject cross-tenant references, retire active grants, and remove active/terminal authority atomically while retaining append-only invocation evidence
- defer external token revocation until the deletion transaction commits; write postcommit cutoff evidence only after revocation succeeds
- add real route coverage for tenant deletion with active/terminal capability authority and a deterministic PostgreSQL pending-proxy writer vs agent-delete race

## Exact evidence
- head: `dc1e69faef42148eb7fca19cfdd23290f9561d28`
- base: `4ff1e671b789c33cacc28f9bd3d2f3ccd232796e`
- exact combined-tree PGLite lifecycle/hardening: 39/39, 389 assertions; 10 real-PG cases skipped locally
- same patch real PostgreSQL lifecycle before conflict-free combined-tree rebase: 21/21, 113 assertions, including both new races
- API/plugin/db dependency build on combined tree: 24/24 PASS
- Biome six changed files and `git diff --check`: PASS
- full plugin store suite intentionally not claimed because it reruns all migrations per test; targeted capability lifecycle passed before rebase

## Merge posture
Keep draft pending exact-head hosted PostgreSQL/CI and independent review.