### PR TITLE
fix(worker): bind default auth tenant per request

### DIFF
--- a/packages/api/src/__tests__/auth-default-tenant-runtime.test.ts
+++ b/packages/api/src/__tests__/auth-default-tenant-runtime.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { defaultAuthTenantId } from "../services/default-auth-tenant";
+
+describe("default auth tenant runtime binding", () => {
+  test("keeps overlapping Worker request snapshots isolated", async () => {
+    let releaseFirst!: () => void;
+    const firstCanFinish = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let firstStarted!: () => void;
+    const firstDidStart = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+
+    const first = withRuntimeEnvironment(
+      { STEWARD_DEFAULT_TENANT_ID: "tenant-first" },
+      async () => {
+        firstStarted();
+        await firstCanFinish;
+        return defaultAuthTenantId();
+      },
+    );
+    await firstDidStart;
+
+    const second = withRuntimeEnvironment(
+      { STEWARD_DEFAULT_TENANT_ID: "tenant-second" },
+      async () => {
+        expect(defaultAuthTenantId()).toBe("tenant-second");
+        releaseFirst();
+        return defaultAuthTenantId();
+      },
+    );
+
+    expect(await Promise.all([first, second])).toEqual(["tenant-first", "tenant-second"]);
+  });
+
+  test("uses the literal default when the active binding is absent or blank", () => {
+    expect(withRuntimeEnvironment({}, () => defaultAuthTenantId())).toBe("default");
+    expect(
+      withRuntimeEnvironment({ STEWARD_DEFAULT_TENANT_ID: "   " }, () => defaultAuthTenantId()),
+    ).toBe("default");
+  });
+});

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -151,6 +151,7 @@ import {
   validateWalletAbusePolicy,
   verifyCaptchaToken,
 } from "../services/auth-abuse";
+import { defaultAuthTenantId } from "../services/default-auth-tenant";
 import { verifyEip1271 } from "../services/eip1271";
 import {
   isAllowedOidcClientSecretEnvForTenant,
@@ -164,8 +165,6 @@ import { getConfiguredVault } from "../services/vault-factory";
 import { dispatchWebhook } from "../services/webhook-dispatch";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
-
-const _DEFAULT_TENANT_ID = process.env.STEWARD_DEFAULT_TENANT_ID || "default";
 
 async function withVerifiedAuthTenant<T>(
   tenantId: string,
@@ -829,7 +828,7 @@ async function validateExplicitAuthTenantHint(
 }
 
 function authTenantHint(c: Context, bodyTenantId?: string): string {
-  return c.req.header("X-Steward-Tenant")?.trim() || bodyTenantId?.trim() || _DEFAULT_TENANT_ID;
+  return c.req.header("X-Steward-Tenant")?.trim() || bodyTenantId?.trim() || defaultAuthTenantId();
 }
 
 function smsLoginPurpose(tenantId: string): string {
@@ -3864,7 +3863,7 @@ async function completeEmailAuth(
   tenantId?: string,
   opts: { allowTenantJoin?: boolean } = {},
 ): Promise<CompletedEmailAuthResult> {
-  const hintedTenantId = c.req.header("X-Steward-Tenant") || tenantId || _DEFAULT_TENANT_ID;
+  const hintedTenantId = c.req.header("X-Steward-Tenant") || tenantId || defaultAuthTenantId();
   const hintedAuthAbuseConfig = await getTenantAuthAbuseConfig(hintedTenantId);
   const hintedEmailPolicyError = validateEmailAbusePolicy(email, hintedAuthAbuseConfig);
   if (hintedEmailPolicyError) {
@@ -7997,7 +7996,7 @@ auth.post("/passkey/register/options", async (c) => {
 
   if (typeof body.emailGrant === "string" && body.emailGrant.length > 0) {
     const resolvedTenantId =
-      c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || _DEFAULT_TENANT_ID;
+      c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || defaultAuthTenantId();
     const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "passkey");
     if (methodResponse) return methodResponse;
     // Peek (not consume): the grant is only burned at register/verify so a
@@ -8118,7 +8117,7 @@ auth.post("/passkey/register/verify", async (c) => {
     // user's OTP verification, while consumption before any state change
     // keeps it strictly single-use.
     grantTenantId =
-      c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || _DEFAULT_TENANT_ID;
+      c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || defaultAuthTenantId();
     const grantOk = await peekEmailGrant(body.emailGrant as string, email, grantTenantId);
     if (!grantOk) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired email grant" }, 401);
@@ -8479,7 +8478,7 @@ auth.post("/email/send", async (c) => {
   const email = body.email.toLowerCase().trim();
   const headerTenantId = c.req.header("X-Steward-Tenant")?.trim();
   const bodyTenantId = body.tenantId?.trim();
-  const resolvedTenantId = headerTenantId || bodyTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = headerTenantId || bodyTenantId || defaultAuthTenantId();
   const tenantHintError = await validateExplicitAuthTenantHint(
     resolvedTenantId,
     Boolean(headerTenantId || bodyTenantId),
@@ -8561,7 +8560,7 @@ auth.get("/callback/email", async (c) => {
   }
 
   const email = emailParam.toLowerCase().trim();
-  const resolvedTenantId = tenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = tenantId || defaultAuthTenantId();
   const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "email");
   if (methodResponse) return redirectEmailAuthFailure(c, "method_disabled");
   const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(
@@ -8660,7 +8659,7 @@ auth.post("/email/verify", async (c) => {
   const email = body.email.toLowerCase().trim();
   const headerTenantId = c.req.header("X-Steward-Tenant")?.trim();
   const bodyTenantId = body.tenantId?.trim();
-  const resolvedTenantId = headerTenantId || bodyTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = headerTenantId || bodyTenantId || defaultAuthTenantId();
   const tenantHintError = await validateExplicitAuthTenantHint(
     resolvedTenantId,
     Boolean(headerTenantId || bodyTenantId),
@@ -8724,7 +8723,8 @@ auth.post("/email/code/verify", async (c) => {
 
   const email = body.email.toLowerCase().trim();
   const code = body.code.trim();
-  const resolvedTenantId = c.req.header("X-Steward-Tenant") || body.tenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId =
+    c.req.header("X-Steward-Tenant") || body.tenantId || defaultAuthTenantId();
   const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "email");
   if (methodResponse) return methodResponse;
   const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(
@@ -8789,7 +8789,7 @@ auth.post("/email/status", async (c) => {
   }
   const headerTenantId = c.req.header("X-Steward-Tenant")?.trim();
   const bodyTenantId = body.tenantId?.trim();
-  const resolvedTenantId = headerTenantId || bodyTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = headerTenantId || bodyTenantId || defaultAuthTenantId();
   const tenantHintError = await validateExplicitAuthTenantHint(
     resolvedTenantId,
     Boolean(headerTenantId || bodyTenantId),
@@ -8836,7 +8836,7 @@ auth.post("/email/otp/send", async (c) => {
   const email = body.email.toLowerCase().trim();
   const headerTenantId = c.req.header("X-Steward-Tenant")?.trim();
   const bodyTenantId = body.tenantId?.trim();
-  const resolvedTenantId = headerTenantId || bodyTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = headerTenantId || bodyTenantId || defaultAuthTenantId();
   const tenantHintError = await validateExplicitAuthTenantHint(
     resolvedTenantId,
     Boolean(headerTenantId || bodyTenantId),
@@ -8911,7 +8911,8 @@ auth.post("/email/otp/verify", async (c) => {
 
   const email = body.email.toLowerCase().trim();
   const code = body.code.trim();
-  const resolvedTenantId = c.req.header("X-Steward-Tenant") || body.tenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId =
+    c.req.header("X-Steward-Tenant") || body.tenantId || defaultAuthTenantId();
   const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "email");
   if (methodResponse) return methodResponse;
   const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(
@@ -8994,7 +8995,7 @@ async function resolveGuestTenant(
   const requested =
     headerTenant ||
     (typeof bodyTenantId === "string" ? bodyTenantId.trim() : "") ||
-    _DEFAULT_TENANT_ID;
+    defaultAuthTenantId();
 
   if (!isValidTenantId(requested)) {
     return { ok: false, status: 400, error: "Invalid tenant id format" };
@@ -9006,7 +9007,7 @@ async function resolveGuestTenant(
   if (!subject) {
     return { ok: false, status: 404, error: `Tenant '${requested}' not found` };
   }
-  if (requested === _DEFAULT_TENANT_ID) {
+  if (requested === defaultAuthTenantId()) {
     return { ok: true, tenantId: requested, isPersonal: false };
   }
   if (subject.join_mode === "open") {
@@ -10627,7 +10628,7 @@ async function getAllowedOAuthRedirectEntries(
   clientId?: string,
 ): Promise<string[]> {
   const explicitTenantId = tenantId?.trim() || undefined;
-  const resolvedTenantId = explicitTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = explicitTenantId || defaultAuthTenantId();
   const entries = new Set<string>();
 
   const normalizedClientId = normalizePublicClientId(clientId);

--- a/packages/api/src/services/default-auth-tenant.ts
+++ b/packages/api/src/services/default-auth-tenant.ts
@@ -1,0 +1,6 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
+/** Resolve the tenant-less auth target from the active request's immutable environment. */
+export function defaultAuthTenantId(): string {
+  return runtimeEnvironmentValue("STEWARD_DEFAULT_TENANT_ID")?.trim() || "default";
+}


### PR DESCRIPTION
Closes #668

## Summary

- resolve STEWARD_DEFAULT_TENANT_ID from the immutable request-local runtime environment at each tenant-less auth use
- preserve the Bun/process fallback and literal default fallback
- prove two overlapping runtime snapshots retain distinct tenant defaults without bleed

## Exact evidence

- base: 98bc4474072304c4e21fad17fa6dd6e0f2d7eb02
- head: 0d9d708d23da684f0f89352cf91945573de77805
- focused request-local resolver tests: 2/2 PASS
- affected dependency and API build: 26/26 PASS
- Biome affected files: PASS
- git diff --check: PASS

Keep draft until exact hosted CI and independent review are green. No production binding or deployment was changed.