### PR TITLE
fix(web): surface partial transaction history failures

### DIFF
--- a/web/e2e/transaction-history-partial-failure.spec.ts
+++ b/web/e2e/transaction-history-partial-failure.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+import { loginWithMagicLink } from "./fixtures/auth";
+
+const API = process.env.E2E_API_URL ?? "http://localhost:3299";
+const WEB = process.env.E2E_WEB_URL ?? "http://localhost:3499";
+
+test("dashboard surfaces partial transaction history without discarding available rows", async ({
+  page,
+  request,
+}) => {
+  await loginWithMagicLink(page, request, `partial-history-${Date.now()}@example.test`);
+
+  await page.route(
+    (url) => url.href.startsWith(API) && url.pathname === "/agents",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          ok: true,
+          data: [
+            { id: "agent-available", name: "Available Agent" },
+            { id: "agent-unavailable", name: "Unavailable Agent" },
+          ],
+        },
+      });
+    },
+  );
+  await page.route(
+    (url) => url.href.startsWith(API) && url.pathname === "/vault/agent-available/history",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          ok: true,
+          data: [
+            {
+              id: "tx-visible",
+              agentId: "agent-available",
+              status: "pending",
+              request: {
+                chainId: 8453,
+                to: "0x1111111111111111111111111111111111111111",
+                value: "1000000000000000",
+              },
+              policyResults: [],
+              createdAt: "2026-08-20T12:00:00.000Z",
+            },
+          ],
+        },
+      });
+    },
+  );
+  await page.route(
+    (url) => url.href.startsWith(API) && url.pathname === "/vault/agent-unavailable/history",
+    async (route) => {
+      await route.fulfill({ status: 503, json: { ok: false, error: "history unavailable" } });
+    },
+  );
+
+  await page.goto(`${WEB}/dashboard`);
+  const overviewWarning = page
+    .getByRole("alert")
+    .filter({ hasText: "Transaction history is incomplete" });
+  await expect(overviewWarning).toContainText("1 agent history failed to load");
+  await expect(page.getByText("Known Pending Approvals")).toBeVisible();
+  await expect(page.getByRole("link", { name: "Available Agent" })).toBeVisible();
+
+  await page.goto(`${WEB}/dashboard/transactions`);
+  const transactionsWarning = page
+    .getByRole("alert")
+    .filter({ hasText: "Transaction history is incomplete" });
+  await expect(transactionsWarning).toContainText(
+    "The list and counts include only the available histories",
+  );
+  await expect(page.getByRole("link", { name: "Available Agent" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "All1" })).toBeVisible();
+});

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -3,7 +3,7 @@
 import type { AgentIdentity, TxRecord } from "@stwd/sdk";
 import { AnimatePresence, motion } from "framer-motion";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { ChainBadge } from "@/components/chain-badge";
 import { StatusBadge } from "@/components/status-badge";
 import { steward } from "@/lib/api";
@@ -15,6 +15,7 @@ interface DashboardData {
   agents: AgentIdentity[];
   recentTx: (TxRecord & { agentName?: string })[];
   pendingCount: number;
+  failedHistoryCount: number;
 }
 
 export default function DashboardOverview() {
@@ -22,16 +23,13 @@ export default function DashboardOverview() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    loadDashboard();
-  }, [loadDashboard]);
-
-  async function loadDashboard() {
+  const loadDashboard = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
       const agentsList = await steward.listAgents();
       const allTx: (TxRecord & { agentName?: string })[] = [];
+      let failedHistoryCount = 0;
 
       for (const agent of agentsList.slice(0, 20)) {
         try {
@@ -44,7 +42,7 @@ export default function DashboardOverview() {
             })),
           );
         } catch {
-          /* agent may not have history */
+          failedHistoryCount += 1;
         }
       }
 
@@ -56,13 +54,18 @@ export default function DashboardOverview() {
         agents: agentsList,
         recentTx: allTx.slice(0, 12),
         pendingCount: allTx.filter((tx) => tx.status === "pending").length,
+        failedHistoryCount,
       });
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to connect");
     } finally {
       setLoading(false);
     }
-  }
+  }, []);
+
+  useEffect(() => {
+    void loadDashboard();
+  }, [loadDashboard]);
 
   if (loading) {
     return (
@@ -93,7 +96,7 @@ export default function DashboardOverview() {
     );
   }
 
-  const { agents, recentTx, pendingCount } = data!;
+  const { agents, recentTx, pendingCount, failedHistoryCount } = data!;
 
   return (
     <motion.div
@@ -113,7 +116,7 @@ export default function DashboardOverview() {
         {[
           { label: "Agents", value: agents.length },
           {
-            label: "Pending Approvals",
+            label: failedHistoryCount > 0 ? "Known Pending Approvals" : "Pending Approvals",
             value: pendingCount,
             accent: pendingCount > 0,
           },
@@ -137,6 +140,22 @@ export default function DashboardOverview() {
           </motion.div>
         ))}
       </div>
+
+      {failedHistoryCount > 0 && (
+        <div role="alert" className="border border-amber-400/30 bg-amber-400/5 p-4">
+          <p className="text-sm text-amber-300">Transaction history is incomplete</p>
+          <p className="mt-1 text-xs text-text-tertiary">
+            {failedHistoryCount} agent {failedHistoryCount === 1 ? "history" : "histories"} failed
+            to load. Counts and recent activity include only the available histories.
+          </p>
+          <button
+            onClick={loadDashboard}
+            className="mt-3 text-xs text-amber-300 hover:text-amber-200 transition-colors"
+          >
+            Retry histories
+          </button>
+        </div>
+      )}
 
       {/* Pending banner */}
       <AnimatePresence>
@@ -178,7 +197,11 @@ export default function DashboardOverview() {
 
         {recentTx.length === 0 ? (
           <div className="py-16 text-center border border-border-subtle">
-            <p className="text-text-tertiary text-sm">No transactions yet</p>
+            <p className="text-text-tertiary text-sm">
+              {failedHistoryCount > 0
+                ? "No transactions returned by the available histories"
+                : "No transactions yet"}
+            </p>
             <p className="text-text-tertiary text-xs mt-1">Create an agent to get started</p>
             <Link
               href="/dashboard/agents"

--- a/web/src/app/dashboard/transactions/page.tsx
+++ b/web/src/app/dashboard/transactions/page.tsx
@@ -3,7 +3,7 @@
 import type { TxRecord } from "@stwd/sdk";
 import { motion } from "framer-motion";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { ChainBadge } from "@/components/chain-badge";
 import { StatusBadge } from "@/components/status-badge";
 import { steward } from "@/lib/api";
@@ -18,18 +18,17 @@ export default function TransactionsPage() {
   const [transactions, setTransactions] = useState<TxWithAgent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [failedHistoryCount, setFailedHistoryCount] = useState(0);
   const [filter, setFilter] = useState<string>("all");
 
-  useEffect(() => {
-    loadTransactions();
-  }, [loadTransactions]);
-
-  async function loadTransactions() {
+  const loadTransactions = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
+      setFailedHistoryCount(0);
       const agents = await steward.listAgents();
       const allTx: TxWithAgent[] = [];
+      let failedCount = 0;
 
       for (const agent of agents) {
         try {
@@ -42,7 +41,7 @@ export default function TransactionsPage() {
             })),
           );
         } catch {
-          /* skip individual agent */
+          failedCount += 1;
         }
       }
 
@@ -50,12 +49,17 @@ export default function TransactionsPage() {
         (a, b) => new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime(),
       );
       setTransactions(allTx);
+      setFailedHistoryCount(failedCount);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to load transactions");
     } finally {
       setLoading(false);
     }
-  }
+  }, []);
+
+  useEffect(() => {
+    void loadTransactions();
+  }, [loadTransactions]);
 
   const filtered =
     filter === "all" ? transactions : transactions.filter((tx) => tx.status === filter);
@@ -104,6 +108,22 @@ export default function TransactionsPage() {
         </div>
       )}
 
+      {!error && failedHistoryCount > 0 && (
+        <div role="alert" className="border border-amber-400/30 bg-amber-400/5 p-4">
+          <p className="text-sm text-amber-300">Transaction history is incomplete</p>
+          <p className="mt-1 text-xs text-text-tertiary">
+            {failedHistoryCount} agent {failedHistoryCount === 1 ? "history" : "histories"} failed
+            to load. The list and counts include only the available histories.
+          </p>
+          <button
+            onClick={loadTransactions}
+            className="mt-3 text-xs text-amber-300 hover:text-amber-200 transition-colors"
+          >
+            Retry histories
+          </button>
+        </div>
+      )}
+
       {/* Filters */}
       <div className="flex gap-1 flex-wrap">
         {FILTERS.map((status) => (
@@ -128,7 +148,11 @@ export default function TransactionsPage() {
       {error ? null : filtered.length === 0 ? (
         <div className="py-16 text-center border border-border-subtle">
           <p className="text-text-tertiary text-sm">
-            {filter === "all" ? "No transactions yet" : `No ${filter} transactions`}
+            {filter === "all"
+              ? failedHistoryCount > 0
+                ? "No transactions returned by the available histories"
+                : "No transactions yet"
+              : `No ${filter} transactions`}
           </p>
           {filter === "all" && (
             <p className="text-text-tertiary text-xs mt-1">


### PR DESCRIPTION
Closes #645

## Summary
- surface per-agent transaction-history failures instead of presenting partial counts as authoritative
- preserve available history and label pending/list totals as partial
- stabilize dashboard loaders and add production-browser coverage across overview and transaction pages

## Exact validation
- base: `90895ea25dd1cae4952f4409a04fcce09bbbc0df`
- head: `dbb212e07511316b06b460655432c6e867bf9569`
- production Chromium regression: 1/1
- production Next build: pass
- `web` TypeScript: pass
- targeted Biome: pass
- `git diff --check`: pass

Draft pending exact hosted CI and independent review.