### PR TITLE
fix(api): anchor every Solana broadcast before external I/O

### DIFF
--- a/packages/api/src/__tests__/vault-approval-gates.test.ts
+++ b/packages/api/src/__tests__/vault-approval-gates.test.ts
@@ -28,7 +28,8 @@
  * observable without real key material. Everything else — auth gates, policy
  * re-evaluation, the audit HMAC chain write, and the rollback — runs for real.
  */
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, spyOn } from "bun:test";
+import { createHash } from "node:crypto";
 import {
   agents,
   approvalQueue,
@@ -42,6 +43,8 @@ import {
   userTenants,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { canonicalJsonStringify } from "@stwd/shared";
+import { ExternalBroadcastOutcomeUnknownError, Vault } from "@stwd/vault";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
@@ -64,6 +67,10 @@ const AGENT_AUDIT = `approval-audit-${Date.now()}`;
 const AGENT_LIFECYCLE = `approval-lifecycle-${Date.now()}`;
 const AGENT_SEPARATION = `approval-separation-${Date.now()}`;
 const AGENT_REMOVED_REVIEWER = `approval-removed-reviewer-${Date.now()}`;
+const AGENT_SOLANA = `approval-solana-${Date.now()}`;
+const SOLANA_RECIPIENT = "7J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg";
+const SOLANA_SIGNATURE =
+  "4oL4p7QvN3UH7V5wMGZgW5PuzEk4A9LXLHk9RxAoKjDKuLbQBsfXN8kEvKfj5K1oEJa8wFF6RVp2h7pP9w2f51ZV";
 
 // One app per auth posture. The approve route reads auth purely from context
 // variables, so a per-test middleware that sets exactly the desired posture is
@@ -165,6 +172,89 @@ async function seedPendingTx(
     });
 }
 
+async function seedPendingSolanaApproval() {
+  await getDb().insert(agents).values({
+    id: AGENT_SOLANA,
+    tenantId: TENANT_ID,
+    name: "Approval Gate Solana Agent",
+    walletAddress: "9J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg",
+  });
+  await seedWhitelist(AGENT_SOLANA, [SOLANA_RECIPIENT]);
+  await getDb()
+    .insert(transactions)
+    .values({
+      id: "tx-approved-solana-recovery",
+      agentId: AGENT_SOLANA,
+      status: "pending",
+      toAddress: SOLANA_RECIPIENT,
+      value: "100",
+      data: "serialized-approved-solana",
+      chainId: 101,
+      actionType: "transaction",
+      actionPayload: { type: "transaction", broadcast: true },
+      policyResults: [],
+    });
+  await getDb().insert(approvalQueue).values({
+    id: "aq-tx-approved-solana-recovery",
+    txId: "tx-approved-solana-recovery",
+    agentId: AGENT_SOLANA,
+    status: "pending",
+  });
+}
+
+async function seedCrashedApprovedSolanaExecution() {
+  const txId = "tx-crashed-approved-solana";
+  const basePayload = { type: "transaction", broadcast: true };
+  const requestDigest = createHash("sha256")
+    .update(
+      canonicalJsonStringify({
+        actionPayload: basePayload,
+        actionType: "transaction",
+        agentId: AGENT_SOLANA,
+        chainId: 101,
+        data: "serialized-crashed-approved-solana",
+        id: txId,
+        toAddress: SOLANA_RECIPIENT,
+        value: "200",
+      }),
+    )
+    .digest("hex");
+  await getDb()
+    .insert(transactions)
+    .values({
+      id: txId,
+      agentId: AGENT_SOLANA,
+      status: "pending",
+      toAddress: SOLANA_RECIPIENT,
+      value: "200",
+      data: "serialized-crashed-approved-solana",
+      chainId: 101,
+      actionType: "transaction",
+      actionPayload: {
+        ...basePayload,
+        recoveryType: "solana_transaction",
+        recoveryActionType: "transaction",
+        recoveryAnchor: true,
+        requestDigest,
+        executionToken: "crashed-owner",
+        attemptLeaseUntil: new Date(Date.now() + 60_000).toISOString(),
+      },
+      policyResults: [],
+    });
+  await getDb()
+    .insert(approvalQueue)
+    .values({
+      id: "aq-tx-crashed-approved-solana",
+      txId,
+      agentId: AGENT_SOLANA,
+      status: "approved",
+      resolvedAt: new Date(),
+      resolvedBy: `user:${ACTOR_ID}`,
+      resolvedByType: "user",
+      resolvedById: ACTOR_ID,
+    });
+}
+
 function approve(app: Awaited<ReturnType<typeof makeApp>>, agentId: string, txId: string) {
   return app.request(`/vault/${agentId}/approve/${txId}`, {
     method: "POST",
@@ -229,6 +319,8 @@ describe("vault approval gates (real /approve path)", () => {
     await seedAgent(AGENT_REMOVED_REVIEWER, "5");
     await seedWhitelist(AGENT_REMOVED_REVIEWER, [RECIPIENT]);
     await seedPendingTx(AGENT_REMOVED_REVIEWER, "tx-removed-reviewer", RECIPIENT);
+    await seedPendingSolanaApproval();
+    await seedCrashedApprovedSolanaExecution();
 
     // Lifecycle scenario: a tx that reached "broadcast" but whose approval-queue
     // row is somehow still pending. The lifecycle route must refuse to promote it
@@ -271,6 +363,131 @@ describe("vault approval gates (real /approve path)", () => {
     const body = (await res.json()) as { ok: boolean; error?: string };
     expect(body.ok).toBe(false);
     expect(body.error).toBe("Transaction approval requires owner or admin session");
+  });
+
+  it("checkpoints an approved Solana broadcast before I/O and keeps ambiguous execution terminal", async () => {
+    const app = await makeApp({ authType: "session-jwt", role: "owner", mfa: true });
+    const sign = spyOn(Vault.prototype, "signSolanaTransaction").mockImplementation(
+      async (request) => {
+        const [before] = await getDb()
+          .select()
+          .from(transactions)
+          .where(eq(transactions.id, "tx-approved-solana-recovery"));
+        expect(before.status).toBe("pending");
+        expect(before.actionPayload).toMatchObject({
+          type: "transaction",
+          recoveryActionType: "transaction",
+          recoveryAnchor: true,
+        });
+        await request.onBroadcastPrepared?.({
+          signature: SOLANA_SIGNATURE,
+          recentBlockhash: "11111111111111111111111111111111",
+        });
+        throw new ExternalBroadcastOutcomeUnknownError(SOLANA_SIGNATURE);
+      },
+    );
+    try {
+      const response = await approve(app, AGENT_SOLANA, "tx-approved-solana-recovery");
+      expect(response.status).toBe(202);
+      expect(await response.json()).toMatchObject({
+        ok: false,
+        data: { txHash: SOLANA_SIGNATURE, reconciliationRequired: true },
+      });
+      const [row] = await getDb()
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, "tx-approved-solana-recovery"));
+      expect(row.status).toBe("outcome_unknown");
+      expect(row.txHash).toBe(SOLANA_SIGNATURE);
+      expect(row.actionPayload).toMatchObject({
+        type: "transaction",
+        recoveryActionType: "transaction",
+        recentBlockhash: "11111111111111111111111111111111",
+      });
+      const [approval] = await getDb()
+        .select()
+        .from(approvalQueue)
+        .where(eq(approvalQueue.txId, "tx-approved-solana-recovery"));
+      expect(approval.status).toBe("approved");
+    } finally {
+      sign.mockRestore();
+    }
+  });
+
+  it("blocks a live approved owner then CAS-takes over its expired pre-checkpoint lease once", async () => {
+    const app = await makeApp({ authType: "session-jwt", role: "owner", mfa: true });
+    const live = await approve(app, AGENT_SOLANA, "tx-crashed-approved-solana");
+    expect(live.status).toBe(409);
+    expect(await live.json()).toMatchObject({
+      ok: false,
+      error: "Approved Solana execution is already in progress",
+    });
+
+    const [crashed] = await getDb()
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, "tx-crashed-approved-solana"));
+    await getDb()
+      .update(transactions)
+      .set({
+        actionPayload: {
+          ...(crashed.actionPayload as Record<string, unknown>),
+          attemptLeaseUntil: new Date(Date.now() - 1_000).toISOString(),
+        },
+      })
+      .where(eq(transactions.id, crashed.id));
+
+    let signCalls = 0;
+    let submitted = 0;
+    let signalWinner!: () => void;
+    const winnerStarted = new Promise<void>((resolve) => {
+      signalWinner = resolve;
+    });
+    let releaseWinner!: () => void;
+    const winnerBarrier = new Promise<void>((resolve) => {
+      releaseWinner = resolve;
+    });
+    const sign = spyOn(Vault.prototype, "signSolanaTransaction").mockImplementation(
+      async (request) => {
+        signCalls += 1;
+        signalWinner();
+        await winnerBarrier;
+        await request.onBroadcastPrepared?.({
+          signature: SOLANA_SIGNATURE,
+          recentBlockhash: "11111111111111111111111111111111",
+        });
+        submitted += 1;
+        return { signature: SOLANA_SIGNATURE, broadcast: true, chainId: 101 };
+      },
+    );
+    try {
+      const winnerPromise = approve(app, AGENT_SOLANA, "tx-crashed-approved-solana");
+      await winnerStarted;
+      const concurrentPromise = approve(app, AGENT_SOLANA, "tx-crashed-approved-solana");
+      await Bun.sleep(10);
+      expect(signCalls).toBe(1);
+      expect(submitted).toBe(0);
+      releaseWinner();
+
+      const [winner, concurrent] = await Promise.all([winnerPromise, concurrentPromise]);
+      expect(winner.status).toBe(200);
+      expect([404, 409]).toContain(concurrent.status);
+      expect(signCalls).toBe(1);
+      expect(submitted).toBe(1);
+      const [row] = await getDb()
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, "tx-crashed-approved-solana"));
+      expect(row.status).toBe("broadcast");
+      expect(row.txHash).toBe(SOLANA_SIGNATURE);
+      expect(row.actionPayload).toMatchObject({
+        executionToken: expect.not.stringMatching(/^crashed-owner$/),
+        recentBlockhash: "11111111111111111111111111111111",
+      });
+    } finally {
+      releaseWinner();
+      sign.mockRestore();
+    }
   });
 
   it("refuses approval from an owner session WITHOUT recent MFA", async () => {

--- a/packages/api/src/__tests__/wallet-actions.test.ts
+++ b/packages/api/src/__tests__/wallet-actions.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { agents, closeDb, getDb, policies, tenants, transactions } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { ExternalBroadcastOutcomeUnknownError } from "@stwd/vault";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
@@ -718,6 +719,123 @@ describe("wallet transfer actions", () => {
     } finally {
       context.vault.buildSolanaSplTransferTransaction = originalBuildSplTransfer;
       context.vault.signSolanaTransaction = originalSignSolanaTransaction;
+    }
+  });
+
+  it("anchors and durably replays an ambiguous SPL broadcast without resending", async () => {
+    const context = await import("../services/context");
+    const originalBuild = context.vault.buildSolanaSplTransferTransaction.bind(context.vault);
+    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
+    const signature =
+      "4oL4p7QvN3UH7V5wMGZgW5PuzEk4A9LXLHk9RxAoKjDKuLbQBsfXN8kEvKfj5K1oEJa8wFF6RVp2h7pP9w2f51ZV";
+    let signCalls = 0;
+    context.vault.buildSolanaSplTransferTransaction = async () => ({
+      transaction: "base64-durable-spl-transfer",
+      sourceTokenAccount: "source-token-account",
+      destinationTokenAccount: "destination-token-account",
+      mint: SOLANA_MINT,
+      tokenProgram: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+      decimals: 9,
+    });
+    context.vault.signSolanaTransaction = async (request) => {
+      signCalls += 1;
+      await request.onBroadcastPrepared?.({
+        signature,
+        recentBlockhash: "11111111111111111111111111111111",
+      });
+      throw new ExternalBroadcastOutcomeUnknownError(signature);
+    };
+    const request = (value = "123") =>
+      app.request(`/vault/${SOLANA_AGENT_ID}/actions/transfer`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "Idempotency-Key": "durable-spl" },
+        body: JSON.stringify({
+          to: ALLOWED_SOLANA,
+          token: SOLANA_MINT,
+          value,
+          chainId: 101,
+          broadcast: true,
+        }),
+      });
+
+    try {
+      const first = await request();
+      const firstBody = await first.json();
+      expect(first.status, JSON.stringify(firstBody)).toBe(202);
+      expect(firstBody).toMatchObject({
+        ok: false,
+        data: { txHash: signature, reconciliationRequired: true },
+      });
+      const replay = await request();
+      expect(replay.status).toBe(202);
+      expect(signCalls).toBe(1);
+      const mismatch = await request("124");
+      expect(mismatch.status).toBe(409);
+      expect(signCalls).toBe(1);
+
+      const [row] = await getDb()
+        .select()
+        .from(transactions)
+        .where(eq(transactions.txHash, signature));
+      expect(row.status).toBe("outcome_unknown");
+      expect(row.actionType).toBe("transfer");
+      expect(row.actionPayload).toMatchObject({
+        type: "transfer",
+        recoveryType: "solana_transaction",
+        recoveryActionType: "transfer",
+        token: SOLANA_MINT,
+        recentBlockhash: "11111111111111111111111111111111",
+      });
+    } finally {
+      context.vault.buildSolanaSplTransferTransaction = originalBuild;
+      context.vault.signSolanaTransaction = originalSign;
+    }
+  });
+
+  it("checkpoints native SOL before its lower-level broadcast and preserves the route payload", async () => {
+    const context = await import("../services/context");
+    const originalSign = context.vault.signTransaction.bind(context.vault);
+    const signature =
+      "5oL4p7QvN3UH7V5wMGZgW5PuzEk4A9LXLHk9RxAoKjDKuLbQBsfXN8kEvKfj5K1oEJa8wFF6RVp2h7pP9w2f51ZV";
+    let signCalls = 0;
+    context.vault.signTransaction = async (_request, metadata) => {
+      signCalls += 1;
+      await metadata.onSolanaBroadcastPrepared?.({
+        signature,
+        recentBlockhash: "11111111111111111111111111111111",
+      });
+      throw new ExternalBroadcastOutcomeUnknownError(signature);
+    };
+    const request = () =>
+      app.request(`/vault/${SOLANA_AGENT_ID}/actions/transfer`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "Idempotency-Key": "durable-native-sol" },
+        body: JSON.stringify({
+          to: ALLOWED_SOLANA,
+          value: "321",
+          chainId: 101,
+          broadcast: true,
+        }),
+      });
+
+    try {
+      expect((await request()).status).toBe(202);
+      expect((await request()).status).toBe(202);
+      expect(signCalls).toBe(1);
+      const [row] = await getDb()
+        .select()
+        .from(transactions)
+        .where(eq(transactions.txHash, signature));
+      expect(row).toMatchObject({ status: "outcome_unknown", actionType: "transfer" });
+      expect(row.actionPayload).toMatchObject({
+        type: "transfer",
+        token: "native",
+        amount: "321",
+        recoveryActionType: "transfer",
+        recentBlockhash: "11111111111111111111111111111111",
+      });
+    } finally {
+      context.vault.signTransaction = originalSign;
     }
   });
 

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -3188,6 +3188,27 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
     gasLimit: isTokenTransfer && !isSolanaTokenTransfer ? "65000" : undefined,
     broadcast: transfer.broadcast,
   };
+  const baseTransferActionPayload = transferActionPayload({
+    token: transfer.token,
+    recipient: transfer.to,
+    amount: transfer.value,
+    broadcast: transfer.broadcast,
+    referenceId: transfer.referenceId,
+    sponsorship: sponsorshipPayload,
+  });
+  const solanaRecoveryBinding =
+    isSolanaTransfer && transfer.broadcast
+      ? createSolanaTransferRecoveryBinding(c, {
+          tenantId,
+          agentId,
+          chainId: transfer.chainId,
+          to: transfer.to,
+          token: transfer.token,
+          value: transfer.value,
+          transaction: signRequest.data,
+          referenceId: transfer.referenceId,
+        })
+      : null;
   const policySet = await getScopedPolicySet(tenantId, agentId, c.get("agentPolicyIds"));
   const conditionSets = await loadConditionSetsForPolicies(tenantId, policySet);
 
@@ -3252,7 +3273,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           conditionSets,
         });
 
-    const actionId = crypto.randomUUID();
+    const actionId = solanaRecoveryBinding?.txId ?? crypto.randomUUID();
     if (!evaluation.approved) {
       const status = evaluation.requiresManualApproval ? "pending" : "rejected";
       await db.insert(transactions).values({
@@ -3369,6 +3390,34 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
       );
     }
 
+    let solanaExecutionToken: string | null = null;
+    let storedTransferActionPayload: Record<string, unknown> = baseTransferActionPayload;
+    if (solanaRecoveryBinding) {
+      try {
+        const staged = await stageSolanaRecoveryAnchor({
+          agentId,
+          transaction: signRequest.data ?? "",
+          chainId: transfer.chainId,
+          toAddress: transfer.to,
+          value: transfer.value,
+          broadcastRequested: true,
+          blindSigned: isSolanaTokenTransfer,
+          policyResults: evaluation.results,
+          binding: solanaRecoveryBinding,
+          actionType: "transfer",
+          actionPayload: baseTransferActionPayload,
+        });
+        if (!staged.executionToken) return solanaTransferReplayResponse(c, staged.row);
+        solanaExecutionToken = staged.executionToken;
+        storedTransferActionPayload = readSolanaRecoveryMetadata(staged.row.actionPayload);
+      } catch (error) {
+        if (error instanceof SolanaIdempotencyConflictError) {
+          return c.json<ApiResponse>({ ok: false, error: error.message }, 409);
+        }
+        throw error;
+      }
+    }
+
     let completedResult: string | null = null;
     let completedStatus: "broadcast" | "signed" | null = null;
     try {
@@ -3407,25 +3456,19 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
         if (!signRequest.data) {
           throw new Error("SPL transfer transaction was not built");
         }
-        await db.insert(transactions).values({
-          id: actionId,
-          agentId,
-          status: "pending",
-          toAddress: transfer.to,
-          value: transfer.value,
-          data: signRequest.data,
-          chainId: transfer.chainId,
-          actionType: "transfer",
-          actionPayload: transferActionPayload({
-            token: transfer.token,
-            recipient: transfer.to,
-            amount: transfer.value,
-            broadcast: transfer.broadcast,
-            referenceId: transfer.referenceId,
-            sponsorship: sponsorshipPayload,
-          }),
-          policyResults: evaluation.results,
-        });
+        if (!solanaRecoveryBinding)
+          await db.insert(transactions).values({
+            id: actionId,
+            agentId,
+            status: "pending",
+            toAddress: transfer.to,
+            value: transfer.value,
+            data: signRequest.data,
+            chainId: transfer.chainId,
+            actionType: "transfer",
+            actionPayload: storedTransferActionPayload,
+            policyResults: evaluation.results,
+          });
         const signed = await vault.signSolanaTransaction({
           agentId,
           tenantId,
@@ -3436,6 +3479,17 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           // byte-level check only models native SOL transfers); the edge
           // policy evaluation above approved this transfer.
           allowBlindSign: true,
+          ...(solanaExecutionToken
+            ? {
+                onBroadcastPrepared: (checkpoint) =>
+                  checkpointSolanaBroadcastSubmission(
+                    actionId,
+                    agentId,
+                    solanaExecutionToken,
+                    checkpoint,
+                  ),
+              }
+            : {}),
         });
         result = signed.signature;
       } else {
@@ -3443,6 +3497,17 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           txId: actionId,
           policyResults: evaluation.results,
           status: transfer.broadcast ? "broadcast" : "signed",
+          ...(solanaExecutionToken
+            ? {
+                onSolanaBroadcastPrepared: (checkpoint) =>
+                  checkpointSolanaBroadcastSubmission(
+                    actionId,
+                    agentId,
+                    solanaExecutionToken,
+                    checkpoint,
+                  ),
+              }
+            : {}),
         });
       }
       const txStatus = transfer.broadcast ? "broadcast" : "signed";
@@ -3455,14 +3520,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           status: txStatus,
           txHash: transfer.broadcast ? result : undefined,
           actionType: "transfer",
-          actionPayload: transferActionPayload({
-            token: transfer.token,
-            recipient: transfer.to,
-            amount: transfer.value,
-            broadcast: transfer.broadcast,
-            referenceId: transfer.referenceId,
-            sponsorship: sponsorshipPayload,
-          }),
+          ...(solanaRecoveryBinding ? {} : { actionPayload: storedTransferActionPayload }),
           policyResults: evaluation.results,
           signedAt: new Date(),
         })
@@ -3534,6 +3592,32 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
         }),
       });
     } catch (e: unknown) {
+      if (solanaRecoveryBinding && e instanceof ExternalBroadcastOutcomeUnknownError) {
+        await preserveUnknownSolanaOutcome(
+          actionId,
+          agentId,
+          solanaExecutionToken,
+          e.transactionHash,
+        );
+        return externalBroadcastOutcomeUnknownResponse(c, e, actionId) as Response;
+      }
+      if (solanaRecoveryBinding && e instanceof SolanaBroadcastNotSubmittedError) {
+        await markSolanaBroadcastNotSubmitted(
+          tenantId,
+          actionId,
+          agentId,
+          solanaExecutionToken,
+          e.transactionHash,
+        );
+        return c.json<ApiResponse>(
+          {
+            ok: false,
+            error: "Solana RPC preflight rejected the transfer",
+            data: { actionId },
+          },
+          502,
+        );
+      }
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
       if (completedResult && completedStatus) {
@@ -3543,14 +3627,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
             status: completedStatus,
             txHash: transfer.broadcast ? completedResult : undefined,
             actionType: "transfer",
-            actionPayload: transferActionPayload({
-              token: transfer.token,
-              recipient: transfer.to,
-              amount: transfer.value,
-              broadcast: transfer.broadcast,
-              referenceId: transfer.referenceId,
-              sponsorship: sponsorshipPayload,
-            }),
+            ...(solanaRecoveryBinding ? {} : { actionPayload: storedTransferActionPayload }),
             policyResults: evaluation.results,
             signedAt: new Date(),
           })
@@ -3573,25 +3650,22 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           }),
         });
       }
-      await db.insert(transactions).values({
-        id: actionId,
-        agentId,
-        status: "failed",
-        toAddress: signRequest.to,
-        value: signRequest.value,
-        data: signRequest.data,
-        chainId: signRequest.chainId,
-        actionType: "transfer",
-        actionPayload: transferActionPayload({
-          token: transfer.token,
-          recipient: transfer.to,
-          amount: transfer.value,
-          broadcast: signRequest.broadcast !== false,
-          referenceId: transfer.referenceId,
-          sponsorship: sponsorshipPayload,
-        }),
-        policyResults: evaluation.results,
-      });
+      if (solanaRecoveryBinding) {
+        await markSolanaRecoveryAnchorFailed(actionId, agentId, solanaExecutionToken);
+      } else {
+        await db.insert(transactions).values({
+          id: actionId,
+          agentId,
+          status: "failed",
+          toAddress: signRequest.to,
+          value: signRequest.value,
+          data: signRequest.data,
+          chainId: signRequest.chainId,
+          actionType: "transfer",
+          actionPayload: baseTransferActionPayload,
+          policyResults: evaluation.results,
+        });
+      }
       await recordSponsoredActionIfNeeded({
         sponsorship: sponsorshipPayload,
         tenantId,
@@ -3734,18 +3808,17 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
     .select({
       transaction: transactions,
       approval: {
+        status: approvalQueue.status,
         requestedByType: approvalQueue.requestedByType,
         requestedById: approvalQueue.requestedById,
+        resolvedByType: approvalQueue.resolvedByType,
+        resolvedById: approvalQueue.resolvedById,
       },
     })
     .from(transactions)
     .innerJoin(
       approvalQueue,
-      and(
-        eq(approvalQueue.txId, transactions.id),
-        eq(approvalQueue.agentId, transactions.agentId),
-        eq(approvalQueue.status, "pending"),
-      ),
+      and(eq(approvalQueue.txId, transactions.id), eq(approvalQueue.agentId, transactions.agentId)),
     )
     .where(
       and(
@@ -3771,6 +3844,34 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
   }
 
   const isSolana = transactionRow.chainId === 101 || transactionRow.chainId === 102;
+  const approvalRecoveryMetadata = readSolanaRecoveryMetadata(transactionRow.actionPayload);
+  const isApprovedSolanaResume = pendingApproval.status === "approved" && isSolana;
+  if (pendingApproval.status !== "pending") {
+    const sameResolver =
+      pendingApproval.resolvedByType === approverPrincipal.type &&
+      pendingApproval.resolvedById === approverPrincipal.id;
+    const leaseUntil =
+      typeof approvalRecoveryMetadata.attemptLeaseUntil === "string"
+        ? Date.parse(approvalRecoveryMetadata.attemptLeaseUntil)
+        : Number.NaN;
+    if (
+      !isApprovedSolanaResume ||
+      !sameResolver ||
+      approvalRecoveryMetadata.recoveryType !== "solana_transaction" ||
+      approvalRecoveryMetadata.recoveryActionType !== (transactionRow.actionType ?? "transaction")
+    ) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Transaction already processed or not found" },
+        409,
+      );
+    }
+    if (!Number.isFinite(leaseUntil) || leaseUntil > Date.now()) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Approved Solana execution is already in progress" },
+        409,
+      );
+    }
+  }
   const transferPayload =
     transactionRow.actionType === "transfer"
       ? getTransferActionPayload(transactionRow.actionPayload)
@@ -3858,6 +3959,8 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
     const resolvedAt = new Date();
     let irreversibleResult = false;
     let completedTxHash: string | null = null;
+    let approvedSolanaExecutionToken: string | null = null;
+    let approvedSolanaActionPayload: Record<string, unknown> | null = null;
     try {
       const requestedBroadcast = transferPayload
         ? transferPayload.broadcast
@@ -4112,23 +4215,37 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         );
       }
 
-      const claimResult = await db
-        .update(approvalQueue)
-        .set({
-          status: "approved",
-          resolvedAt,
-          resolvedBy: `${approverPrincipal.type}:${approverPrincipal.id}`,
-          resolvedByType: approverPrincipal.type,
-          resolvedById: approverPrincipal.id,
-        })
-        .where(
-          and(
-            eq(approvalQueue.txId, txId),
-            eq(approvalQueue.agentId, agentId),
-            eq(approvalQueue.status, "pending"),
-          ),
-        )
-        .returning();
+      const claimResult = isApprovedSolanaResume
+        ? await db
+            .select({ id: approvalQueue.id })
+            .from(approvalQueue)
+            .where(
+              and(
+                eq(approvalQueue.txId, txId),
+                eq(approvalQueue.agentId, agentId),
+                eq(approvalQueue.status, "approved"),
+                eq(approvalQueue.resolvedByType, approverPrincipal.type),
+                eq(approvalQueue.resolvedById, approverPrincipal.id),
+              ),
+            )
+            .limit(1)
+        : await db
+            .update(approvalQueue)
+            .set({
+              status: "approved",
+              resolvedAt,
+              resolvedBy: `${approverPrincipal.type}:${approverPrincipal.id}`,
+              resolvedByType: approverPrincipal.type,
+              resolvedById: approverPrincipal.id,
+            })
+            .where(
+              and(
+                eq(approvalQueue.txId, txId),
+                eq(approvalQueue.agentId, agentId),
+                eq(approvalQueue.status, "pending"),
+              ),
+            )
+            .returning();
 
       if (claimResult.length === 0) {
         return c.json<ApiResponse>(
@@ -4181,6 +4298,13 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           return c.json<ApiResponse>({ ok: false, error: reservationError }, 403);
         }
       }
+      if (isSolana && shouldBroadcast) {
+        const claimed = await claimApprovedSolanaExecution(transactionRow, {
+          takeover: isApprovedSolanaResume,
+        });
+        approvedSolanaExecutionToken = claimed.executionToken;
+        approvedSolanaActionPayload = claimed.actionPayload;
+      }
       dispatchIntentWebhook(tenantId, agentId, "intent.authorized", {
         intentId: txId,
         actionType: transactionRow.actionType,
@@ -4209,6 +4333,17 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           ...(isSolanaTokenTransfer
             ? { allowBlindSign: true }
             : { expectedTo: transactionRow.toAddress, expectedValue: transactionRow.value }),
+          ...(approvedSolanaExecutionToken
+            ? {
+                onBroadcastPrepared: (checkpoint) =>
+                  checkpointSolanaBroadcastSubmission(
+                    txId,
+                    agentId,
+                    approvedSolanaExecutionToken!,
+                    checkpoint,
+                  ),
+              }
+            : {}),
         });
         txHash = result.signature;
         irreversibleResult = shouldBroadcast;
@@ -4319,7 +4454,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           : transactionPayload?.broadcast === false
             ? "signed"
             : "broadcast";
-      await db
+      const updatedApprovedTransactions = await db
         .update(transactions)
         .set({
           status: nextStatus,
@@ -4330,28 +4465,48 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
             ? currentExecutionPolicyRevisionHash
             : transactionRow.executionPolicyRevisionHash,
           policyResults: currentEvaluation.results,
-          actionPayload: transferPayload
-            ? transferActionPayload({
-                token: transferPayload.token,
-                recipient: transferPayload.recipient ?? transactionRow.toAddress,
-                amount: transferPayload.amount ?? transactionRow.value,
-                broadcast: transferPayload.broadcast,
-                referenceId: transferPayload.referenceId,
-                sponsorship: transferPayload.sponsorship,
-              })
-            : transactionPayload
-              ? transactionActionPayload({
-                  broadcast: transactionPayload.broadcast,
-                  referenceId: transactionPayload.referenceId,
-                  nonce: transactionPayload.nonce,
-                  gasLimit: transactionPayload.gasLimit,
-                  venue: transactionPayload.venue,
-                  walletAddress: transactionPayload.walletAddress,
-                })
-              : transactionRow.actionPayload,
+          ...(approvedSolanaActionPayload
+            ? {}
+            : {
+                actionPayload: transferPayload
+                  ? transferActionPayload({
+                      token: transferPayload.token,
+                      recipient: transferPayload.recipient ?? transactionRow.toAddress,
+                      amount: transferPayload.amount ?? transactionRow.value,
+                      broadcast: transferPayload.broadcast,
+                      referenceId: transferPayload.referenceId,
+                      sponsorship: transferPayload.sponsorship,
+                    })
+                  : transactionPayload
+                    ? transactionActionPayload({
+                        broadcast: transactionPayload.broadcast,
+                        referenceId: transactionPayload.referenceId,
+                        nonce: transactionPayload.nonce,
+                        gasLimit: transactionPayload.gasLimit,
+                        venue: transactionPayload.venue,
+                        walletAddress: transactionPayload.walletAddress,
+                      })
+                    : transactionRow.actionPayload,
+              }),
           signedAt: resolvedAt,
         })
-        .where(eq(transactions.id, txId));
+        .where(
+          and(
+            eq(transactions.id, txId),
+            eq(transactions.agentId, agentId),
+            approvedSolanaExecutionToken
+              ? and(
+                  eq(transactions.status, "outcome_unknown"),
+                  eq(transactions.txHash, txHash),
+                  sql`${transactions.actionPayload}->>'executionToken' = ${approvedSolanaExecutionToken}`,
+                )
+              : undefined,
+          ),
+        )
+        .returning({ id: transactions.id });
+      if (updatedApprovedTransactions.length !== 1) {
+        throw new Error("Approved transaction execution owner changed before finalization");
+      }
 
       if (!isSolana && shouldBroadcast) {
         recordVaultSpend(agentId, tenantId, transactionRow.value, transactionRow.chainId).catch(
@@ -4438,9 +4593,29 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         data: !shouldBroadcast ? { txId, signedTx: txHash } : { txId, txHash },
       });
     } catch (e: unknown) {
+      if (e instanceof SolanaExecutionLeaseConflictError) {
+        return c.json<ApiResponse>({ ok: false, error: e.message }, 409);
+      }
       if (e instanceof ExternalBroadcastOutcomeUnknownError) {
         irreversibleResult = true;
         completedTxHash = e.transactionHash;
+      }
+      if (e instanceof SolanaBroadcastNotSubmittedError && approvedSolanaExecutionToken) {
+        await markSolanaBroadcastNotSubmitted(
+          tenantId,
+          txId,
+          agentId,
+          approvedSolanaExecutionToken,
+          e.transactionHash,
+        );
+        return c.json<ApiResponse>(
+          {
+            ok: false,
+            error: "Solana RPC preflight rejected the approved transaction",
+            data: { txId },
+          },
+          502,
+        );
       }
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
@@ -4452,16 +4627,29 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         chainId: transactionRow.chainId,
       });
       if (!irreversibleResult) {
-        await db
-          .update(approvalQueue)
-          .set({
-            status: "pending",
-            resolvedAt: null,
-            resolvedBy: null,
-            resolvedByType: null,
-            resolvedById: null,
-          })
-          .where(and(eq(approvalQueue.txId, txId), eq(approvalQueue.agentId, agentId)));
+        const mayReopenApproval = approvedSolanaExecutionToken
+          ? await releaseApprovedSolanaExecution(txId, agentId, approvedSolanaExecutionToken)
+          : !isApprovedSolanaResume;
+        if (mayReopenApproval) {
+          await db
+            .update(approvalQueue)
+            .set({
+              status: "pending",
+              resolvedAt: null,
+              resolvedBy: null,
+              resolvedByType: null,
+              resolvedById: null,
+            })
+            .where(
+              and(
+                eq(approvalQueue.txId, txId),
+                eq(approvalQueue.agentId, agentId),
+                eq(approvalQueue.status, "approved"),
+                eq(approvalQueue.resolvedByType, approverPrincipal.type),
+                eq(approvalQueue.resolvedById, approverPrincipal.id),
+              ),
+            );
+        }
         if (transferPayload) {
           await recordSponsoredActionIfNeeded({
             sponsorship: transferPayload.sponsorship,
@@ -4484,7 +4672,19 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
               txHash: completedTxHash ?? transactionRow.txHash ?? null,
               signedAt: resolvedAt,
             })
-            .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)));
+            .where(
+              and(
+                eq(transactions.id, txId),
+                eq(transactions.agentId, agentId),
+                approvedSolanaExecutionToken
+                  ? and(
+                      sql`${transactions.status} in ('outcome_unknown', 'broadcast')`,
+                      sql`${transactions.actionPayload}->>'executionToken' = ${approvedSolanaExecutionToken}`,
+                      completedTxHash ? eq(transactions.txHash, completedTxHash) : undefined,
+                    )
+                  : undefined,
+              ),
+            );
         } catch {
           // Approval execution already crossed the durable checkpoint. Keep
           // the approval terminal and preserve the typed response; reopening
@@ -8012,12 +8212,54 @@ type SolanaRecoveryBinding = {
   requestDigest?: string;
 };
 
+function createSolanaTransferRecoveryBinding(
+  c: Context<{ Variables: AppVariables }>,
+  input: {
+    tenantId: string;
+    agentId: string;
+    chainId: number;
+    to: string;
+    token: string;
+    value: string;
+    transaction?: string;
+    referenceId?: string;
+  },
+): SolanaRecoveryBinding {
+  const key = c.req.header("Idempotency-Key");
+  if (!key) throw new Error("Idempotency-Key is required for Solana broadcast");
+  const scope = `${input.tenantId}\0${input.agentId}\0actions/transfer\0${key}`;
+  return {
+    txId: `solana_transfer_${sha256(scope).slice(0, 47)}`,
+    idempotencyKeyDigest: sha256(scope),
+    requestDigest: sha256(
+      canonicalJsonStringify({
+        agentId: input.agentId,
+        broadcast: true,
+        chainId: input.chainId,
+        referenceId: input.referenceId,
+        tenantId: input.tenantId,
+        to: input.to,
+        token: input.token,
+        transaction: input.transaction,
+        value: input.value,
+      }),
+    ),
+  };
+}
+
 const SOLANA_SIGNING_ATTEMPT_LEASE_MS = 2 * 60 * 1000;
 
 class SolanaIdempotencyConflictError extends Error {
   constructor() {
     super("Idempotency-Key was already used for a different Solana transaction");
     this.name = "SolanaIdempotencyConflictError";
+  }
+}
+
+class SolanaExecutionLeaseConflictError extends Error {
+  constructor(message = "Approved Solana execution is already owned by another attempt") {
+    super(message);
+    this.name = "SolanaExecutionLeaseConflictError";
   }
 }
 
@@ -8067,6 +8309,7 @@ type SolanaRecoveryRow = {
   txHash: string | null;
   chainId: number;
   actionPayload: unknown;
+  actionType?: string | null;
 };
 
 function readSolanaRecoveryMetadata(payload: unknown): Record<string, unknown> {
@@ -8116,6 +8359,45 @@ function solanaReplayResponse(
   );
 }
 
+function solanaTransferReplayResponse(
+  c: Context<{ Variables: AppVariables }>,
+  row: SolanaRecoveryRow,
+): Response {
+  if (row.status === "approved") {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "A matching Solana transfer is already in progress",
+        data: { actionId: row.id, status: "processing" },
+      },
+      409,
+    );
+  }
+  if (row.status === "outcome_unknown" && row.txHash) {
+    return externalBroadcastOutcomeUnknownResponse(
+      c,
+      new ExternalBroadcastOutcomeUnknownError(row.txHash),
+      row.id,
+    ) as Response;
+  }
+  if ((row.status === "broadcast" || row.status === "confirmed") && row.txHash) {
+    return c.json<ApiResponse>({
+      ok: true,
+      data: transferActionResponseFromTransaction(
+        row as unknown as typeof transactions.$inferSelect,
+      ),
+    });
+  }
+  return c.json<ApiResponse>(
+    {
+      ok: false,
+      error: "The prior Solana transfer did not complete; use a new Idempotency-Key",
+      data: { actionId: row.id, status: row.status },
+    },
+    409,
+  );
+}
+
 async function stageSolanaRecoveryAnchor(input: {
   agentId: string;
   transaction: string;
@@ -8126,6 +8408,8 @@ async function stageSolanaRecoveryAnchor(input: {
   blindSigned: boolean;
   policyResults: PolicyResult[];
   binding: SolanaRecoveryBinding;
+  actionType?: string;
+  actionPayload?: Record<string, unknown>;
 }): Promise<{ row: SolanaRecoveryRow; executionToken: string | null }> {
   const executionToken = crypto.randomUUID();
   const attemptLeaseUntil = new Date(Date.now() + SOLANA_SIGNING_ATTEMPT_LEASE_MS).toISOString();
@@ -8139,9 +8423,12 @@ async function stageSolanaRecoveryAnchor(input: {
       value: input.value,
       data: input.transaction,
       chainId: input.chainId,
-      actionType: "solana_transaction",
+      actionType: input.actionType ?? "solana_transaction",
       actionPayload: {
-        type: "solana_transaction",
+        ...input.actionPayload,
+        type: input.actionPayload?.type ?? "solana_transaction",
+        recoveryType: "solana_transaction",
+        recoveryActionType: input.actionType ?? "solana_transaction",
         broadcast: input.broadcastRequested,
         blindSigned: input.blindSigned,
         recoveryAnchor: true,
@@ -8165,7 +8452,10 @@ async function stageSolanaRecoveryAnchor(input: {
   if (
     !existing ||
     existing.agentId !== input.agentId ||
-    metadata.type !== "solana_transaction" ||
+    (metadata.recoveryType ?? metadata.type) !== "solana_transaction" ||
+    (metadata.recoveryActionType ??
+      (metadata.type === "solana_transaction" ? "solana_transaction" : null)) !==
+      (input.actionType ?? "solana_transaction") ||
     metadata.idempotencyKeyDigest !== input.binding.idempotencyKeyDigest ||
     metadata.requestDigest !== input.binding.requestDigest
   ) {
@@ -8237,7 +8527,7 @@ async function checkpointSolanaBroadcastSubmission(
       and(
         eq(transactions.id, txId),
         eq(transactions.agentId, agentId),
-        eq(transactions.status, "approved"),
+        sql`${transactions.status} in ('approved', 'pending')`,
         sql`${transactions.actionPayload}->>'executionToken' = ${executionToken}`,
       ),
     )
@@ -8245,6 +8535,112 @@ async function checkpointSolanaBroadcastSubmission(
   if (rows.length !== 1) {
     throw new Error("Solana recovery anchor was not available for broadcast checkpoint");
   }
+}
+
+async function claimApprovedSolanaExecution(
+  row: typeof transactions.$inferSelect,
+  options: { takeover: boolean },
+): Promise<{ executionToken: string; actionPayload: Record<string, unknown> }> {
+  const prior = readSolanaRecoveryMetadata(row.actionPayload);
+  const requestDigest = sha256(
+    canonicalJsonStringify({
+      actionPayload: options.takeover
+        ? Object.fromEntries(
+            Object.entries(prior).filter(
+              ([key]) =>
+                ![
+                  "attemptLeaseUntil",
+                  "executionToken",
+                  "recoveryAnchor",
+                  "recoveryActionType",
+                  "recoveryType",
+                  "requestDigest",
+                ].includes(key),
+            ),
+          )
+        : row.actionPayload,
+      actionType: row.actionType,
+      agentId: row.agentId,
+      chainId: row.chainId,
+      data: row.data,
+      id: row.id,
+      toAddress: row.toAddress,
+      value: row.value,
+    }),
+  );
+  const priorToken = typeof prior.executionToken === "string" ? prior.executionToken : null;
+  const priorLeaseUntil =
+    typeof prior.attemptLeaseUntil === "string" ? Date.parse(prior.attemptLeaseUntil) : Number.NaN;
+  if (options.takeover) {
+    if (
+      prior.recoveryType !== "solana_transaction" ||
+      prior.recoveryActionType !== (row.actionType ?? "transaction") ||
+      prior.requestDigest !== requestDigest ||
+      !priorToken ||
+      !Number.isFinite(priorLeaseUntil) ||
+      priorLeaseUntil > Date.now()
+    ) {
+      throw new SolanaExecutionLeaseConflictError();
+    }
+  } else if (priorToken) {
+    throw new SolanaExecutionLeaseConflictError();
+  }
+  const executionToken = crypto.randomUUID();
+  const actionPayload = {
+    ...prior,
+    recoveryType: "solana_transaction",
+    recoveryActionType: row.actionType ?? "transaction",
+    recoveryAnchor: true,
+    requestDigest,
+    executionToken,
+    attemptLeaseUntil: new Date(Date.now() + SOLANA_SIGNING_ATTEMPT_LEASE_MS).toISOString(),
+  };
+  const [claimed] = await db
+    .update(transactions)
+    .set({ actionPayload })
+    .where(
+      and(
+        eq(transactions.id, row.id),
+        eq(transactions.agentId, row.agentId),
+        eq(transactions.status, "pending"),
+        options.takeover
+          ? sql`${transactions.actionPayload}->>'executionToken' = ${priorToken}`
+          : sql`${transactions.actionPayload}->>'executionToken' is null`,
+      ),
+    )
+    .returning({ id: transactions.id });
+  if (!claimed) throw new SolanaExecutionLeaseConflictError();
+  return { executionToken, actionPayload };
+}
+
+async function releaseApprovedSolanaExecution(
+  txId: string,
+  agentId: string,
+  executionToken: string,
+): Promise<boolean> {
+  const [row] = await db
+    .select({ actionPayload: transactions.actionPayload })
+    .from(transactions)
+    .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)))
+    .limit(1);
+  const {
+    executionToken: _executionToken,
+    attemptLeaseUntil: _attemptLeaseUntil,
+    ...releasedPayload
+  } = readSolanaRecoveryMetadata(row?.actionPayload);
+  const released = await db
+    .update(transactions)
+    .set({ actionPayload: releasedPayload })
+    .where(
+      and(
+        eq(transactions.id, txId),
+        eq(transactions.agentId, agentId),
+        eq(transactions.status, "pending"),
+        sql`${transactions.actionPayload}->>'executionToken' = ${executionToken}`,
+      ),
+    )
+    .returning({ id: transactions.id });
+  return released.length === 1;
 }
 
 async function finalizeSolanaRecoveryAnchor(
@@ -8953,7 +9349,13 @@ vaultRoutes.post("/:agentId/transactions/:txId/reconcile-solana", async (c) => {
     .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)))
     .limit(1);
   const metadata = readSolanaRecoveryMetadata(row?.actionPayload);
-  if (!row || row.actionType !== "solana_transaction") {
+  if (
+    !row ||
+    (metadata.recoveryType ?? metadata.type) !== "solana_transaction" ||
+    (metadata.recoveryActionType ??
+      (row.actionType === "solana_transaction" ? "solana_transaction" : null)) !==
+      (row.actionType ?? "transaction")
+  ) {
     return c.json<ApiResponse>({ ok: false, error: "Solana transaction not found" }, 404);
   }
   if (row.status !== "outcome_unknown") {

--- a/packages/vault/src/__tests__/solana-offline-broadcast.test.ts
+++ b/packages/vault/src/__tests__/solana-offline-broadcast.test.ts
@@ -25,6 +25,7 @@
  */
 import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import { Connection, PublicKey, Transaction } from "@solana/web3.js";
+import bs58 from "bs58";
 import {
   assertSolanaTransferTransactionMatches,
   generateSolanaKeypair,
@@ -36,7 +37,6 @@ import {
 const BLOCKHASH = new PublicKey(new Uint8Array(32).fill(7)).toBase58();
 // Opaque on-chain signature; the real one would come from the RPC. Used to prove
 // the broadcast path returns the RPC signature (not the offline serialized tx).
-const ON_CHAIN_SIGNATURE = "z".repeat(88);
 // Never contacted: every Connection method is stubbed at the prototype.
 const RPC_URL = "https://rpc.invalid/never-contacted";
 
@@ -57,7 +57,13 @@ describe("signSolanaTransaction broadcast gate", () => {
       blockhash: BLOCKHASH,
       lastValidBlockHeight: 1000,
     });
-    send = spyOn(Connection.prototype, "sendTransaction").mockResolvedValue(ON_CHAIN_SIGNATURE);
+    send = spyOn(Connection.prototype, "sendRawTransaction").mockImplementation(
+      async (bytes: Uint8Array) => {
+        const submitted = Transaction.from(bytes);
+        if (!submitted.signature) throw new Error("expected a signed transaction");
+        return bs58.encode(submitted.signature);
+      },
+    );
     confirm = spyOn(Connection.prototype, "confirmTransaction").mockResolvedValue({
       context: { slot: 1 },
       value: { err: null },
@@ -87,7 +93,6 @@ describe("signSolanaTransaction broadcast gate", () => {
     expect(confirm).not.toHaveBeenCalled();
 
     // The returned bytes are a genuinely, fully-signed transfer — NOT a signature.
-    expect(result).not.toBe(ON_CHAIN_SIGNATURE);
     const decoded = decodeSignedTx(result);
     expect(decoded.verifySignatures()).toBe(true);
     expect(decoded.feePayer?.toBase58()).toBe(sender.publicKey);
@@ -104,17 +109,23 @@ describe("signSolanaTransaction broadcast gate", () => {
     const sender = generateSolanaKeypair();
     const recipient = generateSolanaKeypair().publicKey;
 
+    let checkpoint: { signature: string; recentBlockhash: string } | undefined;
     const result = await signSolanaTransaction(sender.secretKey, recipient, 50_000n, RPC_URL, {
       broadcast: true,
+      onBroadcastPrepared: async (prepared) => {
+        expect(send).not.toHaveBeenCalled();
+        checkpoint = prepared;
+      },
     });
 
     expect(send).toHaveBeenCalledTimes(1);
     expect(confirm).toHaveBeenCalledTimes(1);
-    // The caller gets the RPC signature, not the serialized tx.
-    expect(result).toBe(ON_CHAIN_SIGNATURE);
-
     // The transaction handed to the network was the transfer for THIS request.
-    const submitted = send.mock.calls[0][0] as Transaction;
+    const submitted = Transaction.from(send.mock.calls[0][0] as Uint8Array);
+    // The caller gets the deterministic signature of the submitted bytes.
+    expect(result).toBe(bs58.encode(submitted.signature as Uint8Array));
+    expect(checkpoint).toEqual({ signature: result, recentBlockhash: BLOCKHASH });
+    expect(send.mock.calls[0][1]).toMatchObject({ maxRetries: 0 });
     assertSolanaTransferTransactionMatches(submitted, {
       from: restoreSolanaKeypair(sender.secretKey).publicKey,
       to: recipient,
@@ -123,7 +134,7 @@ describe("signSolanaTransaction broadcast gate", () => {
 
     // confirmTransaction was bound to the blockhash we fetched (replay-window guard).
     const confirmArg = confirm.mock.calls[0][0] as { signature: string; blockhash: string };
-    expect(confirmArg.signature).toBe(ON_CHAIN_SIGNATURE);
+    expect(confirmArg.signature).toBe(result);
     expect(confirmArg.blockhash).toBe(BLOCKHASH);
   });
 
@@ -132,9 +143,12 @@ describe("signSolanaTransaction broadcast gate", () => {
     const sender = generateSolanaKeypair();
     const recipient = generateSolanaKeypair().publicKey;
 
-    const result = await signSolanaTransaction(sender.secretKey, recipient, 1n, RPC_URL);
+    const result = await signSolanaTransaction(sender.secretKey, recipient, 1n, RPC_URL, {
+      onBroadcastPrepared: async () => {},
+    });
 
     expect(send).toHaveBeenCalledTimes(1);
-    expect(result).toBe(ON_CHAIN_SIGNATURE);
+    const submitted = Transaction.from(send.mock.calls[0][0] as Uint8Array);
+    expect(result).toBe(bs58.encode(submitted.signature as Uint8Array));
   });
 });

--- a/packages/vault/src/solana.ts
+++ b/packages/vault/src/solana.ts
@@ -6,13 +6,18 @@ import {
   Keypair,
   LAMPORTS_PER_SOL,
   PublicKey,
+  SendTransactionError,
   type Signer,
   SystemProgram,
   Transaction,
   type TransactionInstruction,
 } from "@solana/web3.js";
-
 import { getKnownToken } from "@stwd/shared";
+import bs58 from "bs58";
+import {
+  ExternalBroadcastOutcomeUnknownError,
+  SolanaBroadcastNotSubmittedError,
+} from "./external-key-custody";
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   TOKEN_2022_PROGRAM_ID,
@@ -385,7 +390,14 @@ export async function signSolanaTransaction(
   to: string,
   lamports: bigint,
   rpcUrl: string,
-  options: { broadcast?: boolean; computeBudget?: ComputeBudgetOptions | boolean } = {},
+  options: {
+    broadcast?: boolean;
+    computeBudget?: ComputeBudgetOptions | boolean;
+    onBroadcastPrepared?: (checkpoint: {
+      signature: string;
+      recentBlockhash: string;
+    }) => Promise<void>;
+  } = {},
 ): Promise<string> {
   const keypair = restoreSolanaKeypair(secretKeyHex);
   const connection = new Connection(rpcUrl, "confirmed");
@@ -434,14 +446,39 @@ export async function signSolanaTransaction(
     return btoa(Array.from(tx.serialize(), (b) => String.fromCharCode(b)).join(""));
   }
 
-  const signature = await connection.sendTransaction(tx, [keypair], {
-    skipPreflight: false,
-    preflightCommitment: "confirmed",
-  });
+  tx.sign(keypair);
+  if (!tx.signature) throw new Error("Solana transfer did not produce a signer signature");
+  const preparedSignature = bs58.encode(tx.signature);
+  const signedBytes = tx.serialize();
 
-  await connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight }, "confirmed");
+  // The caller must make the deterministic signature durable before the first
+  // RPC write. A failed checkpoint is therefore a safe, definitely-not-sent
+  // failure and aborts before sendRawTransaction.
+  if (!options.onBroadcastPrepared) {
+    throw new Error("Solana broadcast requires a durable onBroadcastPrepared checkpoint");
+  }
+  await options.onBroadcastPrepared({ signature: preparedSignature, recentBlockhash: blockhash });
+  try {
+    const signature = await connection.sendRawTransaction(signedBytes, {
+      skipPreflight: false,
+      preflightCommitment: "confirmed",
+      maxRetries: 0,
+    });
+    if (signature !== preparedSignature) {
+      throw new Error("Solana RPC returned a signature that does not match the signed bytes");
+    }
+    await connection.confirmTransaction(
+      { signature, blockhash, lastValidBlockHeight },
+      "confirmed",
+    );
+  } catch (error) {
+    if (error instanceof SendTransactionError && error.message.startsWith("Simulation failed.")) {
+      throw new SolanaBroadcastNotSubmittedError(preparedSignature, { cause: error });
+    }
+    throw new ExternalBroadcastOutcomeUnknownError(preparedSignature, { cause: error });
+  }
 
-  return signature;
+  return preparedSignature;
 }
 
 export interface SolanaSplTransferTransaction {

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -459,6 +459,10 @@ export interface SignTransactionOptions {
    */
   expectedBackend?: "local-vault" | "external-custody";
   expectedBackendIdentityDigest?: string;
+  onSolanaBroadcastPrepared?: (checkpoint: {
+    signature: string;
+    recentBlockhash: string;
+  }) => Promise<void>;
 }
 
 export interface ResolvedExecutionTarget {
@@ -1813,6 +1817,7 @@ export class Vault {
       const rpcUrl = this.config.rpcUrl ?? resolveSolanaRpc(chainId);
       hash = await signSolanaTransaction(secretKey, request.to, BigInt(request.value), rpcUrl, {
         broadcast: shouldBroadcast,
+        onBroadcastPrepared: options.onSolanaBroadcastPrepared,
         // Attach adaptive priority fees (simulated CU limit + recent-fee-derived
         // price, bounded by COMPUTE_BUDGET_BOUNDS). Estimation never throws and
         // falls back to safe defaults on RPC error. Set STEWARD_SOLANA_PRIORITY_FEES=0


### PR DESCRIPTION
Closes #651

## Summary

- route native SOL, SPL, parsed/blind signing, and approved Solana broadcasts through durable pre-I/O recovery checkpoints
- bind transfer retries to tenant, agent, route, hashed `Idempotency-Key`, and a canonical request digest
- classify proven preflight rejection separately from ambiguous transport/confirmation outcomes and reconcile exact stored signatures without resending
- add bounded execution leases and CAS-fenced expired-owner takeover for approval execution so a crash cannot strand the approval or permit two sends
- preserve transfer/approval metadata while fencing checkpoint, finalization, failure, replay, and stale callbacks to the current execution token

## Exact head

- base: `90895ea25dd1cae4952f4409a04fcce09bbbc0df`
- head: `4b9290d0827c49c438c1accbb1fccc27b4d5255b`

## Validation

- API typecheck: PASS
- API dependency build: PASS
- Vault typecheck/build: PASS
- mounted transfer/sign recovery suites: 19/19 PASS, 235 assertions
- approved crash/expired-takeover concurrency: 1/1 PASS, 11 assertions; exactly one submission
- approved ambiguous-checkpoint regression: 1/1 PASS, 8 assertions
- Biome affected files: PASS
- `git diff --check`: PASS

One unrelated legacy EVM approval test still relies on a stale `Vault.prototype.signTransaction` spy that no longer observes the current late-bound Vault factory; this PR does not weaken or remove it. Hosted PostgreSQL and the complete exact-head matrix remain required before readiness.

## Integration order

Keep draft. Land the #654 RLS/release-gate correction first, rebase this PR onto the resulting exact `develop`, then rerun every required check and obtain independent approval. Signed-artifact retirement (#653) must be restacked after this patch so it preserves the new checkpoint metadata.
