### PR TITLE
fix(worker): bind spend fallback per request

### DIFF
--- a/packages/api/src/__tests__/redis-enforcement.test.ts
+++ b/packages/api/src/__tests__/redis-enforcement.test.ts
@@ -8,11 +8,13 @@
 
 import { describe, expect, it } from "bun:test";
 import type { PolicyRule } from "@stwd/shared";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import {
   enforceRateLimit,
   extractRateLimitPolicy,
   extractSpendLimitPolicy,
   formatRateLimitHeaders,
+  nativePriceFallbackUsd,
   recordVaultSpend,
 } from "../middleware/redis-enforcement";
 
@@ -209,6 +211,54 @@ describe("formatRateLimitHeaders", () => {
     const headers = formatRateLimitHeaders({ limit: 5, remaining: 4, resetMs: 1_000 });
     expect(headers["Retry-After"]).toBeUndefined();
     expect(headers["RateLimit-Remaining"]).toBe("4");
+  });
+});
+
+describe("nativePriceFallbackUsd", () => {
+  it("isolates hostile overlapping Worker request bindings", async () => {
+    let releaseHigh!: () => void;
+    const highCanFinish = new Promise<void>((resolve) => {
+      releaseHigh = resolve;
+    });
+    let highStarted!: () => void;
+    const highDidStart = new Promise<void>((resolve) => {
+      highStarted = resolve;
+    });
+
+    const high = withRuntimeEnvironment(
+      { STEWARD_NATIVE_PRICE_FALLBACK_USD: "25000" },
+      async () => {
+        highStarted();
+        await highCanFinish;
+        return nativePriceFallbackUsd();
+      },
+    );
+    await highDidStart;
+
+    const hostileLow = withRuntimeEnvironment(
+      { STEWARD_NATIVE_PRICE_FALLBACK_USD: "1" },
+      async () => {
+        expect(nativePriceFallbackUsd()).toBe(1);
+        releaseHigh();
+        return nativePriceFallbackUsd();
+      },
+    );
+
+    expect(await Promise.all([high, hostileLow])).toEqual([25_000, 1]);
+  });
+
+  it("uses the conservative default for absent or invalid request bindings", () => {
+    expect(withRuntimeEnvironment({}, () => nativePriceFallbackUsd())).toBe(10_000);
+    expect(
+      withRuntimeEnvironment({ STEWARD_NATIVE_PRICE_FALLBACK_USD: "Infinity" }, () =>
+        nativePriceFallbackUsd(),
+      ),
+    ).toBe(10_000);
+    expect(
+      withRuntimeEnvironment({ STEWARD_NATIVE_PRICE_FALLBACK_USD: "0" }, () =>
+        nativePriceFallbackUsd(),
+      ),
+    ).toBe(10_000);
   });
 });
 

--- a/packages/api/src/middleware/redis-enforcement.ts
+++ b/packages/api/src/middleware/redis-enforcement.ts
@@ -7,6 +7,7 @@
  */
 
 import { createPriceOracle, type PolicyRule } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   checkAgentRateLimit,
   isRedisAvailable,
@@ -112,6 +113,12 @@ export function formatRateLimitHeaders(input: RateLimitHeaderInput): Record<stri
     headers["Retry-After"] = String(Math.max(1, Math.ceil(input.retryAfterMs / 1000)));
   }
   return headers;
+}
+
+/** Resolve the conservative oracle-outage valuation from the active request binding. */
+export function nativePriceFallbackUsd(): number {
+  const parsed = Number(runtimeEnvironmentValue("STEWARD_NATIVE_PRICE_FALLBACK_USD"));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 10_000;
 }
 
 /**
@@ -236,10 +243,7 @@ export async function recordVaultSpend(
   const decimals = 18; // EVM native tokens use 18 decimals
   const divisor = 10n ** BigInt(decimals);
   const tokenAmount = Number(wei / divisor) + Number(wei % divisor) / Number(divisor);
-  const fallbackNativePriceUsd = (() => {
-    const parsed = Number(process.env.STEWARD_NATIVE_PRICE_FALLBACK_USD);
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : 10_000;
-  })();
+  const fallbackNativePriceUsd = nativePriceFallbackUsd();
   const conservativeUsd = tokenAmount * fallbackNativePriceUsd;
   await recordAgentSpend(agentId, tenantId, conservativeUsd, `chain:${chainId}`);
 }


### PR DESCRIPTION
Closes #671

## Summary

- resolve STEWARD_NATIVE_PRICE_FALLBACK_USD from the immutable request-local runtime environment during vault spend accounting
- prevent overlapping Worker invocations from borrowing another request conservative valuation
- preserve the conservative 10000 USD default for absent, invalid, non-positive, and non-finite values

## Exact evidence

- base: 98bc4474072304c4e21fad17fa6dd6e0f2d7eb02
- head: 5614ed9b6
- redis-enforcement suite: 18/18 PASS, 28 assertions
- hostile overlapping high/low runtime snapshots: PASS
- affected dependency and API build: 26/26 PASS
- Biome affected files: PASS
- git diff --check: PASS

Keep draft until exact hosted CI and independent review are green. No production binding or deployment was changed.