### PR TITLE
fix(worker): bind global wallet gates per request

### DIFF
--- a/packages/api/src/__tests__/global-wallet-runtime.test.ts
+++ b/packages/api/src/__tests__/global-wallet-runtime.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { globalWalletFeatureFlags } from "../services/global-wallet-runtime";
+
+const enabledBindings = {
+  STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING: "true",
+  STEWARD_ALLOW_GLOBAL_WALLET_PERSONAL_SIGN: "true",
+  STEWARD_ALLOW_GLOBAL_WALLET_TYPED_DATA_SIGNING: "true",
+  STEWARD_ALLOW_GLOBAL_WALLET_SEND_TRANSACTION: "true",
+};
+
+describe("global wallet request-local feature gates", () => {
+  it("does not retain enabled gates across an overlapping disabled Worker request", async () => {
+    let releaseEnabled!: () => void;
+    const enabledCanFinish = new Promise<void>((resolve) => {
+      releaseEnabled = resolve;
+    });
+    let enabledStarted!: () => void;
+    const enabledDidStart = new Promise<void>((resolve) => {
+      enabledStarted = resolve;
+    });
+
+    const enabled = withRuntimeEnvironment(enabledBindings, async () => {
+      enabledStarted();
+      await enabledCanFinish;
+      return globalWalletFeatureFlags();
+    });
+    await enabledDidStart;
+
+    const disabled = withRuntimeEnvironment({}, async () => {
+      expect(globalWalletFeatureFlags()).toEqual({
+        unsafeMessageSigning: false,
+        personalSign: false,
+        typedDataSigning: false,
+        sendTransaction: false,
+      });
+      releaseEnabled();
+      return globalWalletFeatureFlags();
+    });
+
+    expect(await enabled).toEqual({
+      unsafeMessageSigning: true,
+      personalSign: true,
+      typedDataSigning: true,
+      sendTransaction: true,
+    });
+    expect(await disabled).toEqual({
+      unsafeMessageSigning: false,
+      personalSign: false,
+      typedDataSigning: false,
+      sendTransaction: false,
+    });
+  });
+
+  it("requires exact lowercase true opt-ins", () => {
+    expect(
+      withRuntimeEnvironment(
+        {
+          STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING: "TRUE",
+          STEWARD_ALLOW_GLOBAL_WALLET_PERSONAL_SIGN: "1",
+          STEWARD_ALLOW_GLOBAL_WALLET_TYPED_DATA_SIGNING: "yes",
+          STEWARD_ALLOW_GLOBAL_WALLET_SEND_TRANSACTION: " true ",
+        },
+        () => globalWalletFeatureFlags(),
+      ),
+    ).toEqual({
+      unsafeMessageSigning: false,
+      personalSign: false,
+      typedDataSigning: false,
+      sendTransaction: false,
+    });
+  });
+});

--- a/packages/api/src/routes/global-wallet.ts
+++ b/packages/api/src/routes/global-wallet.ts
@@ -20,6 +20,7 @@ import {
   setNoStoreHeaders,
   verifySessionToken,
 } from "../services/context";
+import { globalWalletFeatureFlags } from "../services/global-wallet-runtime";
 import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import { getConfiguredVault } from "../services/vault-factory";
 
@@ -62,13 +63,6 @@ const SIGNING_RPC_METHODS = new Set([
   "wallet_signCalls",
 ]);
 const MFA_MAX_AGE_MS = 10 * 60_000;
-const ALLOW_UNSAFE_MESSAGE_SIGNING = process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING === "true";
-const ALLOW_GLOBAL_WALLET_PERSONAL_SIGN =
-  process.env.STEWARD_ALLOW_GLOBAL_WALLET_PERSONAL_SIGN === "true";
-const ALLOW_GLOBAL_WALLET_TYPED_DATA_SIGNING =
-  process.env.STEWARD_ALLOW_GLOBAL_WALLET_TYPED_DATA_SIGNING === "true";
-const ALLOW_GLOBAL_WALLET_SEND_TRANSACTION =
-  process.env.STEWARD_ALLOW_GLOBAL_WALLET_SEND_TRANSACTION === "true";
 const ACTION_CONFIRMATION_TTL_MS = 5 * 60_000;
 const MAX_TRANSACTION_DATA_BYTES = 16_384;
 
@@ -1179,6 +1173,7 @@ globalWalletRoutes.post("/rpc/scan", async (c) => {
     },
   ];
   const blocked = hasCalldata;
+  const { sendTransaction } = globalWalletFeatureFlags();
   await writeGlobalWalletAudit(c, {
     tenantId: parsed.tenantId,
     action: "global_wallet.rpc.transaction_scanned",
@@ -1208,9 +1203,9 @@ globalWalletRoutes.post("/rpc/scan", async (c) => {
       riskLevel: blocked ? "blocked" : parsedTx.valueWei === "0" ? "low" : "medium",
       warnings,
       confirmationRequired: true,
-      executionSupported: ALLOW_GLOBAL_WALLET_SEND_TRANSACTION && !blocked,
+      executionSupported: sendTransaction && !blocked,
       unsupportedReason:
-        ALLOW_GLOBAL_WALLET_SEND_TRANSACTION && !blocked
+        sendTransaction && !blocked
           ? null
           : blocked
             ? "Global wallet transaction execution is disabled for contract calldata until selector-aware scanning is configured."
@@ -1301,7 +1296,8 @@ globalWalletRoutes.post("/rpc", async (c) => {
   }
 
   if (method === "personal_sign") {
-    if (!ALLOW_UNSAFE_MESSAGE_SIGNING || !ALLOW_GLOBAL_WALLET_PERSONAL_SIGN) {
+    const { unsafeMessageSigning, personalSign } = globalWalletFeatureFlags();
+    if (!unsafeMessageSigning || !personalSign) {
       return c.json<ApiResponse>(
         {
           ok: false,
@@ -1400,7 +1396,7 @@ globalWalletRoutes.post("/rpc", async (c) => {
   }
 
   if (method === "eth_signTypedData_v4") {
-    if (!ALLOW_GLOBAL_WALLET_TYPED_DATA_SIGNING) {
+    if (!globalWalletFeatureFlags().typedDataSigning) {
       return c.json<ApiResponse>(
         {
           ok: false,
@@ -1503,7 +1499,7 @@ globalWalletRoutes.post("/rpc", async (c) => {
   }
 
   if (method === "eth_sendTransaction") {
-    if (!ALLOW_GLOBAL_WALLET_SEND_TRANSACTION) {
+    if (!globalWalletFeatureFlags().sendTransaction) {
       return c.json<ApiResponse>(
         {
           ok: false,

--- a/packages/api/src/services/global-wallet-runtime.ts
+++ b/packages/api/src/services/global-wallet-runtime.ts
@@ -1,0 +1,21 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
+export type GlobalWalletFeatureFlags = Readonly<{
+  unsafeMessageSigning: boolean;
+  personalSign: boolean;
+  typedDataSigning: boolean;
+  sendTransaction: boolean;
+}>;
+
+/** Resolve security-sensitive wallet gates from the active request's immutable environment. */
+export function globalWalletFeatureFlags(): GlobalWalletFeatureFlags {
+  return {
+    unsafeMessageSigning:
+      runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING") === "true",
+    personalSign: runtimeEnvironmentValue("STEWARD_ALLOW_GLOBAL_WALLET_PERSONAL_SIGN") === "true",
+    typedDataSigning:
+      runtimeEnvironmentValue("STEWARD_ALLOW_GLOBAL_WALLET_TYPED_DATA_SIGNING") === "true",
+    sendTransaction:
+      runtimeEnvironmentValue("STEWARD_ALLOW_GLOBAL_WALLET_SEND_TRANSACTION") === "true",
+  };
+}


### PR DESCRIPTION
Closes #674

## Summary
- resolve all four global-wallet signing and execution flags through the immutable request-local Worker runtime environment
- prevent a reused isolate from retaining enabled authority after later bindings disable it
- preserve exact lowercase opt-in semantics and process fallback outside request snapshots

## Exact validation
- base: `f915f7fe875eec9ff75cd6ee9db39825240a7b5c`
- head: `4655c32567880a51693e79f28d6b56b861ba98a0`
- runtime + mounted global-wallet tests: 15/15, 113 assertions
- API dependency build: 26/26
- Biome on 3 touched files and `git diff --check`: pass

Draft pending exact hosted CI and independent review.