### PR TITLE
fix(web): fence transaction history refreshes

### DIFF
--- a/web/e2e/transaction-history-partial-failure.spec.ts
+++ b/web/e2e/transaction-history-partial-failure.spec.ts
@@ -1,15 +1,104 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, type Route, test } from "@playwright/test";
 import { loginWithMagicLink } from "./fixtures/auth";
 
 const API = process.env.E2E_API_URL ?? "http://localhost:3299";
 const WEB = process.env.E2E_WEB_URL ?? "http://localhost:3499";
 
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function sessionToken(tenantId: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  return [
+    base64UrlJson({ alg: "none", typ: "JWT" }),
+    base64UrlJson({
+      email: "partial-history@example.test",
+      exp: now + 3600,
+      iat: now,
+      role: "owner",
+      tenantId,
+      tenantRole: "owner",
+      userId: "partial-history-user",
+    }),
+    "test-signature",
+  ].join(".");
+}
+
+function transaction(id: string, agentId: string) {
+  return {
+    id,
+    agentId,
+    status: "pending",
+    request: {
+      chainId: 8453,
+      to: "0x1111111111111111111111111111111111111111",
+      value: "1000000000000000",
+    },
+    policyResults: [],
+    createdAt: "2026-08-20T12:00:00.000Z",
+  };
+}
+
+async function mockTenantSwitcher(page: Page, tenantBToken: string): Promise<void> {
+  await page.route(
+    (url) => url.href.startsWith(API) && url.pathname === "/user/me/tenants",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          ok: true,
+          data: [
+            { tenantId: "tenant-a", tenantName: "Tenant A", role: "owner" },
+            { tenantId: "tenant-b", tenantName: "Tenant B", role: "owner" },
+          ],
+        },
+      });
+    },
+  );
+  await page.route("**/api/auth/refresh", async (route) => {
+    const body = route.request().postDataJSON() as { tenantId?: string };
+    expect(body.tenantId).toBe("tenant-b");
+    await route.fulfill({ json: { ok: true, token: tenantBToken, expiresIn: 3600 } });
+  });
+}
+
+async function waitForStableRequestCount(page: Page, readCount: () => number): Promise<void> {
+  let previous = readCount();
+  let stableChecks = 0;
+  while (stableChecks < 4) {
+    await page.waitForTimeout(250);
+    const current = readCount();
+    if (current === previous) {
+      stableChecks += 1;
+    } else {
+      previous = current;
+      stableChecks = 0;
+    }
+  }
+}
+
+async function switchToTenant(page: Page, email: string, tenantName: string): Promise<void> {
+  await expect
+    .poll(async () => {
+      const tenantMenuItem = page.getByRole("menuitem", { name: tenantName });
+      if (await tenantMenuItem.isVisible().catch(() => false)) {
+        await tenantMenuItem.evaluate((button) => (button as HTMLButtonElement).click());
+        return true;
+      }
+
+      const accountButton = page.getByRole("button", { name: email });
+      if (await accountButton.isVisible().catch(() => false)) {
+        await accountButton.evaluate((button) => (button as HTMLButtonElement).click());
+      }
+      return false;
+    })
+    .toBe(true);
+}
+
 test("dashboard surfaces partial transaction history without discarding available rows", async ({
   page,
   request,
 }) => {
-  await loginWithMagicLink(page, request, `partial-history-${Date.now()}@example.test`);
-
   await page.route(
     (url) => url.href.startsWith(API) && url.pathname === "/agents",
     async (route) => {
@@ -32,16 +121,7 @@ test("dashboard surfaces partial transaction history without discarding availabl
           ok: true,
           data: [
             {
-              id: "tx-visible",
-              agentId: "agent-available",
-              status: "pending",
-              request: {
-                chainId: 8453,
-                to: "0x1111111111111111111111111111111111111111",
-                value: "1000000000000000",
-              },
-              policyResults: [],
-              createdAt: "2026-08-20T12:00:00.000Z",
+              ...transaction("tx-visible", "agent-available"),
             },
           ],
         },
@@ -55,6 +135,7 @@ test("dashboard surfaces partial transaction history without discarding availabl
     },
   );
 
+  await loginWithMagicLink(page, request, `partial-history-${Date.now()}@example.test`);
   await page.goto(`${WEB}/dashboard`);
   const overviewWarning = page
     .getByRole("alert")
@@ -73,3 +154,195 @@ test("dashboard surfaces partial transaction history without discarding availabl
   await expect(page.getByRole("link", { name: "Available Agent" })).toBeVisible();
   await expect(page.getByRole("button", { name: "All1" })).toBeVisible();
 });
+
+test("overview pending counts include agents beyond the former twenty-agent sample", async ({
+  page,
+  request,
+}) => {
+  const agents = Array.from({ length: 21 }, (_, index) => ({
+    id: `agent-${index + 1}`,
+    name: `Agent ${index + 1}`,
+  }));
+
+  await page.route(
+    (url) => url.href.startsWith(API) && url.pathname === "/agents",
+    (route) => route.fulfill({ json: { ok: true, data: agents } }),
+  );
+  await page.route(
+    (url) => url.href.startsWith(API) && /^\/vault\/agent-\d+\/history$/.test(url.pathname),
+    async (route) => {
+      const agentId = new URL(route.request().url()).pathname.split("/")[2];
+      await route.fulfill({
+        json: {
+          ok: true,
+          data: agentId === "agent-21" ? [transaction("tx-agent-21", agentId)] : [],
+        },
+      });
+    },
+  );
+
+  await loginWithMagicLink(page, request, `complete-history-${Date.now()}@example.test`);
+  await page.goto(`${WEB}/dashboard`);
+  const pendingStat = page.getByText("Pending Approvals").locator("..");
+  await expect(pendingStat).toContainText("1");
+  await expect(page.getByRole("link", { name: "Agent 21" })).toBeVisible();
+});
+
+for (const surface of [
+  { name: "overview", path: "/dashboard" },
+  { name: "transactions", path: "/dashboard/transactions" },
+] as const) {
+  test(`${surface.name} ignores a delayed tenant-A completion after switching to tenant B`, async ({
+    page,
+    request,
+  }) => {
+    const email = `tenant-fence-${surface.name}-${Date.now()}@example.test`;
+    const tenantBToken = sessionToken("tenant-b");
+    const delayedTenantA = { current: null as Route | null };
+
+    await mockTenantSwitcher(page, tenantBToken);
+    await page.route(
+      (url) => url.href.startsWith(API) && url.pathname === "/agents",
+      async (route) => {
+        const authorization = route.request().headers().authorization ?? null;
+        const tenant = authorization === `Bearer ${tenantBToken}` ? "b" : "a";
+        await route.fulfill({
+          json: {
+            ok: true,
+            data: [{ id: `agent-${tenant}`, name: `Tenant ${tenant.toUpperCase()} Agent` }],
+          },
+        });
+      },
+    );
+    await page.route(
+      (url) => url.href.startsWith(API) && url.pathname === "/vault/agent-a/history",
+      (route) => {
+        delayedTenantA.current = route;
+      },
+    );
+    await page.route(
+      (url) => url.href.startsWith(API) && url.pathname === "/vault/agent-b/history",
+      (route) => route.fulfill({ json: { ok: true, data: [transaction("tx-b", "agent-b")] } }),
+    );
+
+    await loginWithMagicLink(page, request, email);
+    await page.goto(`${WEB}${surface.path}`);
+    await expect.poll(() => delayedTenantA.current !== null).toBe(true);
+    await switchToTenant(page, email, "Tenant B");
+    await expect(page.getByRole("link", { name: "Tenant B Agent" })).toBeVisible();
+
+    await delayedTenantA.current?.fulfill({
+      json: { ok: true, data: [transaction("tx-a", "agent-a")] },
+    });
+    await page.waitForTimeout(250);
+    await expect(page.getByRole("link", { name: "Tenant B Agent" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Tenant A Agent" })).toHaveCount(0);
+  });
+
+  test(`${surface.name} keeps the newest result when retries overlap`, async ({
+    page,
+    request,
+  }) => {
+    const delayedRetry = { current: null as Route | null };
+    let phase: "initial" | "overlap" = "initial";
+    let totalListRequests = 0;
+    let listRequests = 0;
+    let availableHistoryRequests = 0;
+    let unavailableHistoryRequests = 0;
+
+    await page.route(
+      (url) => url.href.startsWith(API) && url.pathname === "/agents",
+      async (route) => {
+        totalListRequests += 1;
+        if (phase === "overlap") listRequests += 1;
+        const availableName =
+          phase === "initial"
+            ? "Initial Agent"
+            : listRequests === 1
+              ? "Stale Agent"
+              : "Newest Agent";
+        await route.fulfill({
+          json: {
+            ok: true,
+            data: [
+              { id: "agent-available", name: availableName },
+              { id: "agent-unavailable", name: "Unavailable Agent" },
+            ],
+          },
+        });
+      },
+    );
+    await page.route(
+      (url) => url.href.startsWith(API) && url.pathname === "/vault/agent-available/history",
+      async (route) => {
+        if (phase === "initial") {
+          await route.fulfill({
+            json: { ok: true, data: [transaction("tx-initial", "agent-available")] },
+          });
+          return;
+        }
+        availableHistoryRequests += 1;
+        if (availableHistoryRequests === 1) {
+          delayedRetry.current = route;
+          return;
+        }
+        await route.fulfill({
+          json: {
+            ok: true,
+            data: [transaction("tx-newest", "agent-available")],
+          },
+        });
+      },
+    );
+    await page.route(
+      (url) => url.href.startsWith(API) && url.pathname === "/vault/agent-unavailable/history",
+      async (route) => {
+        if (phase === "initial") {
+          await route.fulfill({ status: 503, json: { ok: false, error: "history unavailable" } });
+          return;
+        }
+        unavailableHistoryRequests += 1;
+        // The first retry is still waiting on its available history, so the
+        // first unavailable request belongs to the newer retry.
+        if (unavailableHistoryRequests === 1) {
+          await route.fulfill({ json: { ok: true, data: [] } });
+          return;
+        }
+        await route.fulfill({ status: 503, json: { ok: false, error: "history unavailable" } });
+      },
+    );
+
+    await loginWithMagicLink(
+      page,
+      request,
+      `retry-fence-${surface.name}-${Date.now()}@example.test`,
+    );
+    await page.goto(`${WEB}${surface.path}`);
+    const warning = page
+      .getByRole("alert")
+      .filter({ hasText: "Transaction history is incomplete" });
+    await expect(warning).toBeVisible();
+    // The optional wallet provider can remount these pages once its chunks
+    // settle. Start the deliberate overlap only after automatic loads stop so
+    // the two generations below are the only requests under test.
+    await waitForStableRequestCount(page, () => totalListRequests);
+    await expect(warning).toBeVisible();
+    phase = "overlap";
+    const retry = page.getByRole("button", { name: "Retry histories" });
+    await retry.evaluate((button) => {
+      (button as HTMLButtonElement).click();
+      (button as HTMLButtonElement).click();
+    });
+    await expect.poll(() => delayedRetry.current !== null).toBe(true);
+    await expect(page.getByRole("link", { name: "Newest Agent" })).toBeVisible();
+    await expect(warning).toHaveCount(0);
+
+    await delayedRetry.current?.fulfill({
+      json: { ok: true, data: [transaction("tx-stale", "agent-available")] },
+    });
+    await page.waitForTimeout(250);
+    await expect(page.getByRole("link", { name: "Newest Agent" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Stale Agent" })).toHaveCount(0);
+    await expect(warning).toHaveCount(0);
+  });
+}

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { useAuth } from "@stwd/react";
 import type { AgentIdentity, TxRecord } from "@stwd/sdk";
 import { AnimatePresence, motion } from "framer-motion";
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChainBadge } from "@/components/chain-badge";
 import { StatusBadge } from "@/components/status-badge";
 import { steward } from "@/lib/api";
@@ -12,28 +13,60 @@ import { formatDate, formatNativeAmount, shortenAddress } from "@/lib/utils";
 const easeOutQuart: [number, number, number, number] = [0.25, 1, 0.5, 1];
 
 interface DashboardData {
+  identity: object;
   agents: AgentIdentity[];
   recentTx: (TxRecord & { agentName?: string })[];
   pendingCount: number;
   failedHistoryCount: number;
 }
 
+interface DashboardError {
+  identity: object;
+  message: string;
+}
+
 export default function DashboardOverview() {
+  const auth = useAuth();
   const [data, setData] = useState<DashboardData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [loadingIdentity, setLoadingIdentity] = useState<object | null>(null);
+  const [error, setError] = useState<DashboardError | null>(null);
+  const requestGeneration = useRef(0);
+  const authIdentity = useMemo(
+    () => ({}),
+    [
+      auth.activeTenantId,
+      auth.isAuthenticated,
+      auth.session?.tenantId,
+      auth.session?.token,
+      auth.session?.userId,
+      auth.user?.id,
+    ],
+  );
+  const latestAuthIdentity = useRef(authIdentity);
+  latestAuthIdentity.current = authIdentity;
 
   const loadDashboard = useCallback(async () => {
+    const generation = ++requestGeneration.current;
+    const identity = authIdentity;
+    // Capture methods once so every request in this aggregation uses the same
+    // credential-bound client even if the global compatibility client rotates.
+    const listAgents = steward.listAgents;
+    const getTransactionHistory = steward.getTransactionHistory;
+    const isCurrent = () =>
+      requestGeneration.current === generation && latestAuthIdentity.current === identity;
+
     try {
-      setLoading(true);
-      setError(null);
-      const agentsList = await steward.listAgents();
+      setLoadingIdentity(identity);
+      setError((current) => (current?.identity === identity ? null : current));
+      const agentsList = await listAgents();
       const allTx: (TxRecord & { agentName?: string })[] = [];
       let failedHistoryCount = 0;
 
-      for (const agent of agentsList.slice(0, 20)) {
+      // Pending approvals are an operator-facing count, so sampling only the
+      // first 20 agents would still present an incomplete value as complete.
+      for (const agent of agentsList) {
         try {
-          const history = await steward.getTransactionHistory(agent.id);
+          const history = await getTransactionHistory(agent.id);
           allTx.push(
             ...history.map((tx) => ({
               ...tx,
@@ -50,24 +83,40 @@ export default function DashboardOverview() {
         (a, b) => new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime(),
       );
 
-      setData({
-        agents: agentsList,
-        recentTx: allTx.slice(0, 12),
-        pendingCount: allTx.filter((tx) => tx.status === "pending").length,
-        failedHistoryCount,
-      });
+      if (isCurrent()) {
+        setData({
+          identity,
+          agents: agentsList,
+          recentTx: allTx.slice(0, 12),
+          pendingCount: allTx.filter((tx) => tx.status === "pending").length,
+          failedHistoryCount,
+        });
+        setError(null);
+      }
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Failed to connect");
+      if (isCurrent()) {
+        setError({
+          identity,
+          message: e instanceof Error ? e.message : "Failed to connect",
+        });
+      }
     } finally {
-      setLoading(false);
+      if (isCurrent()) setLoadingIdentity(null);
     }
-  }, []);
+  }, [authIdentity]);
 
   useEffect(() => {
     void loadDashboard();
+    return () => {
+      requestGeneration.current += 1;
+    };
   }, [loadDashboard]);
 
-  if (loading) {
+  const currentData = data?.identity === authIdentity ? data : null;
+  const currentError = error?.identity === authIdentity ? error.message : null;
+  const loading = loadingIdentity === authIdentity;
+
+  if (!currentData && !currentError) {
     return (
       <div className="space-y-8">
         <div className="h-8 w-48 bg-bg-surface animate-pulse" />
@@ -81,13 +130,13 @@ export default function DashboardOverview() {
     );
   }
 
-  if (error) {
+  if (!currentData && currentError) {
     return (
       <div className="py-20 text-center">
         <p className="text-text-tertiary text-sm mb-2">Connection failed</p>
-        <p className="text-text-secondary text-xs mb-6 font-mono">{error}</p>
+        <p className="text-text-secondary text-xs mb-6 font-mono">{currentError}</p>
         <button
-          onClick={loadDashboard}
+          onClick={() => void loadDashboard()}
           className="px-4 py-2 text-sm bg-accent text-bg hover:bg-accent-hover transition-colors"
         >
           Retry
@@ -96,7 +145,7 @@ export default function DashboardOverview() {
     );
   }
 
-  const { agents, recentTx, pendingCount, failedHistoryCount } = data!;
+  const { agents, recentTx, pendingCount, failedHistoryCount } = currentData!;
 
   return (
     <motion.div
@@ -141,6 +190,19 @@ export default function DashboardOverview() {
         ))}
       </div>
 
+      {currentError && (
+        <div role="alert" className="border border-red-400/20 bg-red-400/5 p-4">
+          <p className="text-sm text-text-secondary">Transaction history refresh failed</p>
+          <p className="mt-1 text-xs text-text-tertiary font-mono">{currentError}</p>
+          <button
+            onClick={() => void loadDashboard()}
+            className="mt-3 text-xs text-red-300 hover:text-red-200 transition-colors"
+          >
+            Retry refresh
+          </button>
+        </div>
+      )}
+
       {failedHistoryCount > 0 && (
         <div role="alert" className="border border-amber-400/30 bg-amber-400/5 p-4">
           <p className="text-sm text-amber-300">Transaction history is incomplete</p>
@@ -149,10 +211,11 @@ export default function DashboardOverview() {
             to load. Counts and recent activity include only the available histories.
           </p>
           <button
-            onClick={loadDashboard}
+            onClick={() => void loadDashboard()}
+            aria-busy={loading}
             className="mt-3 text-xs text-amber-300 hover:text-amber-200 transition-colors"
           >
-            Retry histories
+            {loading ? "Retrying histories" : "Retry histories"}
           </button>
         </div>
       )}

--- a/web/src/app/dashboard/transactions/page.tsx
+++ b/web/src/app/dashboard/transactions/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { useAuth } from "@stwd/react";
 import type { TxRecord } from "@stwd/sdk";
 import { motion } from "framer-motion";
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChainBadge } from "@/components/chain-badge";
 import { StatusBadge } from "@/components/status-badge";
 import { steward } from "@/lib/api";
@@ -14,25 +15,56 @@ type TxWithAgent = TxRecord & { agentName?: string };
 
 const FILTERS = ["all", "signed", "confirmed", "pending", "rejected", "failed"] as const;
 
+interface TransactionsData {
+  identity: object;
+  transactions: TxWithAgent[];
+  failedHistoryCount: number;
+}
+
+interface TransactionsError {
+  identity: object;
+  message: string;
+}
+
 export default function TransactionsPage() {
-  const [transactions, setTransactions] = useState<TxWithAgent[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [failedHistoryCount, setFailedHistoryCount] = useState(0);
+  const auth = useAuth();
+  const [data, setData] = useState<TransactionsData | null>(null);
+  const [loadingIdentity, setLoadingIdentity] = useState<object | null>(null);
+  const [error, setError] = useState<TransactionsError | null>(null);
   const [filter, setFilter] = useState<string>("all");
+  const requestGeneration = useRef(0);
+  const authIdentity = useMemo(
+    () => ({}),
+    [
+      auth.activeTenantId,
+      auth.isAuthenticated,
+      auth.session?.tenantId,
+      auth.session?.token,
+      auth.session?.userId,
+      auth.user?.id,
+    ],
+  );
+  const latestAuthIdentity = useRef(authIdentity);
+  latestAuthIdentity.current = authIdentity;
 
   const loadTransactions = useCallback(async () => {
+    const generation = ++requestGeneration.current;
+    const identity = authIdentity;
+    const listAgents = steward.listAgents;
+    const getTransactionHistory = steward.getTransactionHistory;
+    const isCurrent = () =>
+      requestGeneration.current === generation && latestAuthIdentity.current === identity;
+
     try {
-      setLoading(true);
-      setError(null);
-      setFailedHistoryCount(0);
-      const agents = await steward.listAgents();
+      setLoadingIdentity(identity);
+      setError((current) => (current?.identity === identity ? null : current));
+      const agents = await listAgents();
       const allTx: TxWithAgent[] = [];
       let failedCount = 0;
 
       for (const agent of agents) {
         try {
-          const history = await steward.getTransactionHistory(agent.id);
+          const history = await getTransactionHistory(agent.id);
           allTx.push(
             ...history.map((tx) => ({
               ...tx,
@@ -48,18 +80,34 @@ export default function TransactionsPage() {
       allTx.sort(
         (a, b) => new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime(),
       );
-      setTransactions(allTx);
-      setFailedHistoryCount(failedCount);
+      if (isCurrent()) {
+        setData({ identity, transactions: allTx, failedHistoryCount: failedCount });
+        setError(null);
+      }
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Failed to load transactions");
+      if (isCurrent()) {
+        setError({
+          identity,
+          message: e instanceof Error ? e.message : "Failed to load transactions",
+        });
+      }
     } finally {
-      setLoading(false);
+      if (isCurrent()) setLoadingIdentity(null);
     }
-  }, []);
+  }, [authIdentity]);
 
   useEffect(() => {
     void loadTransactions();
+    return () => {
+      requestGeneration.current += 1;
+    };
   }, [loadTransactions]);
+
+  const currentData = data?.identity === authIdentity ? data : null;
+  const currentError = error?.identity === authIdentity ? error.message : null;
+  const loading = loadingIdentity === authIdentity;
+  const transactions = currentData?.transactions ?? [];
+  const failedHistoryCount = currentData?.failedHistoryCount ?? 0;
 
   const filtered =
     filter === "all" ? transactions : transactions.filter((tx) => tx.status === filter);
@@ -72,7 +120,7 @@ export default function TransactionsPage() {
     {} as Record<string, number>,
   );
 
-  if (loading) {
+  if (!currentData && !currentError) {
     return (
       <div className="space-y-8">
         <div className="h-8 w-48 bg-bg-surface animate-pulse" />
@@ -95,12 +143,12 @@ export default function TransactionsPage() {
       </div>
 
       {/* Error state */}
-      {error && !loading && (
+      {currentError && (
         <div className="py-16 text-center border border-red-400/20 bg-red-400/5">
           <p className="text-text-secondary text-sm mb-1">Failed to load transactions</p>
-          <p className="text-text-tertiary text-xs mb-4 font-mono">{error}</p>
+          <p className="text-text-tertiary text-xs mb-4 font-mono">{currentError}</p>
           <button
-            onClick={loadTransactions}
+            onClick={() => void loadTransactions()}
             className="px-4 py-2 text-sm bg-accent text-bg hover:bg-accent-hover transition-colors"
           >
             Retry
@@ -108,7 +156,7 @@ export default function TransactionsPage() {
         </div>
       )}
 
-      {!error && failedHistoryCount > 0 && (
+      {failedHistoryCount > 0 && (
         <div role="alert" className="border border-amber-400/30 bg-amber-400/5 p-4">
           <p className="text-sm text-amber-300">Transaction history is incomplete</p>
           <p className="mt-1 text-xs text-text-tertiary">
@@ -116,10 +164,11 @@ export default function TransactionsPage() {
             to load. The list and counts include only the available histories.
           </p>
           <button
-            onClick={loadTransactions}
+            onClick={() => void loadTransactions()}
+            aria-busy={loading}
             className="mt-3 text-xs text-amber-300 hover:text-amber-200 transition-colors"
           >
-            Retry histories
+            {loading ? "Retrying histories" : "Retry histories"}
           </button>
         </div>
       )}
@@ -145,7 +194,7 @@ export default function TransactionsPage() {
       </div>
 
       {/* List */}
-      {error ? null : filtered.length === 0 ? (
+      {!currentData ? null : filtered.length === 0 ? (
         <div className="py-16 text-center border border-border-subtle">
           <p className="text-text-tertiary text-sm">
             {filter === "all"


### PR DESCRIPTION
Refs #645
Follow-up corrective to merged #655.

## Summary
- bind both dashboard history loaders to one auth/session/active-tenant identity and credential-bound client
- reject stale completions from tenant changes and overlapping retries while preserving usable rows during refresh
- aggregate all overview agents so pending approvals are not silently sampled at twenty
- add production-browser coverage for delayed tenant rotation, overlapping retries, partial history, and 21st-agent counts

## Exact validation
- base: `f915f7fe875eec9ff75cd6ee9db39825240a7b5c`
- head: `427818e99ca633d7f69fc7fef1620004802e1058`
- dependency build: 25/25
- web TypeScript: pass
- production Next build + Chromium: 6/6
- targeted Biome: pass
- `git diff --check`: pass

Issue #645 is currently closed after #655 merged; this draft records the corrective relationship without changing issue state.

Draft pending hosted CI and independent review.