### PR TITLE
fix(security): eliminate CodeQL path races

### DIFF
--- a/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
@@ -191,8 +191,9 @@ beforeAll(async () => {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url =
       typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-    if (url.startsWith(PROXY_URL) && proxyApp) {
-      const path = url.slice(PROXY_URL.length) || "/";
+    const parsedUrl = new URL(url);
+    if (parsedUrl.origin === PROXY_URL && proxyApp) {
+      const path = `${parsedUrl.pathname}${parsedUrl.search}`;
       lastProxyRequestHeaders = new Headers(init?.headers);
       lastProxyRequest = {
         path,

--- a/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
+++ b/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
@@ -88,10 +88,7 @@ beforeAll(async () => {
       {
         id: TENANT_NO_KEY_ID,
         name: "Agent Token Expiry No Key Tenant",
-        // Keep the unique empty hash available for the bootstrap default
-        // tenant. Omitting X-Steward-Key still exercises the unauthenticated
-        // tenant path without racing defaultTenantReady during module import.
-        apiKeyHash: "not-a-real-key-hash-no-key-tenant",
+        apiKeyHash: "",
       },
       {
         id: OTHER_TENANT_ID,

--- a/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
+++ b/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
@@ -88,7 +88,10 @@ beforeAll(async () => {
       {
         id: TENANT_NO_KEY_ID,
         name: "Agent Token Expiry No Key Tenant",
-        apiKeyHash: "",
+        // Keep the unique empty hash available for the bootstrap default
+        // tenant. Omitting X-Steward-Key still exercises the unauthenticated
+        // tenant path without racing defaultTenantReady during module import.
+        apiKeyHash: "not-a-real-key-hash-no-key-tenant",
       },
       {
         id: OTHER_TENANT_ID,

--- a/packages/proxy/src/__tests__/proxy-approval-expiry-audit-atomicity.test.ts
+++ b/packages/proxy/src/__tests__/proxy-approval-expiry-audit-atomicity.test.ts
@@ -64,18 +64,13 @@ let proxyMod: typeof import("../handlers/proxy");
 
 let faultAuditInsert = false;
 
-type TxLike = {
-  execute: (query: unknown) => Promise<unknown>;
-  transaction?: (cb: (tx: TxLike) => Promise<unknown>, ...rest: unknown[]) => Promise<unknown>;
-};
+type TxLike = { execute: (query: unknown) => Promise<unknown> };
 
 function isAuditInsert(dialect: unknown, query: unknown): boolean {
   try {
     const built = (dialect as { sqlToQuery: (q: unknown) => { sql?: string } }).sqlToQuery(query);
-    const text = String(built?.sql ?? "")
-      .toLowerCase()
-      .replaceAll('"', "");
-    return /\binsert\s+into\s+(?:[a-z0-9_]+\.)?audit_events\b/.test(text);
+    const text = String(built?.sql ?? "").toLowerCase();
+    return text.includes("insert into audit_events");
   } catch {
     return false;
   }
@@ -88,32 +83,17 @@ function installFaultInjectingDb(db: unknown): void {
   };
   const dialect = anyDb.dialect;
   const originalTransaction = anyDb.transaction.bind(anyDb);
-  const instrumentTransaction = (tx: TxLike): void => {
-    const originalExecute = tx.execute.bind(tx);
-    tx.execute = async (query: unknown) => {
-      if (faultAuditInsert && isAuditInsert(dialect, query)) {
-        faultAuditInsert = false; // fault the first audit insert only
-        throw new Error("injected audit-chain fault");
-      }
-      return originalExecute(query);
-    };
-
-    if (tx.transaction) {
-      const originalNestedTransaction = tx.transaction.bind(tx);
-      tx.transaction = (cb: (nestedTx: TxLike) => Promise<unknown>, ...rest: unknown[]) =>
-        originalNestedTransaction(
-          async (nestedTx: TxLike) => {
-            instrumentTransaction(nestedTx);
-            return cb(nestedTx);
-          },
-          ...rest,
-        );
-    }
-  };
   anyDb.transaction = (cb: (tx: TxLike) => Promise<unknown>, ...rest: unknown[]) => {
     return originalTransaction(
       async (tx: TxLike) => {
-        instrumentTransaction(tx);
+        const originalExecute = tx.execute.bind(tx);
+        tx.execute = async (query: unknown) => {
+          if (faultAuditInsert && isAuditInsert(dialect, query)) {
+            faultAuditInsert = false; // fault the first audit insert only
+            throw new Error("injected audit-chain fault");
+          }
+          return originalExecute(query);
+        };
         return cb(tx);
       },
       ...rest,

--- a/packages/proxy/src/__tests__/proxy-approval-expiry-audit-atomicity.test.ts
+++ b/packages/proxy/src/__tests__/proxy-approval-expiry-audit-atomicity.test.ts
@@ -64,13 +64,18 @@ let proxyMod: typeof import("../handlers/proxy");
 
 let faultAuditInsert = false;
 
-type TxLike = { execute: (query: unknown) => Promise<unknown> };
+type TxLike = {
+  execute: (query: unknown) => Promise<unknown>;
+  transaction?: (cb: (tx: TxLike) => Promise<unknown>, ...rest: unknown[]) => Promise<unknown>;
+};
 
 function isAuditInsert(dialect: unknown, query: unknown): boolean {
   try {
     const built = (dialect as { sqlToQuery: (q: unknown) => { sql?: string } }).sqlToQuery(query);
-    const text = String(built?.sql ?? "").toLowerCase();
-    return text.includes("insert into audit_events");
+    const text = String(built?.sql ?? "")
+      .toLowerCase()
+      .replaceAll('"', "");
+    return /\binsert\s+into\s+(?:[a-z0-9_]+\.)?audit_events\b/.test(text);
   } catch {
     return false;
   }
@@ -83,17 +88,32 @@ function installFaultInjectingDb(db: unknown): void {
   };
   const dialect = anyDb.dialect;
   const originalTransaction = anyDb.transaction.bind(anyDb);
+  const instrumentTransaction = (tx: TxLike): void => {
+    const originalExecute = tx.execute.bind(tx);
+    tx.execute = async (query: unknown) => {
+      if (faultAuditInsert && isAuditInsert(dialect, query)) {
+        faultAuditInsert = false; // fault the first audit insert only
+        throw new Error("injected audit-chain fault");
+      }
+      return originalExecute(query);
+    };
+
+    if (tx.transaction) {
+      const originalNestedTransaction = tx.transaction.bind(tx);
+      tx.transaction = (cb: (nestedTx: TxLike) => Promise<unknown>, ...rest: unknown[]) =>
+        originalNestedTransaction(
+          async (nestedTx: TxLike) => {
+            instrumentTransaction(nestedTx);
+            return cb(nestedTx);
+          },
+          ...rest,
+        );
+    }
+  };
   anyDb.transaction = (cb: (tx: TxLike) => Promise<unknown>, ...rest: unknown[]) => {
     return originalTransaction(
       async (tx: TxLike) => {
-        const originalExecute = tx.execute.bind(tx);
-        tx.execute = async (query: unknown) => {
-          if (faultAuditInsert && isAuditInsert(dialect, query)) {
-            faultAuditInsert = false; // fault the first audit insert only
-            throw new Error("injected audit-chain fault");
-          }
-          return originalExecute(query);
-        };
+        instrumentTransaction(tx);
         return cb(tx);
       },
       ...rest,

--- a/packages/proxy/src/__tests__/proxy-approval-expiry-audit-atomicity.test.ts
+++ b/packages/proxy/src/__tests__/proxy-approval-expiry-audit-atomicity.test.ts
@@ -9,6 +9,7 @@ import {
   getDb,
   pendingProxyRequests,
   proxyAuditLog,
+  sql,
   tenants,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
@@ -30,10 +31,10 @@ import { PROXY_SCOPE } from "../config";
 // shared `@stwd/db` `withTenantAuditedTransaction` primitive to commit the
 // `expired` transition AND a `proxy.approval.expired` chain event in ONE
 // transaction. This suite drives the real release handler against a PGLite DB
-// whose transaction layer is instrumented to throw at the audit-chain INSERT and
-// proves:
+// with a database trigger that rejects the required audit INSERT inside that
+// same transaction. It proves:
 //   1. audit-chain event present on the happy path (both poll-time & claim-time);
-//   2. both-or-neither: when the chain INSERT faults, the `expired` transition
+//   2. both-or-neither: when the chain append faults, the `expired` transition
 //      rolls back too (I14) and no chain event exists;
 //   3. mutation proof (revert): if the transition is not wrapped with the chain
 //      append, the fault would leave `expired` with no chain event — asserted by
@@ -55,52 +56,6 @@ let resetReleaseClaimBarrier: typeof import("../handlers/release")["__resetRelea
 let setForwardProxyRequest: typeof import("../handlers/proxy")["__setForwardProxyRequestForTests"];
 let proxyMod: typeof import("../handlers/proxy");
 
-// ─── Audit-chain-insert fault injection ───────────────────────────────────────
-//
-// When `faultAuditInsert` is true, the FIRST `insert into audit_events`
-// executed inside any transaction throws. This simulates the exact crash point:
-// the row was just flipped to `expired` in the same transaction and the required
-// chain append fails.
-
-let faultAuditInsert = false;
-
-type TxLike = { execute: (query: unknown) => Promise<unknown> };
-
-function isAuditInsert(dialect: unknown, query: unknown): boolean {
-  try {
-    const built = (dialect as { sqlToQuery: (q: unknown) => { sql?: string } }).sqlToQuery(query);
-    const text = String(built?.sql ?? "").toLowerCase();
-    return text.includes("insert into audit_events");
-  } catch {
-    return false;
-  }
-}
-
-function installFaultInjectingDb(db: unknown): void {
-  const anyDb = db as {
-    dialect: unknown;
-    transaction: (cb: (tx: TxLike) => Promise<unknown>, ...rest: unknown[]) => Promise<unknown>;
-  };
-  const dialect = anyDb.dialect;
-  const originalTransaction = anyDb.transaction.bind(anyDb);
-  anyDb.transaction = (cb: (tx: TxLike) => Promise<unknown>, ...rest: unknown[]) => {
-    return originalTransaction(
-      async (tx: TxLike) => {
-        const originalExecute = tx.execute.bind(tx);
-        tx.execute = async (query: unknown) => {
-          if (faultAuditInsert && isAuditInsert(dialect, query)) {
-            faultAuditInsert = false; // fault the first audit insert only
-            throw new Error("injected audit-chain fault");
-          }
-          return originalExecute(query);
-        };
-        return cb(tx);
-      },
-      ...rest,
-    );
-  };
-}
-
 beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
@@ -109,9 +64,9 @@ beforeAll(async () => {
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.example.com";
   process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS = "api.example.com";
   process.env.STEWARD_ALLOW_BROAD_SECRET_ROUTES = "true";
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
 
   const { db, client } = await createPGLiteDb("memory://");
-  installFaultInjectingDb(db);
   setPGLiteOverride(db, async () => {
     await client.close();
   });
@@ -130,7 +85,6 @@ beforeAll(async () => {
 });
 
 afterEach(() => {
-  faultAuditInsert = false;
   resetReleaseClaimBarrier();
 });
 
@@ -143,7 +97,39 @@ afterAll(async () => {
   delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
   delete process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS;
   delete process.env.STEWARD_ALLOW_BROAD_SECRET_ROUTES;
+  delete process.env.STEWARD_PROXY_DEV_MODE;
 });
+
+async function withExpiryAuditFailure<T>(operation: () => Promise<T>): Promise<T> {
+  await getDb().execute(
+    sql.raw(`
+    CREATE OR REPLACE FUNCTION fail_proxy_expiry_audit_for_test()
+    RETURNS trigger AS $$
+    BEGIN
+      IF NEW.action = 'proxy.approval.expired' THEN
+        RAISE EXCEPTION 'injected audit-chain fault';
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+  `),
+  );
+  await getDb().execute(
+    sql.raw(`
+    CREATE TRIGGER proxy_expiry_audit_failure_for_test
+    BEFORE INSERT ON audit_events
+    FOR EACH ROW EXECUTE FUNCTION fail_proxy_expiry_audit_for_test()
+  `),
+  );
+  try {
+    return await operation();
+  } finally {
+    await getDb().execute(
+      sql.raw("DROP TRIGGER IF EXISTS proxy_expiry_audit_failure_for_test ON audit_events"),
+    );
+    await getDb().execute(sql.raw("DROP FUNCTION IF EXISTS fail_proxy_expiry_audit_for_test()"));
+  }
+}
 
 function buildApp() {
   const app = new Hono();
@@ -289,8 +275,9 @@ describe("proxy approval-expiry audit atomicity (fault injection)", () => {
       .set({ expiresAt: new Date(Date.now() - 60_000), updatedAt: new Date() })
       .where(eq(pendingProxyRequests.id, held.id));
 
-    faultAuditInsert = true;
-    const res = await poll(held.id, await tokenFor(agentId, tenantId));
+    const res = await withExpiryAuditFailure(async () =>
+      poll(held.id, await tokenFor(agentId, tenantId)),
+    );
     // The injected fault propagates out of the release handler as a 5xx.
     expect(res.status).toBeGreaterThanOrEqual(500);
 
@@ -367,8 +354,9 @@ describe("proxy approval-expiry audit atomicity (fault injection)", () => {
     });
     installCountedForwarder();
 
-    faultAuditInsert = true;
-    const res = await poll(held.id, await tokenFor(agentId, tenantId));
+    const res = await withExpiryAuditFailure(async () =>
+      poll(held.id, await tokenFor(agentId, tenantId)),
+    );
     expect(res.status).toBeGreaterThanOrEqual(500);
 
     // ATOMICITY: the approved -> expired transition rolls back with the faulted

--- a/packages/seed/src/__tests__/demo-api-key.test.ts
+++ b/packages/seed/src/__tests__/demo-api-key.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
+  closeSync,
+  constants as fsConstants,
+  fstatSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readdirSync,
   readFileSync,
   realpathSync,
@@ -22,6 +26,16 @@ import {
 
 function tempRoot(prefix: string): string {
   return realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+}
+
+function readFileWithoutFollowingLinks(path: string): { contents: string; mode: number } {
+  const fd = openSync(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    const stat = fstatSync(fd);
+    return { contents: readFileSync(fd, "utf8"), mode: stat.mode };
+  } finally {
+    closeSync(fd);
+  }
 }
 
 describe("demo API key", () => {
@@ -44,11 +58,10 @@ describe("demo API key", () => {
       const nextKey = generateDemoApiKey().key;
       const pending = stageDemoCredentials("waifu.fun", nextKey, path);
       expect(lstatSync(dirname(path)).mode & 0o777).toBe(0o700);
-      expect(lstatSync(pending.pendingPath).mode & 0o777).toBe(0o600);
+      const staged = readFileWithoutFollowingLinks(pending.pendingPath);
+      expect(staged.mode & 0o777).toBe(0o600);
       expect(readFileSync(path, "utf8")).toContain(`STEWARD_API_KEY=${oldKey}`);
-      expect(readFileSync(pending.pendingPath, "utf8")).toBe(
-        `STEWARD_TENANT_ID=waifu.fun\nSTEWARD_API_KEY=${nextKey}\n`,
-      );
+      expect(staged.contents).toBe(`STEWARD_TENANT_ID=waifu.fun\nSTEWARD_API_KEY=${nextKey}\n`);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -172,8 +185,9 @@ describe("demo API key", () => {
       symlinkSync(canonical, linkedFile);
       const pending = stageDemoCredentials("waifu.fun", generateDemoApiKey().key, linkedFile);
       promoteDemoCredentials(pending);
-      expect(lstatSync(linkedFile).isSymbolicLink()).toBe(false);
-      expect(readFileSync(canonical, "utf8")).not.toBe(readFileSync(linkedFile, "utf8"));
+      expect(readFileSync(canonical, "utf8")).not.toBe(
+        readFileWithoutFollowingLinks(linkedFile).contents,
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/seed/src/demo-api-key.ts
+++ b/packages/seed/src/demo-api-key.ts
@@ -43,12 +43,8 @@ function assertApiKey(apiKey: string): void {
 function credentialParent(path: string): { device: number; inode: number } {
   const parentPath = dirname(path);
   mkdirSync(parentPath, { recursive: true, mode: 0o700 });
-  const parent = lstatSync(parentPath);
-  if (!parent.isDirectory() || parent.isSymbolicLink() || realpathSync(parentPath) !== parentPath) {
+  if (realpathSync(parentPath) !== parentPath) {
     throw new Error("Demo credentials parent must not contain redirected directories");
-  }
-  if (typeof process.geteuid === "function" && parent.uid !== process.geteuid()) {
-    throw new Error("Demo credentials parent must be owned by the current user");
   }
   const fd = openSync(
     parentPath,
@@ -56,8 +52,11 @@ function credentialParent(path: string): { device: number; inode: number } {
   );
   try {
     const opened = fstatSync(fd);
-    if (!opened.isDirectory() || opened.dev !== parent.dev || opened.ino !== parent.ino) {
-      throw new Error("Demo credentials parent changed during validation");
+    if (!opened.isDirectory()) {
+      throw new Error("Demo credentials parent must be a directory");
+    }
+    if (typeof process.geteuid === "function" && opened.uid !== process.geteuid()) {
+      throw new Error("Demo credentials parent must be owned by the current user");
     }
     fchmodSync(fd, 0o700);
     return { device: opened.dev, inode: opened.ino };
@@ -181,34 +180,15 @@ export function promoteDemoCredentials(pending: PendingDemoCredentials): string 
         throw new Error(`Could not allocate promotion link; recover ${pending.pendingPath}`);
       }
 
-      const linkedPath = lstatSync(promotionPath);
       const promotionFd = openSync(
         promotionPath,
         fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK,
       );
       try {
         const linkedFd = fstatSync(promotionFd);
-        if (
-          !linkedPath.isFile() ||
-          !linkedFd.isFile() ||
-          linkedPath.dev !== staged.dev ||
-          linkedPath.ino !== staged.ino ||
-          linkedFd.dev !== staged.dev ||
-          linkedFd.ino !== staged.ino
-        ) {
+        if (!linkedFd.isFile() || linkedFd.dev !== staged.dev || linkedFd.ino !== staged.ino) {
           throw new Error(
             `Pending credential changed during promotion; recover ${pending.pendingPath}`,
-          );
-        }
-
-        const beforeRename = lstatSync(promotionPath);
-        if (
-          !beforeRename.isFile() ||
-          beforeRename.dev !== linkedFd.dev ||
-          beforeRename.ino !== linkedFd.ino
-        ) {
-          throw new Error(
-            `Pending credential changed before canonical rename; recover ${pending.pendingPath}`,
           );
         }
 


### PR DESCRIPTION
## Summary
- match the in-process proxy by parsed URL origin instead of a hostname-prefix substring
- validate credential directories and promotion links through opened descriptors
- make file assertions read and inspect the same no-follow descriptor
- replace the proxy expiry audit test's private Drizzle monkeypatch with a real database-trigger rollback proof

## Exact validation
- base: `90895ea25dd1cae4952f4409a04fcce09bbbc0df`
- head: `a2acae68b14d49cbf26bd66d2c1318cc66bbd666`
- JavaScript/TypeScript CodeQL: pass on the owning three-file repair
- package graph build: 36/36
- seed: 8/8
- session broker: 9/9
- proxy CI-equivalent package: 28/28 files
- targeted Biome and `git diff --check`: pass

Closes the five high-severity CodeQL annotations on develop check run 96358509023.

Draft remains intentionally blocked: the hostile empty-hash tenant fixture is preserved, so current develop still exposes #601's production default-tenant bootstrap regression until #654 migration 0112 lands. Rebase and rerun the entire exact matrix afterward.