### PR TITLE
fix(ci): repair failing jobs and CodeQL alerts

### DIFF
--- a/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
@@ -191,8 +191,9 @@ beforeAll(async () => {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url =
       typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-    if (url.startsWith(PROXY_URL) && proxyApp) {
-      const path = url.slice(PROXY_URL.length) || "/";
+    const parsedUrl = new URL(url);
+    if (parsedUrl.origin === PROXY_URL && proxyApp) {
+      const path = `${parsedUrl.pathname}${parsedUrl.search}`;
       lastProxyRequestHeaders = new Headers(init?.headers);
       lastProxyRequest = {
         path,

--- a/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
+++ b/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
@@ -88,7 +88,10 @@ beforeAll(async () => {
       {
         id: TENANT_NO_KEY_ID,
         name: "Agent Token Expiry No Key Tenant",
-        apiKeyHash: "",
+        // The bootstrap tenant owns the legacy empty-hash sentinel. This
+        // fixture still omits the request key and exercises the same 403 path
+        // without colliding with that unique database value.
+        apiKeyHash: "not-a-real-key-hash-no-key-tenant",
       },
       {
         id: OTHER_TENANT_ID,

--- a/packages/proxy/src/__tests__/proxy-approval-expiry-audit-atomicity.test.ts
+++ b/packages/proxy/src/__tests__/proxy-approval-expiry-audit-atomicity.test.ts
@@ -1,5 +1,4 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
-import { signAgentToken } from "@stwd/auth";
 import {
   agents,
   and,
@@ -9,6 +8,7 @@ import {
   getDb,
   pendingProxyRequests,
   proxyAuditLog,
+  sql,
   tenants,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
@@ -47,6 +47,7 @@ setDefaultTimeout(30000);
 
 const MASTER_PASSWORD = "proxy-expiry-audit-master-password";
 
+let signAgentToken: typeof import("@stwd/auth")["signAgentToken"];
 let authMiddleware: typeof import("../middleware/auth")["authMiddleware"];
 let handlePendingProxyRequest: typeof import("../handlers/release")["handlePendingProxyRequest"];
 let holdProxyApprovalRequest: typeof import("../handlers/approvals")["holdProxyApprovalRequest"];
@@ -57,48 +58,39 @@ let proxyMod: typeof import("../handlers/proxy");
 
 // ─── Audit-chain-insert fault injection ───────────────────────────────────────
 //
-// When `faultAuditInsert` is true, the FIRST `insert into audit_events`
-// executed inside any transaction throws. This simulates the exact crash point:
-// the row was just flipped to `expired` in the same transaction and the required
-// chain append fails.
+// A real database trigger rejects the targeted audit-chain INSERT. This
+// simulates the exact crash point after the row is flipped to `expired` in the
+// same transaction, without depending on Drizzle's internal execution methods.
 
-let faultAuditInsert = false;
+const AUDIT_FAULT_TRIGGER = "proxy_expiry_audit_failure";
+const AUDIT_FAULT_FUNCTION = "fail_proxy_expiry_audit";
 
-type TxLike = { execute: (query: unknown) => Promise<unknown> };
-
-function isAuditInsert(dialect: unknown, query: unknown): boolean {
-  try {
-    const built = (dialect as { sqlToQuery: (q: unknown) => { sql?: string } }).sqlToQuery(query);
-    const text = String(built?.sql ?? "").toLowerCase();
-    return text.includes("insert into audit_events");
-  } catch {
-    return false;
-  }
+async function installAuditInsertFault(): Promise<void> {
+  await getDb().execute(
+    sql.raw(`
+      CREATE OR REPLACE FUNCTION ${AUDIT_FAULT_FUNCTION}()
+      RETURNS trigger AS $$
+      BEGIN
+        IF NEW.action = 'proxy.approval.expired' THEN
+          RAISE EXCEPTION 'injected audit-chain fault';
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+    `),
+  );
+  await getDb().execute(
+    sql.raw(`
+      CREATE TRIGGER ${AUDIT_FAULT_TRIGGER}
+      BEFORE INSERT ON audit_events
+      FOR EACH ROW EXECUTE FUNCTION ${AUDIT_FAULT_FUNCTION}()
+    `),
+  );
 }
 
-function installFaultInjectingDb(db: unknown): void {
-  const anyDb = db as {
-    dialect: unknown;
-    transaction: (cb: (tx: TxLike) => Promise<unknown>, ...rest: unknown[]) => Promise<unknown>;
-  };
-  const dialect = anyDb.dialect;
-  const originalTransaction = anyDb.transaction.bind(anyDb);
-  anyDb.transaction = (cb: (tx: TxLike) => Promise<unknown>, ...rest: unknown[]) => {
-    return originalTransaction(
-      async (tx: TxLike) => {
-        const originalExecute = tx.execute.bind(tx);
-        tx.execute = async (query: unknown) => {
-          if (faultAuditInsert && isAuditInsert(dialect, query)) {
-            faultAuditInsert = false; // fault the first audit insert only
-            throw new Error("injected audit-chain fault");
-          }
-          return originalExecute(query);
-        };
-        return cb(tx);
-      },
-      ...rest,
-    );
-  };
+async function removeAuditInsertFault(): Promise<void> {
+  await getDb().execute(sql.raw(`DROP TRIGGER IF EXISTS ${AUDIT_FAULT_TRIGGER} ON audit_events`));
+  await getDb().execute(sql.raw(`DROP FUNCTION IF EXISTS ${AUDIT_FAULT_FUNCTION}()`));
 }
 
 beforeAll(async () => {
@@ -109,13 +101,15 @@ beforeAll(async () => {
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.example.com";
   process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS = "api.example.com";
   process.env.STEWARD_ALLOW_BROAD_SECRET_ROUTES = "true";
+  process.env.NODE_ENV = "test";
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
 
   const { db, client } = await createPGLiteDb("memory://");
-  installFaultInjectingDb(db);
   setPGLiteOverride(db, async () => {
     await client.close();
   });
 
+  ({ signAgentToken } = await import("@stwd/auth"));
   ({ authMiddleware } = await import("../middleware/auth"));
   ({
     handlePendingProxyRequest,
@@ -130,7 +124,6 @@ beforeAll(async () => {
 });
 
 afterEach(() => {
-  faultAuditInsert = false;
   resetReleaseClaimBarrier();
 });
 
@@ -143,6 +136,8 @@ afterAll(async () => {
   delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
   delete process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS;
   delete process.env.STEWARD_ALLOW_BROAD_SECRET_ROUTES;
+  delete process.env.NODE_ENV;
+  delete process.env.STEWARD_PROXY_DEV_MODE;
 });
 
 function buildApp() {
@@ -207,6 +202,15 @@ async function poll(id: string, token: string): Promise<Response> {
   return buildApp().request(`/approvals/proxy/${id}`, {
     headers: { authorization: `Bearer ${token}` },
   });
+}
+
+async function pollWithAuditInsertFault(id: string, token: string): Promise<Response> {
+  await installAuditInsertFault();
+  try {
+    return await poll(id, token);
+  } finally {
+    await removeAuditInsertFault();
+  }
 }
 
 async function fetchRow(id: string) {
@@ -289,8 +293,7 @@ describe("proxy approval-expiry audit atomicity (fault injection)", () => {
       .set({ expiresAt: new Date(Date.now() - 60_000), updatedAt: new Date() })
       .where(eq(pendingProxyRequests.id, held.id));
 
-    faultAuditInsert = true;
-    const res = await poll(held.id, await tokenFor(agentId, tenantId));
+    const res = await pollWithAuditInsertFault(held.id, await tokenFor(agentId, tenantId));
     // The injected fault propagates out of the release handler as a 5xx.
     expect(res.status).toBeGreaterThanOrEqual(500);
 
@@ -367,8 +370,7 @@ describe("proxy approval-expiry audit atomicity (fault injection)", () => {
     });
     installCountedForwarder();
 
-    faultAuditInsert = true;
-    const res = await poll(held.id, await tokenFor(agentId, tenantId));
+    const res = await pollWithAuditInsertFault(held.id, await tokenFor(agentId, tenantId));
     expect(res.status).toBeGreaterThanOrEqual(500);
 
     // ATOMICITY: the approved -> expired transition rolls back with the faulted

--- a/packages/seed/src/__tests__/demo-api-key.test.ts
+++ b/packages/seed/src/__tests__/demo-api-key.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
+  closeSync,
+  constants as fsConstants,
+  fstatSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readdirSync,
   readFileSync,
   realpathSync,
@@ -24,6 +28,17 @@ function tempRoot(prefix: string): string {
   return realpathSync(mkdtempSync(join(tmpdir(), prefix)));
 }
 
+function readRegularFile(path: string): { contents: string; mode: number } {
+  const fd = openSync(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK);
+  try {
+    const stat = fstatSync(fd);
+    if (!stat.isFile()) throw new Error("Expected a regular test fixture file");
+    return { contents: readFileSync(fd, "utf8"), mode: stat.mode };
+  } finally {
+    closeSync(fd);
+  }
+}
+
 describe("demo API key", () => {
   test("is fresh, high-entropy, and verifies only against its own hash", () => {
     const first = generateDemoApiKey();
@@ -43,10 +58,11 @@ describe("demo API key", () => {
       promoteDemoCredentials(stageDemoCredentials("waifu.fun", oldKey, path));
       const nextKey = generateDemoApiKey().key;
       const pending = stageDemoCredentials("waifu.fun", nextKey, path);
+      const pendingFile = readRegularFile(pending.pendingPath);
       expect(lstatSync(dirname(path)).mode & 0o777).toBe(0o700);
-      expect(lstatSync(pending.pendingPath).mode & 0o777).toBe(0o600);
-      expect(readFileSync(path, "utf8")).toContain(`STEWARD_API_KEY=${oldKey}`);
-      expect(readFileSync(pending.pendingPath, "utf8")).toBe(
+      expect(pendingFile.mode & 0o777).toBe(0o600);
+      expect(readRegularFile(path).contents).toContain(`STEWARD_API_KEY=${oldKey}`);
+      expect(pendingFile.contents).toBe(
         `STEWARD_TENANT_ID=waifu.fun\nSTEWARD_API_KEY=${nextKey}\n`,
       );
     } finally {
@@ -89,10 +105,12 @@ describe("demo API key", () => {
       await expect(operation).rejects.toThrow("rotation outcome is uncertain");
       const error = await operation.catch((caught) => (caught as Error).message);
       expect(error).not.toContain("database canary");
-      expect(readFileSync(path, "utf8")).toContain(`STEWARD_API_KEY=${oldKey}`);
+      expect(readRegularFile(path).contents).toContain(`STEWARD_API_KEY=${oldKey}`);
       const pending = readdirSync(root).find((name) => name.includes(".pending-"));
       expect(pending).toBeTruthy();
-      expect(readFileSync(join(root, pending!), "utf8")).toContain(`STEWARD_API_KEY=${nextKey}`);
+      expect(readRegularFile(join(root, pending!)).contents).toContain(
+        `STEWARD_API_KEY=${nextKey}`,
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -121,9 +139,11 @@ describe("demo API key", () => {
       const error = await operation.catch((caught) => (caught as Error).message);
       expect(committed).toBe(true);
       expect(error).not.toContain("rename canary");
-      expect(readFileSync(path, "utf8")).toContain(`STEWARD_API_KEY=${oldKey}`);
+      expect(readRegularFile(path).contents).toContain(`STEWARD_API_KEY=${oldKey}`);
       const pending = readdirSync(root).find((name) => name.includes(".pending-"));
-      expect(readFileSync(join(root, pending!), "utf8")).toContain(`STEWARD_API_KEY=${nextKey}`);
+      expect(readRegularFile(join(root, pending!)).contents).toContain(
+        `STEWARD_API_KEY=${nextKey}`,
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -146,7 +166,7 @@ describe("demo API key", () => {
         ),
       ).toBe(path);
       expect(committed).toBe(true);
-      expect(readFileSync(path, "utf8")).toContain(`STEWARD_API_KEY=${nextKey}`);
+      expect(readRegularFile(path).contents).toContain(`STEWARD_API_KEY=${nextKey}`);
       expect(readdirSync(root).some((name) => name.includes(".pending-"))).toBe(false);
       expect(readdirSync(root).some((name) => name.includes(".promote-"))).toBe(false);
     } finally {
@@ -172,8 +192,7 @@ describe("demo API key", () => {
       symlinkSync(canonical, linkedFile);
       const pending = stageDemoCredentials("waifu.fun", generateDemoApiKey().key, linkedFile);
       promoteDemoCredentials(pending);
-      expect(lstatSync(linkedFile).isSymbolicLink()).toBe(false);
-      expect(readFileSync(canonical, "utf8")).not.toBe(readFileSync(linkedFile, "utf8"));
+      expect(readRegularFile(canonical).contents).not.toBe(readRegularFile(linkedFile).contents);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -189,7 +208,7 @@ describe("demo API key", () => {
 
       expect(() => promoteDemoCredentials(pending)).toThrow();
       expect(lstatSync(pending.pendingPath).isFile()).toBe(true);
-      expect(readFileSync(join(path, "occupied"), "utf8")).toBe("keep");
+      expect(readRegularFile(join(path, "occupied")).contents).toBe("keep");
       expect(readdirSync(root).some((name) => name.includes(".promote-"))).toBe(false);
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/packages/seed/src/demo-api-key.ts
+++ b/packages/seed/src/demo-api-key.ts
@@ -43,21 +43,26 @@ function assertApiKey(apiKey: string): void {
 function credentialParent(path: string): { device: number; inode: number } {
   const parentPath = dirname(path);
   mkdirSync(parentPath, { recursive: true, mode: 0o700 });
-  const parent = lstatSync(parentPath);
-  if (!parent.isDirectory() || parent.isSymbolicLink() || realpathSync(parentPath) !== parentPath) {
-    throw new Error("Demo credentials parent must not contain redirected directories");
+  let fd: number;
+  try {
+    fd = openSync(
+      parentPath,
+      fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+    );
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ELOOP" || code === "ENOTDIR") {
+      throw new Error("Demo credentials parent must not contain redirected directories");
+    }
+    throw error;
   }
-  if (typeof process.geteuid === "function" && parent.uid !== process.geteuid()) {
-    throw new Error("Demo credentials parent must be owned by the current user");
-  }
-  const fd = openSync(
-    parentPath,
-    fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
-  );
   try {
     const opened = fstatSync(fd);
-    if (!opened.isDirectory() || opened.dev !== parent.dev || opened.ino !== parent.ino) {
-      throw new Error("Demo credentials parent changed during validation");
+    if (!opened.isDirectory() || realpathSync(parentPath) !== parentPath) {
+      throw new Error("Demo credentials parent must not contain redirected directories");
+    }
+    if (typeof process.geteuid === "function" && opened.uid !== process.geteuid()) {
+      throw new Error("Demo credentials parent must be owned by the current user");
     }
     fchmodSync(fd, 0o700);
     return { device: opened.dev, inode: opened.ino };
@@ -181,21 +186,13 @@ export function promoteDemoCredentials(pending: PendingDemoCredentials): string 
         throw new Error(`Could not allocate promotion link; recover ${pending.pendingPath}`);
       }
 
-      const linkedPath = lstatSync(promotionPath);
       const promotionFd = openSync(
         promotionPath,
         fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK,
       );
       try {
         const linkedFd = fstatSync(promotionFd);
-        if (
-          !linkedPath.isFile() ||
-          !linkedFd.isFile() ||
-          linkedPath.dev !== staged.dev ||
-          linkedPath.ino !== staged.ino ||
-          linkedFd.dev !== staged.dev ||
-          linkedFd.ino !== staged.ino
-        ) {
+        if (!linkedFd.isFile() || linkedFd.dev !== staged.dev || linkedFd.ino !== staged.ino) {
           throw new Error(
             `Pending credential changed during promotion; recover ${pending.pendingPath}`,
           );


### PR DESCRIPTION
## Summary
- make plugin-trading no-key fixture compatible with the unique API-key-hash constraint
- inject proxy audit failures through a real database trigger so rollback tests exercise production behavior
- use exact URL-origin matching and descriptor-based file validation to clear the reported CodeQL findings

## Validation
- `bun run lint`
- `bun run typecheck` (36/36 package build tasks plus web TypeScript)
- `bun scripts/check-ci-test-inventory.ts`
- `bun run test` in `packages/plugin-capabilities` (15/15 files)
- `bun run test` in `packages/seed` (14/14)
- full `packages/proxy` suite (317 passing; two host-load timeouts passed individually with 30s timeout)
- full `packages/plugin-trading` suite (167 passing; one host-load timeout passed individually with 120s timeout)
- `git diff --check`