### PR TITLE
fix(security): enforce exact platform database authority

### DIFF
--- a/packages/api/src/__tests__/platform-identity-graph.test.ts
+++ b/packages/api/src/__tests__/platform-identity-graph.test.ts
@@ -1,9 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 
-import { hashSha256Hex } from "@stwd/auth";
+import { hashSha256Hex, revocationStore } from "@stwd/auth";
 import {
   accounts,
   agents,
+  auditEvents,
   closeDb,
   getDb,
   refreshTokens,
@@ -14,7 +15,7 @@ import {
   userTenants,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 
 const PLATFORM_KEY = "platform-identity-graph-key";
 const TENANT_ID = "platform-identity-graph-tenant";
@@ -105,6 +106,82 @@ describe("platform global identity graph routes", () => {
       "Content-Type": "application/json",
       "X-Steward-Platform-Key": PLATFORM_KEY,
     };
+  }
+
+  async function createLifecycleFaultUser(label: string) {
+    const [user] = await getDb()
+      .insert(users)
+      .values({ email: `${label}@example.test`, emailVerified: true })
+      .returning({ id: users.id });
+    await getDb().insert(userTenants).values({
+      userId: user.id,
+      tenantId: TENANT_ID,
+      role: "member",
+    });
+    await getDb()
+      .insert(refreshTokens)
+      .values({
+        id: `${label}-refresh-token`,
+        userId: user.id,
+        tenantId: TENANT_ID,
+        tokenHash: `${label}-refresh-hash`,
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+    return user.id;
+  }
+
+  async function lifecycleDatabaseState(faultUserId: string) {
+    const [user] = await getDb()
+      .select({ deactivatedAt: users.deactivatedAt })
+      .from(users)
+      .where(eq(users.id, faultUserId));
+    const tokens = await getDb()
+      .select({ id: refreshTokens.id })
+      .from(refreshTokens)
+      .where(eq(refreshTokens.userId, faultUserId));
+    const audits = await getDb()
+      .select({ action: auditEvents.action })
+      .from(auditEvents)
+      .where(eq(auditEvents.resourceId, faultUserId))
+      .orderBy(asc(auditEvents.seq));
+    return { audits: audits.map((row) => row.action), tokens, user };
+  }
+
+  async function deactivateUser(faultUserId: string) {
+    return platformRoutes.request(`/users/${faultUserId}/deactivate`, {
+      method: "PATCH",
+      headers: headers(),
+      body: JSON.stringify({ deactivated: true }),
+    });
+  }
+
+  async function installOneShotCompletionAuditFailure(name: string, deferred: boolean) {
+    await getDb().execute(sql.raw(`CREATE SEQUENCE ${name}_seq`));
+    await getDb().execute(
+      sql.raw(`
+      CREATE FUNCTION ${name}_fn() RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN
+        IF NEW.action = 'user.deactivate' AND nextval('${name}_seq') = 1 THEN
+          RAISE EXCEPTION '${name}';
+        END IF;
+        RETURN NEW;
+      END
+      $$
+    `),
+    );
+    await getDb().execute(
+      sql.raw(
+        deferred
+          ? `CREATE CONSTRAINT TRIGGER ${name}_trigger AFTER INSERT ON audit_events DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION ${name}_fn()`
+          : `CREATE TRIGGER ${name}_trigger AFTER INSERT ON audit_events FOR EACH ROW EXECUTE FUNCTION ${name}_fn()`,
+      ),
+    );
+  }
+
+  async function removeCompletionAuditFailure(name: string) {
+    await getDb().execute(sql.raw(`DROP TRIGGER IF EXISTS ${name}_trigger ON audit_events`));
+    await getDb().execute(sql.raw(`DROP FUNCTION IF EXISTS ${name}_fn()`));
+    await getDb().execute(sql.raw(`DROP SEQUENCE IF EXISTS ${name}_seq`));
   }
 
   it("gets a global user identity with tenant ids and linked accounts", async () => {
@@ -839,6 +916,73 @@ describe("platform global identity graph routes", () => {
     const reactivateBody = (await reactivate.json()) as { data: { deactivatedAt: string | null } };
     expect(reactivateBody.data.deactivatedAt).toBeNull();
   });
+
+  it("rolls back authorization and mutation when the mounted revoker fails, then retries", async () => {
+    const faultUserId = await createLifecycleFaultUser("platform-revoker-fault");
+    const originalRevoke = revocationStore.revokeUserTokens.bind(revocationStore);
+    let attempts = 0;
+    revocationStore.revokeUserTokens = async (id, issuedBefore, expiresAt) => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("simulated platform revoker failure");
+      return originalRevoke(id, issuedBefore, expiresAt);
+    };
+
+    try {
+      const failed = await deactivateUser(faultUserId);
+      expect(failed.status).toBe(500);
+      expect(await lifecycleDatabaseState(faultUserId)).toEqual({
+        audits: [],
+        tokens: [{ id: "platform-revoker-fault-refresh-token" }],
+        user: { deactivatedAt: null },
+      });
+      expect(await revocationStore.getUserRevokedBefore(faultUserId)).toBeNull();
+
+      const retried = await deactivateUser(faultUserId);
+      expect(retried.status).toBe(200);
+      expect(await lifecycleDatabaseState(faultUserId)).toEqual({
+        audits: ["user.deactivate.authorized", "user.deactivate"],
+        tokens: [],
+        user: { deactivatedAt: expect.any(Date) },
+      });
+      expect(await revocationStore.getUserRevokedBefore(faultUserId)).not.toBeNull();
+    } finally {
+      revocationStore.revokeUserTokens = originalRevoke;
+    }
+  });
+
+  for (const fault of [
+    { deferred: false, label: "completion audit", name: "platform_completion_audit_fault" },
+    { deferred: true, label: "commit", name: "platform_commit_fault" },
+  ]) {
+    it(`rolls back database state on ${fault.label} failure, preserves safe revocation, and retries`, async () => {
+      const faultUserId = await createLifecycleFaultUser(fault.name);
+      await installOneShotCompletionAuditFailure(fault.name, fault.deferred);
+      try {
+        const failed = await deactivateUser(faultUserId);
+        expect(failed.status).toBe(500);
+        expect(await lifecycleDatabaseState(faultUserId)).toEqual({
+          audits: [],
+          tokens: [{ id: `${fault.name}-refresh-token` }],
+          user: { deactivatedAt: null },
+        });
+        const firstCutoff = await revocationStore.getUserRevokedBefore(faultUserId);
+        expect(firstCutoff).not.toBeNull();
+
+        const retried = await deactivateUser(faultUserId);
+        expect(retried.status).toBe(200);
+        expect(await lifecycleDatabaseState(faultUserId)).toEqual({
+          audits: ["user.deactivate.authorized", "user.deactivate"],
+          tokens: [],
+          user: { deactivatedAt: expect.any(Date) },
+        });
+        const retryCutoff = await revocationStore.getUserRevokedBefore(faultUserId);
+        expect(retryCutoff).not.toBeNull();
+        expect(retryCutoff as number).toBeGreaterThanOrEqual(firstCutoff as number);
+      } finally {
+        await removeCompletionAuditFailure(fault.name);
+      }
+    });
+  }
 
   it("hard-deletes users and cascades linked identity rows", async () => {
     const [deleteUser] = await getDb()

--- a/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
@@ -176,6 +176,86 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
         default_sequence_grant: false,
       });
 
+      const expectedPlatformAcls = [
+        "function:steward_bootstrap.platform_delete_user(p_user_id uuid):EXECUTE:false",
+        "function:steward_bootstrap.platform_revoke_user_refresh_tokens(p_user_id uuid):EXECUTE:false",
+        "function:steward_bootstrap.platform_set_user_deactivation(p_user_id uuid, p_deactivated boolean):EXECUTE:false",
+        "function:steward_bootstrap.retention_delete_deactivated_users(p_days integer):EXECUTE:false",
+        "function:steward_rls.tenant_id():EXECUTE:false",
+        "relation:public.audit_chain_heads:INSERT:false",
+        "relation:public.audit_chain_heads:SELECT:false",
+        "relation:public.audit_chain_heads:UPDATE:false",
+        "relation:public.audit_events:INSERT:false",
+        "relation:public.audit_events:SELECT:false",
+        "relation:public.audit_events_id_seq:SELECT:false",
+        "relation:public.audit_events_id_seq:USAGE:false",
+        "schema:steward_bootstrap:USAGE:false",
+        "schema:steward_rls:USAGE:false",
+      ];
+      const platformNamedAcls = async () => {
+        const rows = await db<{ acl: string }[]>`
+          SELECT 'schema:' || namespace.nspname || ':' || privilege.privilege_type || ':' ||
+            privilege.is_grantable AS acl
+          FROM pg_namespace namespace
+          CROSS JOIN LATERAL aclexplode(COALESCE(namespace.nspacl, '{}'::aclitem[])) privilege
+          JOIN pg_roles granted_role ON granted_role.oid = privilege.grantee
+          WHERE granted_role.rolname = ${platformRole}
+          UNION ALL
+          SELECT 'relation:' || namespace.nspname || '.' || relation.relname || ':' ||
+            privilege.privilege_type || ':' || privilege.is_grantable AS acl
+          FROM pg_class relation
+          JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+          CROSS JOIN LATERAL aclexplode(COALESCE(relation.relacl, '{}'::aclitem[])) privilege
+          JOIN pg_roles granted_role ON granted_role.oid = privilege.grantee
+          WHERE relation.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
+            AND granted_role.rolname = ${platformRole}
+          UNION ALL
+          SELECT 'function:' || namespace.nspname || '.' || function_object.proname || '(' ||
+            pg_get_function_identity_arguments(function_object.oid) || '):' ||
+            privilege.privilege_type || ':' || privilege.is_grantable AS acl
+          FROM pg_proc function_object
+          JOIN pg_namespace namespace ON namespace.oid = function_object.pronamespace
+          CROSS JOIN LATERAL aclexplode(COALESCE(function_object.proacl, '{}'::aclitem[])) privilege
+          JOIN pg_roles granted_role ON granted_role.oid = privilege.grantee
+          WHERE granted_role.rolname = ${platformRole}
+          ORDER BY acl
+        `;
+        return rows.map((row) => row.acl);
+      };
+      expect(await platformNamedAcls()).toEqual(expectedPlatformAcls);
+
+      await db.unsafe(`GRANT USAGE ON SCHEMA public TO ${platformRole}`);
+      await db.unsafe(`GRANT UPDATE ON public.audit_events TO ${platformRole} WITH GRANT OPTION`);
+      await db.unsafe(`GRANT USAGE ON SEQUENCE public.audit_checkpoints_id_seq TO ${platformRole}`);
+      await db.unsafe(
+        `GRANT EXECUTE ON FUNCTION steward_bootstrap.platform_stats() TO ${platformRole} WITH GRANT OPTION`,
+      );
+      await runOperatorScript("rls-bootstrap.sql", true);
+      expect(await platformNamedAcls()).toEqual(expectedPlatformAcls);
+
+      await admin.unsafe(`GRANT ${definerRole} TO ${platformRole}`);
+      try {
+        await expect(runOperatorScript("rls-bootstrap.sql", true)).rejects.toThrow(
+          "platform role must not inherit, assume, or be assumable by another role",
+        );
+      } finally {
+        await admin.unsafe(`REVOKE ${definerRole} FROM ${platformRole}`);
+      }
+
+      await db.unsafe("CREATE SEQUENCE public.platform_owned_authority_probe");
+      await db.unsafe(
+        `ALTER SEQUENCE public.platform_owned_authority_probe OWNER TO ${platformRole}`,
+      );
+      try {
+        await expect(runOperatorScript("rls-bootstrap.sql", true)).rejects.toThrow(
+          "platform role must not own database objects",
+        );
+      } finally {
+        await admin.unsafe("DROP SEQUENCE public.platform_owned_authority_probe");
+      }
+      await runOperatorScript("rls-bootstrap.sql", true);
+      expect(await platformNamedAcls()).toEqual(expectedPlatformAcls);
+
       await runOperatorScript("rls-activate.sql");
       const [activated] = await db<{ enabled: number; forced: number; maintenance: number }[]>`
         SELECT

--- a/scripts/postgres/rls-bootstrap.sql
+++ b/scripts/postgres/rls-bootstrap.sql
@@ -83,13 +83,57 @@ SELECT format(
   'steward_bootstrap.retention_delete_deactivated_users(integer) FROM %I',
   :'steward_app_role'
 ) \gexec
+
+-- The platform login is a narrow, separately credentialed authority. Reset
+-- every named ACL it could have retained from an earlier bootstrap before
+-- rebuilding the allowlist below. PUBLIC privileges remain governed by the
+-- schema-wide revocations above.
+SELECT format('REVOKE ALL PRIVILEGES ON DATABASE %I FROM %I', current_database(), :'steward_platform_role') \gexec
+SELECT format('REVOKE ALL PRIVILEGES ON SCHEMA %I FROM %I', namespace.nspname, :'steward_platform_role')
+FROM pg_namespace namespace
+CROSS JOIN LATERAL aclexplode(COALESCE(namespace.nspacl, '{}'::aclitem[])) privilege
+JOIN pg_roles granted_role ON granted_role.oid = privilege.grantee
+WHERE granted_role.rolname = :'steward_platform_role'
+GROUP BY namespace.nspname
+\gexec
+SELECT format(
+  'REVOKE ALL PRIVILEGES ON %s %I.%I FROM %I',
+  CASE WHEN relation.relkind = 'S' THEN 'SEQUENCE' ELSE 'TABLE' END,
+  namespace.nspname,
+  relation.relname,
+  :'steward_platform_role'
+)
+FROM pg_class relation
+JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+CROSS JOIN LATERAL aclexplode(COALESCE(relation.relacl, '{}'::aclitem[])) privilege
+JOIN pg_roles granted_role ON granted_role.oid = privilege.grantee
+WHERE relation.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
+  AND granted_role.rolname = :'steward_platform_role'
+GROUP BY relation.relkind, namespace.nspname, relation.relname
+\gexec
+SELECT format(
+  'REVOKE ALL PRIVILEGES ON FUNCTION %s FROM %I',
+  function_object.oid::regprocedure,
+  :'steward_platform_role'
+)
+FROM pg_proc function_object
+CROSS JOIN LATERAL aclexplode(COALESCE(function_object.proacl, '{}'::aclitem[])) privilege
+JOIN pg_roles granted_role ON granted_role.oid = privilege.grantee
+WHERE granted_role.rolname = :'steward_platform_role'
+GROUP BY function_object.oid
+\gexec
+
 SELECT format('GRANT USAGE ON SCHEMA steward_bootstrap, steward_rls TO %I', :'steward_platform_role') \gexec
 SELECT format(
   'GRANT EXECUTE ON FUNCTION steward_rls.tenant_id() TO %I',
   :'steward_platform_role'
 ) \gexec
 SELECT format(
-  'GRANT SELECT, INSERT, UPDATE ON public.audit_events, public.audit_chain_heads TO %I',
+  'GRANT SELECT, INSERT ON public.audit_events TO %I',
+  :'steward_platform_role'
+) \gexec
+SELECT format(
+  'GRANT SELECT, INSERT, UPDATE ON public.audit_chain_heads TO %I',
   :'steward_platform_role'
 ) \gexec
 SELECT format(
@@ -190,6 +234,16 @@ BEGIN
   ) THEN
     RAISE EXCEPTION 'SEC-169 app role must not inherit or assume platform role';
   END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM pg_auth_members membership
+    JOIN pg_roles member_role ON member_role.oid = membership.member
+    JOIN pg_roles granted_role ON granted_role.oid = membership.roleid
+    WHERE member_role.rolname = current_setting('steward.bootstrap.platform_role')
+       OR granted_role.rolname = current_setting('steward.bootstrap.platform_role')
+  ) THEN
+    RAISE EXCEPTION 'SEC-169 platform role must not inherit, assume, or be assumable by another role';
+  END IF;
   IF pg_has_role(
     current_setting('steward.bootstrap.app_role'),
     current_setting('steward.bootstrap.definer_role'),
@@ -208,6 +262,31 @@ BEGIN
   ) THEN
     RAISE EXCEPTION 'SEC-169 definer role must be NOLOGIN NOSUPERUSER BYPASSRLS';
   END IF;
+  IF EXISTS (
+    SELECT 1 FROM pg_shdepend ownership
+    JOIN pg_roles owner_role ON owner_role.oid = ownership.refobjid
+    WHERE ownership.refclassid = 'pg_authid'::regclass
+      AND ownership.deptype = 'o'
+      AND owner_role.rolname = current_setting('steward.bootstrap.platform_role')
+  ) OR EXISTS (
+    SELECT 1 FROM pg_database database_object
+    JOIN pg_roles owner_role ON owner_role.oid = database_object.datdba
+    WHERE owner_role.rolname = current_setting('steward.bootstrap.platform_role')
+  ) OR EXISTS (
+    SELECT 1 FROM pg_namespace schema_object
+    JOIN pg_roles owner_role ON owner_role.oid = schema_object.nspowner
+    WHERE owner_role.rolname = current_setting('steward.bootstrap.platform_role')
+  ) OR EXISTS (
+    SELECT 1 FROM pg_class relation_object
+    JOIN pg_roles owner_role ON owner_role.oid = relation_object.relowner
+    WHERE owner_role.rolname = current_setting('steward.bootstrap.platform_role')
+  ) OR EXISTS (
+    SELECT 1 FROM pg_proc function_object
+    JOIN pg_roles owner_role ON owner_role.oid = function_object.proowner
+    WHERE owner_role.rolname = current_setting('steward.bootstrap.platform_role')
+  ) THEN
+    RAISE EXCEPTION 'SEC-169 platform role must not own database objects';
+  END IF;
   IF has_schema_privilege(current_setting('steward.bootstrap.app_role'), 'public', 'CREATE')
      OR has_schema_privilege(current_setting('steward.bootstrap.app_role'), 'steward_bootstrap', 'CREATE')
      OR has_schema_privilege(current_setting('steward.bootstrap.app_role'), 'steward_rls', 'CREATE') THEN
@@ -221,8 +300,77 @@ BEGIN
      )
      OR has_function_privilege(
        current_setting('steward.bootstrap.platform_role'), 'steward_rls.user_id()', 'EXECUTE'
-     ) THEN
+  ) THEN
     RAISE EXCEPTION 'SEC-169 platform role must receive only tenant RLS context access';
+  END IF;
+  IF (
+    SELECT array_agg(
+      namespace.nspname || ':' || privilege.privilege_type || ':' || privilege.is_grantable
+      ORDER BY namespace.nspname, privilege.privilege_type, privilege.is_grantable
+    )
+    FROM pg_namespace namespace
+    CROSS JOIN LATERAL aclexplode(COALESCE(namespace.nspacl, '{}'::aclitem[])) privilege
+    JOIN pg_roles granted_role ON granted_role.oid = privilege.grantee
+    WHERE granted_role.rolname = current_setting('steward.bootstrap.platform_role')
+  ) IS DISTINCT FROM ARRAY[
+    'steward_bootstrap:USAGE:false',
+    'steward_rls:USAGE:false'
+  ] THEN
+    RAISE EXCEPTION 'SEC-169 platform schema ACL drift';
+  END IF;
+  IF (
+    SELECT array_agg(
+      namespace.nspname || '.' || relation.relname || ':' || privilege.privilege_type || ':' || privilege.is_grantable
+      ORDER BY namespace.nspname, relation.relname, privilege.privilege_type, privilege.is_grantable
+    )
+    FROM pg_class relation
+    JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+    CROSS JOIN LATERAL aclexplode(COALESCE(relation.relacl, '{}'::aclitem[])) privilege
+    JOIN pg_roles granted_role ON granted_role.oid = privilege.grantee
+    WHERE relation.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
+      AND granted_role.rolname = current_setting('steward.bootstrap.platform_role')
+  ) IS DISTINCT FROM ARRAY[
+    'public.audit_chain_heads:INSERT:false',
+    'public.audit_chain_heads:SELECT:false',
+    'public.audit_chain_heads:UPDATE:false',
+    'public.audit_events:INSERT:false',
+    'public.audit_events:SELECT:false',
+    'public.audit_events_id_seq:SELECT:false',
+    'public.audit_events_id_seq:USAGE:false'
+  ] THEN
+    RAISE EXCEPTION 'SEC-169 platform relation ACL drift';
+  END IF;
+  IF (
+    SELECT array_agg(
+      namespace.nspname || '.' || function_object.proname || '(' ||
+      pg_get_function_identity_arguments(function_object.oid) || '):' ||
+      privilege.privilege_type || ':' || privilege.is_grantable
+      ORDER BY namespace.nspname, function_object.proname,
+        pg_get_function_identity_arguments(function_object.oid),
+        privilege.privilege_type, privilege.is_grantable
+    )
+    FROM pg_proc function_object
+    JOIN pg_namespace namespace ON namespace.oid = function_object.pronamespace
+    CROSS JOIN LATERAL aclexplode(COALESCE(function_object.proacl, '{}'::aclitem[])) privilege
+    JOIN pg_roles granted_role ON granted_role.oid = privilege.grantee
+    WHERE granted_role.rolname = current_setting('steward.bootstrap.platform_role')
+  ) IS DISTINCT FROM ARRAY[
+    'steward_bootstrap.platform_delete_user(p_user_id uuid):EXECUTE:false',
+    'steward_bootstrap.platform_revoke_user_refresh_tokens(p_user_id uuid):EXECUTE:false',
+    'steward_bootstrap.platform_set_user_deactivation(p_user_id uuid, p_deactivated boolean):EXECUTE:false',
+    'steward_bootstrap.retention_delete_deactivated_users(p_days integer):EXECUTE:false',
+    'steward_rls.tenant_id():EXECUTE:false'
+  ] THEN
+    RAISE EXCEPTION 'SEC-169 platform function ACL drift';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM pg_default_acl defaults
+    CROSS JOIN LATERAL aclexplode(COALESCE(defaults.defaclacl, '{}'::aclitem[])) privilege
+    JOIN pg_roles granted_role ON granted_role.oid = privilege.grantee
+    WHERE granted_role.rolname = current_setting('steward.bootstrap.platform_role')
+  ) THEN
+    RAISE EXCEPTION 'SEC-169 platform role must not receive default privileges';
   END IF;
   IF NOT has_sequence_privilege(
        current_setting('steward.bootstrap.platform_role'),


### PR DESCRIPTION
Closes #654

## Summary

This post-merge corrective closes the two acceptance gaps left after #667:

- rebuild the platform database role from an exact rerun-safe named ACL allowlist;
- add mounted platform user-lifecycle fault proofs for revoker, completion-audit, and true commit failure.

The bootstrap now removes stale named database, schema, relation, sequence, and function grants before granting only the platform audit and lifecycle surface. It removes UPDATE on audit_events, rejects every platform role membership edge and database-object ownership, rejects default privileges, grant options, extra named ACLs, unrelated sequence/function access, superuser, and BYPASSRLS authority.

The real mounted Hono route tests prove that revoker failure rolls back authorization before mutation, completion-audit and deferred COMMIT failures roll back database state and both audit rows, a successful external cutoff remains monotonic and fail-closed, and retry commits exactly one authorization/completion pair.

## Type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, dependencies
- [ ] `test` — Adding or updating tests

## Scope

- PostgreSQL RLS/bootstrap role topology
- DB real-PostgreSQL operator coverage
- API mounted platform identity lifecycle coverage

## Breaking Changes

None. Existing platform credentials remain valid, but operators must rerun the bootstrap before activation so stale named grants are removed.

## Exact lineage

- base: `f915f7fe875eec9ff75cd6ee9db39825240a7b5c`
- head: `dd592011485075a15967f61e5ffabd1de42fc40a`

## Validation

- mounted platform identity graph: 22/22 PASS, including one-shot revoker, completion-audit trigger, and deferred COMMIT faults with idempotent retry
- RLS policy, audit retry, and request-handle suites: 31/31 PASS
- API/DB dependency build: 24/24 packages PASS
- Biome affected TypeScript: PASS
- git diff --check: PASS
- merge-tree against exact base: clean

No local PostgreSQL service or Docker daemon was available. The expanded real-PostgreSQL operator test is checked in and must pass on the exact hosted head before readiness or merge.

## Checklist

- [x] Tests added/updated for changes
- [x] Documentation updated if needed
- [ ] CI passes (`bun test`, typecheck)
- [x] PR targets `develop` (not `main`)
- [x] Commit messages follow conventional format (`type(scope): description`)

Keep draft. Require exact-head hosted PostgreSQL, full CI, and independent review before marking ready. Do not activate #343 from this PR alone.
