### PR TITLE
fix(ci): allow integration suite to finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,7 +451,7 @@ jobs:
   integration:
     name: Integration Tests (Postgres)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     env:
       REDIS_URL: "redis://localhost:6379"
 


### PR DESCRIPTION
## Summary
- align the PostgreSQL integration job timeout with its documented 25-minute bound
- prevent the serial per-file API suite from being canceled at 15 minutes

## Exact failure evidence
- develop SHA: `f915f7fe875eec9ff75cd6ee9db39825240a7b5c`
- CI run: `32357308544`
- job: `96389154546` (`Integration Tests (Postgres)`)
- job started: `2026-08-20T10:10:46Z`
- API integration step started: `2026-08-20T10:13:18Z`
- job canceled by the 15-minute ceiling at `2026-08-20T10:26:04Z` while the API suite was still running

The workflow comment already specifies a 25-minute job timeout for this serial, migration-heavy suite; the configured value was still 15.

## Validation
- Ruby YAML parse: PASS
- `git diff --check`: PASS

Keep draft until exact-head hosted CI, CodeQL, Docker, and independent last-push review are green.