### PR TITLE
fix(api): make Solana recovery ownership atomic

### DIFF
--- a/packages/api/src/__tests__/solana-recovery-anchor.test.ts
+++ b/packages/api/src/__tests__/solana-recovery-anchor.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeou
 import {
   __resetAuditHmacKeyCacheForTests,
   agents,
+  auditEvents,
   closeDb,
   getDb,
   policies,
@@ -10,8 +11,11 @@ import {
   transactions,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { ExternalBroadcastOutcomeUnknownError } from "@stwd/vault";
-import { eq, sql } from "drizzle-orm";
+import {
+  ExternalBroadcastOutcomeUnknownError,
+  SolanaBroadcastNotSubmittedError,
+} from "@stwd/vault";
+import { and, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { idempotencyMiddleware, MemoryIdempotencyStore } from "../middleware/idempotency";
 import type { AppVariables } from "../services/context";
@@ -111,6 +115,7 @@ describe("Solana durable recovery anchors", () => {
       "solana-recovery-anchor-audit-hmac-key-with-more-than-32-bytes";
     __resetAuditHmacKeyCacheForTests();
     delete process.env.STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING;
+    delete process.env.REDIS_URL;
     await getDb().delete(transactions).where(eq(transactions.agentId, AGENT_ID));
   });
 
@@ -120,6 +125,7 @@ describe("Solana durable recovery anchors", () => {
     delete process.env.STEWARD_AUDIT_HMAC_KEY;
     delete process.env.STEWARD_ALLOW_DEV_SECRETS;
     delete process.env.STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING;
+    delete process.env.REDIS_URL;
     __resetAuditHmacKeyCacheForTests();
   });
 
@@ -219,20 +225,50 @@ describe("Solana durable recovery anchors", () => {
         }),
       });
 
-      expect(response.status).toBe(200);
-      expect(await response.json()).toMatchObject({
-        ok: true,
-        data: { signature: SIGNATURE, broadcast: true },
-      });
+      expect(response.status).toBe(500);
       const surviving = await onlyRecoveryRow();
       expect(surviving.status).toBe("broadcast");
       expect(surviving.txHash).toBe(SIGNATURE);
       expect(surviving.data).toBe("not-a-solana-transaction");
+      expect(readPayload(surviving.actionPayload).recoveryEffectsState).toBe("pending");
     } finally {
       context.vault.signSolanaTransaction = originalSign;
       process.env.STEWARD_AUDIT_HMAC_KEY =
         "solana-recovery-anchor-audit-hmac-key-with-more-than-32-bytes";
       __resetAuditHmacKeyCacheForTests();
+    }
+  });
+
+  it("keeps recovery effects pending while a configured Redis backend is unavailable", async () => {
+    process.env.REDIS_URL = "redis://127.0.0.1:1";
+    const context = await import("../services/context");
+    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
+    context.vault.signSolanaTransaction = async (request) => {
+      await request.onBroadcastPrepared?.({
+        signature: SIGNATURE,
+        recentBlockhash: RECENT_BLOCKHASH,
+      });
+      return { signature: SIGNATURE, broadcast: true, chainId: request.chainId ?? 101 };
+    };
+
+    try {
+      const response = await app.request(`/vault/${AGENT_ID}/sign-solana`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "solana-recovery-redis-unavailable",
+        },
+        body: JSON.stringify({ transaction: WITHIN_CAP_V0_TRANSFER, broadcast: true }),
+      });
+
+      expect(response.status).toBe(500);
+      const surviving = await onlyRecoveryRow();
+      expect(surviving.status).toBe("broadcast");
+      expect(surviving.txHash).toBe(SIGNATURE);
+      expect(readPayload(surviving.actionPayload).recoveryEffectsState).toBe("pending");
+    } finally {
+      context.vault.signSolanaTransaction = originalSign;
+      delete process.env.REDIS_URL;
     }
   });
 
@@ -272,6 +308,52 @@ describe("Solana durable recovery anchors", () => {
       const surviving = await onlyRecoveryRow();
       expect(surviving.status).toBe("outcome_unknown");
       expect(surviving.txHash).toBe(SIGNATURE);
+    } finally {
+      context.vault.signSolanaTransaction = originalSign;
+    }
+  });
+
+  it("replays the confirmed winner when definite-preflight cleanup loses its signature CAS", async () => {
+    const context = await import("../services/context");
+    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
+    context.vault.signSolanaTransaction = async (request) => {
+      await request.onBroadcastPrepared?.({
+        signature: SIGNATURE,
+        recentBlockhash: RECENT_BLOCKHASH,
+      });
+      const checkpoint = await onlyRecoveryRow();
+      await getDb()
+        .update(transactions)
+        .set({ status: "confirmed", confirmedAt: new Date() })
+        .where(eq(transactions.id, checkpoint.id));
+      throw new SolanaBroadcastNotSubmittedError(SIGNATURE);
+    };
+    try {
+      const response = await app.request(`/vault/${AGENT_ID}/sign-solana`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "solana-preflight-cas-winner",
+        },
+        body: JSON.stringify({ transaction: WITHIN_CAP_V0_TRANSFER, broadcast: true }),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        data: { signature: SIGNATURE, broadcast: true },
+      });
+      const row = await onlyRecoveryRow();
+      expect(row.status).toBe("confirmed");
+      const notSubmittedAudits = await getDb()
+        .select()
+        .from(auditEvents)
+        .where(
+          and(
+            eq(auditEvents.resourceId, row.id),
+            eq(auditEvents.action, "vault.sign.solana.not_submitted"),
+          ),
+        );
+      expect(notSubmittedAudits).toHaveLength(0);
     } finally {
       context.vault.signSolanaTransaction = originalSign;
     }
@@ -337,6 +419,17 @@ describe("Solana durable recovery anchors", () => {
       const row = await onlyRecoveryRow();
       expect(row.status).toBe("broadcast");
       expect(readPayload(row.actionPayload).recentBlockhash).toBe(RECENT_BLOCKHASH);
+      expect(readPayload(row.actionPayload).recoveryEffectsState).toBe("complete");
+      const completionAudits = await getDb()
+        .select()
+        .from(auditEvents)
+        .where(
+          and(
+            eq(auditEvents.resourceId, row.id),
+            eq(auditEvents.action, "vault.sign.solana.effects_completed"),
+          ),
+        );
+      expect(completionAudits).toHaveLength(1);
       expect((await context.getTransactionStats(AGENT_ID, 101)).recentTxCount24h).toBe(1);
 
       const mismatch = await app.request(`/vault/${AGENT_ID}/sign-solana`, {
@@ -430,7 +523,7 @@ describe("Solana durable recovery anchors", () => {
       expect(submittedCalls).toBe(0);
 
       releaseStale();
-      expect((await staleResponse).status).toBe(500);
+      expect((await staleResponse).status).toBe(409);
       expect((await onlyRecoveryRow()).status).toBe("approved");
       expect(submittedCalls).toBe(0);
 
@@ -473,6 +566,13 @@ describe("Solana durable recovery anchors", () => {
               type: "solana_transaction",
               recoveryAnchor: true,
               recentBlockhash: RECENT_BLOCKHASH,
+              ...(index === 0
+                ? {
+                    recoveryEffectsState: "processing",
+                    recoveryEffectsToken: "crashed-effects-owner",
+                    recoveryEffectsLeaseUntil: new Date(Date.now() - 1_000).toISOString(),
+                  }
+                : {}),
             },
           });
         context.vault.reconcileSolanaBroadcast = async (input) => {
@@ -490,6 +590,19 @@ describe("Solana durable recovery anchors", () => {
         expect(response.status).toBe(testCase.status);
         const [row] = await getDb().select().from(transactions).where(eq(transactions.id, txId));
         expect(row?.status).toBe(testCase.outcome);
+        if (testCase.outcome === "confirmed" || testCase.outcome === "broadcast") {
+          expect(readPayload(row?.actionPayload).recoveryEffectsState).toBe("complete");
+          const completionAudits = await getDb()
+            .select()
+            .from(auditEvents)
+            .where(
+              and(
+                eq(auditEvents.resourceId, txId),
+                eq(auditEvents.action, "vault.sign.solana.effects_completed"),
+              ),
+            );
+          expect(completionAudits).toHaveLength(1);
+        }
       }
     } finally {
       context.vault.reconcileSolanaBroadcast = originalReconcile;

--- a/packages/api/src/__tests__/vault-approval-gates.test.ts
+++ b/packages/api/src/__tests__/vault-approval-gates.test.ts
@@ -44,7 +44,11 @@ import {
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { canonicalJsonStringify } from "@stwd/shared";
-import { ExternalBroadcastOutcomeUnknownError, Vault } from "@stwd/vault";
+import {
+  ExternalBroadcastOutcomeUnknownError,
+  SolanaBroadcastNotSubmittedError,
+  Vault,
+} from "@stwd/vault";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
@@ -373,7 +377,7 @@ describe("vault approval gates (real /approve path)", () => {
           .select()
           .from(transactions)
           .where(eq(transactions.id, "tx-approved-solana-recovery"));
-        expect(before.status).toBe("pending");
+        expect(before.status).toBe("approved");
         expect(before.actionPayload).toMatchObject({
           type: "transaction",
           recoveryActionType: "transaction",
@@ -414,13 +418,88 @@ describe("vault approval gates (real /approve path)", () => {
     }
   });
 
+  it("atomically rolls back a native approval reset when the queue owner changes", async () => {
+    const txId = "tx-native-approval-reset-race";
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: txId,
+        agentId: AGENT_SOLANA,
+        status: "pending",
+        toAddress: SOLANA_RECIPIENT,
+        value: "123",
+        chainId: 101,
+        actionType: "transfer",
+        actionPayload: {
+          type: "transfer",
+          token: "native",
+          recipient: SOLANA_RECIPIENT,
+          amount: "123",
+          broadcast: true,
+        },
+        policyResults: [],
+      });
+    await getDb()
+      .insert(approvalQueue)
+      .values({
+        id: `aq-${txId}`,
+        txId,
+        agentId: AGENT_SOLANA,
+        status: "pending",
+      });
+    const app = await makeApp({ authType: "session-jwt", role: "owner", mfa: true });
+    const sign = spyOn(Vault.prototype, "signTransaction").mockImplementation(
+      async (_request, options) => {
+        await options.onSolanaBroadcastPrepared?.({
+          signature: SOLANA_SIGNATURE,
+          recentBlockhash: "11111111111111111111111111111111",
+        });
+        await getDb()
+          .update(approvalQueue)
+          .set({ resolvedById: REMOVED_ACTOR_ID })
+          .where(eq(approvalQueue.txId, txId));
+        throw new SolanaBroadcastNotSubmittedError(SOLANA_SIGNATURE);
+      },
+    );
+    try {
+      const response = await approve(app, AGENT_SOLANA, txId);
+      expect(response.status).toBe(202);
+      expect(await response.json()).toMatchObject({
+        ok: false,
+        data: { txId, txHash: SOLANA_SIGNATURE, reconciliationRequired: true },
+      });
+      const [transaction] = await getDb()
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, txId));
+      expect(transaction).toMatchObject({ status: "outcome_unknown", txHash: SOLANA_SIGNATURE });
+      const [approval] = await getDb()
+        .select()
+        .from(approvalQueue)
+        .where(eq(approvalQueue.txId, txId));
+      expect(approval).toMatchObject({ status: "approved", resolvedById: REMOVED_ACTOR_ID });
+      const notSubmittedAudits = await getDb()
+        .select()
+        .from(auditEvents)
+        .where(
+          and(
+            eq(auditEvents.resourceId, txId),
+            eq(auditEvents.action, "vault.sign.solana.not_submitted"),
+          ),
+        );
+      expect(notSubmittedAudits).toHaveLength(0);
+    } finally {
+      sign.mockRestore();
+    }
+  });
+
   it("blocks a live approved owner then CAS-takes over its expired pre-checkpoint lease once", async () => {
     const app = await makeApp({ authType: "session-jwt", role: "owner", mfa: true });
     const live = await approve(app, AGENT_SOLANA, "tx-crashed-approved-solana");
     expect(live.status).toBe(409);
     expect(await live.json()).toMatchObject({
       ok: false,
-      error: "Approved Solana execution is already in progress",
+      error: "Approved Solana execution is already owned by another attempt",
     });
 
     const [crashed] = await getDb()

--- a/packages/api/src/__tests__/webhook-dispatch.test.ts
+++ b/packages/api/src/__tests__/webhook-dispatch.test.ts
@@ -37,6 +37,9 @@ const updatedDeliveries: Record<string, unknown>[] = [];
 const dispatches: DispatchRecord[] = [];
 const dispatcherOptions: DispatcherOptions[] = [];
 const tenantConfigs = new Map<string, { webhookUrl?: string }>();
+const persistedDeliveries = new Map<string, Record<string, unknown>>();
+const webhookConfigsTable = { tenantId: "tenantId", enabled: "enabled" };
+const webhookDeliveriesTable = { id: "id" };
 let nextDispatchResult: DispatchResult = {
   success: true,
   attempts: 1,
@@ -47,14 +50,31 @@ process.env.STEWARD_MASTER_PASSWORD = "webhook-dispatch-test-master-password";
 
 const db = {
   select: () => ({
-    from: () => ({
-      where: () => Promise.resolve(webhookRows.filter((row) => row.enabled)),
-    }),
+    from: (table: unknown) =>
+      table === webhookDeliveriesTable
+        ? {
+            where: () => ({
+              limit: () => Promise.resolve([...persistedDeliveries.values()].slice(0, 1)),
+            }),
+          }
+        : {
+            where: () => Promise.resolve(webhookRows.filter((row) => row.enabled)),
+          },
   }),
   insert: () => ({
     values: (value: Record<string, unknown>) => {
-      insertedDeliveries.push(value);
-      return { returning: () => Promise.resolve([{ id: "delivery-1" }]) };
+      const insert = () => {
+        insertedDeliveries.push(value);
+        persistedDeliveries.set(String(value.id), value);
+        return [{ id: value.id ?? "delivery-1" }];
+      };
+      return {
+        returning: () => Promise.resolve(insert()),
+        onConflictDoNothing: () => ({
+          returning: () =>
+            Promise.resolve(persistedDeliveries.has(String(value.id)) ? [] : insert()),
+        }),
+      };
     },
   }),
   update: () => ({
@@ -82,8 +102,8 @@ mock.module("../services/context", () => ({ db, tenantConfigs }));
 mock.module("@stwd/db", () => ({
   and: () => true,
   eq: () => true,
-  webhookConfigs: { tenantId: "tenantId", enabled: "enabled" },
-  webhookDeliveries: { id: "id" },
+  webhookConfigs: webhookConfigsTable,
+  webhookDeliveries: webhookDeliveriesTable,
 }));
 // NOTE: bun's mock.module replaces the ENTIRE module and is sticky per-process,
 // so this mock must re-export every binding the module-under-test (and any
@@ -118,7 +138,7 @@ mock.module("node:dns/promises", () => ({
   lookup: async () => [{ address: "93.184.216.34", family: 4 }],
 }));
 
-const { dispatchWebhook } = await import("../services/webhook-dispatch");
+const { dispatchWebhook, dispatchWebhookDurably } = await import("../services/webhook-dispatch");
 const { webhookEventRegistry } = await import("../services/webhook-events");
 
 beforeEach(() => {
@@ -127,6 +147,7 @@ beforeEach(() => {
   updatedDeliveries.length = 0;
   dispatches.length = 0;
   dispatcherOptions.length = 0;
+  persistedDeliveries.clear();
   tenantConfigs.clear();
   nextDispatchResult = {
     success: true,
@@ -140,6 +161,36 @@ afterAll(() => {
 });
 
 describe("dispatchWebhook", () => {
+  it("creates a stable durable delivery only once across recovery retries", async () => {
+    webhookRows.push({
+      tenantId: "tenant-1",
+      url: "https://example.com/signed",
+      secret: "whsec_signed",
+      events: ["tx.signed"],
+      enabled: true,
+      maxRetries: 2,
+      retryBackoffMs: 1000,
+    });
+
+    await dispatchWebhookDurably(
+      "tenant-1",
+      "agent-1",
+      "tx_signed",
+      { txId: "tx-1" },
+      "solana:tx-1:signature-1",
+    );
+    await dispatchWebhookDurably(
+      "tenant-1",
+      "agent-1",
+      "tx_signed",
+      { txId: "tx-1" },
+      "solana:tx-1:signature-1",
+    );
+
+    expect(insertedDeliveries).toHaveLength(1);
+    expect(dispatches).toHaveLength(1);
+  });
+
   it("dispatches subscribed persisted webhook configs with their own secret", async () => {
     webhookRows.push(
       {

--- a/packages/api/src/middleware/redis-enforcement.ts
+++ b/packages/api/src/middleware/redis-enforcement.ts
@@ -6,7 +6,7 @@
  * for policy definitions; Redis provides fast, sliding-window enforcement.
  */
 
-import { createPriceOracle, type PolicyRule } from "@stwd/shared";
+import { createPriceOracle, getNativeDecimalsStrict, type PolicyRule } from "@stwd/shared";
 import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   checkAgentRateLimit,
@@ -213,24 +213,39 @@ export async function recordVaultSpend(
   tenantId: string,
   valueWei: string,
   chainId: number,
+  options: {
+    eventId?: string;
+    occurredAt?: Date | number;
+    throwOnError?: boolean;
+  } = {},
 ): Promise<void> {
-  if (!isRedisAvailable()) return;
+  if (!isRedisAvailable()) {
+    if (options.throwOnError && isRedisConfigured()) {
+      throw new Error("Configured Redis spend backend is unavailable");
+    }
+    return;
+  }
 
   // Skip zero/empty values without touching the oracle.
   let wei: bigint;
   try {
     wei = BigInt(valueWei);
-  } catch {
+  } catch (error) {
+    if (options.throwOnError) throw error;
     return;
   }
-  if (wei <= 0n) return;
+  if (wei < 0n) {
+    if (options.throwOnError) throw new Error("invalid negative vault spend amount");
+    return;
+  }
+  if (wei === 0n) return;
 
   // Convert native wei → USD using the oracle. weiToUsd does bigint-safe scaling
   // (no Number(BigInt) precision loss) and applies the per-chain native price.
   const usdValue = await priceOracle.weiToUsd(valueWei, chainId);
 
   if (usdValue !== null && usdValue > 0) {
-    await recordAgentSpend(agentId, tenantId, usdValue, `chain:${chainId}`);
+    await recordAgentSpend(agentId, tenantId, usdValue, `chain:${chainId}`, options);
     return;
   }
 
@@ -240,10 +255,14 @@ export async function recordVaultSpend(
   // the spend with a deliberately HIGH conservative native-price floor so the spend still
   // counts against the same `chain:${chainId}` USD cap and can trip it. Over-counting during
   // an oracle outage is the safe direction; the priced path above is unaffected.
-  const decimals = 18; // EVM native tokens use 18 decimals
+  const decimals = getNativeDecimalsStrict(chainId);
+  if (decimals === null) {
+    if (options.throwOnError) throw new Error(`unknown native decimals for chain ${chainId}`);
+    return;
+  }
   const divisor = 10n ** BigInt(decimals);
   const tokenAmount = Number(wei / divisor) + Number(wei % divisor) / Number(divisor);
   const fallbackNativePriceUsd = nativePriceFallbackUsd();
   const conservativeUsd = tokenAmount * fallbackNativePriceUsd;
-  await recordAgentSpend(agentId, tenantId, conservativeUsd, `chain:${chainId}`);
+  await recordAgentSpend(agentId, tenantId, conservativeUsd, `chain:${chainId}`, options);
 }

--- a/packages/api/src/middleware/redis.ts
+++ b/packages/api/src/middleware/redis.ts
@@ -16,6 +16,7 @@ import {
   type RateLimitResult,
   recordSpend,
   type SpendPeriod,
+  type SpendRecordOptions,
 } from "@stwd/redis";
 import { redactedThrownDiagnostics } from "@stwd/shared";
 
@@ -205,12 +206,20 @@ export async function recordAgentSpend(
   tenantId: string,
   costUsd: number,
   host: string,
+  options: SpendRecordOptions & { throwOnError?: boolean } = {},
 ): Promise<void> {
-  if (!redisAvailable || costUsd <= 0) return;
+  if (!redisAvailable) {
+    if (options.throwOnError && isRedisConfigured()) {
+      throw new Error("Configured Redis spend backend is unavailable");
+    }
+    return;
+  }
+  if (costUsd <= 0) return;
 
   try {
-    await recordSpend(agentId, tenantId, costUsd, host);
+    await recordSpend(agentId, tenantId, costUsd, host, options);
   } catch (err) {
+    if (options.throwOnError) throw err;
     console.error("[steward:redis] Failed to record spend", redactedThrownDiagnostics(err));
   }
 }

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -53,10 +53,12 @@ import {
   parseSolanaTransaction,
   readEip7702Delegation,
   SolanaBroadcastNotSubmittedError,
+  SolanaRecoveryOwnershipLostError,
   type UnpackedUserOperationFields,
 } from "@stwd/vault";
 import { and, desc, eq, type SQL, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
+import { isRedisAvailable, isRedisConfigured } from "../middleware/redis";
 import { enforceRateLimit, recordVaultSpend } from "../middleware/redis-enforcement";
 import { type AuditEventInput, writeAuditEvent } from "../services/audit";
 import {
@@ -108,7 +110,7 @@ import {
 import { plaintextKeyExportResponseGateError } from "../services/key-export-plaintext-gate";
 import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import { verifySignerCredential } from "../services/signer-credentials";
-import { dispatchWebhook } from "../services/webhook-dispatch";
+import { dispatchWebhook, dispatchWebhookDurably } from "../services/webhook-dispatch";
 import {
   decryptImportSessionJson,
   encryptImportSessionJson,
@@ -2371,7 +2373,22 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
       }
     }
 
-    const executionTxId = crypto.randomUUID();
+    const solanaNativeBinding =
+      !isEvmSignRequest && shouldBroadcast
+        ? createSolanaRecoveryBinding(c, {
+            routeFamily: "sign",
+            tenantId,
+            agentId,
+            transaction: signRequest.data ?? "",
+            chainId: resolvedChainId,
+            toAddress: signRequest.to,
+            value: signRequest.value,
+            broadcastRequested: true,
+            blindSigned: false,
+          })
+        : null;
+    const executionTxId = solanaNativeBinding?.txId ?? crypto.randomUUID();
+    let solanaNativeExecutionToken: string | null = null;
     try {
       const txId = executionTxId;
       const txStatus: "broadcast" | "signed" = shouldBroadcast ? "broadcast" : "signed";
@@ -2424,6 +2441,31 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
           policyResults: evaluation.results,
         },
       });
+      if (solanaNativeBinding) {
+        const staged = await stageSolanaRecoveryAnchor({
+          agentId,
+          transaction: signRequest.data ?? "",
+          chainId: resolvedChainId,
+          toAddress: signRequest.to,
+          value: signRequest.value,
+          broadcastRequested: true,
+          blindSigned: false,
+          policyResults: evaluation.results,
+          binding: solanaNativeBinding,
+          actionType: "transaction",
+          actionPayload: transactionActionPayload({
+            broadcast: true,
+            nonce: signRequest.nonce,
+            gasLimit: signRequest.gasLimit,
+            venue: signRequest.venue,
+            walletAddress: signRequest.walletAddress,
+          }),
+        });
+        if (!staged.executionToken) {
+          return solanaLostOwnershipResponse(c, txId, agentId, "sign");
+        }
+        solanaNativeExecutionToken = staged.executionToken;
+      }
       const result =
         executionAuthorization && executionPayloadDigest
           ? await new GovernedVault(vault, async (authorization, expected) => {
@@ -2506,10 +2548,22 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
                 txId,
                 policyResults: evaluation.results,
                 status: txStatus,
+                ...(solanaNativeExecutionToken
+                  ? {
+                      solanaRecoveryExecutionToken: solanaNativeExecutionToken,
+                      onSolanaBroadcastPrepared: (checkpoint) =>
+                        checkpointSolanaBroadcastSubmission(
+                          txId,
+                          agentId,
+                          solanaNativeExecutionToken!,
+                          checkpoint,
+                        ),
+                    }
+                  : {}),
               });
             })();
 
-      await db
+      const updated = await db
         .update(transactions)
         .set({
           status: txStatus,
@@ -2519,60 +2573,95 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
           policyResults: evaluation.results,
           signedAt: new Date(),
         })
-        .where(eq(transactions.id, txId));
-
-      // ── Record spend in Redis (fire-and-forget) ──────────────────────────────
-      recordVaultSpend(agentId, tenantId, signRequest.value, resolvedChainId).catch((err) =>
-        console.error("[vault] Failed to record spend", redactedThrownDiagnostics(err)),
-      );
-
-      // ── Record the authoritative aggregation event ───────────────────────────
-      // AWAITED (unlike recordVaultSpend) and still inside the per-agent spend
-      // lock, so the next request's loadAggregationsForPolicies snapshot already
-      // includes this contribution — cumulative caps cannot be raced past the
-      // threshold by overlapping signs. The tx is already committed/broadcast at
-      // this point, so a record failure cannot retroactively fail the request;
-      // we log it loudly (an undercounted aggregate is a known residual risk of
-      // any post-commit counter, bounded by the spend lock's serialization).
-      try {
-        await recordAggregationEvent({
-          agentId,
-          valueRaw: signRequest.value,
-          to: signRequest.to,
-          chainId: resolvedChainId,
-        });
-      } catch (err) {
-        console.error("[vault] Failed to record aggregation event", redactedThrownDiagnostics(err));
+        .where(
+          and(
+            eq(transactions.id, txId),
+            eq(transactions.agentId, agentId),
+            solanaNativeExecutionToken
+              ? and(
+                  eq(transactions.status, "broadcast"),
+                  eq(transactions.txHash, result),
+                  sql`${transactions.actionPayload}->>'executionToken' = ${solanaNativeExecutionToken}`,
+                )
+              : undefined,
+          ),
+        )
+        .returning({ id: transactions.id });
+      if (updated.length !== 1) {
+        if (solanaNativeExecutionToken) {
+          return solanaLostOwnershipResponse(c, txId, agentId, "sign");
+        }
+        throw new Error("Transaction success write was not applied");
       }
 
-      await writeVaultAudit(c, {
-        tenantId,
-        actorType: "agent",
-        actorId: agentId,
-        action: "vault.sign",
-        resourceType: "transaction",
-        resourceId: txId,
-        metadata: {
-          chainId: resolvedChainId,
-          to: signRequest.to,
-          value: signRequest.value,
-          broadcast: shouldBroadcast,
-          ...signerAuthAuditMetadata(signerAuthorization.auth),
-          txHash: shouldBroadcast ? result : undefined,
-        },
-      });
+      if (solanaNativeExecutionToken) {
+        if (
+          !(await completeSolanaRecoveryEffects({
+            tenantId,
+            agentId,
+            txId,
+            signature: result,
+          }))
+        ) {
+          return solanaLostOwnershipResponse(c, txId, agentId, "sign");
+        }
+      } else {
+        // ── Record spend in Redis (fire-and-forget) ──────────────────────────────
+        recordVaultSpend(agentId, tenantId, signRequest.value, resolvedChainId).catch((err) =>
+          console.error("[vault] Failed to record spend", redactedThrownDiagnostics(err)),
+        );
 
-      dispatchWebhook(tenantId, agentId, "tx_signed", {
-        txId,
-        txHash: shouldBroadcast ? result : undefined,
-      });
-      if (shouldBroadcast) {
-        dispatchTransactionLifecycleWebhook(tenantId, agentId, "transaction.broadcasted", {
-          txId,
-          txHash: result,
-          chainId: resolvedChainId,
-          status: "broadcast",
+        // ── Record the authoritative aggregation event ───────────────────────────
+        // AWAITED (unlike recordVaultSpend) and still inside the per-agent spend
+        // lock, so the next request's loadAggregationsForPolicies snapshot already
+        // includes this contribution — cumulative caps cannot be raced past the
+        // threshold by overlapping signs. The tx is already committed/broadcast at
+        // this point, so a record failure cannot retroactively fail the request;
+        // we log it loudly (an undercounted aggregate is a known residual risk of
+        // any post-commit counter, bounded by the spend lock's serialization).
+        try {
+          await recordAggregationEvent({
+            agentId,
+            valueRaw: signRequest.value,
+            to: signRequest.to,
+            chainId: resolvedChainId,
+          });
+        } catch (err) {
+          console.error(
+            "[vault] Failed to record aggregation event",
+            redactedThrownDiagnostics(err),
+          );
+        }
+
+        await writeVaultAudit(c, {
+          tenantId,
+          actorType: "agent",
+          actorId: agentId,
+          action: "vault.sign",
+          resourceType: "transaction",
+          resourceId: txId,
+          metadata: {
+            chainId: resolvedChainId,
+            to: signRequest.to,
+            value: signRequest.value,
+            broadcast: shouldBroadcast,
+            ...signerAuthAuditMetadata(signerAuthorization.auth),
+            txHash: shouldBroadcast ? result : undefined,
+          },
         });
+
+        dispatchWebhook(tenantId, agentId, "tx_signed", {
+          txId,
+          txHash: shouldBroadcast ? result : undefined,
+        });
+        if (shouldBroadcast) {
+          dispatchTransactionLifecycleWebhook(tenantId, agentId, "transaction.broadcasted", {
+            txId,
+            txHash: result,
+            chainId: resolvedChainId,
+            status: "broadcast",
+          });
+        }
       }
 
       if (shouldBroadcast) {
@@ -2587,6 +2676,9 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
         data: { txId, signedTx: result },
       });
     } catch (e: unknown) {
+      if (e instanceof SolanaRecoveryOwnershipLostError) {
+        return solanaLostOwnershipResponse(c, executionTxId, agentId, "sign");
+      }
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
       const bindingMismatch = await backendBindingMismatchResponse(c, e, {
@@ -2599,6 +2691,26 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
       if (authorizationError) return authorizationError;
       const outcomeUnknown = externalBroadcastOutcomeUnknownResponse(c, e, executionTxId);
       if (outcomeUnknown) {
+        if (solanaNativeExecutionToken && e instanceof ExternalBroadcastOutcomeUnknownError) {
+          const preserved = await preserveUnknownSolanaOutcome(
+            executionTxId,
+            agentId,
+            solanaNativeExecutionToken,
+            e.transactionHash,
+          );
+          if (
+            !preserved ||
+            !(await completeSolanaRecoveryEffects({
+              tenantId,
+              agentId,
+              txId: executionTxId,
+              signature: e.transactionHash,
+            }))
+          ) {
+            return solanaLostOwnershipResponse(c, executionTxId, agentId, "sign");
+          }
+          return outcomeUnknown;
+        }
         // This is also the fallback for a failed Vault.recordSignedTransaction
         // write. Preserve the irreversible hash on the pre-staged intent before
         // returning the typed 202 response.
@@ -2655,10 +2767,22 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
         });
         return outcomeUnknown;
       }
-      await db
-        .update(transactions)
-        .set({ status: "failed" })
-        .where(and(eq(transactions.id, executionTxId), eq(transactions.agentId, agentId)));
+      if (solanaNativeExecutionToken) {
+        if (
+          !(await markSolanaRecoveryAnchorFailed(
+            executionTxId,
+            agentId,
+            solanaNativeExecutionToken,
+          ))
+        ) {
+          return solanaLostOwnershipResponse(c, executionTxId, agentId, "sign");
+        }
+      } else {
+        await db
+          .update(transactions)
+          .set({ status: "failed" })
+          .where(and(eq(transactions.id, executionTxId), eq(transactions.agentId, agentId)));
+      }
       const requestId = c.get("requestId") || "unknown";
       console.error(`[${requestId}] Sign transaction failed for agent ${agentId}`);
 
@@ -3407,7 +3531,9 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           actionType: "transfer",
           actionPayload: baseTransferActionPayload,
         });
-        if (!staged.executionToken) return solanaTransferReplayResponse(c, staged.row);
+        if (!staged.executionToken) {
+          return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
+        }
         solanaExecutionToken = staged.executionToken;
         storedTransferActionPayload = readSolanaRecoveryMetadata(staged.row.actionPayload);
       } catch (error) {
@@ -3499,6 +3625,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           status: transfer.broadcast ? "broadcast" : "signed",
           ...(solanaExecutionToken
             ? {
+                solanaRecoveryExecutionToken: solanaExecutionToken,
                 onSolanaBroadcastPrepared: (checkpoint) =>
                   checkpointSolanaBroadcastSubmission(
                     actionId,
@@ -3514,7 +3641,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
       completedResult = result;
       completedStatus = txStatus;
       const signedTx = transfer.broadcast ? undefined : result;
-      await db
+      const updatedTransfer = await db
         .update(transactions)
         .set({
           status: txStatus,
@@ -3524,56 +3651,88 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           policyResults: evaluation.results,
           signedAt: new Date(),
         })
-        .where(eq(transactions.id, actionId));
-
-      if (transfer.broadcast) {
-        recordVaultSpend(agentId, tenantId, signRequest.value, signRequest.chainId).catch((err) =>
-          console.error(
-            "[vault] Failed to record transfer action spend",
-            redactedThrownDiagnostics(err),
+        .where(
+          and(
+            eq(transactions.id, actionId),
+            eq(transactions.agentId, agentId),
+            solanaExecutionToken
+              ? and(
+                  eq(transactions.status, "broadcast"),
+                  eq(transactions.txHash, result),
+                  sql`${transactions.actionPayload}->>'executionToken' = ${solanaExecutionToken}`,
+                )
+              : undefined,
           ),
-        );
+        )
+        .returning({ id: transactions.id });
+      if (updatedTransfer.length !== 1) {
+        if (solanaExecutionToken) {
+          return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
+        }
+        throw new Error("Transfer success write was not applied");
       }
-      await recordSponsoredActionIfNeeded({
-        sponsorship: sponsorshipPayload,
-        tenantId,
-        agentId,
-        txId: actionId,
-        chainId: signRequest.chainId,
-        caip2: toCaip2(signRequest.chainId),
-        txHash: transfer.broadcast ? result : undefined,
-        actionType: "transfer",
-        status: transfer.broadcast ? "submitted" : "signed",
-      });
 
-      await writeVaultAudit(c, {
-        tenantId,
-        actorType: "agent",
-        actorId: agentId,
-        action: "wallet_action.transfer.succeeded",
-        resourceType: "wallet_action",
-        resourceId: actionId,
-        metadata: {
-          chainId: signRequest.chainId,
-          to: transfer.to,
-          value: transfer.value,
-          token: transfer.token,
-          broadcast: transfer.broadcast,
-          ...signerAuthAuditMetadata(signerAuthorization.auth),
-          txHash: transfer.broadcast ? result : undefined,
-        },
-      });
-      dispatchWebhook(tenantId, agentId, "wallet_action.transfer.succeeded", {
-        actionId,
-        txHash: transfer.broadcast ? result : undefined,
-      });
-      if (transfer.broadcast) {
-        dispatchTransactionLifecycleWebhook(tenantId, agentId, "transaction.broadcasted", {
+      if (solanaExecutionToken && transfer.broadcast) {
+        if (
+          !(await completeSolanaRecoveryEffects({
+            tenantId,
+            agentId,
+            txId: actionId,
+            signature: result,
+          }))
+        ) {
+          return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
+        }
+      } else {
+        if (transfer.broadcast) {
+          recordVaultSpend(agentId, tenantId, signRequest.value, signRequest.chainId).catch((err) =>
+            console.error(
+              "[vault] Failed to record transfer action spend",
+              redactedThrownDiagnostics(err),
+            ),
+          );
+        }
+        await recordSponsoredActionIfNeeded({
+          sponsorship: sponsorshipPayload,
+          tenantId,
+          agentId,
           txId: actionId,
-          txHash: result,
           chainId: signRequest.chainId,
-          status: "broadcast",
+          caip2: toCaip2(signRequest.chainId),
+          txHash: transfer.broadcast ? result : undefined,
+          actionType: "transfer",
+          status: transfer.broadcast ? "submitted" : "signed",
         });
+
+        await writeVaultAudit(c, {
+          tenantId,
+          actorType: "agent",
+          actorId: agentId,
+          action: "wallet_action.transfer.succeeded",
+          resourceType: "wallet_action",
+          resourceId: actionId,
+          metadata: {
+            chainId: signRequest.chainId,
+            to: transfer.to,
+            value: transfer.value,
+            token: transfer.token,
+            broadcast: transfer.broadcast,
+            ...signerAuthAuditMetadata(signerAuthorization.auth),
+            txHash: transfer.broadcast ? result : undefined,
+          },
+        });
+        dispatchWebhook(tenantId, agentId, "wallet_action.transfer.succeeded", {
+          actionId,
+          txHash: transfer.broadcast ? result : undefined,
+        });
+        if (transfer.broadcast) {
+          dispatchTransactionLifecycleWebhook(tenantId, agentId, "transaction.broadcasted", {
+            txId: actionId,
+            txHash: result,
+            chainId: signRequest.chainId,
+            status: "broadcast",
+          });
+        }
       }
 
       return c.json<ApiResponse>({
@@ -3592,23 +3751,38 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
         }),
       });
     } catch (e: unknown) {
+      if (e instanceof SolanaRecoveryOwnershipLostError) {
+        return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
+      }
       if (solanaRecoveryBinding && e instanceof ExternalBroadcastOutcomeUnknownError) {
-        await preserveUnknownSolanaOutcome(
+        const preserved = await preserveUnknownSolanaOutcome(
           actionId,
           agentId,
           solanaExecutionToken,
           e.transactionHash,
         );
+        if (
+          !preserved ||
+          !(await completeSolanaRecoveryEffects({
+            tenantId,
+            agentId,
+            txId: actionId,
+            signature: e.transactionHash,
+          }))
+        ) {
+          return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
+        }
         return externalBroadcastOutcomeUnknownResponse(c, e, actionId) as Response;
       }
       if (solanaRecoveryBinding && e instanceof SolanaBroadcastNotSubmittedError) {
-        await markSolanaBroadcastNotSubmitted(
+        const marked = await markSolanaBroadcastNotSubmitted(
           tenantId,
           actionId,
           agentId,
           solanaExecutionToken,
           e.transactionHash,
         );
+        if (!marked) return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
         return c.json<ApiResponse>(
           {
             ok: false,
@@ -3621,18 +3795,31 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
       if (completedResult && completedStatus) {
-        await db
-          .update(transactions)
-          .set({
-            status: completedStatus,
-            txHash: transfer.broadcast ? completedResult : undefined,
-            actionType: "transfer",
-            ...(solanaRecoveryBinding ? {} : { actionPayload: storedTransferActionPayload }),
-            policyResults: evaluation.results,
-            signedAt: new Date(),
-          })
-          .where(eq(transactions.id, actionId))
-          .catch(() => null);
+        if (solanaExecutionToken && transfer.broadcast) {
+          if (
+            !(await completeSolanaRecoveryEffects({
+              tenantId,
+              agentId,
+              txId: actionId,
+              signature: completedResult,
+            }))
+          ) {
+            return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
+          }
+        } else {
+          await db
+            .update(transactions)
+            .set({
+              status: completedStatus,
+              txHash: transfer.broadcast ? completedResult : undefined,
+              actionType: "transfer",
+              actionPayload: storedTransferActionPayload,
+              policyResults: evaluation.results,
+              signedAt: new Date(),
+            })
+            .where(eq(transactions.id, actionId))
+            .catch(() => null);
+        }
 
         return c.json<ApiResponse>({
           ok: true,
@@ -3651,7 +3838,9 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
         });
       }
       if (solanaRecoveryBinding) {
-        await markSolanaRecoveryAnchorFailed(actionId, agentId, solanaExecutionToken);
+        if (!(await markSolanaRecoveryAnchorFailed(actionId, agentId, solanaExecutionToken))) {
+          return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
+        }
       } else {
         await db.insert(transactions).values({
           id: actionId,
@@ -3820,13 +4009,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       approvalQueue,
       and(eq(approvalQueue.txId, transactions.id), eq(approvalQueue.agentId, transactions.agentId)),
     )
-    .where(
-      and(
-        eq(transactions.id, txId),
-        eq(transactions.agentId, agentId),
-        eq(transactions.status, "pending"),
-      ),
-    );
+    .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)));
   if (!transaction) {
     return c.json<ApiResponse>({ ok: false, error: "Transaction not found" }, 404);
   }
@@ -3845,32 +4028,39 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
 
   const isSolana = transactionRow.chainId === 101 || transactionRow.chainId === 102;
   const approvalRecoveryMetadata = readSolanaRecoveryMetadata(transactionRow.actionPayload);
-  const isApprovedSolanaResume = pendingApproval.status === "approved" && isSolana;
-  if (pendingApproval.status !== "pending") {
-    const sameResolver =
-      pendingApproval.resolvedByType === approverPrincipal.type &&
-      pendingApproval.resolvedById === approverPrincipal.id;
-    const leaseUntil =
-      typeof approvalRecoveryMetadata.attemptLeaseUntil === "string"
-        ? Date.parse(approvalRecoveryMetadata.attemptLeaseUntil)
-        : Number.NaN;
-    if (
-      !isApprovedSolanaResume ||
-      !sameResolver ||
-      approvalRecoveryMetadata.recoveryType !== "solana_transaction" ||
-      approvalRecoveryMetadata.recoveryActionType !== (transactionRow.actionType ?? "transaction")
-    ) {
-      return c.json<ApiResponse>(
-        { ok: false, error: "Transaction already processed or not found" },
-        409,
-      );
-    }
-    if (!Number.isFinite(leaseUntil) || leaseUntil > Date.now()) {
-      return c.json<ApiResponse>(
-        { ok: false, error: "Approved Solana execution is already in progress" },
-        409,
-      );
-    }
+  if (
+    isSolana &&
+    pendingApproval.status === "approved" &&
+    (transactionRow.status === "outcome_unknown" ||
+      transactionRow.status === "broadcast" ||
+      transactionRow.status === "confirmed")
+  ) {
+    return solanaLostOwnershipResponse(c, txId, agentId, "approval");
+  }
+  const sameResolver =
+    pendingApproval.resolvedByType === approverPrincipal.type &&
+    pendingApproval.resolvedById === approverPrincipal.id;
+  const leaseUntil =
+    typeof approvalRecoveryMetadata.attemptLeaseUntil === "string"
+      ? Date.parse(approvalRecoveryMetadata.attemptLeaseUntil)
+      : Number.NaN;
+  const isFreshApproval =
+    transactionRow.status === "pending" && pendingApproval.status === "pending";
+  const isApprovedSolanaResume =
+    isSolana &&
+    pendingApproval.status === "approved" &&
+    sameResolver &&
+    approvalRecoveryMetadata.recoveryType === "solana_transaction" &&
+    approvalRecoveryMetadata.recoveryActionType === (transactionRow.actionType ?? "transaction") &&
+    (transactionRow.status === "pending" ||
+      (transactionRow.status === "approved" &&
+        Number.isFinite(leaseUntil) &&
+        leaseUntil <= Date.now()));
+  if (!isFreshApproval && !isApprovedSolanaResume) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Transaction already processed or not found" },
+      409,
+    );
   }
   const transferPayload =
     transactionRow.actionType === "transfer"
@@ -4316,36 +4506,51 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       let txHash: string;
 
       if (isSolana) {
-        if (!transactionRow.data) {
-          throw new Error("Solana transaction blob not found; cannot replay approval");
-        }
         const isSolanaTokenTransfer =
           transferPayload !== null && transferPayload.token !== "native";
-        const result = await vault.signSolanaTransaction({
-          agentId,
-          tenantId,
-          transaction: transactionRow.data,
-          chainId: transactionRow.chainId,
-          broadcast: shouldBroadcast,
-          // SEC-163: token transfers have no vault-layer envelope — the
-          // approval-queue policy grant above stands in for it (allowBlindSign);
-          // native transfers keep the byte-level envelope assertion.
-          ...(isSolanaTokenTransfer
-            ? { allowBlindSign: true }
-            : { expectedTo: transactionRow.toAddress, expectedValue: transactionRow.value }),
-          ...(approvedSolanaExecutionToken
-            ? {
-                onBroadcastPrepared: (checkpoint) =>
-                  checkpointSolanaBroadcastSubmission(
-                    txId,
-                    agentId,
-                    approvedSolanaExecutionToken!,
-                    checkpoint,
-                  ),
-              }
-            : {}),
-        });
-        txHash = result.signature;
+        const checkpoint = approvedSolanaExecutionToken
+          ? (prepared: { signature: string; recentBlockhash: string }) =>
+              checkpointSolanaBroadcastSubmission(
+                txId,
+                agentId,
+                approvedSolanaExecutionToken!,
+                prepared,
+              )
+          : undefined;
+        if (transferPayload?.token === "native" && !transactionRow.data) {
+          txHash = await vault.signTransaction(approvalSignRequest, {
+            txId,
+            policyResults: currentEvaluation.results,
+            status: shouldBroadcast ? "broadcast" : "signed",
+            onSolanaBroadcastPrepared: checkpoint,
+            solanaRecoveryExecutionToken: approvedSolanaExecutionToken ?? undefined,
+          });
+        } else {
+          if (!transactionRow.data) {
+            throw new Error("Solana transaction blob not found; cannot replay approval");
+          }
+          const result = await vault.signSolanaTransaction({
+            agentId,
+            tenantId,
+            transaction: transactionRow.data,
+            chainId: transactionRow.chainId,
+            broadcast: shouldBroadcast,
+            ...(isSolanaTokenTransfer
+              ? { allowBlindSign: true }
+              : { expectedTo: transactionRow.toAddress, expectedValue: transactionRow.value }),
+            onBroadcastPrepared: checkpoint,
+          });
+          txHash = result.signature;
+          if (shouldBroadcast && approvedSolanaExecutionToken) {
+            const finalized = await finalizeSolanaRecoveryAnchor(
+              txId,
+              agentId,
+              approvedSolanaExecutionToken,
+              result,
+            );
+            if (!finalized) return solanaLostOwnershipResponse(c, txId, agentId, "approval");
+          }
+        }
         irreversibleResult = shouldBroadcast;
         if (shouldBroadcast) completedTxHash = txHash;
       } else {
@@ -4496,7 +4701,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
             eq(transactions.agentId, agentId),
             approvedSolanaExecutionToken
               ? and(
-                  eq(transactions.status, "outcome_unknown"),
+                  eq(transactions.status, "broadcast"),
                   eq(transactions.txHash, txHash),
                   sql`${transactions.actionPayload}->>'executionToken' = ${approvedSolanaExecutionToken}`,
                 )
@@ -4508,84 +4713,97 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         throw new Error("Approved transaction execution owner changed before finalization");
       }
 
-      if (!isSolana && shouldBroadcast) {
-        recordVaultSpend(agentId, tenantId, transactionRow.value, transactionRow.chainId).catch(
-          (err) =>
-            console.error(
-              "[vault] Failed to record approved transaction spend",
-              redactedThrownDiagnostics(err),
-            ),
-        );
-      }
-      if (transferPayload) {
-        await recordSponsoredActionIfNeeded({
-          sponsorship: transferPayload.sponsorship,
-          tenantId,
-          agentId,
-          txId,
-          chainId: transactionRow.chainId,
-          caip2: toCaip2(transactionRow.chainId),
-          txHash: shouldBroadcast ? txHash : undefined,
-          actionType: "transfer",
-          status: shouldBroadcast ? "submitted" : "signed",
-        });
-      }
-
-      await writeVaultAudit(c, {
-        tenantId,
-        actorType: "user",
-        actorId,
-        action: transferPayload
-          ? "wallet_action.transfer.succeeded"
-          : isSendCallsAction
-            ? "wallet_action.send_calls.succeeded"
-            : "vault.approve",
-        resourceType: transferPayload || isSendCallsAction ? "wallet_action" : "transaction",
-        resourceId: txId,
-        metadata: {
-          agentId,
-          chainId: transactionRow.chainId,
-          txHash: shouldBroadcast ? txHash : undefined,
-          broadcast:
-            transferPayload?.broadcast ??
-            sendCallsPayload?.broadcast ??
-            transactionPayload?.broadcast,
-        },
-      });
-
-      if (transferPayload) {
-        dispatchWebhook(tenantId, agentId, "wallet_action.transfer.succeeded", {
-          actionId: txId,
-          txHash: transferPayload.broadcast ? txHash : undefined,
-        });
-      } else if (isSendCallsAction) {
-        dispatchWebhook(tenantId, agentId, "wallet_action.send_calls.succeeded", {
-          actionId: txId,
-          txHash: sendCallsPayload.broadcast ? txHash : undefined,
-        });
+      if (approvedSolanaExecutionToken && shouldBroadcast) {
+        if (
+          !(await completeSolanaRecoveryEffects({
+            tenantId,
+            agentId,
+            txId,
+            signature: txHash,
+          }))
+        ) {
+          return solanaLostOwnershipResponse(c, txId, agentId, "approval");
+        }
       } else {
-        dispatchWebhook(tenantId, agentId, "tx_signed", {
-          txId,
+        if (!isSolana && shouldBroadcast) {
+          recordVaultSpend(agentId, tenantId, transactionRow.value, transactionRow.chainId).catch(
+            (err) =>
+              console.error(
+                "[vault] Failed to record approved transaction spend",
+                redactedThrownDiagnostics(err),
+              ),
+          );
+        }
+        if (transferPayload) {
+          await recordSponsoredActionIfNeeded({
+            sponsorship: transferPayload.sponsorship,
+            tenantId,
+            agentId,
+            txId,
+            chainId: transactionRow.chainId,
+            caip2: toCaip2(transactionRow.chainId),
+            txHash: shouldBroadcast ? txHash : undefined,
+            actionType: "transfer",
+            status: shouldBroadcast ? "submitted" : "signed",
+          });
+        }
+
+        await writeVaultAudit(c, {
+          tenantId,
+          actorType: "user",
+          actorId,
+          action: transferPayload
+            ? "wallet_action.transfer.succeeded"
+            : isSendCallsAction
+              ? "wallet_action.send_calls.succeeded"
+              : "vault.approve",
+          resourceType: transferPayload || isSendCallsAction ? "wallet_action" : "transaction",
+          resourceId: txId,
+          metadata: {
+            agentId,
+            chainId: transactionRow.chainId,
+            txHash: shouldBroadcast ? txHash : undefined,
+            broadcast:
+              transferPayload?.broadcast ??
+              sendCallsPayload?.broadcast ??
+              transactionPayload?.broadcast,
+          },
+        });
+
+        if (transferPayload) {
+          dispatchWebhook(tenantId, agentId, "wallet_action.transfer.succeeded", {
+            actionId: txId,
+            txHash: transferPayload.broadcast ? txHash : undefined,
+          });
+        } else if (isSendCallsAction) {
+          dispatchWebhook(tenantId, agentId, "wallet_action.send_calls.succeeded", {
+            actionId: txId,
+            txHash: sendCallsPayload.broadcast ? txHash : undefined,
+          });
+        } else {
+          dispatchWebhook(tenantId, agentId, "tx_signed", {
+            txId,
+            txHash: shouldBroadcast ? txHash : undefined,
+            signedTx: shouldBroadcast ? undefined : txHash,
+          });
+        }
+        dispatchIntentWebhook(tenantId, agentId, "intent.executed", {
+          intentId: txId,
+          actionType: transactionRow.actionType,
+          status: "executed",
           txHash: shouldBroadcast ? txHash : undefined,
           signedTx: shouldBroadcast ? undefined : txHash,
+          referenceId: actionReferenceId(transactionRow.actionPayload),
+          policyResults: transactionRow.policyResults,
         });
-      }
-      dispatchIntentWebhook(tenantId, agentId, "intent.executed", {
-        intentId: txId,
-        actionType: transactionRow.actionType,
-        status: "executed",
-        txHash: shouldBroadcast ? txHash : undefined,
-        signedTx: shouldBroadcast ? undefined : txHash,
-        referenceId: actionReferenceId(transactionRow.actionPayload),
-        policyResults: transactionRow.policyResults,
-      });
-      if (shouldBroadcast) {
-        dispatchTransactionLifecycleWebhook(tenantId, agentId, "transaction.broadcasted", {
-          txId,
-          txHash,
-          chainId: transactionRow.chainId,
-          status: "broadcast",
-        });
+        if (shouldBroadcast) {
+          dispatchTransactionLifecycleWebhook(tenantId, agentId, "transaction.broadcasted", {
+            txId,
+            txHash,
+            chainId: transactionRow.chainId,
+            status: "broadcast",
+          });
+        }
       }
 
       return c.json<ApiResponse<{ txId: string; txHash?: string; signedTx?: string }>>({
@@ -4593,6 +4811,9 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         data: !shouldBroadcast ? { txId, signedTx: txHash } : { txId, txHash },
       });
     } catch (e: unknown) {
+      if (e instanceof SolanaRecoveryOwnershipLostError) {
+        return solanaLostOwnershipResponse(c, txId, agentId, "approval");
+      }
       if (e instanceof SolanaExecutionLeaseConflictError) {
         return c.json<ApiResponse>({ ok: false, error: e.message }, 409);
       }
@@ -4601,13 +4822,17 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         completedTxHash = e.transactionHash;
       }
       if (e instanceof SolanaBroadcastNotSubmittedError && approvedSolanaExecutionToken) {
-        await markSolanaBroadcastNotSubmitted(
+        const reset = await resetSolanaApprovalBroadcastNotSubmitted(
           tenantId,
           txId,
           agentId,
           approvedSolanaExecutionToken,
           e.transactionHash,
+          transactionRow.actionPayload,
+          approverPrincipal.type,
+          approverPrincipal.id,
         );
+        if (!reset) return solanaLostOwnershipResponse(c, txId, agentId, "approval");
         return c.json<ApiResponse>(
           {
             ok: false,
@@ -4628,9 +4853,20 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       });
       if (!irreversibleResult) {
         const mayReopenApproval = approvedSolanaExecutionToken
-          ? await releaseApprovedSolanaExecution(txId, agentId, approvedSolanaExecutionToken)
+          ? await resetSolanaApprovalRecoveryAnchor(
+              tenantId,
+              txId,
+              agentId,
+              approvedSolanaExecutionToken,
+              transactionRow.actionPayload,
+              approverPrincipal.type,
+              approverPrincipal.id,
+            )
           : !isApprovedSolanaResume;
-        if (mayReopenApproval) {
+        if (!mayReopenApproval && approvedSolanaExecutionToken) {
+          return solanaLostOwnershipResponse(c, txId, agentId, "approval");
+        }
+        if (mayReopenApproval && !approvedSolanaExecutionToken) {
           await db
             .update(approvalQueue)
             .set({
@@ -4664,27 +4900,44 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         }
       } else {
         try {
-          await db
-            .update(transactions)
-            .set({
-              status:
-                e instanceof ExternalBroadcastOutcomeUnknownError ? "outcome_unknown" : "broadcast",
-              txHash: completedTxHash ?? transactionRow.txHash ?? null,
-              signedAt: resolvedAt,
-            })
-            .where(
-              and(
-                eq(transactions.id, txId),
-                eq(transactions.agentId, agentId),
-                approvedSolanaExecutionToken
-                  ? and(
-                      sql`${transactions.status} in ('outcome_unknown', 'broadcast')`,
-                      sql`${transactions.actionPayload}->>'executionToken' = ${approvedSolanaExecutionToken}`,
-                      completedTxHash ? eq(transactions.txHash, completedTxHash) : undefined,
-                    )
-                  : undefined,
-              ),
-            );
+          if (approvedSolanaExecutionToken && completedTxHash) {
+            const refreshed =
+              e instanceof ExternalBroadcastOutcomeUnknownError
+                ? await preserveUnknownSolanaOutcome(
+                    txId,
+                    agentId,
+                    approvedSolanaExecutionToken,
+                    completedTxHash,
+                  )
+                : (
+                    await db
+                      .update(transactions)
+                      .set({ status: "broadcast", signedAt: resolvedAt })
+                      .where(
+                        and(
+                          eq(transactions.id, txId),
+                          eq(transactions.agentId, agentId),
+                          eq(transactions.status, "broadcast"),
+                          eq(transactions.txHash, completedTxHash),
+                          sql`${transactions.actionPayload}->>'executionToken' = ${approvedSolanaExecutionToken}`,
+                        ),
+                      )
+                      .returning({ id: transactions.id })
+                  ).length === 1;
+            if (!refreshed) return solanaLostOwnershipResponse(c, txId, agentId, "approval");
+          } else {
+            await db
+              .update(transactions)
+              .set({
+                status:
+                  e instanceof ExternalBroadcastOutcomeUnknownError
+                    ? "outcome_unknown"
+                    : "broadcast",
+                txHash: completedTxHash ?? transactionRow.txHash ?? null,
+                signedAt: resolvedAt,
+              })
+              .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)));
+          }
         } catch {
           // Approval execution already crossed the durable checkpoint. Keep
           // the approval terminal and preserve the typed response; reopening
@@ -4698,6 +4951,19 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
 
       const outcomeUnknown = externalBroadcastOutcomeUnknownResponse(c, e, txId);
       if (outcomeUnknown) {
+        if (approvedSolanaExecutionToken && completedTxHash) {
+          if (
+            !(await completeSolanaRecoveryEffects({
+              tenantId,
+              agentId,
+              txId,
+              signature: completedTxHash,
+            }))
+          ) {
+            return solanaLostOwnershipResponse(c, txId, agentId, "approval");
+          }
+          return outcomeUnknown;
+        }
         recordVaultSpend(agentId, tenantId, transactionRow.value, transactionRow.chainId).catch(
           (err) =>
             console.error(
@@ -4738,6 +5004,17 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         console.error(
           `[${requestId}] Approved transaction ${txId} broadcast before bookkeeping failed; returning broadcast result to prevent duplicate retry`,
         );
+        if (
+          approvedSolanaExecutionToken &&
+          !(await completeSolanaRecoveryEffects({
+            tenantId,
+            agentId,
+            txId,
+            signature: completedTxHash,
+          }))
+        ) {
+          return solanaLostOwnershipResponse(c, txId, agentId, "approval");
+        }
         return c.json<ApiResponse<{ txId: string; txHash: string }>>({
           ok: true,
           data: { txId, txHash: completedTxHash },
@@ -8041,6 +8318,7 @@ async function signSolanaBlind(
     }
 
     const binding = createSolanaRecoveryBinding(c, {
+      routeFamily: "sign-solana",
       tenantId,
       agentId,
       transaction: args.transaction,
@@ -8071,7 +8349,9 @@ async function signSolanaBlind(
         policyResults: evaluation.results,
         binding,
       });
-      if (!staged.executionToken) return solanaReplayResponse(c, staged.row);
+      if (!staged.executionToken) {
+        return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
+      }
       const ownerToken = staged.executionToken;
       executionToken = ownerToken;
       const result = await vault.signSolanaTransaction({
@@ -8086,32 +8366,43 @@ async function signSolanaBlind(
           checkpointSolanaBroadcastSubmission(txId, agentId, ownerToken, checkpoint),
       });
       completedResult = { txId, ...result };
-      await finalizeSolanaRecoveryAnchor(txId, agentId, ownerToken, result);
-      recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
-        console.error("[vault] Failed to record Solana spend", redactedThrownDiagnostics(err)),
-      );
-      await writeVaultAudit(c, {
-        tenantId,
-        actorType: "agent",
-        actorId: agentId,
-        action: "vault.sign.solana.blind",
-        resourceType: "transaction",
-        resourceId: txId,
-        metadata: {
-          chainId,
-          to: toAddress,
-          value: txValue,
-          blindSigned: true,
-          unparsedReason: args.unparsedReason,
-          broadcast: result.broadcast,
-          ...signerAuthAuditMetadata(signerAuthorization.auth),
-          signature: result.broadcast ? result.signature : undefined,
-        },
-      });
-      dispatchWebhook(tenantId, agentId, "tx_signed", {
-        txId,
-        txHash: result.broadcast ? result.signature : undefined,
-      });
+      if (!(await finalizeSolanaRecoveryAnchor(txId, agentId, ownerToken, result))) {
+        return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
+      }
+      if (
+        result.broadcast &&
+        !(await completeSolanaRecoveryEffects({
+          tenantId,
+          agentId,
+          txId,
+          signature: result.signature,
+        }))
+      ) {
+        return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
+      }
+      if (!result.broadcast) {
+        recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
+          console.error("[vault] Failed to record Solana spend", redactedThrownDiagnostics(err)),
+        );
+        await writeVaultAudit(c, {
+          tenantId,
+          actorType: "agent",
+          actorId: agentId,
+          action: "vault.sign.solana.blind",
+          resourceType: "transaction",
+          resourceId: txId,
+          metadata: {
+            chainId,
+            to: toAddress,
+            value: txValue,
+            blindSigned: true,
+            unparsedReason: args.unparsedReason,
+            broadcast: false,
+            ...signerAuthAuditMetadata(signerAuthorization.auth),
+          },
+        });
+        dispatchWebhook(tenantId, agentId, "tx_signed", { txId });
+      }
       return c.json<
         ApiResponse<{
           txId: string;
@@ -8131,6 +8422,16 @@ async function signSolanaBlind(
         console.error(
           `[${requestId}] Solana blind sign completed before bookkeeping failed for agent ${agentId}, tx ${txId}; returning completed result to prevent duplicate retry`,
         );
+        if (
+          !(await completeSolanaRecoveryEffects({
+            tenantId,
+            agentId,
+            txId,
+            signature: completedResult.signature,
+          }))
+        ) {
+          return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
+        }
         setNoStoreHeaders(c);
         return c.json<
           ApiResponse<{
@@ -8146,44 +8447,45 @@ async function signSolanaBlind(
         return c.json<ApiResponse>({ ok: false, error: e.message }, 409);
       }
       if (e instanceof SolanaBroadcastNotSubmittedError) {
-        await markSolanaBroadcastNotSubmitted(
+        const marked = await markSolanaBroadcastNotSubmitted(
           tenantId,
           txId,
           agentId,
           executionToken,
           e.transactionHash,
         );
+        if (!marked) return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
         return c.json<ApiResponse>(
           { ok: false, error: "Solana RPC preflight rejected the transaction", data: { txId } },
           502,
         );
       }
       if (e instanceof ExternalBroadcastOutcomeUnknownError) {
-        await preserveUnknownSolanaOutcome(txId, agentId, executionToken, e.transactionHash);
-        recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
-          console.error(
-            "[vault] Failed to record ambiguous Solana spend",
-            redactedThrownDiagnostics(err),
-          ),
+        const preserved = await preserveUnknownSolanaOutcome(
+          txId,
+          agentId,
+          executionToken,
+          e.transactionHash,
         );
-        await writeOutcomeUnknownAudit(c, {
-          tenantId,
-          actorType: "agent",
-          actorId: agentId,
-          action: "vault.sign.solana.blind.outcome_unknown",
-          resourceType: "transaction",
-          resourceId: txId,
-          metadata: {
-            chainId,
-            to: toAddress,
-            value: txValue,
-            blindSigned: true,
+        if (
+          !preserved ||
+          !(await completeSolanaRecoveryEffects({
+            tenantId,
+            agentId,
+            txId,
             signature: e.transactionHash,
-          },
-        });
+          }))
+        ) {
+          return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
+        }
         return externalBroadcastOutcomeUnknownResponse(c, e, txId) as Response;
       }
-      await markSolanaRecoveryAnchorFailed(txId, agentId, executionToken);
+      if (
+        shouldBroadcast &&
+        !(await markSolanaRecoveryAnchorFailed(txId, agentId, executionToken))
+      ) {
+        return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
+      }
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
       dispatchWebhook(tenantId, agentId, "tx_failed", {
@@ -8270,6 +8572,7 @@ function sha256(value: string): string {
 function createSolanaRecoveryBinding(
   c: Context<{ Variables: AppVariables }>,
   input: {
+    routeFamily: "sign" | "sign-solana";
     tenantId: string;
     agentId: string;
     transaction: string;
@@ -8283,13 +8586,14 @@ function createSolanaRecoveryBinding(
   if (!input.broadcastRequested) return { txId: crypto.randomUUID() };
   const key = c.req.header("Idempotency-Key");
   if (!key) throw new Error("Idempotency-Key is required for Solana broadcast");
-  const scope = `${input.tenantId}\0${input.agentId}\0${key}`;
+  const scope = `${input.tenantId}\0${input.agentId}\0${input.routeFamily}\0${key}`;
   return {
     txId: `solana_${sha256(scope).slice(0, 56)}`,
     idempotencyKeyDigest: sha256(scope),
     requestDigest: sha256(
       canonicalJsonStringify({
         agentId: input.agentId,
+        routeFamily: input.routeFamily,
         blindSigned: input.blindSigned,
         broadcast: true,
         chainId: input.chainId,
@@ -8357,6 +8661,120 @@ function solanaReplayResponse(
     },
     409,
   );
+}
+
+function solanaNativeSignReplayResponse(
+  c: Context<{ Variables: AppVariables }>,
+  row: SolanaRecoveryRow,
+): Response {
+  if (row.status === "approved") {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "A matching Solana signing attempt is already in progress",
+        data: { txId: row.id, status: "processing" },
+      },
+      409,
+    );
+  }
+  if (row.status === "outcome_unknown" && row.txHash) {
+    return externalBroadcastOutcomeUnknownResponse(
+      c,
+      new ExternalBroadcastOutcomeUnknownError(row.txHash),
+      row.id,
+    ) as Response;
+  }
+  if ((row.status === "broadcast" || row.status === "confirmed") && row.txHash) {
+    return c.json<ApiResponse<{ txId: string; txHash: string }>>({
+      ok: true,
+      data: { txId: row.id, txHash: row.txHash },
+    });
+  }
+  return c.json<ApiResponse>(
+    {
+      ok: false,
+      error: "The prior Solana request did not complete; use a new Idempotency-Key",
+      data: { txId: row.id, status: row.status },
+    },
+    409,
+  );
+}
+
+function solanaApprovalReplayResponse(
+  c: Context<{ Variables: AppVariables }>,
+  row: SolanaRecoveryRow,
+): Response {
+  if (row.status === "approved") {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "The approved Solana execution is already in progress",
+        data: { txId: row.id, status: "processing" },
+      },
+      409,
+    );
+  }
+  if (row.status === "outcome_unknown" && row.txHash) {
+    return externalBroadcastOutcomeUnknownResponse(
+      c,
+      new ExternalBroadcastOutcomeUnknownError(row.txHash),
+      row.id,
+    ) as Response;
+  }
+  if ((row.status === "broadcast" || row.status === "confirmed") && row.txHash) {
+    return c.json<ApiResponse<{ txId: string; txHash: string }>>({
+      ok: true,
+      data: { txId: row.id, txHash: row.txHash },
+    });
+  }
+  return c.json<ApiResponse>(
+    { ok: false, error: "The approved Solana execution cannot be replayed" },
+    409,
+  );
+}
+
+async function solanaLostOwnershipResponse(
+  c: Context<{ Variables: AppVariables }>,
+  txId: string,
+  agentId: string,
+  routeFamily: "approval" | "sign" | "sign-solana" | "transfer",
+): Promise<Response> {
+  const [row] = await db
+    .select()
+    .from(transactions)
+    .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)))
+    .limit(1);
+  if (!row) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "The Solana execution lease is no longer owned by this request" },
+      409,
+    );
+  }
+  if (
+    row.txHash &&
+    (row.status === "outcome_unknown" || row.status === "broadcast" || row.status === "confirmed")
+  ) {
+    const completed = await completeSolanaRecoveryEffects({
+      tenantId: c.get("tenantId"),
+      agentId,
+      txId,
+      signature: row.txHash,
+    });
+    if (!completed) {
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error: "Solana recovery accounting is being completed; retry",
+          data: { txId, status: row.status },
+        },
+        409,
+      );
+    }
+  }
+  if (routeFamily === "approval") return solanaApprovalReplayResponse(c, row);
+  if (routeFamily === "transfer") return solanaTransferReplayResponse(c, row);
+  if (routeFamily === "sign") return solanaNativeSignReplayResponse(c, row);
+  return solanaReplayResponse(c, row);
 }
 
 function solanaTransferReplayResponse(
@@ -8571,7 +8989,7 @@ async function claimApprovedSolanaExecution(
   const priorToken = typeof prior.executionToken === "string" ? prior.executionToken : null;
   const priorLeaseUntil =
     typeof prior.attemptLeaseUntil === "string" ? Date.parse(prior.attemptLeaseUntil) : Number.NaN;
-  if (options.takeover) {
+  if (options.takeover && priorToken) {
     if (
       prior.recoveryType !== "solana_transaction" ||
       prior.recoveryActionType !== (row.actionType ?? "transaction") ||
@@ -8597,13 +9015,13 @@ async function claimApprovedSolanaExecution(
   };
   const [claimed] = await db
     .update(transactions)
-    .set({ actionPayload })
+    .set({ status: "approved", actionPayload })
     .where(
       and(
         eq(transactions.id, row.id),
         eq(transactions.agentId, row.agentId),
-        eq(transactions.status, "pending"),
-        options.takeover
+        eq(transactions.status, row.status),
+        priorToken
           ? sql`${transactions.actionPayload}->>'executionToken' = ${priorToken}`
           : sql`${transactions.actionPayload}->>'executionToken' is null`,
       ),
@@ -8613,34 +9031,133 @@ async function claimApprovedSolanaExecution(
   return { executionToken, actionPayload };
 }
 
-async function releaseApprovedSolanaExecution(
+class SolanaApprovalResetCasLostError extends Error {}
+
+async function resetSolanaApprovalRecoveryAnchor(
+  tenantId: string,
   txId: string,
   agentId: string,
   executionToken: string,
+  originalActionPayload: unknown,
+  resolverType: string,
+  resolverId: string,
 ): Promise<boolean> {
-  const [row] = await db
-    .select({ actionPayload: transactions.actionPayload })
-    .from(transactions)
-    .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)))
-    .limit(1);
-  const {
-    executionToken: _executionToken,
-    attemptLeaseUntil: _attemptLeaseUntil,
-    ...releasedPayload
-  } = readSolanaRecoveryMetadata(row?.actionPayload);
-  const released = await db
-    .update(transactions)
-    .set({ actionPayload: releasedPayload })
-    .where(
-      and(
-        eq(transactions.id, txId),
-        eq(transactions.agentId, agentId),
-        eq(transactions.status, "pending"),
-        sql`${transactions.actionPayload}->>'executionToken' = ${executionToken}`,
-      ),
-    )
-    .returning({ id: transactions.id });
-  return released.length === 1;
+  try {
+    return await withTenantAuditedTransaction(tenantId, async (rawTx) => {
+      const tx = rawTx as typeof db;
+      const [released] = await tx
+        .update(transactions)
+        .set({
+          status: "pending",
+          txHash: null,
+          signedAt: null,
+          actionPayload: originalActionPayload as Record<string, unknown>,
+        })
+        .where(
+          and(
+            eq(transactions.id, txId),
+            eq(transactions.agentId, agentId),
+            eq(transactions.status, "approved"),
+            sql`${transactions.actionPayload}->>'executionToken' = ${executionToken}`,
+          ),
+        )
+        .returning({ id: transactions.id });
+      if (!released) return false;
+      const [reopened] = await tx
+        .update(approvalQueue)
+        .set({
+          status: "pending",
+          resolvedAt: null,
+          resolvedBy: null,
+          resolvedByType: null,
+          resolvedById: null,
+        })
+        .where(
+          and(
+            eq(approvalQueue.txId, txId),
+            eq(approvalQueue.agentId, agentId),
+            eq(approvalQueue.status, "approved"),
+            eq(approvalQueue.resolvedByType, resolverType),
+            eq(approvalQueue.resolvedById, resolverId),
+          ),
+        )
+        .returning({ id: approvalQueue.id });
+      if (!reopened) throw new SolanaApprovalResetCasLostError();
+      return true;
+    });
+  } catch (error) {
+    if (error instanceof SolanaApprovalResetCasLostError) return false;
+    throw error;
+  }
+}
+
+async function resetSolanaApprovalBroadcastNotSubmitted(
+  tenantId: string,
+  txId: string,
+  agentId: string,
+  executionToken: string,
+  signature: string,
+  originalActionPayload: unknown,
+  resolverType: string,
+  resolverId: string,
+): Promise<boolean> {
+  try {
+    return await withTenantAuditedTransaction(tenantId, async (rawTx, appendRequiredAudit) => {
+      const tx = rawTx as typeof db;
+      const [reset] = await tx
+        .update(transactions)
+        .set({
+          status: "pending",
+          txHash: null,
+          signedAt: null,
+          actionPayload: originalActionPayload as Record<string, unknown>,
+        })
+        .where(
+          and(
+            eq(transactions.id, txId),
+            eq(transactions.agentId, agentId),
+            eq(transactions.status, "outcome_unknown"),
+            eq(transactions.txHash, signature),
+            sql`${transactions.actionPayload}->>'executionToken' = ${executionToken}`,
+          ),
+        )
+        .returning({ id: transactions.id });
+      if (!reset) return false;
+      const [reopened] = await tx
+        .update(approvalQueue)
+        .set({
+          status: "pending",
+          resolvedAt: null,
+          resolvedBy: null,
+          resolvedByType: null,
+          resolvedById: null,
+        })
+        .where(
+          and(
+            eq(approvalQueue.txId, txId),
+            eq(approvalQueue.agentId, agentId),
+            eq(approvalQueue.status, "approved"),
+            eq(approvalQueue.resolvedByType, resolverType),
+            eq(approvalQueue.resolvedById, resolverId),
+          ),
+        )
+        .returning({ id: approvalQueue.id });
+      if (!reopened) throw new SolanaApprovalResetCasLostError();
+      await appendRequiredAudit({
+        tenantId,
+        actorType: "system",
+        actorId: "solana-rpc-preflight",
+        action: "vault.sign.solana.not_submitted",
+        resourceType: "transaction",
+        resourceId: txId,
+        metadata: { previousStatus: "outcome_unknown", status: "pending", signature },
+      });
+      return true;
+    });
+  } catch (error) {
+    if (error instanceof SolanaApprovalResetCasLostError) return false;
+    throw error;
+  }
 }
 
 async function finalizeSolanaRecoveryAnchor(
@@ -8648,7 +9165,7 @@ async function finalizeSolanaRecoveryAnchor(
   agentId: string,
   executionToken: string,
   result: SolanaSigningResult,
-): Promise<void> {
+): Promise<boolean> {
   const rows = await db
     .update(transactions)
     .set({
@@ -8670,9 +9187,7 @@ async function finalizeSolanaRecoveryAnchor(
       ),
     )
     .returning({ id: transactions.id });
-  if (rows.length !== 1) {
-    throw new Error("Solana recovery anchor was not available for finalization");
-  }
+  return rows.length === 1;
 }
 
 async function preserveUnknownSolanaOutcome(
@@ -8680,10 +9195,10 @@ async function preserveUnknownSolanaOutcome(
   agentId: string,
   executionToken: string | null,
   signature: string,
-): Promise<void> {
-  if (!executionToken) return;
+): Promise<boolean> {
+  if (!executionToken) return false;
   try {
-    await db
+    const rows = await db
       .update(transactions)
       .set({ status: "outcome_unknown", txHash: signature, signedAt: new Date() })
       .where(
@@ -8693,7 +9208,9 @@ async function preserveUnknownSolanaOutcome(
           sql`${transactions.status} in ('approved', 'outcome_unknown')`,
           sql`${transactions.actionPayload}->>'executionToken' = ${executionToken}`,
         ),
-      );
+      )
+      .returning({ id: transactions.id });
+    return rows.length === 1;
   } catch (error) {
     // The pre-sign approved row is already durable. Preserve the typed 202
     // response even when the database cannot enrich it with the known hash.
@@ -8701,6 +9218,7 @@ async function preserveUnknownSolanaOutcome(
       "[vault] Failed to persist ambiguous Solana broadcast hash",
       redactedThrownDiagnostics(error),
     );
+    return false;
   }
 }
 
@@ -8708,10 +9226,10 @@ async function markSolanaRecoveryAnchorFailed(
   txId: string,
   agentId: string,
   executionToken: string | null,
-): Promise<void> {
-  if (!executionToken) return;
+): Promise<boolean> {
+  if (!executionToken) return false;
   try {
-    await db
+    const rows = await db
       .update(transactions)
       .set({ status: "failed" })
       .where(
@@ -8721,12 +9239,15 @@ async function markSolanaRecoveryAnchorFailed(
           eq(transactions.status, "approved"),
           sql`${transactions.actionPayload}->>'executionToken' = ${executionToken}`,
         ),
-      );
+      )
+      .returning({ id: transactions.id });
+    return rows.length === 1;
   } catch (error) {
     console.error(
       "[vault] Failed to mark Solana recovery anchor as failed",
       redactedThrownDiagnostics(error),
     );
+    return false;
   }
 }
 
@@ -8736,9 +9257,9 @@ async function markSolanaBroadcastNotSubmitted(
   agentId: string,
   executionToken: string | null,
   signature: string,
-): Promise<void> {
-  if (!executionToken) return;
-  await withTenantAuditedTransaction(tenantId, async (rawTx, appendRequiredAudit) => {
+): Promise<boolean> {
+  if (!executionToken) return false;
+  return withTenantAuditedTransaction(tenantId, async (rawTx, appendRequiredAudit) => {
     const tx = rawTx as typeof db;
     const [updated] = await tx
       .update(transactions)
@@ -8753,7 +9274,7 @@ async function markSolanaBroadcastNotSubmitted(
         ),
       )
       .returning({ id: transactions.id });
-    if (!updated) return;
+    if (!updated) return false;
     await appendRequiredAudit({
       tenantId,
       actorType: "system",
@@ -8763,7 +9284,156 @@ async function markSolanaBroadcastNotSubmitted(
       resourceId: txId,
       metadata: { previousStatus: "outcome_unknown", status: "failed", signature },
     });
+    return true;
   });
+}
+
+async function completeSolanaRecoveryEffects(input: {
+  tenantId: string;
+  agentId: string;
+  txId: string;
+  signature: string;
+}): Promise<boolean> {
+  const [row] = await db
+    .select()
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.id, input.txId),
+        eq(transactions.agentId, input.agentId),
+        eq(transactions.txHash, input.signature),
+        sql`${transactions.status} in ('outcome_unknown', 'broadcast', 'confirmed')`,
+      ),
+    )
+    .limit(1);
+  if (!row) return false;
+  const metadata = readSolanaRecoveryMetadata(row.actionPayload);
+  if (metadata.recoveryEffectsState === "complete") return true;
+  const claimToken = crypto.randomUUID();
+  const claimLeaseUntil = new Date(Date.now() + 60_000).toISOString();
+  const claimableBefore = new Date().toISOString();
+  const [claimed] = await db
+    .update(transactions)
+    .set({
+      actionPayload: sql`jsonb_set(jsonb_set(jsonb_set(coalesce(${transactions.actionPayload}, '{}'::jsonb), '{recoveryEffectsState}', '"processing"'::jsonb), '{recoveryEffectsToken}', ${JSON.stringify(claimToken)}::jsonb), '{recoveryEffectsLeaseUntil}', ${JSON.stringify(claimLeaseUntil)}::jsonb)`,
+    })
+    .where(
+      and(
+        eq(transactions.id, input.txId),
+        eq(transactions.agentId, input.agentId),
+        eq(transactions.txHash, input.signature),
+        eq(transactions.status, row.status),
+        sql`(
+          coalesce(${transactions.actionPayload}->>'recoveryEffectsState', 'pending') = 'pending'
+          or (
+            ${transactions.actionPayload}->>'recoveryEffectsState' = 'processing'
+            and coalesce(${transactions.actionPayload}->>'recoveryEffectsLeaseUntil', '') <= ${claimableBefore}
+          )
+        )`,
+      ),
+    )
+    .returning({ id: transactions.id });
+  if (!claimed) return false;
+
+  try {
+    if (isRedisConfigured() && !isRedisAvailable()) {
+      throw new Error("Configured Redis accounting backend is unavailable");
+    }
+    const occurredAt = row.signedAt ?? row.createdAt;
+    if (isRedisAvailable()) {
+      await recordVaultSpend(input.agentId, input.tenantId, row.value, row.chainId, {
+        eventId: `solana:${input.txId}:${input.signature}`,
+        occurredAt,
+        throwOnError: true,
+      });
+      await recordAggregationEvent({
+        eventId: `solana:${input.txId}:${input.signature}`,
+        agentId: input.agentId,
+        valueRaw: row.value,
+        to: row.toAddress,
+        chainId: row.chainId,
+        timestamp: occurredAt.getTime(),
+      });
+    }
+    const transferPayload = getTransferActionPayload(row.actionPayload);
+    if (transferPayload) {
+      await recordSponsoredActionIfNeeded({
+        sponsorship: transferPayload.sponsorship,
+        tenantId: input.tenantId,
+        agentId: input.agentId,
+        txId: input.txId,
+        chainId: row.chainId,
+        caip2: toCaip2(row.chainId),
+        txHash: input.signature,
+        actionType: "transfer",
+        status: "submitted",
+      });
+      await dispatchWebhookDurably(
+        input.tenantId,
+        input.agentId,
+        "wallet_action.transfer.succeeded",
+        { actionId: input.txId, txHash: input.signature },
+        `solana:${input.txId}:${input.signature}`,
+      );
+    } else {
+      await dispatchWebhookDurably(
+        input.tenantId,
+        input.agentId,
+        "tx_signed",
+        {
+          txId: input.txId,
+          txHash: input.signature,
+        },
+        `solana:${input.txId}:${input.signature}`,
+      );
+    }
+    return await withTenantAuditedTransaction(
+      input.tenantId,
+      async (rawTx, appendRequiredAudit) => {
+        const tx = rawTx as typeof db;
+        const [completed] = await tx
+          .update(transactions)
+          .set({
+            actionPayload: sql`jsonb_set(jsonb_set(coalesce(${transactions.actionPayload}, '{}'::jsonb), '{recoveryEffectsState}', '"complete"'::jsonb), '{recoveryEffectsCompletedAt}', ${JSON.stringify(new Date().toISOString())}::jsonb) - 'recoveryEffectsToken' - 'recoveryEffectsLeaseUntil'`,
+          })
+          .where(
+            and(
+              eq(transactions.id, input.txId),
+              eq(transactions.agentId, input.agentId),
+              eq(transactions.txHash, input.signature),
+              sql`${transactions.actionPayload}->>'recoveryEffectsToken' = ${claimToken}`,
+            ),
+          )
+          .returning({ id: transactions.id });
+        if (!completed) return false;
+        await appendRequiredAudit({
+          tenantId: input.tenantId,
+          actorType: "system",
+          actorId: "solana-recovery",
+          action: transferPayload
+            ? "wallet_action.transfer.succeeded"
+            : "vault.sign.solana.effects_completed",
+          resourceType: transferPayload ? "wallet_action" : "transaction",
+          resourceId: input.txId,
+          metadata: { signature: input.signature, status: row.status },
+        });
+        return true;
+      },
+    );
+  } catch (error) {
+    await db
+      .update(transactions)
+      .set({
+        actionPayload: sql`jsonb_set(coalesce(${transactions.actionPayload}, '{}'::jsonb), '{recoveryEffectsState}', '"pending"'::jsonb) - 'recoveryEffectsToken' - 'recoveryEffectsLeaseUntil'`,
+      })
+      .where(
+        and(
+          eq(transactions.id, input.txId),
+          sql`${transactions.actionPayload}->>'recoveryEffectsToken' = ${claimToken}`,
+        ),
+      );
+    throw error;
+  }
 }
 
 vaultRoutes.post("/:agentId/sign-solana", async (c) => {
@@ -9127,6 +9797,7 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
     }
 
     const binding = createSolanaRecoveryBinding(c, {
+      routeFamily: "sign-solana",
       tenantId,
       agentId,
       transaction: body.transaction,
@@ -9170,7 +9841,9 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         policyResults: evaluation.results,
         binding,
       });
-      if (!staged.executionToken) return solanaReplayResponse(c, staged.row);
+      if (!staged.executionToken) {
+        return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
+      }
       const ownerToken = staged.executionToken;
       executionToken = ownerToken;
       const result = await vault.signSolanaTransaction({
@@ -9190,43 +9863,50 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
       });
       completedResult = { txId, ...result };
 
-      await finalizeSolanaRecoveryAnchor(txId, agentId, ownerToken, result);
+      if (!(await finalizeSolanaRecoveryAnchor(txId, agentId, ownerToken, result))) {
+        return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
+      }
 
-      // ── Record spend in Redis (fire-and-forget) ──────────────────────────────
-      recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
-        console.error("[vault] Failed to record Solana spend", redactedThrownDiagnostics(err)),
-      );
-
-      await writeVaultAudit(c, {
-        tenantId,
-        actorType: "agent",
-        actorId: agentId,
-        action: "vault.sign.solana",
-        resourceType: "transaction",
-        resourceId: txId,
-        metadata: {
-          chainId,
-          to: toAddress,
-          value: txValue,
-          broadcast: result.broadcast,
-          ...signerAuthAuditMetadata(signerAuthorization.auth),
-          signature: result.broadcast ? result.signature : undefined,
-          // Authoritative, parser-derived effects (not caller-supplied).
-          derivedFromTransaction: true,
-          movesNativeSol: derived.movesNativeSol,
-          programIds: derived.programIds,
-          tokenTransfers: derived.summary.tokenTransfers.map((t) => ({
-            mint: t.mint,
-            destination: t.destination,
-            amount: t.amount,
-          })),
-        },
-      });
-
-      dispatchWebhook(tenantId, agentId, "tx_signed", {
-        txId,
-        txHash: result.broadcast ? result.signature : undefined,
-      });
+      if (
+        result.broadcast &&
+        !(await completeSolanaRecoveryEffects({
+          tenantId,
+          agentId,
+          txId,
+          signature: result.signature,
+        }))
+      ) {
+        return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
+      }
+      if (!result.broadcast) {
+        recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
+          console.error("[vault] Failed to record Solana spend", redactedThrownDiagnostics(err)),
+        );
+        await writeVaultAudit(c, {
+          tenantId,
+          actorType: "agent",
+          actorId: agentId,
+          action: "vault.sign.solana",
+          resourceType: "transaction",
+          resourceId: txId,
+          metadata: {
+            chainId,
+            to: toAddress,
+            value: txValue,
+            broadcast: false,
+            ...signerAuthAuditMetadata(signerAuthorization.auth),
+            derivedFromTransaction: true,
+            movesNativeSol: derived.movesNativeSol,
+            programIds: derived.programIds,
+            tokenTransfers: derived.summary.tokenTransfers.map((transfer) => ({
+              mint: transfer.mint,
+              destination: transfer.destination,
+              amount: transfer.amount,
+            })),
+          },
+        });
+        dispatchWebhook(tenantId, agentId, "tx_signed", { txId });
+      }
 
       setNoStoreHeaders(c);
       return c.json<
@@ -9251,6 +9931,16 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         console.error(
           `[${requestId}] Solana sign completed before bookkeeping failed for agent ${agentId}, tx ${txId}; returning completed result to prevent duplicate retry`,
         );
+        if (
+          !(await completeSolanaRecoveryEffects({
+            tenantId,
+            agentId,
+            txId,
+            signature: completedResult.signature,
+          }))
+        ) {
+          return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
+        }
         setNoStoreHeaders(c);
         return c.json<
           ApiResponse<{
@@ -9267,44 +9957,45 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         return c.json<ApiResponse>({ ok: false, error: e.message }, 409);
       }
       if (e instanceof SolanaBroadcastNotSubmittedError) {
-        await markSolanaBroadcastNotSubmitted(
+        const marked = await markSolanaBroadcastNotSubmitted(
           tenantId,
           txId,
           agentId,
           executionToken,
           e.transactionHash,
         );
+        if (!marked) return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
         return c.json<ApiResponse>(
           { ok: false, error: "Solana RPC preflight rejected the transaction", data: { txId } },
           502,
         );
       }
       if (e instanceof ExternalBroadcastOutcomeUnknownError) {
-        await preserveUnknownSolanaOutcome(txId, agentId, executionToken, e.transactionHash);
-        recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
-          console.error(
-            "[vault] Failed to record ambiguous Solana spend",
-            redactedThrownDiagnostics(err),
-          ),
+        const preserved = await preserveUnknownSolanaOutcome(
+          txId,
+          agentId,
+          executionToken,
+          e.transactionHash,
         );
-        await writeOutcomeUnknownAudit(c, {
-          tenantId,
-          actorType: "agent",
-          actorId: agentId,
-          action: "vault.sign.solana.outcome_unknown",
-          resourceType: "transaction",
-          resourceId: txId,
-          metadata: {
-            chainId,
-            to: toAddress,
-            value: txValue,
+        if (
+          !preserved ||
+          !(await completeSolanaRecoveryEffects({
+            tenantId,
+            agentId,
+            txId,
             signature: e.transactionHash,
-            derivedFromTransaction: true,
-          },
-        });
+          }))
+        ) {
+          return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
+        }
         return externalBroadcastOutcomeUnknownResponse(c, e, txId) as Response;
       }
-      await markSolanaRecoveryAnchorFailed(txId, agentId, executionToken);
+      if (
+        shouldBroadcast &&
+        !(await markSolanaRecoveryAnchorFailed(txId, agentId, executionToken))
+      ) {
+        return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
+      }
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
 
@@ -9434,6 +10125,20 @@ vaultRoutes.post("/:agentId/transactions/:txId/reconcile-solana", async (c) => {
   );
   if (!transitioned) {
     return c.json<ApiResponse>({ ok: false, error: "Transaction state changed; retry" }, 409);
+  }
+  if (
+    nextStatus !== "failed" &&
+    !(await completeSolanaRecoveryEffects({
+      tenantId,
+      agentId,
+      txId,
+      signature,
+    }))
+  ) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Solana recovery accounting is being completed; retry" },
+      409,
+    );
   }
   return c.json<ApiResponse>({
     ok: true,

--- a/packages/api/src/services/webhook-dispatch.ts
+++ b/packages/api/src/services/webhook-dispatch.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { and, eq, waitUntilRequestDatabaseTask, webhookConfigs, webhookDeliveries } from "@stwd/db";
 import { redactedThrownDiagnostics, type WebhookEvent } from "@stwd/shared";
 import {
@@ -71,6 +71,30 @@ export function dispatchWebhook(
   // former second fan-out through a bare URL both duplicate-delivered each
   // event and could only sign with a process-wide key. Persisted /webhooks
   // endpoints with receiver-known per-endpoint secrets are now the sole path.
+}
+
+/** Await durable delivery creation for recovery paths before acknowledging replay success. */
+export async function dispatchWebhookDurably(
+  tenantId: string,
+  agentId: string,
+  type: DispatchableWebhookEventType,
+  data: Record<string, unknown>,
+  idempotencyKey: string,
+): Promise<void> {
+  const configuredType = toConfiguredWebhookEventType(type);
+  const isPluginEvent = configuredType === null && webhookEventRegistry.has(type);
+  await dispatchConfiguredWebhooks(
+    {
+      type: (configuredType ?? type) as WebhookEvent["type"],
+      tenantId,
+      agentId,
+      data: redactWebhookSecrets(data) as Record<string, unknown>,
+      timestamp: new Date(),
+    },
+    configuredType,
+    isPluginEvent ? type : null,
+    idempotencyKey,
+  );
 }
 
 export async function dispatchTestWebhook(config: {
@@ -146,6 +170,7 @@ async function dispatchConfiguredWebhooks(
   event: WebhookEvent,
   configuredType: ConfiguredWebhookEventType | null,
   pluginEventType: string | null = null,
+  idempotencyKey?: string,
 ): Promise<void> {
   const configs = await db
     .select()
@@ -173,6 +198,7 @@ async function dispatchConfiguredWebhooks(
           events: config.events,
           maxRetries: config.maxRetries,
           retryBackoffMs: config.retryBackoffMs,
+          idempotencyKey,
         }),
       ),
   );
@@ -189,6 +215,7 @@ async function dispatchConfiguredWebhook(
     retryBackoffMs: number;
     visibilityTimeoutMs?: number;
     replayedFromDeliveryId?: string | null;
+    idempotencyKey?: string;
   },
 ): Promise<typeof webhookDeliveries.$inferSelect> {
   const signingSecret = decryptWebhookSecret(config.secret);
@@ -205,7 +232,9 @@ async function dispatchConfiguredWebhook(
       .set({ secret: encryptedSecret, updatedAt: new Date() })
       .where(and(eq(webhookConfigs.id, config.id), eq(webhookConfigs.secret, config.secret)));
   }
-  const deliveryId = randomUUID();
+  const deliveryId = config.idempotencyKey
+    ? deterministicDeliveryId(config.id, event.type, config.idempotencyKey)
+    : randomUUID();
   const signedAt = Math.floor(Date.now() / 1000);
   const eventWithDelivery: WebhookEvent & {
     deliveryId: string;
@@ -220,32 +249,38 @@ async function dispatchConfiguredWebhook(
       ? { replayedFromDeliveryId: config.replayedFromDeliveryId }
       : {}),
   };
-  const [delivery] = await db
-    .insert(webhookDeliveries)
-    .values({
-      id: deliveryId,
-      tenantId: event.tenantId,
-      webhookConfigId: config.id,
-      agentId: event.agentId,
-      eventType: event.type,
-      replayedFromDeliveryId: config.replayedFromDeliveryId ?? null,
-      payload: eventWithDelivery as unknown as Record<string, unknown>,
-      url: config.url,
-      secret: encryptedSecret,
-      events: config.events,
-      status: "processing",
-      attempts: 0,
-      maxAttempts: config.maxRetries + 1,
-      nextRetryAt:
-        config.visibilityTimeoutMs === 0
-          ? null
-          : new Date(
-              Date.now() + (config.visibilityTimeoutMs ?? INLINE_DELIVERY_VISIBILITY_TIMEOUT_MS),
-            ),
-    })
-    .returning();
+  const deliveryInsert = db.insert(webhookDeliveries).values({
+    id: deliveryId,
+    tenantId: event.tenantId,
+    webhookConfigId: config.id,
+    agentId: event.agentId,
+    eventType: event.type,
+    replayedFromDeliveryId: config.replayedFromDeliveryId ?? null,
+    payload: eventWithDelivery as unknown as Record<string, unknown>,
+    url: config.url,
+    secret: encryptedSecret,
+    events: config.events,
+    status: "processing",
+    attempts: 0,
+    maxAttempts: config.maxRetries + 1,
+    nextRetryAt:
+      config.visibilityTimeoutMs === 0
+        ? null
+        : new Date(
+            Date.now() + (config.visibilityTimeoutMs ?? INLINE_DELIVERY_VISIBILITY_TIMEOUT_MS),
+          ),
+  });
+  const [delivery] = config.idempotencyKey
+    ? await deliveryInsert.onConflictDoNothing().returning()
+    : await deliveryInsert.returning();
 
   if (!delivery) {
+    const [existing] = await db
+      .select()
+      .from(webhookDeliveries)
+      .where(eq(webhookDeliveries.id, deliveryId))
+      .limit(1);
+    if (existing) return existing;
     throw new Error("Failed to create webhook delivery record");
   }
 
@@ -288,4 +323,9 @@ async function dispatchConfiguredWebhook(
     .returning();
 
   return updated ?? delivery;
+}
+
+function deterministicDeliveryId(configId: string, eventType: string, key: string): string {
+  const hex = createHash("sha256").update(`${configId}\0${eventType}\0${key}`).digest("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
 }

--- a/packages/redis/src/__tests__/aggregation-tracker.test.ts
+++ b/packages/redis/src/__tests__/aggregation-tracker.test.ts
@@ -80,6 +80,32 @@ describeRedis("aggregation tracker", () => {
     expect(count).toBe(4n);
   });
 
+  test("stable recovery event ids are idempotent across retries", async () => {
+    const agent = agentId("recovery-idempotency");
+    const now = Date.now();
+    const event = {
+      eventId: "solana:tx-123:signature-123",
+      agentId: agent,
+      to: "0xabc",
+      chainId: 101,
+      valueRaw: "123",
+      timestamp: now - 100,
+    };
+    await recordAggregationEvent(event);
+    await recordAggregationEvent({ ...event, valueRaw: "999", timestamp: now });
+
+    const count = await getAggregationSnapshot(
+      { agentId: agent, metric: "tx_count", windowSeconds: 3600, scope: "agent", scopeKey: "" },
+      now,
+    );
+    const sum = await getAggregationSnapshot(
+      { agentId: agent, metric: "value_sum", windowSeconds: 3600, scope: "agent", scopeKey: "" },
+      now,
+    );
+    expect(count).toBe(1n);
+    expect(sum).toBe(123n);
+  });
+
   test("window boundary is half-open (now - S*1000, now]: event exactly at edge excluded", async () => {
     const agent = agentId("boundary");
     const now = Date.now();

--- a/packages/redis/src/__tests__/spend-tracker.test.ts
+++ b/packages/redis/src/__tests__/spend-tracker.test.ts
@@ -95,6 +95,26 @@ describeRedis("Spend Tracker", () => {
     expect(byHost["api.anthropic.com"]).toBeCloseTo(0.05, 4);
   });
 
+  test("records a recovery event id exactly once across retries", async () => {
+    const eventId = `solana-recovery-${Date.now()}`;
+    await recordSpend(TEST_AGENT, TEST_TENANT, 0.25, "chain:101", { eventId });
+    await recordSpend(TEST_AGENT, TEST_TENANT, 0.25, "chain:101", { eventId });
+
+    expect(await getSpend(TEST_AGENT, "day")).toBeCloseTo(0.25, 4);
+    expect((await getSpendByHost(TEST_AGENT, "day"))["chain:101"]).toBeCloseTo(0.25, 4);
+  });
+
+  test("keeps a delayed recovery event in its authoritative spend bucket", async () => {
+    const occurredAt = new Date(Date.now() - 2 * 86400_000);
+    await recordSpend(TEST_AGENT, TEST_TENANT, 0.25, "chain:101", {
+      eventId: `solana-delayed-recovery-${Date.now()}`,
+      occurredAt,
+    });
+
+    expect(await getSpend(TEST_AGENT, "day", occurredAt)).toBeCloseTo(0.25, 4);
+    expect(await getSpend(TEST_AGENT, "day")).toBe(0);
+  });
+
   test("checks spend limit — under limit", async () => {
     await recordSpend(TEST_AGENT, TEST_TENANT, 10.0, "api.openai.com");
 

--- a/packages/redis/src/aggregation-tracker.ts
+++ b/packages/redis/src/aggregation-tracker.ts
@@ -37,6 +37,8 @@ export type AggregationScope = "agent" | "per_recipient" | "per_chain";
 /** A single authoritative activity event to fold into the rolling aggregates. */
 export interface AggregationEvent {
   agentId: string;
+  /** Stable idempotency identity for recovery/replay writers. */
+  eventId?: string;
   /** Recipient address (lowercased on write). Required for per_recipient scope. */
   to: string;
   /** Numeric chain id. Required for per_chain scope. */
@@ -111,6 +113,29 @@ end
 return 1
 `;
 
+// Idempotent recovery writer. KEYS[1] is the stable event marker, followed by
+// value/count sets and then recipient sets. The marker and every metric write
+// happen in one script so a retry cannot refresh the original score, change
+// its value, or partially duplicate only one metric family.
+// ARGV[1]=now ARGV[2]=cutoff ARGV[3]=ttlMs ARGV[4]=valueMember
+// ARGV[5]=recipientMember ARGV[6]=firstRecipientKeyIndex
+const RECORD_IDEMPOTENT_LUA = `
+local ttl = tonumber(ARGV[3])
+if redis.call('SET', KEYS[1], '1', 'NX', 'PX', ttl) == false then
+  return 0
+end
+local cutoff = tonumber(ARGV[2])
+local score = tonumber(ARGV[1])
+local firstRecipient = tonumber(ARGV[6])
+for i = 2, #KEYS do
+  local member = i < firstRecipient and ARGV[4] or ARGV[5]
+  redis.call('ZREMRANGEBYSCORE', KEYS[i], 0, cutoff)
+  redis.call('ZADD', KEYS[i], score, member .. ':' .. i)
+  redis.call('PEXPIRE', KEYS[i], ttl)
+end
+return 1
+`;
+
 // Read a window: prune expired, then return every member whose score is within
 // (windowStart, now]. We return raw members and aggregate in JS (bigint-exact
 // for value sums; Set-based for unique recipients). ZADD-pruning keeps the set
@@ -144,8 +169,9 @@ export async function recordAggregationEvent(event: AggregationEvent): Promise<v
   // Build the scoped key set. value + count families share the same member
   // (the value payload). recipients family stores the recipient as the payload
   // so unique-recipient counts collapse duplicate addresses within a window.
-  const valueMember = `${now}:${cryptoSeq()}|${valueRaw.toString()}`;
-  const recipientMember = `${now}:${cryptoSeq()}|${to}`;
+  const memberIdentity = event.eventId ? `event:${event.eventId}` : `${now}:${cryptoSeq()}`;
+  const valueMember = `${memberIdentity}|${valueRaw.toString()}`;
+  const recipientMember = `${memberIdentity}|${to}`;
 
   const redis = getRedis();
 
@@ -165,10 +191,27 @@ export async function recordAggregationEvent(event: AggregationEvent): Promise<v
     recipientKeys.push(aggKey(event.agentId, "recipients", "per_chain", chainKey));
   }
 
-  // value + count families carry the value payload member.
-  await runRecord(redis, [...valueKeys, ...countKeys], now, cutoff, valueMember);
-  // recipients family carries the recipient payload member.
-  await runRecord(redis, recipientKeys, now, cutoff, recipientMember);
+  if (event.eventId) {
+    const valueAndCountKeys = [...valueKeys, ...countKeys];
+    await redis.eval(
+      RECORD_IDEMPOTENT_LUA,
+      1 + valueAndCountKeys.length + recipientKeys.length,
+      `agg:${event.agentId}:event:${event.eventId}`,
+      ...valueAndCountKeys,
+      ...recipientKeys,
+      String(now),
+      String(cutoff),
+      String(RETENTION_MS),
+      valueMember,
+      recipientMember,
+      String(2 + valueAndCountKeys.length),
+    );
+  } else {
+    // value + count families carry the value payload member.
+    await runRecord(redis, [...valueKeys, ...countKeys], now, cutoff, valueMember);
+    // recipients family carries the recipient payload member.
+    await runRecord(redis, recipientKeys, now, cutoff, recipientMember);
+  }
 }
 
 async function runRecord(

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -62,6 +62,7 @@ export {
   reserveSpend,
   type SpendLimitSnapshot,
   type SpendPeriod,
+  type SpendRecordOptions,
   type SpendReservation,
   settleReservedSpend,
 } from "./spend-tracker.js";

--- a/packages/redis/src/spend-tracker.ts
+++ b/packages/redis/src/spend-tracker.ts
@@ -29,6 +29,13 @@ export interface SpendReservation {
   buckets: Array<{ period: SpendPeriod; dateKey: string; key: string }>;
 }
 
+export interface SpendRecordOptions {
+  /** Stable identity used by recovery writers to make the increment idempotent. */
+  eventId?: string;
+  /** Authoritative event time; retries must not move spend into a later bucket. */
+  occurredAt?: Date | number;
+}
+
 const TTL_SECONDS: Record<SpendPeriod, number> = {
   day: 172800, // 2 days
   week: 691200, // 8 days
@@ -65,6 +72,21 @@ local current = tonumber(redis.call('HGET', KEYS[1], 'reserved') or '0')
 local after = math.max(0, current - release)
 redis.call('HSET', KEYS[1], 'reserved', after)
 return after
+`;
+
+// KEYS[1]=idempotency marker, KEYS[2..4]=day/week/month buckets.
+// ARGV[1]=units ARGV[2]=host ARGV[3]=tenantId ARGV[4..6]=bucket TTLs.
+const RECORD_IDEMPOTENT_SPEND_LUA = `
+if redis.call('SET', KEYS[1], '1', 'NX', 'EX', tonumber(ARGV[6])) == false then
+  return 0
+end
+for i = 2, 4 do
+  redis.call('HINCRBY', KEYS[i], 'total', tonumber(ARGV[1]))
+  redis.call('HINCRBY', KEYS[i], 'host:' .. ARGV[2], tonumber(ARGV[1]))
+  redis.call('HSET', KEYS[i], 'tenantId', ARGV[3])
+  redis.call('EXPIRE', KEYS[i], tonumber(ARGV[i + 2]))
+end
+return 1
 `;
 
 /**
@@ -158,12 +180,36 @@ export async function recordSpend(
   tenantId: string,
   costUsd: number,
   host: string,
+  options: SpendRecordOptions = {},
 ): Promise<void> {
   const costCents = toSpendUnits(costUsd); // throws on negative/NaN; 0 → no-op below
   if (costCents <= 0) return;
 
   const redis = getRedis();
-  const now = new Date();
+  const now =
+    options.occurredAt instanceof Date
+      ? new Date(options.occurredAt.getTime())
+      : new Date(options.occurredAt ?? Date.now());
+  if (Number.isNaN(now.getTime())) throw new Error("invalid spend event timestamp");
+
+  if (options.eventId) {
+    const bucketKeys = (["day", "week", "month"] as SpendPeriod[]).map((period) =>
+      spendKey(agentId, period, getDateKey(period, now)),
+    );
+    await redis.eval(
+      RECORD_IDEMPOTENT_SPEND_LUA,
+      4,
+      `spend:${agentId}:event:${options.eventId}`,
+      ...bucketKeys,
+      String(costCents),
+      host,
+      tenantId,
+      String(TTL_SECONDS.day),
+      String(TTL_SECONDS.week),
+      String(TTL_SECONDS.month),
+    );
+    return;
+  }
 
   const pipeline = redis.multi();
 

--- a/packages/vault/src/__tests__/transaction-id-hardening.test.ts
+++ b/packages/vault/src/__tests__/transaction-id-hardening.test.ts
@@ -3,7 +3,7 @@ import { agents, closeDb, getDb, tenants, transactions } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import type { SignRequest } from "@stwd/shared";
 import { eq } from "drizzle-orm";
-import { Vault } from "../vault";
+import { SolanaRecoveryOwnershipLostError, Vault } from "../vault";
 
 const tenantId = `transaction-owner-${crypto.randomUUID()}`;
 const firstAgentId = `transaction-owner-first-${crypto.randomUUID()}`;
@@ -16,7 +16,11 @@ type TransactionRecorder = {
     chainId: number,
     shouldBroadcast: boolean,
     hash: string,
-    options: { txId: string; status?: "signed" | "broadcast" | "outcome_unknown" },
+    options: {
+      txId: string;
+      status?: "signed" | "broadcast" | "outcome_unknown";
+      solanaRecoveryExecutionToken?: string;
+    },
   ): Promise<void>;
 };
 
@@ -91,5 +95,45 @@ describe("transaction id hardening", () => {
     expect(recorded?.value).toBe("2");
     expect(recorded?.txHash).toBe("0xupdated");
     expect(recorded?.status).toBe("broadcast");
+  });
+
+  test("never regresses a reconciled Solana row after losing the exact recovery CAS", async () => {
+    const recoveryTxId = `solana-recovery-cas-${crypto.randomUUID()}`;
+    const executionToken = crypto.randomUUID();
+    const signature = "solana-recovery-signature";
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: recoveryTxId,
+        agentId: firstAgentId,
+        status: "confirmed",
+        toAddress: requestFor(firstAgentId, "7").to,
+        value: "7",
+        chainId: 101,
+        txHash: signature,
+        actionPayload: { executionToken, recoveryType: "solana_transaction" },
+        confirmedAt: new Date(),
+      });
+    const recorder = new Vault({
+      masterPassword: "transaction-owner-test",
+    }) as unknown as TransactionRecorder;
+
+    await expect(
+      recorder.recordSignedTransaction(requestFor(firstAgentId, "8"), 101, true, signature, {
+        txId: recoveryTxId,
+        status: "broadcast",
+        solanaRecoveryExecutionToken: executionToken,
+      }),
+    ).rejects.toBeInstanceOf(SolanaRecoveryOwnershipLostError);
+
+    const [recorded] = await getDb()
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, recoveryTxId));
+    expect(recorded).toMatchObject({
+      status: "confirmed",
+      txHash: signature,
+      value: "7",
+    });
   });
 });

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -236,6 +236,7 @@ export type {
 export {
   BackendBindingMismatchError,
   externalCustodyIdentityDigest,
+  SolanaRecoveryOwnershipLostError,
   Vault,
   Vault as VaultClient,
 } from "./vault";

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -463,6 +463,19 @@ export interface SignTransactionOptions {
     signature: string;
     recentBlockhash: string;
   }) => Promise<void>;
+  /**
+   * Ownership token for a gateway-staged Solana recovery anchor. When set,
+   * the post-broadcast write is an exact outcome_unknown+signature+token CAS
+   * instead of an upsert, so a stale signer cannot overwrite reconciliation.
+   */
+  solanaRecoveryExecutionToken?: string;
+}
+
+export class SolanaRecoveryOwnershipLostError extends Error {
+  constructor() {
+    super("Solana recovery execution ownership changed");
+    this.name = "SolanaRecoveryOwnershipLostError";
+  }
 }
 
 export interface ResolvedExecutionTarget {
@@ -871,6 +884,34 @@ export class Vault {
     const db = getDb();
     const txId = options.txId ?? crypto.randomUUID();
     const signedAt = new Date();
+    if (shouldBroadcast && options.solanaRecoveryExecutionToken) {
+      const recordedTransactions = await db
+        .update(transactions)
+        .set({
+          status: options.status ?? "broadcast",
+          toAddress: request.to,
+          value: request.value,
+          data: request.data,
+          chainId,
+          txHash: hash,
+          executionBackend: options.expectedBackend,
+          executionBackendIdentityDigest: options.expectedBackendIdentityDigest,
+          policyResults: options.policyResults ?? [],
+          signedAt,
+        })
+        .where(
+          and(
+            eq(transactions.id, txId),
+            eq(transactions.agentId, request.agentId),
+            eq(transactions.status, "outcome_unknown"),
+            eq(transactions.txHash, hash),
+            sql`${transactions.actionPayload}->>'executionToken' = ${options.solanaRecoveryExecutionToken}`,
+          ),
+        )
+        .returning({ id: transactions.id });
+      if (recordedTransactions.length !== 1) throw new SolanaRecoveryOwnershipLostError();
+      return;
+    }
     const recordedTransactions = await db
       .insert(transactions)
       .values({


### PR DESCRIPTION
## Summary

- fence every native, SPL, parsed, blind, transfer, and approved Solana broadcast with an exact execution-token/signature/status CAS so stale owners cannot regress a reconciled result or perform post-ownership side effects
- reset an approved transaction and its approval queue atomically, and replay the current winner when definite-preflight cleanup loses ownership
- make irreversible recovery effects durable and retryable: spend and aggregation counters use stable event identities and the original signed time, sponsorship is upserted, webhook delivery creation is deterministic, and required audit completion is transactionally marked
- keep recovery effects pending when configured Redis accounting is unavailable or throws, preventing a confirmed broadcast from being acknowledged with silently incomplete cumulative accounting
- preserve request-local native-price fallback configuration while using strict per-chain native decimals, including Solana lamports

## Validation

- exact head `dc283fd50b730bd9588b450b932db1fbfee83bd0` on develop `46d01b88f5ec85db1a3c02367182ae69da35aae6`
- isolated owning suites: 73 pass / 448 assertions across wallet actions, approval gates, recovery anchors, webhook dispatch, Solana policy derivation, Redis enforcement, Vault offline broadcast, and transaction CAS hardening
- disposable real Redis: 24 pass / 58 assertions across spend and aggregation trackers, including duplicate recovery events and delayed authoritative bucket placement
- `bunx turbo run build --filter=@stwd/api...`: 24/24 tasks passed
- Biome clean on all 15 changed files
- `git diff --check origin/develop...HEAD` clean

Closes #651
Closes #673
