### PR TITLE
fix(ci): allow Postgres integration suite to finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,7 +451,10 @@ jobs:
   integration:
     name: Integration Tests (Postgres)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # The serial API suite intentionally runs each PGLite-heavy file in a
+    # separate process. Keep the job budget aligned with the documented
+    # 25-minute bound below; 15 minutes cancels healthy hosted runs mid-suite.
+    timeout-minutes: 25
     env:
       REDIS_URL: "redis://localhost:6379"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -538,9 +538,8 @@ jobs:
   integration:
     name: Integration Tests (Postgres)
     runs-on: ubuntu-latest
-    # 25m: the per-test timeout was raised to 30s to absorb PGLite migration
-    # latency under the concurrent --isolate load, which lengthens worst-case
-    # wall-clock for the full 122-file run. Give the job comfortable headroom.
+    # The serial isolated runner below keeps migration-heavy files from starving
+    # each other. Give the complete API suite enough bounded wall-clock headroom.
     timeout-minutes: 25
     env:
       REDIS_URL: "redis://localhost:6379"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -662,10 +662,11 @@ jobs:
         # size) and each process frees its WASM heap on exit. Reproduced in a
         # 6GB-capped Linux container: the single `--isolate` process is killed
         # at exit 137; a 6-way --shard split still OOMs (25 files/shard is too
-        # much); this runner at TEST_JOBS=2 finishes the full suite with zero
-        # OOM in ~2.3min. TEST_TIMEOUT=30000 absorbs per-file PGLite migration
-        # latency.
-        run: TEST_JOBS=2 TEST_TIMEOUT=30000 bun packages/api/scripts/run-tests-isolated.ts
+        # much). Keep this serial: even two PGLite processes can starve an API
+        # request long enough to hit Bun's per-test timeout. The 120-second
+        # per-file timeout matches push CI and leaves headroom for the
+        # migration-heavy public-boundary suites.
+        run: TEST_JOBS=1 TEST_TIMEOUT=120000 bun packages/api/scripts/run-tests-isolated.ts
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
           PORT: "3299"

--- a/packages/api/src/__tests__/adapters-app-mount.test.ts
+++ b/packages/api/src/__tests__/adapters-app-mount.test.ts
@@ -1,22 +1,18 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { hashApiKey } from "@stwd/auth";
-import { closeDb, getDb, tenants } from "@stwd/db";
-import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { getDb, tenants } from "@stwd/db";
+import { eq } from "drizzle-orm";
 
 const TENANT_ID = `adapter-app-mount-${Date.now()}`;
 const API_KEY = `stw_adapter_mount_${Date.now()}`;
+const SKIP = !process.env.DATABASE_URL;
 
-describe("adapter app mount", () => {
+describe.skipIf(SKIP)("adapter app mount", () => {
   let app: Awaited<typeof import("../app")>["app"];
 
   beforeAll(async () => {
-    process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_MASTER_PASSWORD = "adapter-app-mount-master-password";
     process.env.STEWARD_AUDIT_HMAC_KEY = "adapter-app-mount-audit-hmac-key-with-enough-entropy";
-    const { db, client } = await createPGLiteDb("memory://");
-    setPGLiteOverride(db, async () => {
-      await client.close();
-    });
     await getDb()
       .insert(tenants)
       .values({
@@ -28,8 +24,7 @@ describe("adapter app mount", () => {
   }, 120_000);
 
   afterAll(async () => {
-    await closeDb();
-    delete process.env.STEWARD_PGLITE_MEMORY;
+    await getDb().delete(tenants).where(eq(tenants.id, TENANT_ID));
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_AUDIT_HMAC_KEY;
   });

--- a/packages/api/src/__tests__/agent-jwt-hardening.test.ts
+++ b/packages/api/src/__tests__/agent-jwt-hardening.test.ts
@@ -63,7 +63,7 @@ describe("external agent JWT hardening", () => {
       "agentTokenScopes.some((scope) => scope.startsWith(CAPABILITY_TOKEN_SCOPE_PREFIX))",
     );
     const agentLookup = contextSource.indexOf(
-      "const agent = await ensureAgentForTenant(payload.tenantId, payload.agentId as string);",
+      "const agentSubject = await findAgentBootstrapSubject(",
     );
     expect(refusal).toBeGreaterThanOrEqual(0);
     expect(agentLookup).toBeGreaterThan(refusal);

--- a/packages/api/src/__tests__/agent-signers.test.ts
+++ b/packages/api/src/__tests__/agent-signers.test.ts
@@ -459,7 +459,8 @@ describe("agent signer API", () => {
     const beforeAudits = await getDb()
       .select({ id: auditEvents.id })
       .from(auditEvents)
-      .where(eq(auditEvents.tenantId, TENANT_ID));
+      .where(eq(auditEvents.tenantId, TENANT_ID))
+      .orderBy(asc(auditEvents.id));
 
     const pauseResponse = await noMfaApp.request(`/agents/${AGENT_ID}/signers/${created.data.id}`, {
       method: "PATCH",
@@ -486,7 +487,8 @@ describe("agent signer API", () => {
       await getDb()
         .select({ id: auditEvents.id })
         .from(auditEvents)
-        .where(eq(auditEvents.tenantId, TENANT_ID)),
+        .where(eq(auditEvents.tenantId, TENANT_ID))
+        .orderBy(asc(auditEvents.id)),
     ).toEqual(beforeAudits);
   });
 

--- a/packages/api/src/__tests__/agent-signers.test.ts
+++ b/packages/api/src/__tests__/agent-signers.test.ts
@@ -301,7 +301,8 @@ describe("agent signer API", () => {
     const beforeAudits = await getDb()
       .select({ id: auditEvents.id })
       .from(auditEvents)
-      .where(eq(auditEvents.tenantId, TENANT_ID));
+      .where(eq(auditEvents.tenantId, TENANT_ID))
+      .orderBy(asc(auditEvents.id));
     const createResponse = await noMfaApp.request(`/agents/${AGENT_ID}/signers`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -337,7 +338,8 @@ describe("agent signer API", () => {
       await getDb()
         .select({ id: auditEvents.id })
         .from(auditEvents)
-        .where(eq(auditEvents.tenantId, TENANT_ID)),
+        .where(eq(auditEvents.tenantId, TENANT_ID))
+        .orderBy(asc(auditEvents.id)),
     ).toEqual(beforeAudits);
   });
 

--- a/packages/api/src/__tests__/auth-audit-hardening.test.ts
+++ b/packages/api/src/__tests__/auth-audit-hardening.test.ts
@@ -51,9 +51,9 @@ describe("auth and audit hardening", () => {
   it("revokes already minted access tokens when refresh-token reuse is detected", () => {
     const reusedBranch = authSource.indexOf('rotatedRefresh.status === "reused"');
     expect(reusedBranch).toBeGreaterThanOrEqual(0);
-    expect(
-      authSource.indexOf("revokeUserRefreshSessions(rotatedRefresh.userId)", reusedBranch),
-    ).toBeGreaterThan(reusedBranch);
+    expect(authSource.indexOf("await revokeUserRefreshSessions(", reusedBranch)).toBeGreaterThan(
+      reusedBranch,
+    );
     expect(authSource.indexOf("auth.refresh.reuse_detected", reusedBranch)).toBeGreaterThan(
       reusedBranch,
     );
@@ -73,7 +73,7 @@ describe("auth and audit hardening", () => {
     ).toBeGreaterThan(rotationStart);
     expect(
       authSource.indexOf("revocationStore.getUserRevokedBefore(record.userId)", rotationStart),
-    ).toBeLessThan(authSource.indexOf(".insert(refreshTokens)", rotationStart));
+    ).toBeLessThan(authSource.indexOf("auth_rotate_refresh_token(", rotationStart));
     expect(
       authSource.indexOf("Session was revoked. Please sign in again.", routeStart),
     ).toBeGreaterThan(routeStart);

--- a/packages/api/src/__tests__/auth-session-membership.test.ts
+++ b/packages/api/src/__tests__/auth-session-membership.test.ts
@@ -7,11 +7,17 @@ const authSource = readFileSync(join(import.meta.dir, "..", "routes", "auth.ts")
 
 describe("session membership hardening", () => {
   it("rejects missing users and rechecks tenant membership during session verification", () => {
-    for (const source of [contextSource, authSource]) {
-      expect(source).toContain("!user || user.deactivatedAt");
-      expect(source).toContain("from(userTenants)");
-      expect(source).toContain("eq(userTenants.tenantId, payload.tenantId)");
-      expect(source).toContain("if (!membership) return null");
-    }
+    // The shared context uses the SECURITY DEFINER bootstrap function so the
+    // lookup remains available before a tenant RLS transaction is installed.
+    expect(contextSource).toContain("steward_bootstrap.session_subject(");
+    expect(contextSource).toContain("if (!user || user.deactivated_at) return null");
+    expect(contextSource).toContain("if (payload.tenantId && !user.membership_role) return null");
+
+    // The auth router performs the equivalent checks through tenant-scoped
+    // Drizzle queries once its verified auth transaction is active.
+    expect(authSource).toContain("if (!user || user.deactivatedAt) return null");
+    expect(authSource).toContain(".from(userTenants)");
+    expect(authSource).toContain("eq(userTenants.tenantId, payload.tenantId)");
+    expect(authSource).toContain("if (!membership) return null");
   });
 });

--- a/packages/api/src/__tests__/generic-http-public-boundary-e2e.test.ts
+++ b/packages/api/src/__tests__/generic-http-public-boundary-e2e.test.ts
@@ -12,7 +12,16 @@ import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "
 import { generateKeyPairSync } from "node:crypto";
 import { createServer, type Server } from "node:http";
 import { signAccessToken } from "@stwd/auth";
-import { agents, closeDb, getDb, secrets, tenants, users, userTenants } from "@stwd/db";
+import {
+  agents,
+  closeDb,
+  getDb,
+  secretRoutes,
+  secrets,
+  tenants,
+  users,
+  userTenants,
+} from "@stwd/db";
 import { GENERIC_HTTP_PROVIDER_ACTION_PROFILE } from "@stwd/shared";
 import { KeyStore } from "@stwd/vault";
 import { eq, inArray } from "drizzle-orm";
@@ -171,7 +180,16 @@ describe.skipIf(!process.env.DATABASE_URL)("#201 generic-http true public-bounda
   });
 
   afterAll(async () => {
+    // Agent deletion is deliberately guarded while an enabled route can still
+    // resolve its secret. Disable first, let the tenant cascade remove all
+    // governed authority rows, then remove the non-FK route/secret records.
+    await getDb()
+      .update(secretRoutes)
+      .set({ enabled: false, authorityMode: "legacy", providerOperationId: null })
+      .where(eq(secretRoutes.tenantId, F.tenant));
     await getDb().delete(tenants).where(eq(tenants.id, F.tenant));
+    await getDb().delete(secretRoutes).where(eq(secretRoutes.tenantId, F.tenant));
+    await getDb().delete(secrets).where(eq(secrets.tenantId, F.tenant));
     await getDb()
       .delete(users)
       .where(inArray(users.id, [F.owner, F.approver]));

--- a/packages/api/src/__tests__/generic-http-public-boundary-e2e.test.ts
+++ b/packages/api/src/__tests__/generic-http-public-boundary-e2e.test.ts
@@ -12,10 +12,10 @@ import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "
 import { generateKeyPairSync } from "node:crypto";
 import { createServer, type Server } from "node:http";
 import { signAccessToken } from "@stwd/auth";
-import { agents, closeDb, secrets, tenants, users, userTenants } from "@stwd/db";
-import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { agents, closeDb, getDb, secrets, tenants, users, userTenants } from "@stwd/db";
 import { GENERIC_HTTP_PROVIDER_ACTION_PROFILE } from "@stwd/shared";
 import { KeyStore } from "@stwd/vault";
+import { eq, inArray } from "drizzle-orm";
 import type { Hono } from "hono";
 import { exportJWK, generateKeyPair, type KeyLike, SignJWT } from "jose";
 import type { AppVariables } from "../services/context";
@@ -83,9 +83,8 @@ async function expectCreated(response: Response, label: string): Promise<void> {
   }
 }
 
-describe("#201 generic-http true public-boundary E2E", () => {
+describe.skipIf(!process.env.DATABASE_URL)("#201 generic-http true public-boundary E2E", () => {
   beforeAll(async () => {
-    process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_AUDIT_HMAC_KEY = "0".repeat(64);
     process.env.STEWARD_EXECUTION_AUTH_SECRET = "1".repeat(64);
     process.env.STEWARD_MASTER_PASSWORD = "generic-public-boundary-master-password";
@@ -98,8 +97,7 @@ describe("#201 generic-http true public-boundary E2E", () => {
       .export({ format: "pem", type: "pkcs8" })
       .toString();
 
-    const { db, client } = await createPGLiteDb("memory://");
-    setPGLiteOverride(db, async () => client.close());
+    const db = getDb();
 
     const keyStore = new KeyStore(process.env.STEWARD_MASTER_PASSWORD, undefined, "secret-vault");
     const encrypted = keyStore.encrypt(CREDENTIAL, {
@@ -173,10 +171,13 @@ describe("#201 generic-http true public-boundary E2E", () => {
   });
 
   afterAll(async () => {
+    await getDb().delete(tenants).where(eq(tenants.id, F.tenant));
+    await getDb()
+      .delete(users)
+      .where(inArray(users.id, [F.owner, F.approver]));
     await closeDb();
     await new Promise<void>((resolve) => jwksServer.close(() => resolve()));
     for (const key of [
-      "STEWARD_PGLITE_MEMORY",
       "STEWARD_AUDIT_HMAC_KEY",
       "STEWARD_EXECUTION_AUTH_SECRET",
       "STEWARD_MASTER_PASSWORD",

--- a/packages/api/src/__tests__/privy-completeness.integration.test.ts
+++ b/packages/api/src/__tests__/privy-completeness.integration.test.ts
@@ -2,9 +2,8 @@ import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { generateTotp, hashSha256Hex } from "@stwd/auth";
 import { agents, closeDb, getDb, tenantConfigs, tenants, users, userTenants } from "@stwd/db";
-import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { isValidMnemonic } from "@stwd/vault";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 
 const webhookDispatches: Array<{
   event: { type: string; deliveryId?: string; data?: unknown };
@@ -38,13 +37,14 @@ const EMAIL = `privy-completeness-${TEST_ID}@example.test`;
 const USER_ADDRESS = "0x00000000000000000000000000000000000000cd";
 const RESTORE_MNEMONIC =
   "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const fixtureUsers = new Set([USER_ID]);
+const fixtureTenants = new Set([TENANT_ID]);
 
-describe("Privy-competitor integration completeness", () => {
+describe.skipIf(!process.env.DATABASE_URL)("Privy-competitor integration completeness", () => {
   let app: Awaited<typeof import("../app")>["app"];
   let createSessionToken: Awaited<typeof import("../routes/auth")>["createSessionToken"];
 
   beforeAll(async () => {
-    process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_MASTER_PASSWORD = "privy-completeness-master-password";
     process.env.STEWARD_JWT_SECRET = "privy-completeness-jwt-secret-with-enough-entropy";
     process.env.JWT_SECRET = "privy-completeness-jwt-secret-with-enough-entropy";
@@ -53,11 +53,6 @@ describe("Privy-competitor integration completeness", () => {
     process.env.EMAIL_PROVIDER = "mock";
     process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING = "true";
     process.env.STEWARD_ALLOW_USER_UNSAFE_MESSAGE_SIGNING = "true";
-
-    const { db, client } = await createPGLiteDb("memory://");
-    setPGLiteOverride(db, async () => {
-      await client.close();
-    });
 
     await getDb().insert(users).values({
       id: USER_ID,
@@ -78,8 +73,13 @@ describe("Privy-competitor integration completeness", () => {
   }, 120_000);
 
   afterAll(async () => {
+    await getDb()
+      .delete(tenants)
+      .where(inArray(tenants.id, [...fixtureTenants]));
+    await getDb()
+      .delete(users)
+      .where(inArray(users.id, [...fixtureUsers]));
     await closeDb();
-    delete process.env.STEWARD_PGLITE_MEMORY;
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_JWT_SECRET;
     delete process.env.JWT_SECRET;
@@ -113,6 +113,8 @@ describe("Privy-competitor integration completeness", () => {
     const userId = randomUUID();
     const tenantId = `personal-${userId}`;
     const email = `privy-${label}-${userId}@example.test`;
+    fixtureUsers.add(userId);
+    fixtureTenants.add(tenantId);
     await getDb().insert(users).values({
       id: userId,
       email,

--- a/packages/api/src/__tests__/provider-case-snapshot-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/provider-case-snapshot-postgres.integration.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Mounted real-Postgres proof for provider-case KC06 snapshot consistency.
+ *
+ * The request reads its binding before approval_queue. Holding an ACCESS
+ * EXCLUSIVE lock on approval_queue pauses the mounted handler after its first
+ * snapshot read. A second connection then commits an operation change. The
+ * manifest must retain the pre-change operation value; READ COMMITTED would
+ * observe the concurrent value on the later provider_operations statement.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { signAccessToken } from "@stwd/auth";
+import { closeDb, createPostgresClient, getDb, providerOperations } from "@stwd/db";
+import { eq } from "drizzle-orm";
+import { F } from "./provider-approval-fixture";
+import { createPendingCase, seedCaseFixture, wipeCase } from "./provider-case-fixture";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const SKIP = !DATABASE_URL;
+const ORIGINAL_RISK_CLASS = "write";
+const CONCURRENT_RISK_CLASS = "read";
+
+describe.skipIf(SKIP)("provider-case mounted repeatable-read snapshot (Postgres)", () => {
+  const admin = createPostgresClient(DATABASE_URL!);
+  const locker = createPostgresClient(DATABASE_URL!);
+  const writer = createPostgresClient(DATABASE_URL!);
+  let app: any;
+  let caseId: string;
+  let ownerToken: string;
+
+  beforeAll(async () => {
+    process.env.STEWARD_AUDIT_HMAC_KEY ??= "a".repeat(64);
+    process.env.STEWARD_MASTER_PASSWORD ??= "provider-case-snapshot-master-password";
+    process.env.STEWARD_JWT_SECRET ??=
+      "provider-case-snapshot-jwt-secret-0123456789abcdef0123456789";
+    await wipeCase();
+    await seedCaseFixture();
+    ({ intentId: caseId } = await createPendingCase("pgsnap01"));
+    await getDb()
+      .update(providerOperations)
+      .set({ riskClass: ORIGINAL_RISK_CLASS })
+      .where(eq(providerOperations.id, F.OP));
+    ownerToken = await signAccessToken({
+      address: "0xsnapshot-owner",
+      tenantId: F.TENANT,
+      userId: F.APPROVER_2,
+      mfaVerifiedAt: Date.now(),
+      mfaMethod: "totp",
+    });
+    const mod = await import("../app");
+    app = mod.mountCoreIdempotencyAndRoutes(mod.createApp());
+  }, 120_000);
+
+  afterAll(async () => {
+    await wipeCase();
+    await Promise.all([admin.end(), locker.end(), writer.end()]);
+    await closeDb();
+  });
+
+  test("later reads ignore a concurrent committed operation change", async () => {
+    let releaseLock!: () => void;
+    let lockHeld!: () => void;
+    const release = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    const locked = new Promise<void>((resolve) => {
+      lockHeld = resolve;
+    });
+    const lockTask = locker.begin(async (tx) => {
+      await tx.unsafe("LOCK TABLE approval_queue IN ACCESS EXCLUSIVE MODE");
+      lockHeld();
+      await release;
+    });
+    await locked;
+
+    let response: Response;
+    try {
+      const responsePromise = app.request(`/v2/provider-actions/${caseId}/case`, {
+        headers: {
+          Authorization: `Bearer ${ownerToken}`,
+          "X-Steward-Tenant": F.TENANT,
+        },
+      });
+
+      const deadline = Date.now() + 10_000;
+      let blocked = false;
+      while (Date.now() < deadline) {
+        const [row] = await admin<{ blocked: boolean }[]>`
+          SELECT EXISTS (
+            SELECT 1
+            FROM pg_locks waiting
+            WHERE waiting.relation = 'approval_queue'::regclass
+              AND NOT waiting.granted
+          ) AS blocked
+        `;
+        if (row?.blocked) {
+          blocked = true;
+          break;
+        }
+        await Bun.sleep(20);
+      }
+      expect(blocked).toBe(true);
+
+      await writer`
+        UPDATE provider_operations
+        SET risk_class = ${CONCURRENT_RISK_CLASS}
+        WHERE id = ${F.OP}
+      `;
+      releaseLock();
+      await lockTask;
+      response = await responsePromise;
+    } finally {
+      releaseLock();
+      await lockTask;
+    }
+
+    expect(response.status).toBe(200);
+    const manifest = (await response.json()) as { operation: { riskClass: string } };
+    expect(manifest.operation.riskClass).toBe(ORIGINAL_RISK_CLASS);
+    const [current] = await writer<{ risk_class: string }[]>`
+      SELECT risk_class FROM provider_operations WHERE id = ${F.OP}
+    `;
+    expect(current?.risk_class).toBe(CONCURRENT_RISK_CLASS);
+  }, 30_000);
+});

--- a/packages/api/src/__tests__/provider-case-snapshot-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/provider-case-snapshot-postgres.integration.test.ts
@@ -20,14 +20,17 @@ const ORIGINAL_RISK_CLASS = "write";
 const CONCURRENT_RISK_CLASS = "read";
 
 describe.skipIf(SKIP)("provider-case mounted repeatable-read snapshot (Postgres)", () => {
-  const admin = createPostgresClient(DATABASE_URL!);
-  const locker = createPostgresClient(DATABASE_URL!);
-  const writer = createPostgresClient(DATABASE_URL!);
+  let admin: ReturnType<typeof createPostgresClient>;
+  let locker: ReturnType<typeof createPostgresClient>;
+  let writer: ReturnType<typeof createPostgresClient>;
   let app: any;
   let caseId: string;
   let ownerToken: string;
 
   beforeAll(async () => {
+    admin = createPostgresClient(DATABASE_URL!);
+    locker = createPostgresClient(DATABASE_URL!);
+    writer = createPostgresClient(DATABASE_URL!);
     process.env.STEWARD_AUDIT_HMAC_KEY ??= "a".repeat(64);
     process.env.STEWARD_MASTER_PASSWORD ??= "provider-case-snapshot-master-password";
     process.env.STEWARD_JWT_SECRET ??=

--- a/packages/api/src/__tests__/retention.test.ts
+++ b/packages/api/src/__tests__/retention.test.ts
@@ -148,6 +148,9 @@ describe.skipIf(SKIP)("retention sweep", () => {
     const { runRetentionSweep } = await import("../services/retention");
     delete process.env.STEWARD_RETENTION_AUDIT_EVENTS_DAYS;
     const db = getDb();
+    // Earlier sweep cases may emit their own retention audit event for this
+    // tenant. Reset the tenant-local chain so this assertion owns seq 1.
+    await db.execute(sql`DELETE FROM audit_events WHERE tenant_id = ${TENANT}`);
     // Insert an ancient audit event directly (bypassing the chain — just for retention assertion).
     await db.execute(sql`
       INSERT INTO audit_events

--- a/packages/api/src/__tests__/retention.test.ts
+++ b/packages/api/src/__tests__/retention.test.ts
@@ -8,8 +8,9 @@
 
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { getDb } from "@stwd/db";
+import { appendAuditEvent, getDb } from "@stwd/db";
 import { sql } from "drizzle-orm";
+import { verifyAuditChain } from "../services/audit";
 
 const SKIP = !process.env.DATABASE_URL;
 
@@ -158,14 +159,9 @@ describe.skipIf(SKIP)("retention sweep", () => {
       await tx.execute(sql`DELETE FROM audit_events WHERE tenant_id = ${TENANT}`);
       await tx.execute(sql`DELETE FROM audit_chain_heads WHERE tenant_id = ${TENANT}`);
     });
-    // Insert an ancient audit event directly (bypassing the chain — just for retention assertion).
-    await db.execute(sql`
-      INSERT INTO audit_events
-        (tenant_id, seq, prev_hash, hmac, actor_type, action, created_at)
-      VALUES
-        (${TENANT}, 1, '\\x00'::bytea, '\\x00'::bytea, 'system', 'test.old',
-         now() - interval '1000 days')
-    `);
+    // Use the production writer so the survival assertion begins and ends with
+    // a valid event plus matching out-of-band chain head.
+    await appendAuditEvent({ tenantId: TENANT, actorType: "system", action: "test.old" });
 
     const results = await runRetentionSweep();
     expect(results.find((r) => r.table === "audit_events")).toBeUndefined();
@@ -174,6 +170,7 @@ describe.skipIf(SKIP)("retention sweep", () => {
       sql`SELECT seq FROM audit_events WHERE tenant_id = ${TENANT} AND action = 'test.old'`,
     )) as Array<{ seq: number | string }>;
     expect(rows.length).toBe(1);
+    expect(await verifyAuditChain(TENANT, { requireHead: true })).toMatchObject({ valid: true });
   });
 
   it("deletes expired auth_kv_store rows", async () => {

--- a/packages/api/src/__tests__/retention.test.ts
+++ b/packages/api/src/__tests__/retention.test.ts
@@ -24,7 +24,10 @@ async function cleanup(): Promise<void> {
   await db.execute(sql`DELETE FROM refresh_tokens WHERE tenant_id = ${TENANT}`);
   await db.execute(sql`DELETE FROM transactions WHERE agent_id = ${AGENT}`);
   await db.execute(sql`DELETE FROM agents WHERE id = ${AGENT}`);
-  await db.execute(sql`DELETE FROM audit_events WHERE tenant_id = ${TENANT}`);
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`DELETE FROM audit_events WHERE tenant_id = ${TENANT}`);
+    await tx.execute(sql`DELETE FROM audit_chain_heads WHERE tenant_id = ${TENANT}`);
+  });
   await db.execute(sql`DELETE FROM auth_kv_store WHERE namespace = ${`retention-test-${SUFFIX}`}`);
   await db.execute(sql`DELETE FROM tenants WHERE id = ${TENANT}`);
   await db.execute(sql`DELETE FROM users WHERE id = ${USER_ID}`);
@@ -148,9 +151,13 @@ describe.skipIf(SKIP)("retention sweep", () => {
     const { runRetentionSweep } = await import("../services/retention");
     delete process.env.STEWARD_RETENTION_AUDIT_EVENTS_DAYS;
     const db = getDb();
-    // Earlier sweep cases may emit their own retention audit event for this
-    // tenant. Reset the tenant-local chain so this assertion owns seq 1.
-    await db.execute(sql`DELETE FROM audit_events WHERE tenant_id = ${TENANT}`);
+    // Earlier sweep cases emit retention audit events for this tenant. Reset
+    // both the rows and their out-of-band high-water mark atomically so this
+    // assertion owns a valid tenant-local chain beginning at seq 1.
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`DELETE FROM audit_events WHERE tenant_id = ${TENANT}`);
+      await tx.execute(sql`DELETE FROM audit_chain_heads WHERE tenant_id = ${TENANT}`);
+    });
     // Insert an ancient audit event directly (bypassing the chain — just for retention assertion).
     await db.execute(sql`
       INSERT INTO audit_events

--- a/packages/api/src/__tests__/retention.test.ts
+++ b/packages/api/src/__tests__/retention.test.ts
@@ -164,7 +164,7 @@ describe.skipIf(SKIP)("retention sweep", () => {
     expect(results.find((r) => r.table === "audit_events")).toBeUndefined();
 
     const rows = (await db.execute(
-      sql`SELECT seq FROM audit_events WHERE tenant_id = ${TENANT}`,
+      sql`SELECT seq FROM audit_events WHERE tenant_id = ${TENANT} AND action = 'test.old'`,
     )) as Array<{ seq: number | string }>;
     expect(rows.length).toBe(1);
   });

--- a/packages/api/src/__tests__/tenant-app-clients.test.ts
+++ b/packages/api/src/__tests__/tenant-app-clients.test.ts
@@ -127,7 +127,7 @@ describe("tenant app clients hardening", () => {
 
     expect(cors).toContain("tenantAppClientsTable");
     expect(cors).toContain("eq(tenantAppClientsTable.enabled, true)");
-    expect(auth).toContain("tenantAppClients");
+    expect(auth).toContain("authAppClientSubjects(resolvedTenantId)");
     expect(auth).toContain("client_id");
     expect(auth).toContain("stateData.clientId");
     expect(auth).toContain("getTenantAppClientLoginMethods");

--- a/packages/api/src/routes/provider-case.ts
+++ b/packages/api/src/routes/provider-case.ts
@@ -30,11 +30,13 @@ import {
   type AppVariables,
   setNoStoreHeaders,
   tenantAuth,
+  withAuthenticatedTenantDatabase,
 } from "../services/context";
 import {
   CaseRangeTooLargeError,
   getProviderCase,
-  getProviderCaseEvidence,
+  readProviderCaseEvidenceSnapshot,
+  signProviderCaseEvidenceSnapshot,
 } from "../services/provider-case";
 
 export const providerCaseRoutes = new Hono<{ Variables: AppVariables }>();
@@ -50,6 +52,10 @@ providerCaseRoutes.use("/provider-actions/:id/evidence", auditOwnerAdminMfaGate)
 // path-traversal / null-byte / control-char id (N37/N38/N39) is rejected before
 // any DB access and returns the SAME uniform 404 as a genuine miss.
 const CASE_ID_PATTERN = /^pa_[0-9a-fA-F-]{36}$/;
+const SNAPSHOT_CHARACTERISTICS = {
+  isolationLevel: "repeatable read" as const,
+  readOnly: true,
+};
 
 function isValidCaseId(id: string): boolean {
   return CASE_ID_PATTERN.test(id);
@@ -74,8 +80,19 @@ providerCaseRoutes.get("/provider-actions/:id/case", async (c) => {
 
   let manifestOrNull;
   try {
-    const authorized = await tenantWorkspaceIds(tenantId);
-    const assembly = await getProviderCase(tenantId, caseId, authorized);
+    const userId = c.get("userId");
+    if (!userId) return c.json<ApiResponse>({ ok: false, error: "Forbidden" }, 403);
+    const assembly = await withAuthenticatedTenantDatabase(
+      tenantId,
+      "provider-case-snapshot",
+      userId,
+      async () => {
+        const authorized = await tenantWorkspaceIds(tenantId);
+        return getProviderCase(tenantId, caseId, authorized);
+      },
+      userId,
+      SNAPSHOT_CHARACTERISTICS,
+    );
     manifestOrNull = assembly?.manifest ?? null;
   } catch (err) {
     console.error(
@@ -105,8 +122,20 @@ providerCaseRoutes.get("/provider-actions/:id/evidence", async (c) => {
 
   let evidence;
   try {
-    const authorized = await tenantWorkspaceIds(tenantId);
-    evidence = await getProviderCaseEvidence(tenantId, caseId, authorized);
+    const userId = c.get("userId");
+    if (!userId) return c.json<ApiResponse>({ ok: false, error: "Forbidden" }, 403);
+    const snapshot = await withAuthenticatedTenantDatabase(
+      tenantId,
+      "provider-case-snapshot",
+      userId,
+      async () => {
+        const authorized = await tenantWorkspaceIds(tenantId);
+        return readProviderCaseEvidenceSnapshot(tenantId, caseId, authorized);
+      },
+      userId,
+      SNAPSHOT_CHARACTERISTICS,
+    );
+    evidence = snapshot ? await signProviderCaseEvidenceSnapshot(snapshot) : null;
   } catch (err) {
     if (err instanceof AuditSigningKeyError) {
       return c.json<ApiResponse>({ ok: false, error: "CASE_EVIDENCE_SIGNING_DISABLED" }, 503);
@@ -155,7 +184,7 @@ export function registerProviderCaseRoutes(app: Hono<{ Variables: AppVariables }
       setNoStoreHeaders(c);
       await next();
     });
-    app.use(p, (c, next) => tenantAuth(c, next));
+    app.use(p, (c, next) => tenantAuth(c, next, { bindTenantDatabase: false }));
   }
   app.route("/v2", providerCaseRoutes);
 }

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -26,6 +26,7 @@ import {
   operatorTransferReservations,
   policies,
   sessionSigners,
+  type TenantTransactionCharacteristics,
   tenantContextFromAuthenticatedPrincipal,
   toPolicyRule,
   transactions,
@@ -755,12 +756,18 @@ export async function withAuthenticatedTenantDatabase<T>(
   subject: string,
   callback: () => Promise<T>,
   userId?: string,
+  characteristics?: TenantTransactionCharacteristics,
 ): Promise<T> {
-  if (hasTenantTransactionDatabase({ tenantId, userId })) return callback();
+  if (hasTenantTransactionDatabase({ tenantId, userId, ...characteristics })) return callback();
   const context = tenantContextFromAuthenticatedPrincipal({ tenantId, method, subject, userId });
   const driver = isPGLiteRuntime ? "pglite" : getDatabaseDriver();
-  return withTenantRlsTransaction(getDb() as never, driver, context, async (tx) =>
-    withTenantTransactionDatabase(tx as never, { tenantId, userId }, callback),
+  return withTenantRlsTransaction(
+    getDb() as never,
+    driver,
+    context,
+    async (tx) =>
+      withTenantTransactionDatabase(tx as never, { tenantId, userId }, callback, characteristics),
+    characteristics,
   );
 }
 
@@ -777,7 +784,7 @@ export async function continueWithTenantDatabase(
 export async function tenantAuth(
   c: Context<{ Variables: AppVariables }>,
   next: Next,
-  options?: { requireTenantMatch?: string },
+  options?: { requireTenantMatch?: string; bindTenantDatabase?: boolean },
 ) {
   await defaultTenantReady;
 
@@ -902,6 +909,7 @@ export async function tenantAuth(
           }
           c.set("authType", "session-jwt");
         }
+        if (options?.bindTenantDatabase === false) return next();
         return continueWithTenantDatabase(
           payload.tenantId,
           isAgentToken ? "agent-jwt" : "session-jwt",
@@ -965,6 +973,7 @@ export async function tenantAuth(
       tenantConfigs.get(parsedAppId.tenantId) || { id: appTenant.id, name: appTenant.name },
     );
     c.set("authType", "app-secret");
+    if (options?.bindTenantDatabase === false) return next();
     await continueWithTenantDatabase(
       parsedAppId.tenantId,
       "app-secret",
@@ -993,6 +1002,7 @@ export async function tenantAuth(
   c.set("tenantConfig", tenantConfigs.get(tenantId) || { id: tenant.id, name: tenant.name });
   c.set("authType", "api-key");
 
+  if (options?.bindTenantDatabase === false) return next();
   await continueWithTenantDatabase(tenantId, "api-key", tenantId, next);
 }
 

--- a/packages/api/src/services/provider-case.ts
+++ b/packages/api/src/services/provider-case.ts
@@ -316,9 +316,18 @@ export async function getProviderCase(
   caseId: string,
   authorizedWorkspaceIds: string[],
 ): Promise<ProviderCaseAssembly | null> {
-  return runInSnapshot((sdb) =>
+  return runInSnapshot(tenantId, (sdb) =>
     assembleWithinSnapshot(sdb, tenantId, caseId, authorizedWorkspaceIds),
   );
+}
+
+export interface ProviderCaseEvidenceSnapshot {
+  tenantId: string;
+  caseId: string;
+  assembly: ProviderCaseAssembly;
+  bundleData: AuditBundleData;
+  segmentFrom: number;
+  segmentTo: number;
 }
 
 /**
@@ -332,47 +341,54 @@ export async function getProviderCaseEvidence(
   caseId: string,
   authorizedWorkspaceIds: string[],
 ): Promise<ProviderCaseEvidenceV1 | null> {
-  // 1) Assemble the manifest + fix the segment bounds inside ONE read-only
-  //    snapshot (all correlation/verify reads coherent).
-  const assembly = await runInSnapshot((sdb) =>
-    assembleWithinSnapshot(sdb, tenantId, caseId, authorizedWorkspaceIds),
-  );
-  if (!assembly) return null;
+  const snapshot = await readProviderCaseEvidenceSnapshot(tenantId, caseId, authorizedWorkspaceIds);
+  return snapshot ? signProviderCaseEvidenceSnapshot(snapshot) : null;
+}
 
-  const { manifest, segmentFrom, segmentTo } = assembly;
-
-  // 2) Read the bundle segment + sign OUTSIDE the read-only snapshot. The
-  //    audit chain is append-only and immutable once written, so re-reading the
-  //    SAME fixed [segmentFrom, segmentTo] range returns byte-identical events;
-  //    doing the signing (which persists a checkpoint best-effort) outside the
-  //    snapshot avoids a write-inside-read-only-tx deadlock on PGLite's single
-  //    connection while preserving manifest↔bundle consistency (the manifest's
-  //    seq+hmac index already pins exactly which events belong to the case).
-  let bundle: SignedAuditBundle;
-  if (segmentFrom == null || segmentTo == null) {
-    const empty: AuditBundleData = {
-      head: null,
-      events: [],
-      bundleHeadHmac: null,
-      bundleHeadSeq: null,
-    };
-    bundle = await signAuditBundle(tenantId, 0, 0, empty);
-  } else {
-    // Enforce the segment cap before reading the range: a case whose
-    // contiguous span exceeds MAX_CASE_SEGMENT_EVENTS (pathological same-tenant
-    // interleave, KC15) must NOT materialize/sign an unbounded range of
-    // unrelated audit rows via /evidence. Fail closed with a typed error the
-    // route maps to 400 CASE_RANGE_TOO_LARGE (§5.4); the manifest already
-    // carries `unknown` + a size-exceeded reason, and /case (manifest-only)
-    // still works for triage.
-    if (segmentTo - segmentFrom + 1 > MAX_CASE_SEGMENT_EVENTS) {
+/**
+ * Read every manifest and bundle input in one snapshot. Route callers end the
+ * read-only transaction before passing this immutable material to the signer,
+ * whose best-effort checkpoint persistence is intentionally a separate write.
+ */
+export async function readProviderCaseEvidenceSnapshot(
+  tenantId: string,
+  caseId: string,
+  authorizedWorkspaceIds: string[],
+): Promise<ProviderCaseEvidenceSnapshot | null> {
+  return runInSnapshot(tenantId, async (sdb) => {
+    const assembly = await assembleWithinSnapshot(sdb, tenantId, caseId, authorizedWorkspaceIds);
+    if (!assembly) return null;
+    const { segmentFrom, segmentTo } = assembly;
+    if (
+      segmentFrom != null &&
+      segmentTo != null &&
+      segmentTo - segmentFrom + 1 > MAX_CASE_SEGMENT_EVENTS
+    ) {
       throw new CaseRangeTooLargeError(
         `case segment [${segmentFrom},${segmentTo}] exceeds ${MAX_CASE_SEGMENT_EVENTS} events`,
       );
     }
-    const bundleData = await readAuditBundleData(tenantId, segmentFrom, segmentTo);
-    bundle = await signAuditBundle(tenantId, segmentFrom, segmentTo, bundleData);
-  }
+    const from = segmentFrom ?? 0;
+    const to = segmentTo ?? 0;
+    const bundleData =
+      segmentFrom == null || segmentTo == null
+        ? { head: null, events: [], bundleHeadHmac: null, bundleHeadSeq: null }
+        : await readAuditBundleData(tenantId, segmentFrom, segmentTo, sdb);
+    return { tenantId, caseId, assembly, bundleData, segmentFrom: from, segmentTo: to };
+  });
+}
+
+export async function signProviderCaseEvidenceSnapshot(
+  snapshot: ProviderCaseEvidenceSnapshot,
+): Promise<ProviderCaseEvidenceV1> {
+  const { tenantId, caseId, assembly, bundleData, segmentFrom, segmentTo } = snapshot;
+  const { manifest } = assembly;
+  const bundle: SignedAuditBundle = await signAuditBundle(
+    tenantId,
+    segmentFrom,
+    segmentTo,
+    bundleData,
+  );
 
   return {
     version: 1,
@@ -842,26 +858,27 @@ async function loadAccount(
  * non-blocking (§4.1). The audit chain-verify + bundle read are threaded the tx
  * executor so they share this snapshot (KC06).
  */
-async function runInSnapshot<T>(fn: (sdb: SnapshotDb) => Promise<T>): Promise<T> {
+async function runInSnapshot<T>(tenantId: string, fn: (sdb: SnapshotDb) => Promise<T>): Promise<T> {
   const db = getDb();
-  // Authenticated routes already run inside the tenant-bound transaction. A
-  // nested Drizzle transaction is only a savepoint: SET TRANSACTION is invalid
-  // there (and aborts the savepoint on Postgres), while PGLite can deadlock its
-  // single connection. Reuse the outer transaction; it is already one coherent
-  // request snapshot and carries the required RLS context.
-  if (hasTenantTransactionDatabase()) return fn(db as SnapshotDb);
+  // Mounted case routes deliberately establish this tenant-bound snapshot
+  // before entering the service. A nested Drizzle transaction would only be a
+  // savepoint, so reuse is permitted only when the tenant and transaction
+  // characteristics match exactly; ordinary READ COMMITTED reuse fails closed.
+  if (
+    hasTenantTransactionDatabase({
+      tenantId,
+      isolationLevel: "repeatable read",
+      readOnly: true,
+    })
+  ) {
+    return fn(db as SnapshotDb);
+  }
   try {
     return await db.transaction(async (tx) => {
       if (!isPGLiteRuntime()) {
-        try {
-          await (tx as unknown as AuditReadExecutor).execute(
-            sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`,
-          );
-        } catch {
-          // Some drivers set isolation only at BEGIN; a failure here is
-          // non-fatal — the reads are still coherent enough for a monotonic
-          // append-only chain. Never fail the read on this.
-        }
+        await (tx as unknown as AuditReadExecutor).execute(
+          sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`,
+        );
       }
       return await fn(tx as unknown as SnapshotDb);
     });

--- a/packages/api/src/services/provider-case.ts
+++ b/packages/api/src/services/provider-case.ts
@@ -23,6 +23,7 @@ import {
   approvalQueue,
   executionAuthorizationNonces,
   getDb,
+  hasTenantTransactionDatabase,
   providerAccounts,
   providerActionBindings,
   providerOperations,
@@ -843,6 +844,12 @@ async function loadAccount(
  */
 async function runInSnapshot<T>(fn: (sdb: SnapshotDb) => Promise<T>): Promise<T> {
   const db = getDb();
+  // Authenticated routes already run inside the tenant-bound transaction. A
+  // nested Drizzle transaction is only a savepoint: SET TRANSACTION is invalid
+  // there (and aborts the savepoint on Postgres), while PGLite can deadlock its
+  // single connection. Reuse the outer transaction; it is already one coherent
+  // request snapshot and carries the required RLS context.
+  if (hasTenantTransactionDatabase()) return fn(db as SnapshotDb);
   try {
     return await db.transaction(async (tx) => {
       if (!isPGLiteRuntime()) {

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -86,6 +86,27 @@ describe("request-scoped database context", () => {
     );
   });
 
+  test("validates snapshot characteristics before reusing a tenant transaction", async () => {
+    const transactionDb = { marker: "snapshot" } as unknown as ReturnType<typeof getDb>;
+    await withTenantTransactionDatabase(
+      transactionDb,
+      { tenantId: "tenant-a" },
+      async () => {
+        expect(
+          hasTenantTransactionDatabase({
+            tenantId: "tenant-a",
+            isolationLevel: "repeatable read",
+            readOnly: true,
+          }),
+        ).toBe(true);
+        expect(() =>
+          hasTenantTransactionDatabase({ tenantId: "tenant-a", readOnly: false }),
+        ).toThrow("RLS_TENANT_DATABASE_CHARACTERISTICS_MISMATCH");
+      },
+      { isolationLevel: "repeatable read", readOnly: true },
+    );
+  });
+
   test("deadline phases preserve the exact tenant transaction capability", async () => {
     const executed: unknown[] = [];
     const transactionDb = {

--- a/packages/db/src/__tests__/tenant-rls-context.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-context.test.ts
@@ -187,4 +187,32 @@ describe("tenant RLS transaction context", () => {
     expect(result).toBe("bound");
     expect(executeCount).toBe(4);
   });
+
+  test("establishes repeatable-read read-only before any tenant context query", async () => {
+    const calls: unknown[] = [];
+    let executeCount = 0;
+    const tx = {
+      async execute(query: unknown) {
+        calls.push(query);
+        executeCount += 1;
+        return executeCount === 5 ? [{ tenant_id: "tenant-snapshot", user_id: null }] : [];
+      },
+    };
+    const db = {
+      async transaction<T>(callback: (value: typeof tx) => Promise<T>) {
+        return callback(tx);
+      },
+    };
+    await withTenantRlsTransaction(
+      db,
+      "postgres-js",
+      tenantContextForInternalJob({ tenantId: "tenant-snapshot", job: "provider-case" }),
+      async () => undefined,
+      { isolationLevel: "repeatable read", readOnly: true },
+    );
+    expect(calls).toHaveLength(5);
+    expect(JSON.stringify(calls[0])).toContain(
+      "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
+    );
+  });
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -490,6 +490,8 @@ interface RequestDatabaseContext {
   active: boolean;
   tenantId?: string;
   userId?: string;
+  isolationLevel?: "repeatable read";
+  readOnly?: boolean;
   pendingTasks: Set<Promise<unknown>>;
   guardedObjects: WeakMap<object, object>;
 }
@@ -500,6 +502,8 @@ export function hasTenantTransactionDatabase(expected?: {
   tenantId: string;
   userId?: string;
   db?: RequestDatabase;
+  isolationLevel?: "repeatable read";
+  readOnly?: boolean;
 }): boolean {
   const context = tenantTransactionDatabaseStorage.getStore();
   if (!context?.active || !context.db) return false;
@@ -509,6 +513,14 @@ export function hasTenantTransactionDatabase(expected?: {
       (expected.userId !== undefined && context.userId !== expected.userId))
   ) {
     throw new Error("RLS_TENANT_DATABASE_CONTEXT_MISMATCH");
+  }
+  if (
+    expected &&
+    ((expected.isolationLevel !== undefined &&
+      context.isolationLevel !== expected.isolationLevel) ||
+      (expected.readOnly !== undefined && context.readOnly !== expected.readOnly))
+  ) {
+    throw new Error("RLS_TENANT_DATABASE_CHARACTERISTICS_MISMATCH");
   }
   if (expected?.db !== undefined && expected.db !== context.db) return false;
   return true;
@@ -655,6 +667,7 @@ export async function withTenantTransactionDatabase<T>(
   transactionDb: RequestDatabase,
   identity: { tenantId: string; userId?: string },
   callback: () => Promise<T>,
+  characteristics?: { isolationLevel?: "repeatable read"; readOnly?: boolean },
 ): Promise<T> {
   if (tenantTransactionDatabaseStorage.getStore()) {
     throw new Error("RLS_TENANT_DATABASE_CONTEXT_NESTED");
@@ -665,6 +678,8 @@ export async function withTenantTransactionDatabase<T>(
     active: true,
     tenantId: identity.tenantId,
     userId: identity.userId,
+    isolationLevel: characteristics?.isolationLevel,
+    readOnly: characteristics?.readOnly,
     pendingTasks: new Set(),
     guardedObjects: new WeakMap(),
   };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -70,6 +70,7 @@ export * from "./schema-auth";
 export {
   assertTenantRlsDriver,
   type TenantRlsDriver,
+  type TenantTransactionCharacteristics,
   type TrustedTenantContext,
   tenantContextForInternalJob,
   tenantContextFromAuthenticatedPrincipal,

--- a/packages/db/src/tenant-rls-context.ts
+++ b/packages/db/src/tenant-rls-context.ts
@@ -97,6 +97,11 @@ interface TenantTransactionalDatabase<Tx extends TenantTransactionExecutor> {
   transaction<T>(callback: (tx: Tx) => Promise<T>): Promise<T>;
 }
 
+export interface TenantTransactionCharacteristics {
+  isolationLevel?: "repeatable read";
+  readOnly?: boolean;
+}
+
 function hasTrustedBrand(context: unknown): context is TrustedTenantContext {
   return typeof context === "object" && context !== null && trustedTenantContexts.has(context);
 }
@@ -120,6 +125,7 @@ export async function withTenantRlsTransaction<Tx extends TenantTransactionExecu
   driver: TenantRlsDriver,
   context: TrustedTenantContext,
   callback: (tx: Tx) => Promise<T>,
+  characteristics?: TenantTransactionCharacteristics,
 ): Promise<T> {
   assertTenantRlsDriver(driver);
   if (!hasTrustedBrand(context)) throw new Error("RLS_TENANT_CONTEXT_UNTRUSTED");
@@ -130,6 +136,13 @@ export async function withTenantRlsTransaction<Tx extends TenantTransactionExecu
   if (is(db, PgTransaction)) throw new Error("RLS_TENANT_TRANSACTION_NESTED");
 
   const outcome = await db.transaction(async (tx) => {
+    if (driver !== "pglite" && characteristics?.isolationLevel === "repeatable read") {
+      await tx.execute(
+        characteristics.readOnly
+          ? sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`
+          : sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ`,
+      );
+    }
     // A non-empty value here means this connection carries a session-level
     // setting or the helper was nested inside another tenant transaction.
     // Overwriting either would conceal a lifecycle bug and could restore the


### PR DESCRIPTION
## Summary

- raise the isolated Postgres integration job budget from 15 to 25 minutes and run API files serially with a 120-second per-file ceiling
- move app-boundary fixtures that cannot safely nest PGLite transactions onto the workflow real Postgres service
- reuse the authenticated tenant transaction for provider-case snapshots, avoiding invalid nested `SET TRANSACTION` savepoints and PGLite single-connection deadlocks
- update stale source-contract assertions to the hardened implementations
- make signer audit comparisons deterministic and reset retention audit rows plus `audit_chain_heads` atomically

## Failure progression

- develop CI `32357308544`: Integration Tests exceeded the old 15-minute job boundary
- PR run `32359343455`: 9 API files failed after the job was allowed to finish
- PR run `32362995227`: reduced to 4 real-Postgres failures
- subsequent commits repair those four failures and the audit-chain fixture integrity issue

## Exact lineage

- rebased base: `7b128ade83e0bb44b1e28be20f1e220156cef18e`
- current head: `a1cee0635aa7b36eeda07f7e58163391960eea26`

## Validation

Exact current head after restack:
- API dependency build: 24/24
- Biome on ten changed TypeScript files: clean
- actionlint on both changed workflows: clean
- committed diff check: clean

Pre-restack feature commits additionally passed:
- Postgres `agent-signers.test.ts`: 10/10
- Postgres `retention.test.ts`: 5/5
- Postgres + Redis generic HTTP boundary and provider snapshot: 3/3
- Postgres Privy completeness: 1/1, 94 assertions
- focused hardened-source assertions: 31/31

This remains draft until the new exact-head hosted PostgreSQL, proxy, CLI, Compose, and full required matrix are green.