### PR TITLE
fix(ci): gate staging on exact green builds

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,9 +4,10 @@
 #   develop  ──(this workflow, auto)──▶  STAGING
 #   main     ──(deploy-railway.yml, manual/gated)──▶  PRODUCTION
 #
-# This runs automatically after the Docker image for `develop` is built +
-# pushed, then points the Railway staging steward-api service at that image.
-# Staging therefore always tracks the latest green develop, so it can never
+# This runs automatically after the full CI workflow for `develop` succeeds,
+# then verifies the exact Docker image also built successfully before pointing
+# Railway staging at that immutable image. Staging therefore tracks accepted
+# develop commits, so it can never
 # silently drift behind (the failure mode that stranded staging on a stale
 # pre-#129 build and broke the cloud→Steward auth-gate).
 #
@@ -15,11 +16,10 @@
 name: Deploy Staging
 
 on:
-  # Run after the Docker build+push workflow completes successfully on develop.
-  # Gating on workflow_run (not push) means we only ship an image that actually
-  # built + passed the Docker workflow — no half-built staging.
+  # Run only after the complete CI workflow finishes on develop. The job then
+  # waits for and verifies the independent exact-SHA Docker build.
   workflow_run:
-    workflows: ["Docker"]
+    workflows: ["CI"]
     types: [completed]
     branches: [develop]
 
@@ -33,6 +33,7 @@ on:
         default: "develop"
 
 permissions:
+  actions: read
   contents: read
   deployments: write
 
@@ -45,11 +46,9 @@ concurrency:
 jobs:
   deploy-staging:
     runs-on: ubuntu-latest
-    # On workflow_run, deploy only a successful Docker build for the commit
-    # that is still at the tip of develop. GITHUB_SHA for workflow_run is the
-    # default-branch tip when this downstream run is created; without this
-    # equality check, a slower Docker run for an older push can deploy after a
-    # newer commit has already landed.
+    # On workflow_run, deploy only after the complete CI workflow succeeds.
+    # The verification step below independently binds the SHA to live develop
+    # and to a completed successful Docker build.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
@@ -58,6 +57,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Bun
+        if: github.event_name == 'workflow_run'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3"
+
+      - name: Verify exact CI candidate and Docker image
+        if: github.event_name == 'workflow_run'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_REPOSITORY: ${{ github.repository }}
+          TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
+          TARGET_BRANCH: develop
+          TARGET_CI_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: bun scripts/verify-staging-deploy-readiness.ts
 
       - name: Resolve image tag
         id: resolve

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,9 +4,9 @@
 #   develop  ──(this workflow, auto)──▶  STAGING
 #   main     ──(deploy-railway.yml, manual/gated)──▶  PRODUCTION
 #
-# This runs automatically after the full CI workflow for `develop` succeeds,
-# then verifies the exact Docker image also built successfully before pointing
-# Railway staging at that immutable image. Staging therefore tracks accepted
+# This reconciles after either the full CI or Docker workflow for `develop`
+# succeeds, then verifies that both exact-SHA runs completed successfully before
+# pointing Railway staging at that immutable image. Staging therefore tracks accepted
 # develop commits, so it can never
 # silently drift behind (the failure mode that stranded staging on a stale
 # pre-#129 build and broke the cloud→Steward auth-gate).
@@ -16,10 +16,10 @@
 name: Deploy Staging
 
 on:
-  # Run only after the complete CI workflow finishes on develop. The job then
-  # waits for and verifies the independent exact-SHA Docker build.
+  # Either completion retriggers reconciliation. This avoids missing a deploy
+  # when one workflow finishes (or is successfully rerun) after the other.
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI", "Docker"]
     types: [completed]
     branches: [develop]
 
@@ -46,9 +46,9 @@ concurrency:
 jobs:
   deploy-staging:
     runs-on: ubuntu-latest
-    # On workflow_run, deploy only after the complete CI workflow succeeds.
-    # The verification step below independently binds the SHA to live develop
-    # and to a completed successful Docker build.
+    # On workflow_run, start only for a successful upstream completion whose SHA
+    # is still live. The verifier independently requires successful exact-SHA
+    # CI and Docker runs, regardless of which workflow triggered this run.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
@@ -65,17 +65,20 @@ jobs:
           bun-version: "1.3"
 
       - name: Verify exact CI candidate and Docker image
+        id: verify
         if: github.event_name == 'workflow_run'
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_REPOSITORY: ${{ github.repository }}
           TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
           TARGET_BRANCH: develop
-          TARGET_CI_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: bun scripts/verify-staging-deploy-readiness.ts
 
       - name: Resolve image tag
         id: resolve
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.verify.outputs.deploy == 'true'
         env:
           DISPATCH_TAG: ${{ inputs.image_tag }}
           EVENT_NAME: ${{ github.event_name }}
@@ -93,6 +96,9 @@ jobs:
 
       - name: Create GitHub deployment (staging)
         id: deployment
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.verify.outputs.deploy == 'true'
         uses: chrnorm/deployment-action@500aa6a23c81ffa1acf71072aee3cfa2cc2e556a # v2
         with:
           token: ${{ github.token }}
@@ -102,6 +108,9 @@ jobs:
 
       - name: Deploy to Railway staging
         id: deploy
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.verify.outputs.deploy == 'true'
         # Instance-specific targets come from the DEPLOYER's repo config, never
         # hardcoded in this sovereign OSS repo. A self-hoster sets their own
         # STAGING_RAILWAY_* repo variables (or this job no-ops via the guard in
@@ -117,7 +126,9 @@ jobs:
           ./scripts/railway-deploy.sh "$RESOLVED_TAG"
 
       - name: Update deployment status (success)
-        if: success()
+        if: >-
+          (github.event_name == 'workflow_dispatch' ||
+          steps.verify.outputs.deploy == 'true') && success()
         uses: chrnorm/deployment-status@6df8d036fd2fee9eb82936733953da1f8382b41e # v2
         with:
           token: ${{ github.token }}
@@ -126,7 +137,9 @@ jobs:
           environment-url: ${{ vars.STAGING_RAILWAY_HEALTH_URL }}
 
       - name: Update deployment status (failure)
-        if: failure()
+        if: >-
+          (github.event_name == 'workflow_dispatch' ||
+          steps.verify.outputs.deploy == 'true') && failure()
         uses: chrnorm/deployment-status@6df8d036fd2fee9eb82936733953da1f8382b41e # v2
         with:
           token: ${{ github.token }}

--- a/scripts/__tests__/verify-staging-deploy-readiness.test.ts
+++ b/scripts/__tests__/verify-staging-deploy-readiness.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { evaluateStagingReadiness } from "../verify-staging-deploy-readiness";
+
+const SHA = "a".repeat(40);
+const successfulRun = {
+  id: 10,
+  event: "push",
+  head_branch: "develop",
+  head_sha: SHA,
+  status: "completed",
+  conclusion: "success",
+  run_started_at: "2026-08-20T08:00:00Z",
+  created_at: "2026-08-20T07:59:00Z",
+};
+
+function evaluate(overrides: Partial<Parameters<typeof evaluateStagingReadiness>[0]> = {}) {
+  return evaluateStagingReadiness({
+    targetSha: SHA,
+    targetBranch: "develop",
+    ciConclusion: "success",
+    liveBranchSha: SHA,
+    dockerRuns: [successfulRun],
+    ...overrides,
+  });
+}
+
+describe("staging deployment readiness", () => {
+  test("accepts only the live SHA with an exact completed successful Docker run", () => {
+    expect(evaluate()).toEqual({ kind: "ready", runId: 10 });
+  });
+
+  test("rejects a stale candidate before considering Docker results", () => {
+    expect(evaluate({ liveBranchSha: "b".repeat(40) })).toEqual({
+      kind: "rejected",
+      reason: "candidate is no longer the live branch tip",
+    });
+  });
+
+  test("rejects a red or incomplete CI conclusion", () => {
+    for (const conclusion of ["failure", "cancelled", "skipped", "neutral", ""]) {
+      expect(evaluate({ ciConclusion: conclusion }).kind).toBe("rejected");
+    }
+  });
+
+  test("waits for missing and pending exact Docker runs", () => {
+    expect(evaluate({ dockerRuns: [] }).kind).toBe("pending");
+    expect(
+      evaluate({ dockerRuns: [{ ...successfulRun, status: "in_progress", conclusion: null }] })
+        .kind,
+    ).toBe("pending");
+  });
+
+  test("rejects failed, cancelled, wrong-branch, and wrong-SHA runs", () => {
+    for (const conclusion of ["failure", "cancelled", "skipped", "neutral"]) {
+      expect(evaluate({ dockerRuns: [{ ...successfulRun, conclusion }] }).kind).toBe("rejected");
+    }
+    expect(evaluate({ dockerRuns: [{ ...successfulRun, head_branch: "main" }] }).kind).toBe(
+      "pending",
+    );
+    expect(evaluate({ dockerRuns: [{ ...successfulRun, head_sha: "b".repeat(40) }] }).kind).toBe(
+      "pending",
+    );
+  });
+
+  test("uses the latest retry and rejects an ambiguous latest start", () => {
+    const olderFailure = {
+      ...successfulRun,
+      id: 9,
+      conclusion: "failure",
+      run_started_at: "2026-08-20T07:00:00Z",
+    };
+    expect(evaluate({ dockerRuns: [olderFailure, successfulRun] })).toEqual({
+      kind: "ready",
+      runId: 10,
+    });
+    expect(evaluate({ dockerRuns: [successfulRun, { ...successfulRun, id: 11 }] }).kind).toBe(
+      "rejected",
+    );
+  });
+});

--- a/scripts/__tests__/verify-staging-deploy-readiness.test.ts
+++ b/scripts/__tests__/verify-staging-deploy-readiness.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { evaluateStagingReadiness } from "../verify-staging-deploy-readiness";
+import {
+  evaluateStagingReadiness,
+  isSuccessfulAutomaticStagingDeployment,
+} from "../verify-staging-deploy-readiness";
 
 const SHA = "a".repeat(40);
 const successfulRun = {
@@ -17,8 +20,8 @@ function evaluate(overrides: Partial<Parameters<typeof evaluateStagingReadiness>
   return evaluateStagingReadiness({
     targetSha: SHA,
     targetBranch: "develop",
-    ciConclusion: "success",
     liveBranchSha: SHA,
+    ciRuns: [{ ...successfulRun, id: 9 }],
     dockerRuns: [successfulRun],
     ...overrides,
   });
@@ -26,7 +29,7 @@ function evaluate(overrides: Partial<Parameters<typeof evaluateStagingReadiness>
 
 describe("staging deployment readiness", () => {
   test("accepts only the live SHA with an exact completed successful Docker run", () => {
-    expect(evaluate()).toEqual({ kind: "ready", runId: 10 });
+    expect(evaluate()).toEqual({ kind: "ready", ciRunId: 9, dockerRunId: 10 });
   });
 
   test("rejects a stale candidate before considering Docker results", () => {
@@ -36,13 +39,18 @@ describe("staging deployment readiness", () => {
     });
   });
 
-  test("rejects a red or incomplete CI conclusion", () => {
+  test("rejects a red exact CI run", () => {
     for (const conclusion of ["failure", "cancelled", "skipped", "neutral", ""]) {
-      expect(evaluate({ ciConclusion: conclusion }).kind).toBe("rejected");
+      expect(evaluate({ ciRuns: [{ ...successfulRun, id: 9, conclusion }] }).kind).toBe("rejected");
     }
   });
 
-  test("waits for missing and pending exact Docker runs", () => {
+  test("waits for missing and pending exact CI or Docker runs", () => {
+    expect(evaluate({ ciRuns: [] }).kind).toBe("pending");
+    expect(
+      evaluate({ ciRuns: [{ ...successfulRun, id: 9, status: "in_progress", conclusion: null }] })
+        .kind,
+    ).toBe("pending");
     expect(evaluate({ dockerRuns: [] }).kind).toBe("pending");
     expect(
       evaluate({ dockerRuns: [{ ...successfulRun, status: "in_progress", conclusion: null }] })
@@ -71,10 +79,70 @@ describe("staging deployment readiness", () => {
     };
     expect(evaluate({ dockerRuns: [olderFailure, successfulRun] })).toEqual({
       kind: "ready",
-      runId: 10,
+      ciRunId: 9,
+      dockerRunId: 10,
     });
     expect(evaluate({ dockerRuns: [successfulRun, { ...successfulRun, id: 11 }] }).kind).toBe(
       "rejected",
     );
+  });
+
+  test("reconciles either completion order and accepts a later successful retry", () => {
+    const pending = { ...successfulRun, status: "in_progress", conclusion: null };
+    expect(evaluate({ dockerRuns: [pending] }).kind).toBe("pending");
+    expect(evaluate({ ciRuns: [{ ...pending, id: 9 }] }).kind).toBe("pending");
+
+    const failed = { ...successfulRun, conclusion: "failure" };
+    const successfulRetry = {
+      ...successfulRun,
+      id: 11,
+      run_started_at: "2026-08-20T09:00:00Z",
+    };
+    expect(evaluate({ dockerRuns: [failed] }).kind).toBe("rejected");
+    expect(evaluate({ dockerRuns: [failed, successfulRetry] })).toEqual({
+      kind: "ready",
+      ciRunId: 9,
+      dockerRunId: 11,
+    });
+    expect(
+      evaluate({
+        ciRuns: [
+          { ...failed, id: 9 },
+          { ...successfulRetry, id: 12 },
+        ],
+      }),
+    ).toEqual({ kind: "ready", ciRunId: 12, dockerRunId: 10 });
+  });
+
+  test("suppresses only an exact successful latest automatic staging deployment", () => {
+    const deployment = {
+      id: 20,
+      creator: { login: "github-actions[bot]" },
+      description: `Deploy ghcr.io/steward-fi/steward:sha-${SHA} to Railway staging`,
+      environment: "staging",
+      sha: SHA,
+    };
+    expect(
+      isSuccessfulAutomaticStagingDeployment({
+        deployment,
+        latestStatus: { state: "success" },
+        targetSha: SHA,
+      }),
+    ).toBe(true);
+    for (const changed of [
+      { deployment: { ...deployment, sha: "b".repeat(40) } },
+      { deployment: { ...deployment, environment: "Production" } },
+      { deployment: { ...deployment, creator: { login: "attacker" } } },
+      { deployment: { ...deployment, description: "unrelated deployment" } },
+      { latestStatus: { state: "failure" } },
+    ]) {
+      expect(
+        isSuccessfulAutomaticStagingDeployment({
+          deployment: changed.deployment ?? deployment,
+          latestStatus: changed.latestStatus ?? { state: "success" },
+          targetSha: SHA,
+        }),
+      ).toBe(false);
+    }
   });
 });

--- a/scripts/verify-staging-deploy-readiness.ts
+++ b/scripts/verify-staging-deploy-readiness.ts
@@ -1,0 +1,118 @@
+interface WorkflowRun {
+  id: number;
+  event: string;
+  head_branch: string | null;
+  head_sha: string;
+  status: string;
+  conclusion: string | null;
+  run_started_at: string | null;
+  created_at: string;
+}
+
+export type StagingReadiness =
+  | { kind: "ready"; runId: number }
+  | { kind: "pending"; reason: string }
+  | { kind: "rejected"; reason: string };
+
+export function evaluateStagingReadiness(input: {
+  targetSha: string;
+  targetBranch: string;
+  ciConclusion: string;
+  liveBranchSha: string;
+  dockerRuns: WorkflowRun[];
+}): StagingReadiness {
+  if (input.ciConclusion !== "success") {
+    return { kind: "rejected", reason: `exact CI concluded ${input.ciConclusion}` };
+  }
+  if (input.liveBranchSha !== input.targetSha) {
+    return { kind: "rejected", reason: "candidate is no longer the live branch tip" };
+  }
+  const matches = input.dockerRuns.filter(
+    (run) =>
+      run.event === "push" &&
+      run.head_branch === input.targetBranch &&
+      run.head_sha === input.targetSha,
+  );
+  if (matches.length === 0) {
+    return { kind: "pending", reason: "exact Docker run has not appeared" };
+  }
+  const timestamps = matches.map((run) => run.run_started_at ?? run.created_at);
+  const latestTimestamp = timestamps.sort().at(-1);
+  const latest = matches.filter(
+    (run) => (run.run_started_at ?? run.created_at) === latestTimestamp,
+  );
+  if (latest.length !== 1) {
+    return { kind: "rejected", reason: "exact Docker retry ordering is ambiguous" };
+  }
+  const run = latest[0];
+  if (run.status !== "completed") {
+    return { kind: "pending", reason: "exact Docker run is not complete" };
+  }
+  if (run.conclusion !== "success") {
+    return {
+      kind: "rejected",
+      reason: `exact Docker run concluded ${run.conclusion ?? "unknown"}`,
+    };
+  }
+  return { kind: "ready", runId: run.id };
+}
+
+async function githubJson(path: string, token: string): Promise<unknown> {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) throw new Error(`GitHub API ${path} returned ${response.status}`);
+  return response.json();
+}
+
+function workflowEnvironmentValue(name: string): string | undefined {
+  return process.env[name];
+}
+
+async function main(): Promise<void> {
+  const token = workflowEnvironmentValue("GH_TOKEN");
+  const repository = workflowEnvironmentValue("TARGET_REPOSITORY");
+  const targetSha = workflowEnvironmentValue("TARGET_SHA");
+  const targetBranch = workflowEnvironmentValue("TARGET_BRANCH");
+  const ciConclusion = workflowEnvironmentValue("TARGET_CI_CONCLUSION");
+  if (!token || !repository || !targetSha || !targetBranch || !ciConclusion) {
+    throw new Error("staging readiness environment is incomplete");
+  }
+
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const branch = (await githubJson(
+      `/repos/${repository}/git/ref/heads/${encodeURIComponent(targetBranch)}`,
+      token,
+    )) as { object?: { sha?: string } };
+    const runs = (await githubJson(
+      `/repos/${repository}/actions/workflows/docker.yml/runs?branch=${encodeURIComponent(targetBranch)}&event=push&per_page=100`,
+      token,
+    )) as { workflow_runs?: WorkflowRun[] };
+    const result = evaluateStagingReadiness({
+      targetSha,
+      targetBranch,
+      ciConclusion,
+      liveBranchSha: branch.object?.sha ?? "",
+      dockerRuns: runs.workflow_runs ?? [],
+    });
+    if (result.kind === "ready") {
+      console.log(`Exact Docker run ${result.runId} is complete and successful.`);
+      return;
+    }
+    if (result.kind === "rejected") throw new Error(result.reason);
+    if (attempt === 39) throw new Error(`Timed out: ${result.reason}`);
+    await Bun.sleep(15_000);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : "staging readiness failed");
+    process.exit(1);
+  });
+}

--- a/scripts/verify-staging-deploy-readiness.ts
+++ b/scripts/verify-staging-deploy-readiness.ts
@@ -1,3 +1,5 @@
+import { appendFileSync } from "node:fs";
+
 interface WorkflowRun {
   id: number;
   event: string;
@@ -9,32 +11,37 @@ interface WorkflowRun {
   created_at: string;
 }
 
+interface Deployment {
+  id: number;
+  creator?: { login?: string } | null;
+  description?: string | null;
+  environment?: string | null;
+  sha?: string | null;
+}
+
+interface DeploymentStatus {
+  state?: string | null;
+}
+
 export type StagingReadiness =
-  | { kind: "ready"; runId: number }
+  | { kind: "ready"; ciRunId: number; dockerRunId: number }
   | { kind: "pending"; reason: string }
   | { kind: "rejected"; reason: string };
 
-export function evaluateStagingReadiness(input: {
+function evaluateWorkflowRuns(input: {
+  workflowName: string;
   targetSha: string;
   targetBranch: string;
-  ciConclusion: string;
-  liveBranchSha: string;
-  dockerRuns: WorkflowRun[];
-}): StagingReadiness {
-  if (input.ciConclusion !== "success") {
-    return { kind: "rejected", reason: `exact CI concluded ${input.ciConclusion}` };
-  }
-  if (input.liveBranchSha !== input.targetSha) {
-    return { kind: "rejected", reason: "candidate is no longer the live branch tip" };
-  }
-  const matches = input.dockerRuns.filter(
+  runs: WorkflowRun[];
+}): StagingReadiness | { kind: "workflow-ready"; runId: number } {
+  const matches = input.runs.filter(
     (run) =>
       run.event === "push" &&
       run.head_branch === input.targetBranch &&
       run.head_sha === input.targetSha,
   );
   if (matches.length === 0) {
-    return { kind: "pending", reason: "exact Docker run has not appeared" };
+    return { kind: "pending", reason: `exact ${input.workflowName} run has not appeared` };
   }
   const timestamps = matches.map((run) => run.run_started_at ?? run.created_at);
   const latestTimestamp = timestamps.sort().at(-1);
@@ -42,19 +49,49 @@ export function evaluateStagingReadiness(input: {
     (run) => (run.run_started_at ?? run.created_at) === latestTimestamp,
   );
   if (latest.length !== 1) {
-    return { kind: "rejected", reason: "exact Docker retry ordering is ambiguous" };
+    return {
+      kind: "rejected",
+      reason: `exact ${input.workflowName} retry ordering is ambiguous`,
+    };
   }
   const run = latest[0];
   if (run.status !== "completed") {
-    return { kind: "pending", reason: "exact Docker run is not complete" };
+    return { kind: "pending", reason: `exact ${input.workflowName} run is not complete` };
   }
   if (run.conclusion !== "success") {
     return {
       kind: "rejected",
-      reason: `exact Docker run concluded ${run.conclusion ?? "unknown"}`,
+      reason: `exact ${input.workflowName} run concluded ${run.conclusion ?? "unknown"}`,
     };
   }
-  return { kind: "ready", runId: run.id };
+  return { kind: "workflow-ready", runId: run.id };
+}
+
+export function evaluateStagingReadiness(input: {
+  targetSha: string;
+  targetBranch: string;
+  liveBranchSha: string;
+  ciRuns: WorkflowRun[];
+  dockerRuns: WorkflowRun[];
+}): StagingReadiness {
+  if (input.liveBranchSha !== input.targetSha) {
+    return { kind: "rejected", reason: "candidate is no longer the live branch tip" };
+  }
+  const ci = evaluateWorkflowRuns({
+    workflowName: "CI",
+    targetSha: input.targetSha,
+    targetBranch: input.targetBranch,
+    runs: input.ciRuns,
+  });
+  if (ci.kind !== "workflow-ready") return ci;
+  const docker = evaluateWorkflowRuns({
+    workflowName: "Docker",
+    targetSha: input.targetSha,
+    targetBranch: input.targetBranch,
+    runs: input.dockerRuns,
+  });
+  if (docker.kind !== "workflow-ready") return docker;
+  return { kind: "ready", ciRunId: ci.runId, dockerRunId: docker.runId };
 }
 
 async function githubJson(path: string, token: string): Promise<unknown> {
@@ -74,13 +111,33 @@ function workflowEnvironmentValue(name: string): string | undefined {
   return process.env[name];
 }
 
+export function isSuccessfulAutomaticStagingDeployment(input: {
+  deployment: Deployment;
+  latestStatus: DeploymentStatus | undefined;
+  targetSha: string;
+}): boolean {
+  return (
+    input.deployment.sha === input.targetSha &&
+    input.deployment.environment === "staging" &&
+    input.deployment.creator?.login === "github-actions[bot]" &&
+    input.deployment.description ===
+      `Deploy ghcr.io/steward-fi/steward:sha-${input.targetSha} to Railway staging` &&
+    input.latestStatus?.state === "success"
+  );
+}
+
+function writeDeployOutput(deploy: boolean): void {
+  const outputPath = workflowEnvironmentValue("GITHUB_OUTPUT");
+  if (!outputPath) throw new Error("GITHUB_OUTPUT is unavailable");
+  appendFileSync(outputPath, `deploy=${deploy ? "true" : "false"}\n`, { encoding: "utf8" });
+}
+
 async function main(): Promise<void> {
   const token = workflowEnvironmentValue("GH_TOKEN");
   const repository = workflowEnvironmentValue("TARGET_REPOSITORY");
   const targetSha = workflowEnvironmentValue("TARGET_SHA");
   const targetBranch = workflowEnvironmentValue("TARGET_BRANCH");
-  const ciConclusion = workflowEnvironmentValue("TARGET_CI_CONCLUSION");
-  if (!token || !repository || !targetSha || !targetBranch || !ciConclusion) {
+  if (!token || !repository || !targetSha || !targetBranch) {
     throw new Error("staging readiness environment is incomplete");
   }
 
@@ -89,19 +146,50 @@ async function main(): Promise<void> {
       `/repos/${repository}/git/ref/heads/${encodeURIComponent(targetBranch)}`,
       token,
     )) as { object?: { sha?: string } };
-    const runs = (await githubJson(
-      `/repos/${repository}/actions/workflows/docker.yml/runs?branch=${encodeURIComponent(targetBranch)}&event=push&per_page=100`,
-      token,
-    )) as { workflow_runs?: WorkflowRun[] };
+    const [ciRuns, dockerRuns] = (await Promise.all([
+      githubJson(
+        `/repos/${repository}/actions/workflows/ci.yml/runs?branch=${encodeURIComponent(targetBranch)}&event=push&per_page=100`,
+        token,
+      ),
+      githubJson(
+        `/repos/${repository}/actions/workflows/docker.yml/runs?branch=${encodeURIComponent(targetBranch)}&event=push&per_page=100`,
+        token,
+      ),
+    ])) as [{ workflow_runs?: WorkflowRun[] }, { workflow_runs?: WorkflowRun[] }];
     const result = evaluateStagingReadiness({
       targetSha,
       targetBranch,
-      ciConclusion,
       liveBranchSha: branch.object?.sha ?? "",
-      dockerRuns: runs.workflow_runs ?? [],
+      ciRuns: ciRuns.workflow_runs ?? [],
+      dockerRuns: dockerRuns.workflow_runs ?? [],
     });
     if (result.kind === "ready") {
-      console.log(`Exact Docker run ${result.runId} is complete and successful.`);
+      console.log(
+        `Exact CI run ${result.ciRunId} and Docker run ${result.dockerRunId} are complete and successful.`,
+      );
+      const deployments = (await githubJson(
+        `/repos/${repository}/deployments?environment=staging&per_page=1`,
+        token,
+      )) as Deployment[];
+      const deployment = deployments[0];
+      if (deployment) {
+        const statuses = (await githubJson(
+          `/repos/${repository}/deployments/${deployment.id}/statuses?per_page=1`,
+          token,
+        )) as DeploymentStatus[];
+        if (
+          isSuccessfulAutomaticStagingDeployment({
+            deployment,
+            latestStatus: statuses[0],
+            targetSha,
+          })
+        ) {
+          console.log(`Exact SHA ${targetSha} already has a successful staging deployment.`);
+          writeDeployOutput(false);
+          return;
+        }
+      }
+      writeDeployOutput(true);
       return;
     }
     if (result.kind === "rejected") throw new Error(result.reason);


### PR DESCRIPTION
Closes #659

## Summary
- trigger reconciliation after either exact develop CI or Docker completion, including successful reruns
- independently require current develop tip plus completed successful exact-SHA runs for both workflows
- serialize duplicate triggers and suppress only an already-successful latest automatic deployment of the same immutable SHA
- fail closed for missing, pending, failed, cancelled, skipped, neutral, stale, or ambiguous evidence

## Exact validation
- base: `90895ea25dd1cae4952f4409a04fcce09bbbc0df`
- head: `cfc2e59826fd9ea4d055cde90151603f9f5ce94d`
- staging readiness tests: 8/8, 30 assertions
- Actionlint: pass
- targeted Biome: pass
- `git diff --check`: pass
- independent adversarial review: ACCEPT

Draft pending fresh exact-head hosted CI and final queue review.