### PR TITLE
fix(security): close RLS activation release gates

### DIFF
--- a/packages/api/src/__tests__/fixtures/rls-app-role-exercise.ts
+++ b/packages/api/src/__tests__/fixtures/rls-app-role-exercise.ts
@@ -176,13 +176,22 @@ try {
     "rls-platform-audit-verify",
     async () =>
       getDb()
-        .select({ action: auditEvents.action })
+        .select({ seq: auditEvents.seq, action: auditEvents.action })
         .from(auditEvents)
         .where(eq(auditEvents.resourceId, userId)),
   );
   assert(
-    platformAudits.some((row) => row.action === "user.deactivate"),
-    "global platform lifecycle did not write its reserved-tenant audit event",
+    platformAudits.filter((row) => row.action === "user.deactivate.authorized").length === 1 &&
+      platformAudits.filter((row) => row.action === "user.deactivate").length === 1,
+    "global platform lifecycle did not write exactly one authorization and completion audit",
+  );
+  const authorizedAudit = platformAudits.find((row) => row.action === "user.deactivate.authorized");
+  const completionAudit = platformAudits.find((row) => row.action === "user.deactivate");
+  assert(
+    authorizedAudit !== undefined &&
+      completionAudit !== undefined &&
+      authorizedAudit.seq < completionAudit.seq,
+    "global platform lifecycle audit authorization did not precede completion",
   );
 
   const tenantRuns = await runInternalJobForEachTenant(

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -3731,15 +3731,6 @@ platform.patch("/users/:userId/deactivate", async (c) => {
   if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
   const deactivated = body.deactivated !== false;
 
-  await writeAuditEvent({
-    tenantId: PLATFORM_AUDIT_TENANT_ID,
-    actorType: "platform",
-    action: deactivated ? "user.deactivate.authorized" : "user.reactivate.authorized",
-    resourceType: "user",
-    resourceId: userId,
-    ...auditCtx(c),
-  });
-
   const result = await withPlatformAuthorityDatabase((platformDb) =>
     withTenantAuditedTransactionOnDb(
       platformDb,
@@ -3752,6 +3743,14 @@ platform.patch("/users/:userId/deactivate", async (c) => {
         await tx.execute(
           sql`SELECT pg_advisory_xact_lock(hashtextextended(${"platform_user_account_" + userId}, 0))`,
         );
+        await appendRequiredAudit({
+          tenantId: PLATFORM_AUDIT_TENANT_ID,
+          actorType: "platform",
+          action: deactivated ? "user.deactivate.authorized" : "user.reactivate.authorized",
+          resourceType: "user",
+          resourceId: userId,
+          ...auditCtx(c),
+        });
         const issuedBefore = await revocationStore.revokeUserTokens(userId);
         const [updated] = rowsFromExecute<{
           user_id: string;
@@ -3812,15 +3811,6 @@ platform.delete("/users/:userId", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Invalid user id format" }, 400);
   }
 
-  await writeAuditEvent({
-    tenantId: PLATFORM_AUDIT_TENANT_ID,
-    actorType: "platform",
-    action: "user.delete.authorized",
-    resourceType: "user",
-    resourceId: userId,
-    ...auditCtx(c),
-  });
-
   const issuedBefore = await withPlatformAuthorityDatabase((platformDb) =>
     withTenantAuditedTransactionOnDb(
       platformDb,
@@ -3833,6 +3823,14 @@ platform.delete("/users/:userId", async (c) => {
         await tx.execute(
           sql`SELECT pg_advisory_xact_lock(hashtextextended(${"platform_user_account_" + userId}, 0))`,
         );
+        await appendRequiredAudit({
+          tenantId: PLATFORM_AUDIT_TENANT_ID,
+          actorType: "platform",
+          action: "user.delete.authorized",
+          resourceType: "user",
+          resourceId: userId,
+          ...auditCtx(c),
+        });
         const cutoff = await revocationStore.revokeUserTokens(userId);
         const [deleted] = rowsFromExecute<{ user_id: string }>(
           await tx.execute(sql`

--- a/packages/db/src/__tests__/audit-chain-retry.test.ts
+++ b/packages/db/src/__tests__/audit-chain-retry.test.ts
@@ -9,8 +9,12 @@
  * unearned reliance on the caller's retry-idempotency contract.
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { withTenantAuditedTransaction } from "../audit-chain";
-import { closeDb, setPGLiteOverride } from "../client";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  withTenantAuditedTransaction,
+  withTenantAuditedTransactionOnDb,
+} from "../audit-chain";
+import { closeDb, getDb, setPGLiteOverride, withTenantTransactionDatabase } from "../client";
 import { createPGLiteDb } from "../pglite";
 
 function uniqueViolation(constraint: string): Error {
@@ -93,5 +97,48 @@ describe("audit-chain retry classification (SEC-167)", () => {
     });
     expect(result).toBe("committed");
     expect(calls).toBe(2);
+  });
+
+  test("a distinct handle inside tenant ALS keeps audit writes on its own transaction", async () => {
+    const previousAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+    process.env.STEWARD_AUDIT_HMAC_KEY = "ab".repeat(32);
+    __resetAuditHmacKeyCacheForTests();
+    const outerDb = { marker: "outer-app-transaction" } as unknown as ReturnType<typeof getDb>;
+    let topLevelAuditCalls = 0;
+    let transactionAuditCalls = 0;
+    const separateDb = {
+      async execute() {
+        topLevelAuditCalls += 1;
+        throw new Error("CROSS_HANDLE_TOP_LEVEL_AUDIT");
+      },
+      async transaction(callback: (tx: unknown) => Promise<unknown>) {
+        return callback({
+          async execute() {
+            transactionAuditCalls += 1;
+            throw new Error("CROSS_HANDLE_TRANSACTION_AUDIT");
+          },
+        });
+      },
+    } as unknown as ReturnType<typeof getDb>;
+
+    try {
+      await withTenantTransactionDatabase(outerDb, { tenantId: "platform" }, async () => {
+        await expect(
+          withTenantAuditedTransactionOnDb(separateDb, "platform", async (_tx, append) => {
+            await append({
+              tenantId: "platform",
+              actorType: "platform",
+              action: "user.deactivate.authorized",
+            });
+          }),
+        ).rejects.toThrow("CROSS_HANDLE_TRANSACTION_AUDIT");
+      });
+      expect(topLevelAuditCalls).toBe(0);
+      expect(transactionAuditCalls).toBe(1);
+    } finally {
+      if (previousAuditKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+      else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditKey;
+      __resetAuditHmacKeyCacheForTests();
+    }
   });
 });

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -64,8 +64,15 @@ describe("request-scoped database context", () => {
           hasTenantTransactionDatabase({
             tenantId: "tenant-a",
             userId: "11111111-1111-4111-8111-111111111111",
+            db: getDb(),
           }),
         ).toBe(true);
+        expect(
+          hasTenantTransactionDatabase({
+            tenantId: "tenant-a",
+            db: { marker: "separate-handle" } as unknown as ReturnType<typeof getDb>,
+          }),
+        ).toBe(false);
         expect(() => hasTenantTransactionDatabase({ tenantId: "tenant-b" })).toThrow(
           "RLS_TENANT_DATABASE_CONTEXT_MISMATCH",
         );

--- a/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
@@ -143,6 +143,23 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
         rolbypassrls: false,
         rolsuper: false,
       });
+      const [platformRlsPrivileges] = await db<
+        {
+          schema_usage: boolean;
+          tenant_id_execute: boolean;
+          user_id_execute: boolean;
+        }[]
+      >`
+        SELECT
+          has_schema_privilege(${platformRole}, 'steward_rls', 'USAGE') AS schema_usage,
+          has_function_privilege(${platformRole}, 'steward_rls.tenant_id()', 'EXECUTE') AS tenant_id_execute,
+          has_function_privilege(${platformRole}, 'steward_rls.user_id()', 'EXECUTE') AS user_id_execute
+      `;
+      expect(platformRlsPrivileges).toEqual({
+        schema_usage: true,
+        tenant_id_execute: true,
+        user_id_execute: false,
+      });
 
       await runOperatorScript("rls-activate.sql");
       const [activated] = await db<{ enabled: number; forced: number; maintenance: number }[]>`

--- a/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
@@ -267,8 +267,20 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
           STEWARD_RETENTION_DEACTIVATED_USERS_DELETE_CONFIRMED: undefined,
         },
       );
-      expect(appRoleEvidence).toContain('"ok":true');
-      expect(appRoleEvidence).toContain('"platformAuditActions"');
+      const evidenceLine = appRoleEvidence
+        .trim()
+        .split("\n")
+        .findLast((line) => line.startsWith('{"ok":true'));
+      expect(evidenceLine).toBeDefined();
+      const evidence = JSON.parse(evidenceLine as string) as {
+        ok: boolean;
+        platformAuditActions: string[];
+      };
+      expect(evidence.ok).toBe(true);
+      expect(evidence.platformAuditActions).toEqual([
+        "user.deactivate",
+        "user.deactivate.authorized",
+      ]);
 
       await runOperatorScript("rls-rollback.sql");
       const [rolledBack] = await db<{ enabled: number; forced: number }[]>`

--- a/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
@@ -148,17 +148,32 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
           schema_usage: boolean;
           tenant_id_execute: boolean;
           user_id_execute: boolean;
+          audit_sequence_usage: boolean;
+          other_sequence_usage: boolean;
+          default_sequence_grant: boolean;
         }[]
       >`
         SELECT
           has_schema_privilege(${platformRole}, 'steward_rls', 'USAGE') AS schema_usage,
           has_function_privilege(${platformRole}, 'steward_rls.tenant_id()', 'EXECUTE') AS tenant_id_execute,
-          has_function_privilege(${platformRole}, 'steward_rls.user_id()', 'EXECUTE') AS user_id_execute
+          has_function_privilege(${platformRole}, 'steward_rls.user_id()', 'EXECUTE') AS user_id_execute,
+          has_sequence_privilege(${platformRole}, 'public.audit_events_id_seq', 'USAGE,SELECT') AS audit_sequence_usage,
+          has_sequence_privilege(${platformRole}, 'public.audit_checkpoints_id_seq', 'USAGE') AS other_sequence_usage,
+          EXISTS (
+            SELECT 1
+            FROM pg_default_acl defaults
+            CROSS JOIN LATERAL aclexplode(COALESCE(defaults.defaclacl, '{}'::aclitem[])) privilege
+            JOIN pg_roles granted_role ON granted_role.oid = privilege.grantee
+            WHERE defaults.defaclobjtype = 'S' AND granted_role.rolname = ${platformRole}
+          ) AS default_sequence_grant
       `;
       expect(platformRlsPrivileges).toEqual({
         schema_usage: true,
         tenant_id_execute: true,
         user_id_execute: false,
+        audit_sequence_usage: true,
+        other_sequence_usage: false,
+        default_sequence_grant: false,
       });
 
       await runOperatorScript("rls-activate.sql");

--- a/packages/db/src/audit-chain.ts
+++ b/packages/db/src/audit-chain.ts
@@ -553,7 +553,7 @@ export async function withTenantAuditedTransactionOnDb<T>(
   };
 
   const execute = async () => {
-    if (hasTenantTransactionDatabase({ tenantId })) {
+    if (hasTenantTransactionDatabase({ tenantId, db })) {
       assertRemaining();
       // The authenticated middleware owns the outer tenant transaction. Keep
       // mutations in a savepoint so a Hono error response cannot accidentally

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -499,6 +499,7 @@ const tenantTransactionDatabaseStorage = new AsyncLocalStorage<RequestDatabaseCo
 export function hasTenantTransactionDatabase(expected?: {
   tenantId: string;
   userId?: string;
+  db?: RequestDatabase;
 }): boolean {
   const context = tenantTransactionDatabaseStorage.getStore();
   if (!context?.active || !context.db) return false;
@@ -509,6 +510,7 @@ export function hasTenantTransactionDatabase(expected?: {
   ) {
     throw new Error("RLS_TENANT_DATABASE_CONTEXT_MISMATCH");
   }
+  if (expected?.db !== undefined && expected.db !== context.db) return false;
   return true;
 }
 

--- a/scripts/postgres/rls-bootstrap.sql
+++ b/scripts/postgres/rls-bootstrap.sql
@@ -93,6 +93,10 @@ SELECT format(
   :'steward_platform_role'
 ) \gexec
 SELECT format(
+  'GRANT USAGE, SELECT ON SEQUENCE public.audit_events_id_seq TO %I',
+  :'steward_platform_role'
+) \gexec
+SELECT format(
   'GRANT EXECUTE ON FUNCTION '
   'steward_bootstrap.platform_set_user_deactivation(uuid,boolean), '
   'steward_bootstrap.platform_delete_user(uuid), '
@@ -219,6 +223,26 @@ BEGIN
        current_setting('steward.bootstrap.platform_role'), 'steward_rls.user_id()', 'EXECUTE'
      ) THEN
     RAISE EXCEPTION 'SEC-169 platform role must receive only tenant RLS context access';
+  END IF;
+  IF NOT has_sequence_privilege(
+       current_setting('steward.bootstrap.platform_role'),
+       'public.audit_events_id_seq',
+       'USAGE,SELECT'
+     )
+     OR has_sequence_privilege(
+       current_setting('steward.bootstrap.platform_role'),
+       'public.audit_checkpoints_id_seq',
+       'USAGE'
+     )
+     OR EXISTS (
+       SELECT 1
+       FROM pg_default_acl defaults
+       CROSS JOIN LATERAL aclexplode(COALESCE(defaults.defaclacl, '{}'::aclitem[])) privilege
+       JOIN pg_roles granted_role ON granted_role.oid = privilege.grantee
+       WHERE defaults.defaclobjtype = 'S'
+         AND granted_role.rolname = current_setting('steward.bootstrap.platform_role')
+     ) THEN
+    RAISE EXCEPTION 'SEC-169 platform role must receive only the audit event sequence grant';
   END IF;
   IF EXISTS (
     SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace

--- a/scripts/postgres/rls-bootstrap.sql
+++ b/scripts/postgres/rls-bootstrap.sql
@@ -83,7 +83,11 @@ SELECT format(
   'steward_bootstrap.retention_delete_deactivated_users(integer) FROM %I',
   :'steward_app_role'
 ) \gexec
-SELECT format('GRANT USAGE ON SCHEMA steward_bootstrap TO %I', :'steward_platform_role') \gexec
+SELECT format('GRANT USAGE ON SCHEMA steward_bootstrap, steward_rls TO %I', :'steward_platform_role') \gexec
+SELECT format(
+  'GRANT EXECUTE ON FUNCTION steward_rls.tenant_id() TO %I',
+  :'steward_platform_role'
+) \gexec
 SELECT format(
   'GRANT SELECT, INSERT, UPDATE ON public.audit_events, public.audit_chain_heads TO %I',
   :'steward_platform_role'
@@ -204,6 +208,17 @@ BEGIN
      OR has_schema_privilege(current_setting('steward.bootstrap.app_role'), 'steward_bootstrap', 'CREATE')
      OR has_schema_privilege(current_setting('steward.bootstrap.app_role'), 'steward_rls', 'CREATE') THEN
     RAISE EXCEPTION 'SEC-169 app role must not create schema objects';
+  END IF;
+  IF NOT has_schema_privilege(
+       current_setting('steward.bootstrap.platform_role'), 'steward_rls', 'USAGE'
+     )
+     OR NOT has_function_privilege(
+       current_setting('steward.bootstrap.platform_role'), 'steward_rls.tenant_id()', 'EXECUTE'
+     )
+     OR has_function_privilege(
+       current_setting('steward.bootstrap.platform_role'), 'steward_rls.user_id()', 'EXECUTE'
+     ) THEN
+    RAISE EXCEPTION 'SEC-169 platform role must receive only tenant RLS context access';
   END IF;
   IF EXISTS (
     SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace


### PR DESCRIPTION
Closes #654

## Corrective delta after premature #662 merge

#662 merged the earlier 1317e6d8 carrier before real restricted-role PostgreSQL validation exposed four production blockers. This PR is rebased on exact current develop and contains only their corrective delta:

- remove the platform audit advisory-lock inversion by keeping authorization, external cutoff, definer mutation, and completion audit in one platform-role audited transaction
- bind nested audited savepoints to the exact database handle, so a distinct platform connection cannot inherit the outer app transaction or GUC by tenant name alone
- grant the platform role only steward_rls.tenant_id(), not user_id(), for its audit-table RLS policy
- grant only USAGE and SELECT on audit_events_id_seq, with explicit denial of unrelated sequences and broad default sequence privileges

The merged #662 base already contains the broader #654 implementation: exact request-owned deadline context, startup/readiness/Worker role and catalog gates, generated core and optional policy manifest, split platform role, immutable core migration 0112 and capabilities migration 0003, CodeQL fixes, and real proxy audit-trigger proof.

## Exact head

- base: 55f27c750dcc158fd0429615074339ae3a427399
- head: b19cfbbd5adf4681514c6c553c3d418d67177abc

## Exact validation

- real PostgreSQL 16 SEC-169 lifecycle at this rebased head: 1/1 PASS, 20 assertions
  - fresh 92-migration replay
  - four-role bootstrap and exact least privileges
  - 71-relation and 73-policy activation
  - restricted app/platform route exercise with ordered authorization and completion audits
  - rollback, reactivation, and migrator rerun
- focused audit, request-context, platform, Worker, and RLS suites: PASS
- DB and API builds: PASS
- Biome affected files: PASS
- git diff --check: PASS
- temporary PostgreSQL database and roles removed

## Safety and deployment

Keep draft. Current develop contains the incomplete #662 version until this corrective PR lands. Do not activate #343 or promote or release it. Operators must still provision distinct app and platform role credentials and rerun bootstrap before activation. Require fresh exact-head hosted PostgreSQL, Worker, CodeQL, full CI, and independent review. No production role, secret, or activation was changed by this work.