### PR TITLE
fix(auth): recover OAuth browser callback failures

### DIFF
--- a/packages/api/src/__tests__/auth-nonce-binding.test.ts
+++ b/packages/api/src/__tests__/auth-nonce-binding.test.ts
@@ -43,7 +43,7 @@ describe("wallet nonce binding hardening", () => {
     expect(exchange).toBeGreaterThan(stateLoad);
     expect(userInfo).toBeGreaterThan(exchange);
     expect(consume).toBeGreaterThan(userInfo);
-    expect(callbackRoute).toContain("Invalid or already-used OAuth state");
+    expect(callbackRoute).toContain('code: "oauth_state_consumed"');
   });
 
   it("binds Sign in with Apple id_tokens to an authorize-request nonce", () => {

--- a/packages/api/src/__tests__/auth-oauth-callback-browser.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-callback-browser.test.ts
@@ -140,6 +140,22 @@ describe("OAuth browser callback failures", () => {
     });
   }
 
+  it("keeps an explicit text/html rejection over a more permissive wildcard", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-specificity-state",
+      {
+        headers: {
+          accept: "application/json, text/html;q=0, */*;q=1",
+          "sec-fetch-mode": "navigate",
+        },
+      },
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toMatchObject({ ok: false, code: "oauth_state_expired" });
+  });
+
   it("renders a sanitized provision-policy error with a validated recovery link", async () => {
     process.env.APP_URL = "https://api.example.test";
     process.env.GOOGLE_CLIENT_ID = "google-client";

--- a/packages/api/src/__tests__/auth-oauth-callback-browser.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-callback-browser.test.ts
@@ -156,6 +156,33 @@ describe("OAuth browser callback failures", () => {
     expect(await response.json()).toMatchObject({ ok: false, code: "oauth_state_expired" });
   });
 
+  it("prefers explicitly higher-quality JSON over acceptable HTML", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-quality-state",
+      {
+        headers: {
+          accept: "application/json, text/html;q=0.1",
+          "sec-fetch-mode": "navigate",
+        },
+      },
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toMatchObject({ ok: false, code: "oauth_state_expired" });
+  });
+
+  it("keeps bare wildcard requests on JSON unless they are browser navigations", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-wildcard-client-state",
+      { headers: { accept: "*/*" } },
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toMatchObject({ ok: false, code: "oauth_state_expired" });
+  });
+
   it("renders a sanitized provision-policy error with a validated recovery link", async () => {
     process.env.APP_URL = "https://api.example.test";
     process.env.GOOGLE_CLIENT_ID = "google-client";

--- a/packages/api/src/__tests__/auth-oauth-callback-browser.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-callback-browser.test.ts
@@ -1,0 +1,194 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, mock } from "bun:test";
+import { closeDb } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+
+const REDIRECT_URI = "https://app.example.test/callback?from=oauth";
+const ORIGINAL_FETCH = globalThis.fetch;
+
+let authRoutes: typeof import("../routes/auth").authRoutes;
+let getAuthChallengeStore: typeof import("../routes/auth").getAuthChallengeStore;
+
+function browserHeaders(): HeadersInit {
+  return {
+    accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "sec-fetch-mode": "navigate",
+  };
+}
+
+async function expectBrowserError(
+  response: Response,
+  expected: { status: number; code: string },
+): Promise<string> {
+  expect(response.status).toBe(expected.status);
+  expect(response.headers.get("content-type")).toContain("text/html");
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  expect(response.headers.get("content-security-policy")).toContain("default-src 'none'");
+  const body = await response.text();
+  expect(body).toContain(`data-error-code="${expected.code}"`);
+  expect(body).toContain("Sign-in could not be completed");
+  expect(body).not.toContain('{"ok":false');
+  return body;
+}
+
+beforeAll(async () => {
+  process.env.NODE_ENV = "test";
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = "oauth-callback-browser-master-password";
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+  ({ authRoutes, getAuthChallengeStore } = await import("../routes/auth"));
+});
+
+afterEach(() => {
+  mock.restore();
+  globalThis.fetch = ORIGINAL_FETCH;
+  delete process.env.APP_URL;
+  delete process.env.GOOGLE_CLIENT_ID;
+  delete process.env.GOOGLE_CLIENT_SECRET;
+  delete process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS;
+});
+
+afterAll(async () => {
+  await closeDb();
+  delete process.env.NODE_ENV;
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_MASTER_PASSWORD;
+});
+
+describe("OAuth browser callback failures", () => {
+  it("renders a non-reflective HTML page for provider errors", async () => {
+    const attackerText = '<img src=x onerror="fetch(`https://attacker.test`) ">';
+    process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS = REDIRECT_URI;
+    const state = "provider-denial-state";
+    await getAuthChallengeStore().set(
+      `oauth:${state}`,
+      JSON.stringify({ provider: "github", redirectUri: REDIRECT_URI, appState: "client-state" }),
+    );
+    const response = await authRoutes.request(
+      `/oauth/github/callback?error=${encodeURIComponent(attackerText)}&state=${state}`,
+      { headers: browserHeaders() },
+    );
+    const body = await expectBrowserError(response, {
+      status: 400,
+      code: "oauth_authorization_failed",
+    });
+
+    expect(body).not.toContain(attackerText);
+    expect(body).not.toContain("attacker.test");
+    expect(body).toContain("Return and try again");
+    expect(body).toContain("error=oauth_authorization_failed");
+    expect(body).toContain("state=client-state");
+  });
+
+  it("renders an HTML recovery page for expired OAuth state", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-state",
+      { headers: browserHeaders() },
+    );
+    await expectBrowserError(response, { status: 401, code: "oauth_state_expired" });
+  });
+
+  it("keeps JSON for an explicitly programmatic callback client", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-json-state",
+      { headers: { accept: "application/json" } },
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "This sign-in attempt is invalid or has expired.",
+      code: "oauth_state_expired",
+    });
+  });
+
+  it("honors an explicit q=0 rejection of HTML even for navigation-shaped requests", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-q-zero-state",
+      {
+        headers: {
+          accept: "application/json, text/html;q=0",
+          "sec-fetch-mode": "navigate",
+        },
+      },
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toMatchObject({ ok: false, code: "oauth_state_expired" });
+  });
+
+  it("renders a sanitized provision-policy error with a validated recovery link", async () => {
+    process.env.APP_URL = "https://api.example.test";
+    process.env.GOOGLE_CLIENT_ID = "google-client";
+    process.env.GOOGLE_CLIENT_SECRET = "google-secret";
+    process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS = REDIRECT_URI;
+    const state = "unverified-email-state";
+    await getAuthChallengeStore().set(
+      `oauth:${state}`,
+      JSON.stringify({
+        provider: "google",
+        redirectUri: REDIRECT_URI,
+        appState: '<script id="state-canary">',
+      }),
+    );
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://oauth2.googleapis.com/token") {
+        return Response.json({ access_token: "provider-access-secret", token_type: "Bearer" });
+      }
+      if (url === "https://www.googleapis.com/oauth2/v3/userinfo") {
+        return Response.json({
+          id: "google-unverified-user",
+          email: "unverified@example.test",
+          verified_email: false,
+        });
+      }
+      return new Response("unexpected provider endpoint", { status: 500 });
+    }) as typeof fetch;
+
+    const response = await authRoutes.request(
+      `/oauth/google/callback?code=provider-code&state=${state}`,
+      { headers: browserHeaders() },
+    );
+    const body = await expectBrowserError(response, {
+      status: 403,
+      code: "oauth_verified_email_required",
+    });
+
+    expect(body).toContain("Provider email must be verified");
+    expect(body).toContain("Return and try again");
+    expect(body).toContain("error=oauth_verified_email_required");
+    expect(body).toContain("state=%3Cscript+id%3D%22state-canary%22%3E");
+    expect(body).not.toContain('<script id="state-canary">');
+    expect(body).not.toContain("provider-access-secret");
+    expect(body).not.toContain("unverified@example.test");
+  });
+});
+
+describe("OIDC browser callback failures", () => {
+  it("renders a non-reflective HTML page for provider errors", async () => {
+    const response = await authRoutes.request(
+      "/oidc/acme/callback?error=%3Csvg%20onload%3Dalert(1)%3E",
+      { headers: browserHeaders() },
+    );
+    const body = await expectBrowserError(response, {
+      status: 400,
+      code: "oidc_authorization_failed",
+    });
+
+    expect(body).not.toContain("<svg");
+    expect(body).not.toContain("onload");
+  });
+
+  it("renders an HTML recovery page for expired OIDC state", async () => {
+    const response = await authRoutes.request(
+      "/oidc/acme/callback?code=provider-code&state=expired-state",
+      { headers: browserHeaders() },
+    );
+    await expectBrowserError(response, { status: 401, code: "oidc_state_expired" });
+  });
+});

--- a/packages/api/src/__tests__/auth-oauth-callback-browser.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-callback-browser.test.ts
@@ -87,7 +87,8 @@ describe("OAuth browser callback failures", () => {
       "/oauth/github/callback?code=provider-code&state=expired-state",
       { headers: browserHeaders() },
     );
-    await expectBrowserError(response, { status: 401, code: "oauth_state_expired" });
+    const body = await expectBrowserError(response, { status: 401, code: "oauth_state_expired" });
+    expect(body).not.toContain("Return and try again");
   });
 
   it("keeps JSON for an explicitly programmatic callback client", async () => {
@@ -120,6 +121,24 @@ describe("OAuth browser callback failures", () => {
     expect(response.headers.get("content-type")).toContain("application/json");
     expect(await response.json()).toMatchObject({ ok: false, code: "oauth_state_expired" });
   });
+
+  for (const excludedHtmlRange of ["text/*;q=0", "*/*;q=0"]) {
+    it(`honors ${excludedHtmlRange} when navigation fallback would otherwise select HTML`, async () => {
+      const response = await authRoutes.request(
+        "/oauth/github/callback?code=provider-code&state=expired-wildcard-state",
+        {
+          headers: {
+            accept: `application/json, ${excludedHtmlRange}`,
+            "sec-fetch-mode": "navigate",
+          },
+        },
+      );
+
+      expect(response.status).toBe(401);
+      expect(response.headers.get("content-type")).toContain("application/json");
+      expect(await response.json()).toMatchObject({ ok: false, code: "oauth_state_expired" });
+    });
+  }
 
   it("renders a sanitized provision-policy error with a validated recovery link", async () => {
     process.env.APP_URL = "https://api.example.test";
@@ -184,11 +203,36 @@ describe("OIDC browser callback failures", () => {
     expect(body).not.toContain("onload");
   });
 
+  it("offers a validated recovery link for a provider error with live OIDC state", async () => {
+    process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS = REDIRECT_URI;
+    const state = "oidc-provider-denial-state";
+    await getAuthChallengeStore().set(
+      `oidc:${state}`,
+      JSON.stringify({
+        providerId: "acme",
+        redirectUri: REDIRECT_URI,
+        appState: "oidc-client-state",
+      }),
+    );
+    const response = await authRoutes.request(
+      `/oidc/acme/callback?error=access_denied&state=${state}`,
+      { headers: browserHeaders() },
+    );
+    const body = await expectBrowserError(response, {
+      status: 400,
+      code: "oidc_authorization_failed",
+    });
+    expect(body).toContain("Return and try again");
+    expect(body).toContain("error=oidc_authorization_failed");
+    expect(body).toContain("state=oidc-client-state");
+  });
+
   it("renders an HTML recovery page for expired OIDC state", async () => {
     const response = await authRoutes.request(
       "/oidc/acme/callback?code=provider-code&state=expired-state",
       { headers: browserHeaders() },
     );
-    await expectBrowserError(response, { status: 401, code: "oidc_state_expired" });
+    const body = await expectBrowserError(response, { status: 401, code: "oidc_state_expired" });
+    expect(body).not.toContain("Return and try again");
   });
 });

--- a/packages/api/src/__tests__/auth-sso-oidc-code-flow.test.ts
+++ b/packages/api/src/__tests__/auth-sso-oidc-code-flow.test.ts
@@ -41,14 +41,14 @@ describe("enterprise OIDC authorization-code SSO hardening", () => {
     expect(callbackRoute).toContain("await getChallengeStore().get(stateKey)");
     expect(callbackRoute).toContain("stateData.providerId !== providerId");
     expect(callbackRoute).toContain("code.length > 4_096 || state.length > 256");
-    expect(callbackRoute).toContain('error: "OIDC authorization failed"');
+    expect(callbackRoute).toContain('code: "oidc_authorization_failed"');
     expect(callbackRoute).not.toContain("`OIDC error: ${errorParam}`");
     expect(callbackRoute).toContain("exchangeOidcAuthorizationCode");
     expect(callbackRoute).toContain("verifyOidcJwt(stateData.tenantId, provider, idToken)");
     expect(callbackRoute).toContain("verified.claims.nonce !== stateData.nonce");
-    expect(callbackRoute).toContain("Enterprise OIDC SSO requires a verified email claim");
+    expect(callbackRoute).toContain('code: "oidc_verified_email_required"');
     expect(callbackRoute).toContain("isVerifiedSsoEmailDomainForTenant");
-    expect(callbackRoute).toContain("Enterprise OIDC SSO email domain is not verified");
+    expect(callbackRoute).toContain('code: "oidc_email_domain_unverified"');
     expect(callbackRoute.indexOf("await getChallengeStore().get(stateKey)")).toBeLessThan(
       callbackRoute.indexOf("exchangeOidcAuthorizationCode"),
     );

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -4065,17 +4065,34 @@ function escapeOAuthCallbackHtml(value: string): string {
 
 function oauthCallbackPrefersHtml(c: Context): boolean {
   const accept = c.req.header("accept")?.toLowerCase() ?? "";
-  let htmlWasExplicitlyListed = false;
-  let htmlIsAcceptable = false;
+  let htmlMatch: { specificity: number; quality: number } | undefined;
+  let xhtmlMatch: { specificity: number; quality: number } | undefined;
   for (const range of accept.split(",")) {
     const [mediaType, ...parameters] = range.split(";").map((part) => part.trim());
-    if (mediaType !== "text/html" && mediaType !== "application/xhtml+xml") continue;
-    htmlWasExplicitlyListed = true;
     const qualityParameter = parameters.find((parameter) => parameter.startsWith("q="));
     const quality = qualityParameter ? Number(qualityParameter.slice(2)) : 1;
-    if (Number.isFinite(quality) && quality > 0) htmlIsAcceptable = true;
+    const normalizedQuality =
+      Number.isFinite(quality) && quality >= 0 && quality <= 1 ? quality : 0;
+    const htmlSpecificity =
+      mediaType === "text/html" ? 2 : mediaType === "text/*" ? 1 : mediaType === "*/*" ? 0 : -1;
+    const xhtmlSpecificity =
+      mediaType === "application/xhtml+xml"
+        ? 2
+        : mediaType === "application/*"
+          ? 1
+          : mediaType === "*/*"
+            ? 0
+            : -1;
+    if (htmlSpecificity >= 0 && (!htmlMatch || htmlSpecificity > htmlMatch.specificity)) {
+      htmlMatch = { specificity: htmlSpecificity, quality: normalizedQuality };
+    }
+    if (xhtmlSpecificity >= 0 && (!xhtmlMatch || xhtmlSpecificity > xhtmlMatch.specificity)) {
+      xhtmlMatch = { specificity: xhtmlSpecificity, quality: normalizedQuality };
+    }
   }
-  if (htmlWasExplicitlyListed) return htmlIsAcceptable;
+  if (htmlMatch || xhtmlMatch) {
+    return (htmlMatch?.quality ?? 0) > 0 || (xhtmlMatch?.quality ?? 0) > 0;
+  }
   return c.req.header("sec-fetch-mode")?.toLowerCase() === "navigate";
 }
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -4066,7 +4066,6 @@ function escapeOAuthCallbackHtml(value: string): string {
 function oauthCallbackPrefersHtml(c: Context): boolean {
   const accept = c.req.header("accept")?.toLowerCase() ?? "";
   let htmlMatch: { specificity: number; quality: number } | undefined;
-  let xhtmlMatch: { specificity: number; quality: number } | undefined;
   for (const range of accept.split(",")) {
     const [mediaType, ...parameters] = range.split(";").map((part) => part.trim());
     const qualityParameter = parameters.find((parameter) => parameter.startsWith("q="));
@@ -4075,24 +4074,12 @@ function oauthCallbackPrefersHtml(c: Context): boolean {
       Number.isFinite(quality) && quality >= 0 && quality <= 1 ? quality : 0;
     const htmlSpecificity =
       mediaType === "text/html" ? 2 : mediaType === "text/*" ? 1 : mediaType === "*/*" ? 0 : -1;
-    const xhtmlSpecificity =
-      mediaType === "application/xhtml+xml"
-        ? 2
-        : mediaType === "application/*"
-          ? 1
-          : mediaType === "*/*"
-            ? 0
-            : -1;
     if (htmlSpecificity >= 0 && (!htmlMatch || htmlSpecificity > htmlMatch.specificity)) {
       htmlMatch = { specificity: htmlSpecificity, quality: normalizedQuality };
     }
-    if (xhtmlSpecificity >= 0 && (!xhtmlMatch || xhtmlSpecificity > xhtmlMatch.specificity)) {
-      xhtmlMatch = { specificity: xhtmlSpecificity, quality: normalizedQuality };
-    }
   }
-  if (htmlMatch || xhtmlMatch) {
-    return (htmlMatch?.quality ?? 0) > 0 || (xhtmlMatch?.quality ?? 0) > 0;
-  }
+  if (htmlMatch) return htmlMatch.quality > 0;
+  if (accept.trim()) return false;
   return c.req.header("sec-fetch-mode")?.toLowerCase() === "navigate";
 }
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -4036,6 +4036,144 @@ function redirectEmailAuthFailure(c: Context, reason: string): Response {
   );
 }
 
+type OAuthCallbackFailureStatus = 400 | 401 | 403 | 404 | 409 | 500 | 502 | 503;
+
+interface OAuthCallbackFailureOptions {
+  code: string;
+  message: string;
+  status: OAuthCallbackFailureStatus;
+  redirectUrl?: URL;
+  appState?: string;
+}
+
+function escapeOAuthCallbackHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => {
+    switch (character) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}
+
+function oauthCallbackPrefersHtml(c: Context): boolean {
+  const accept = c.req.header("accept")?.toLowerCase() ?? "";
+  let htmlWasExplicitlyListed = false;
+  let htmlIsAcceptable = false;
+  for (const range of accept.split(",")) {
+    const [mediaType, ...parameters] = range.split(";").map((part) => part.trim());
+    if (mediaType !== "text/html" && mediaType !== "application/xhtml+xml") continue;
+    htmlWasExplicitlyListed = true;
+    const qualityParameter = parameters.find((parameter) => parameter.startsWith("q="));
+    const quality = qualityParameter ? Number(qualityParameter.slice(2)) : 1;
+    if (Number.isFinite(quality) && quality > 0) htmlIsAcceptable = true;
+  }
+  if (htmlWasExplicitlyListed) return htmlIsAcceptable;
+  return c.req.header("sec-fetch-mode")?.toLowerCase() === "navigate";
+}
+
+async function oauthCallbackRecoveryFromStoredState(
+  kind: "oauth" | "oidc",
+  state: string | undefined,
+  providerName: string,
+): Promise<{ redirectUrl: URL; appState?: string } | undefined> {
+  if (!state || state.length > 256) return undefined;
+  try {
+    const rawPayload = await getChallengeStore().get(`${kind}:${state}`);
+    if (!rawPayload) return undefined;
+    const stateData = JSON.parse(rawPayload) as Record<string, unknown>;
+    const storedProvider = kind === "oauth" ? stateData.provider : stateData.providerId;
+    if (storedProvider !== providerName || typeof stateData.redirectUri !== "string") {
+      return undefined;
+    }
+    const tenantId = typeof stateData.tenantId === "string" ? stateData.tenantId : undefined;
+    const clientId = typeof stateData.clientId === "string" ? stateData.clientId : undefined;
+    const redirectUrl = await assertAllowedOAuthRedirectUri(
+      stateData.redirectUri,
+      tenantId,
+      clientId,
+    );
+    return {
+      redirectUrl,
+      appState: typeof stateData.appState === "string" ? stateData.appState : undefined,
+    };
+  } catch {
+    // Recovery is optional. Invalid, stale, or unavailable state must never
+    // replace the original callback failure or create an unvalidated link.
+    return undefined;
+  }
+}
+
+function oauthCallbackFailure(c: Context, options: OAuthCallbackFailureOptions): Response {
+  if (!oauthCallbackPrefersHtml(c)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: options.message, code: options.code } as ApiResponse & { code: string },
+      options.status,
+    );
+  }
+
+  let recoveryLink = "";
+  if (options.redirectUrl) {
+    const recoveryUrl = new URL(options.redirectUrl);
+    recoveryUrl.searchParams.set("error", options.code);
+    if (options.appState) recoveryUrl.searchParams.set("state", options.appState);
+    recoveryLink = `<a class="stwd-oauth-error__action" href="${escapeOAuthCallbackHtml(
+      recoveryUrl.toString(),
+    )}">Return and try again</a>`;
+  }
+
+  const escapedMessage = escapeOAuthCallbackHtml(options.message);
+  const escapedCode = escapeOAuthCallbackHtml(options.code);
+  const recoveryInstruction = recoveryLink
+    ? recoveryLink
+    : '<p class="stwd-oauth-error__hint">Close this window and restart sign-in from the application.</p>';
+  const body = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sign-in could not be completed | Steward</title>
+  <style>
+    :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+    * { box-sizing: border-box; }
+    body { min-height: 100vh; margin: 0; display: grid; place-items: center; padding: 24px; background: #090b10; color: #f6f7fb; }
+    .stwd-oauth-error { width: min(100%, 520px); padding: 32px; border: 1px solid #2a3040; border-radius: 18px; background: #121621; box-shadow: 0 24px 70px rgb(0 0 0 / 35%); }
+    .stwd-oauth-error__eyebrow { margin: 0 0 10px; color: #98a2b8; font-size: 13px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+    h1 { margin: 0; font-size: clamp(24px, 6vw, 34px); line-height: 1.15; }
+    .stwd-oauth-error__message { margin: 18px 0; color: #cbd1de; line-height: 1.6; }
+    .stwd-oauth-error__code { display: inline-block; margin-bottom: 24px; padding: 6px 9px; border-radius: 7px; background: #080a0f; color: #aab4ca; font-size: 12px; }
+    .stwd-oauth-error__action { display: inline-block; padding: 12px 18px; border-radius: 9px; background: #f6f7fb; color: #11141c; font-weight: 750; text-decoration: none; }
+    .stwd-oauth-error__action:focus-visible { outline: 3px solid #7aa2ff; outline-offset: 3px; }
+    .stwd-oauth-error__hint { margin: 0; color: #98a2b8; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <main class="stwd-oauth-error" data-error-code="${escapedCode}">
+    <p class="stwd-oauth-error__eyebrow">Steward authentication</p>
+    <h1>Sign-in could not be completed</h1>
+    <p class="stwd-oauth-error__message">${escapedMessage}</p>
+    <code class="stwd-oauth-error__code">${escapedCode}</code>
+    <div>${recoveryInstruction}</div>
+  </main>
+</body>
+</html>`;
+
+  return c.html(body, options.status, {
+    "Cache-Control": "no-store",
+    "Content-Security-Policy":
+      "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'",
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+  });
+}
+
 // ─── Route group ──────────────────────────────────────────────────────────────
 
 const auth = new Hono();
@@ -5075,19 +5213,41 @@ auth.get("/oidc/:provider/callback", async (c) => {
   if (errorParam) {
     // Provider-supplied query text is untrusted and may contain diagnostics or
     // attacker-controlled markup. Do not reflect it to the browser.
-    return c.json<ApiResponse>({ ok: false, error: "OIDC authorization failed" }, 400);
+    const recovery = await oauthCallbackRecoveryFromStoredState("oidc", state, providerId);
+    return oauthCallbackFailure(c, {
+      code: "oidc_authorization_failed",
+      message: "The identity provider did not authorize this sign-in.",
+      status: 400,
+      ...recovery,
+    });
   }
   if (!code || !state) {
-    return c.json<ApiResponse>({ ok: false, error: "code and state are required" }, 400);
+    const recovery = await oauthCallbackRecoveryFromStoredState("oidc", state, providerId);
+    return oauthCallbackFailure(c, {
+      code: "oidc_callback_incomplete",
+      message: "The identity provider returned an incomplete sign-in response.",
+      status: 400,
+      ...recovery,
+    });
   }
   if (code.length > 4_096 || state.length > 256) {
-    return c.json<ApiResponse>({ ok: false, error: "code or state is too long" }, 400);
+    const recovery = await oauthCallbackRecoveryFromStoredState("oidc", state, providerId);
+    return oauthCallbackFailure(c, {
+      code: "oidc_callback_invalid",
+      message: "The identity provider returned an invalid sign-in response.",
+      status: 400,
+      ...recovery,
+    });
   }
 
   const stateKey = `oidc:${state}`;
   const rawPayload = await getChallengeStore().get(stateKey);
   if (!rawPayload) {
-    return c.json<ApiResponse>({ ok: false, error: "Invalid or expired OIDC state" }, 401);
+    return oauthCallbackFailure(c, {
+      code: "oidc_state_expired",
+      message: "This sign-in attempt is invalid or has expired.",
+      status: 401,
+    });
   }
 
   let stateData: {
@@ -5104,15 +5264,27 @@ auth.get("/oidc/:provider/callback", async (c) => {
   try {
     stateData = JSON.parse(rawPayload) as typeof stateData;
   } catch {
-    return c.json<ApiResponse>({ ok: false, error: "Malformed OIDC state payload" }, 400);
+    return oauthCallbackFailure(c, {
+      code: "oidc_state_invalid",
+      message: "This sign-in attempt could not be validated.",
+      status: 400,
+    });
   }
   if (stateData.providerId !== providerId) {
-    return c.json<ApiResponse>({ ok: false, error: "Provider mismatch in state" }, 400);
+    return oauthCallbackFailure(c, {
+      code: "oidc_provider_mismatch",
+      message: "The identity provider does not match this sign-in attempt.",
+      status: 400,
+    });
   }
 
   const provider = selectOidcProvider(await getTenantOidcProviders(stateData.tenantId), providerId);
   if (!provider?.clientId || !provider.tokenUrl) {
-    return c.json<ApiResponse>({ ok: false, error: "OIDC provider not found or disabled" }, 404);
+    return oauthCallbackFailure(c, {
+      code: "oidc_provider_unavailable",
+      message: "This identity provider is not available.",
+      status: 404,
+    });
   }
 
   const methodResponse = await requireTenantLoginMethodAllowed(
@@ -5122,7 +5294,13 @@ auth.get("/oidc/:provider/callback", async (c) => {
     provider.id,
     stateData.clientId,
   );
-  if (methodResponse) return methodResponse;
+  if (methodResponse) {
+    return oauthCallbackFailure(c, {
+      code: "oidc_login_disabled",
+      message: "OIDC sign-in is disabled for this application.",
+      status: 403,
+    });
+  }
 
   let redirectUrl: URL;
   try {
@@ -5132,10 +5310,12 @@ auth.get("/oidc/:provider/callback", async (c) => {
       stateData.clientId,
     );
   } catch (err) {
-    return c.json<ApiResponse>(
-      { ok: false, error: err instanceof Error ? err.message : "Invalid redirect_uri" },
-      400,
-    );
+    console.error("[OidcAuth] Callback redirect validation failed", redactedThrownDiagnostics(err));
+    return oauthCallbackFailure(c, {
+      code: "oidc_redirect_invalid",
+      message: "The application return address is not allowed.",
+      status: 400,
+    });
   }
 
   let idToken: string;
@@ -5148,32 +5328,54 @@ auth.get("/oidc/:provider/callback", async (c) => {
       codeVerifier: stateData.codeVerifier,
     });
   } catch (err) {
-    return c.json<ApiResponse>(
-      { ok: false, error: err instanceof Error ? err.message : "OIDC token exchange failed" },
-      502,
-    );
+    console.error("[OidcAuth] Callback token exchange failed", redactedThrownDiagnostics(err));
+    return oauthCallbackFailure(c, {
+      code: "oidc_token_exchange_failed",
+      message: "The identity provider could not complete sign-in. Please try again.",
+      status: 502,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   try {
     const verified = await verifyOidcJwt(stateData.tenantId, provider, idToken);
     if (verified.claims.nonce !== stateData.nonce) {
-      return c.json<ApiResponse>({ ok: false, error: "OIDC nonce mismatch" }, 401);
+      return oauthCallbackFailure(c, {
+        code: "oidc_nonce_mismatch",
+        message: "This sign-in response could not be matched to your browser.",
+        status: 401,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
     if (!verified.email || verified.emailVerified !== true) {
-      return c.json<ApiResponse>(
-        { ok: false, error: "Enterprise OIDC SSO requires a verified email claim" },
-        403,
-      );
+      return oauthCallbackFailure(c, {
+        code: "oidc_verified_email_required",
+        message: "Enterprise OIDC sign-in requires a verified email address.",
+        status: 403,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
     if (!(await isVerifiedSsoEmailDomainForTenant(stateData.tenantId, verified.email))) {
-      return c.json<ApiResponse>(
-        { ok: false, error: "Enterprise OIDC SSO email domain is not verified for this tenant" },
-        403,
-      );
+      return oauthCallbackFailure(c, {
+        code: "oidc_email_domain_unverified",
+        message: "Your email domain is not approved for this organization.",
+        status: 403,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
     const consumedPayload = await getChallengeStore().consume(stateKey);
     if (consumedPayload !== rawPayload) {
-      return c.json<ApiResponse>({ ok: false, error: "Invalid or already-used OIDC state" }, 401);
+      return oauthCallbackFailure(c, {
+        code: "oidc_state_consumed",
+        message: "This sign-in attempt is invalid or has already been used.",
+        status: 401,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
     await withPreAuthTenant(stateData.tenantId, "oidc-callback-authorization-audit", () =>
       writeAuditEvent({
@@ -5205,16 +5407,31 @@ auth.get("/oidc/:provider/callback", async (c) => {
       tenantRole: "viewer",
     });
     if (!result.ok) {
-      redirectUrl.searchParams.set("error", result.error);
-      return c.redirect(redirectUrl.toString(), 302);
+      return oauthCallbackFailure(c, {
+        code: "oidc_account_provisioning_failed",
+        message: "Your account could not be prepared for sign-in.",
+        status: result.status ?? 500,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
     if (result.response.ok === false) {
-      redirectUrl.searchParams.set("error", String(result.response.error || "auth_failed"));
-      return c.redirect(redirectUrl.toString(), 302);
+      return oauthCallbackFailure(c, {
+        code: "oidc_authentication_failed",
+        message: "Sign-in could not be completed.",
+        status: 403,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
     if (result.response.mfaRequired) {
-      redirectUrl.searchParams.set("error", "mfa_required");
-      return c.redirect(redirectUrl.toString(), 302);
+      return oauthCallbackFailure(c, {
+        code: "mfa_required",
+        message: "Additional verification is required to complete sign-in.",
+        status: 403,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
 
     const exchangeCode = randomBase64Url(32);
@@ -5237,13 +5454,14 @@ auth.get("/oidc/:provider/callback", async (c) => {
     setRedirectFragment(redirectUrl, { code: exchangeCode, state: stateData.appState });
     return c.redirect(redirectUrl.toString(), 302);
   } catch (err) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: err instanceof Error ? err.message : "OIDC token verification failed",
-      },
-      401,
-    );
+    console.error("[OidcAuth] Callback verification failed", redactedThrownDiagnostics(err));
+    return oauthCallbackFailure(c, {
+      code: "oidc_token_verification_failed",
+      message: "The identity provider response could not be verified.",
+      status: 401,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 });
 
@@ -9491,15 +9709,33 @@ auth.get("/oauth/:provider/callback", async (c) => {
   const errorParam = c.req.query("error");
 
   if (errorParam) {
-    return c.json<ApiResponse>({ ok: false, error: `OAuth error: ${errorParam}` }, 400);
+    // Provider-controlled text may contain markup, credentials, or diagnostics.
+    // Keep the browser response stable and non-reflective.
+    const recovery = await oauthCallbackRecoveryFromStoredState("oauth", state, providerName);
+    return oauthCallbackFailure(c, {
+      code: "oauth_authorization_failed",
+      message: "The provider did not authorize this sign-in.",
+      status: 400,
+      ...recovery,
+    });
   }
 
   if (!isBuiltInProvider(providerName)) {
-    return c.json<ApiResponse>({ ok: false, error: `Unknown provider: ${providerName}` }, 400);
+    return oauthCallbackFailure(c, {
+      code: "oauth_provider_unknown",
+      message: "This sign-in provider is not supported.",
+      status: 400,
+    });
   }
 
   if (!code || !state) {
-    return c.json<ApiResponse>({ ok: false, error: "code and state are required" }, 400);
+    const recovery = await oauthCallbackRecoveryFromStoredState("oauth", state, providerName);
+    return oauthCallbackFailure(c, {
+      code: "oauth_callback_incomplete",
+      message: "The provider returned an incomplete sign-in response.",
+      status: 400,
+      ...recovery,
+    });
   }
 
   // Load state before provider calls, then consume it only after provider token
@@ -9508,7 +9744,11 @@ auth.get("/oauth/:provider/callback", async (c) => {
   const stateKey = `oauth:${state}`;
   const rawPayload = await getChallengeStore().get(stateKey);
   if (!rawPayload) {
-    return c.json<ApiResponse>({ ok: false, error: "Invalid or expired OAuth state" }, 401);
+    return oauthCallbackFailure(c, {
+      code: "oauth_state_expired",
+      message: "This sign-in attempt is invalid or has expired.",
+      status: 401,
+    });
   }
 
   let stateData: {
@@ -9526,11 +9766,19 @@ auth.get("/oauth/:provider/callback", async (c) => {
   try {
     stateData = JSON.parse(rawPayload) as typeof stateData;
   } catch {
-    return c.json<ApiResponse>({ ok: false, error: "Malformed OAuth state payload" }, 400);
+    return oauthCallbackFailure(c, {
+      code: "oauth_state_invalid",
+      message: "This sign-in attempt could not be validated.",
+      status: 400,
+    });
   }
 
   if (stateData.provider !== providerName) {
-    return c.json<ApiResponse>({ ok: false, error: "Provider mismatch in state" }, 400);
+    return oauthCallbackFailure(c, {
+      code: "oauth_provider_mismatch",
+      message: "The provider does not match this sign-in attempt.",
+      status: 400,
+    });
   }
   const methodResponse = await requireTenantLoginMethodAllowed(
     c,
@@ -9539,7 +9787,13 @@ auth.get("/oauth/:provider/callback", async (c) => {
     providerName,
     stateData.clientId,
   );
-  if (methodResponse) return methodResponse;
+  if (methodResponse) {
+    return oauthCallbackFailure(c, {
+      code: "oauth_login_disabled",
+      message: "OAuth sign-in is disabled for this application.",
+      status: 403,
+    });
+  }
 
   let redirectUrl: URL;
   try {
@@ -9549,26 +9803,29 @@ auth.get("/oauth/:provider/callback", async (c) => {
       stateData.clientId,
     );
   } catch (err) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: err instanceof Error ? err.message : "Invalid redirect_uri",
-      },
-      400,
+    console.error(
+      "[OAuthAuth] Callback redirect validation failed",
+      redactedThrownDiagnostics(err),
     );
+    return oauthCallbackFailure(c, {
+      code: "oauth_redirect_invalid",
+      message: "The application return address is not allowed.",
+      status: 400,
+    });
   }
 
   let oauthClient: OAuthClient;
   try {
     oauthClient = new OAuthClient(getProviderConfig(providerName));
   } catch (err) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: err instanceof Error ? err.message : "Provider not configured",
-      },
-      503,
-    );
+    console.error("[OAuthAuth] Callback provider setup failed", redactedThrownDiagnostics(err));
+    return oauthCallbackFailure(c, {
+      code: "oauth_provider_unavailable",
+      message: "This sign-in provider is not available.",
+      status: 503,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   const callbackUrl = buildOAuthCallbackUrl(c, providerName);
@@ -9581,13 +9838,14 @@ auth.get("/oauth/:provider/callback", async (c) => {
   try {
     tokenResponse = await oauthClient.exchangeCode(code, callbackUrl, stateData.codeVerifier);
   } catch (err) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: err instanceof Error ? err.message : "Token exchange failed",
-      },
-      502,
-    );
+    console.error("[OAuthAuth] Callback token exchange failed", redactedThrownDiagnostics(err));
+    return oauthCallbackFailure(c, {
+      code: "oauth_token_exchange_failed",
+      message: "The provider could not complete sign-in. Please try again.",
+      status: 502,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   // Fetch user info from provider
@@ -9595,13 +9853,14 @@ auth.get("/oauth/:provider/callback", async (c) => {
   try {
     providerUser = await oauthClient.getUserInfo(tokenResponse.access_token);
   } catch (err) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: err instanceof Error ? err.message : "Failed to fetch user info",
-      },
-      502,
-    );
+    console.error("[OAuthAuth] Callback profile fetch failed", redactedThrownDiagnostics(err));
+    return oauthCallbackFailure(c, {
+      code: "oauth_profile_fetch_failed",
+      message: "The provider profile could not be loaded. Please try again.",
+      status: 502,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   // Twitter and some providers do not return an email address.
@@ -9609,10 +9868,13 @@ auth.get("/oauth/:provider/callback", async (c) => {
   // This email is never displayed or sent — it is purely an internal identity key.
   if (!providerUser.email) {
     if (!providerUser.id) {
-      return c.json<ApiResponse>(
-        { ok: false, error: "Provider returned neither email nor user ID" },
-        400,
-      );
+      return oauthCallbackFailure(c, {
+        code: "oauth_identity_incomplete",
+        message: "The provider did not return enough account information.",
+        status: 400,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
     providerUser = {
       ...providerUser,
@@ -9623,7 +9885,13 @@ auth.get("/oauth/:provider/callback", async (c) => {
 
   const consumedPayload = await getChallengeStore().consume(stateKey);
   if (consumedPayload !== rawPayload) {
-    return c.json<ApiResponse>({ ok: false, error: "Invalid or already-used OAuth state" }, 401);
+    return oauthCallbackFailure(c, {
+      code: "oauth_state_consumed",
+      message: "This sign-in attempt is invalid or has already been used.",
+      status: 401,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   // Create/find user + provision wallet + link tenant
@@ -9636,17 +9904,39 @@ auth.get("/oauth/:provider/callback", async (c) => {
   });
 
   if (!result.ok) {
-    return c.json<ApiResponse>({ ok: false, error: result.error }, result.status ?? 500);
+    const isUnverifiedEmail =
+      result.error === "Provider email must be verified before OAuth sign-in is allowed";
+    return oauthCallbackFailure(c, {
+      code: isUnverifiedEmail
+        ? "oauth_verified_email_required"
+        : "oauth_account_provisioning_failed",
+      message: isUnverifiedEmail
+        ? "Provider email must be verified before OAuth sign-in is allowed."
+        : "Your account could not be prepared for sign-in.",
+      status: result.status ?? 500,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   if (result.response.ok === false) {
-    redirectUrl.searchParams.set("error", String(result.response.error || "auth_failed"));
-    return c.redirect(redirectUrl.toString(), 302);
+    return oauthCallbackFailure(c, {
+      code: "oauth_authentication_failed",
+      message: "Sign-in could not be completed.",
+      status: 403,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   if (result.response.mfaRequired) {
-    redirectUrl.searchParams.set("error", "mfa_required");
-    return c.redirect(redirectUrl.toString(), 302);
+    return oauthCallbackFailure(c, {
+      code: "mfa_required",
+      message: "Additional verification is required to complete sign-in.",
+      status: 403,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   // Nonce-exchange path: issue a one-time, short-lived (60s) code that the

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -4065,21 +4065,39 @@ function escapeOAuthCallbackHtml(value: string): string {
 
 function oauthCallbackPrefersHtml(c: Context): boolean {
   const accept = c.req.header("accept")?.toLowerCase() ?? "";
-  let htmlMatch: { specificity: number; quality: number } | undefined;
-  for (const range of accept.split(",")) {
-    const [mediaType, ...parameters] = range.split(";").map((part) => part.trim());
-    const qualityParameter = parameters.find((parameter) => parameter.startsWith("q="));
-    const quality = qualityParameter ? Number(qualityParameter.slice(2)) : 1;
-    const normalizedQuality =
-      Number.isFinite(quality) && quality >= 0 && quality <= 1 ? quality : 0;
-    const htmlSpecificity =
-      mediaType === "text/html" ? 2 : mediaType === "text/*" ? 1 : mediaType === "*/*" ? 0 : -1;
-    if (htmlSpecificity >= 0 && (!htmlMatch || htmlSpecificity > htmlMatch.specificity)) {
-      htmlMatch = { specificity: htmlSpecificity, quality: normalizedQuality };
+  const qualityFor = (target: "application/json" | "text/html"): number | undefined => {
+    const [targetType] = target.split("/");
+    let bestMatch: { specificity: number; quality: number } | undefined;
+    for (const range of accept.split(",")) {
+      const [mediaType, ...parameters] = range.split(";").map((part) => part.trim());
+      const qualityParameter = parameters.find((parameter) => parameter.startsWith("q="));
+      const quality = qualityParameter ? Number(qualityParameter.slice(2)) : 1;
+      const normalizedQuality =
+        Number.isFinite(quality) && quality >= 0 && quality <= 1 ? quality : 0;
+      const specificity =
+        mediaType === target
+          ? 2
+          : mediaType === `${targetType}/*`
+            ? 1
+            : mediaType === "*/*"
+              ? 0
+              : -1;
+      if (
+        specificity >= 0 &&
+        (!bestMatch ||
+          specificity > bestMatch.specificity ||
+          (specificity === bestMatch.specificity && normalizedQuality > bestMatch.quality))
+      ) {
+        bestMatch = { specificity, quality: normalizedQuality };
+      }
     }
-  }
-  if (htmlMatch) return htmlMatch.quality > 0;
-  if (accept.trim()) return false;
+    return bestMatch?.quality;
+  };
+
+  const htmlQuality = qualityFor("text/html") ?? 0;
+  const jsonQuality = qualityFor("application/json") ?? 0;
+  if (htmlQuality <= 0) return false;
+  if (htmlQuality !== jsonQuality) return htmlQuality > jsonQuality;
   return c.req.header("sec-fetch-mode")?.toLowerCase() === "navigate";
 }
 

--- a/packages/auth/src/__tests__/oauth.test.ts
+++ b/packages/auth/src/__tests__/oauth.test.ts
@@ -721,6 +721,111 @@ describe("OAuthClient.getUserInfo — provider response normalization", () => {
     globalThis.fetch = originalFetch;
   });
 
+  it("resolves a public GitHub email's verified status through /user/emails", async () => {
+    const originalFetch = globalThis.fetch;
+    const requestedUrls: string[] = [];
+    globalThis.fetch = asFetchMock(async (input) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url.endsWith("/userinfo")) {
+        return Response.json({
+          id: "gh-public-verified",
+          email: "Public@Example.com",
+          login: "public-user",
+        });
+      }
+      return Response.json([
+        { email: "other@example.com", primary: true, verified: true },
+        { email: "public@example.com", primary: false, verified: true },
+      ]);
+    });
+    try {
+      const client = new OAuthClient({
+        clientId: "c",
+        clientSecret: "s",
+        authorizationUrl: "https://example.com/auth",
+        tokenUrl: "https://example.com/token",
+        userInfoUrl: "https://example.com/userinfo",
+        emailUrl: "https://example.com/emails",
+        scopes: [],
+      });
+
+      const info = await client.getUserInfo("tok");
+
+      expect(requestedUrls).toEqual(["https://example.com/userinfo", "https://example.com/emails"]);
+      expect(info.email).toBe("public@example.com");
+      expect(info.verified_email).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("keeps a public GitHub email unverified when /user/emails says it is unverified", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = asFetchMock(async (input) => {
+      if (String(input).endsWith("/userinfo")) {
+        return Response.json({
+          id: "gh-public-unverified",
+          email: "unverified@example.com",
+          login: "unverified-user",
+        });
+      }
+      return Response.json([
+        { email: "primary@example.com", primary: true, verified: true },
+        { email: "unverified@example.com", primary: false, verified: false },
+      ]);
+    });
+    try {
+      const client = new OAuthClient({
+        clientId: "c",
+        clientSecret: "s",
+        authorizationUrl: "https://example.com/auth",
+        tokenUrl: "https://example.com/token",
+        userInfoUrl: "https://example.com/userinfo",
+        emailUrl: "https://example.com/emails",
+        scopes: [],
+      });
+
+      const info = await client.getUserInfo("tok");
+
+      expect(info.email).toBe("unverified@example.com");
+      expect(info.verified_email).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not override an explicit false verification claim with the email endpoint", async () => {
+    const originalFetch = globalThis.fetch;
+    let callCount = 0;
+    globalThis.fetch = asFetchMock(async () => {
+      callCount += 1;
+      return Response.json({
+        id: "explicitly-unverified",
+        email: "unverified@example.com",
+        verified_email: false,
+      });
+    });
+    try {
+      const client = new OAuthClient({
+        clientId: "c",
+        clientSecret: "s",
+        authorizationUrl: "https://example.com/auth",
+        tokenUrl: "https://example.com/token",
+        userInfoUrl: "https://example.com/userinfo",
+        emailUrl: "https://example.com/emails",
+        scopes: [],
+      });
+
+      const info = await client.getUserInfo("tok");
+
+      expect(callCount).toBe(1);
+      expect(info.verified_email).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("maps custom provider profile fields including nested array paths", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = asFetchMock(

--- a/packages/auth/src/oauth.ts
+++ b/packages/auth/src/oauth.ts
@@ -809,8 +809,12 @@ export class OAuthClient {
       verified_email: Boolean(verifiedEmail ?? false),
     } satisfies OAuthUserInfo;
 
-    if (!userInfo.email && this.provider.emailUrl) {
-      const emailInfo = await this.getPrimaryEmail(accessToken);
+    // GitHub's /user profile may include a public email but never includes a
+    // verification bit. Resolve both the address and its verification status
+    // through /user/emails in that case. An explicit false from a provider is
+    // authoritative and must remain fail-closed.
+    if (this.provider.emailUrl && (!userInfo.email || verifiedEmail === undefined)) {
+      const emailInfo = await this.getPrimaryEmail(accessToken, userInfo.email || undefined);
       if (emailInfo) {
         userInfo.email = emailInfo.email;
         userInfo.verified_email = emailInfo.verified ?? userInfo.verified_email;
@@ -858,7 +862,10 @@ export class OAuthClient {
     throw new Error("Unsupported OIDC provider configuration");
   }
 
-  private async getPrimaryEmail(accessToken: string): Promise<OAuthEmailAddress | null> {
+  private async getPrimaryEmail(
+    accessToken: string,
+    preferredEmail?: string,
+  ): Promise<OAuthEmailAddress | null> {
     if (!this.provider.emailUrl) return null;
 
     const res = await fetch(this.provider.emailUrl, {
@@ -881,6 +888,14 @@ export class OAuthClient {
       (entry): entry is OAuthEmailAddress =>
         entry != null && typeof entry === "object" && typeof entry.email === "string",
     );
+
+    const normalizedPreferredEmail = preferredEmail?.trim().toLowerCase();
+    if (normalizedPreferredEmail) {
+      const matchingEmail = emails.find(
+        (entry) => entry.email.trim().toLowerCase() === normalizedPreferredEmail,
+      );
+      if (matchingEmail) return matchingEmail;
+    }
 
     return (
       emails.find((entry) => entry.primary && entry.verified) ??


### PR DESCRIPTION
Closes #688
Closes #689

## Summary

- resolve GitHub public profile email verification through `/user/emails`, matching the profile address before falling back to the provider primary/verified selection
- preserve fail-closed rejection for genuinely unverified addresses and providers that explicitly report `false`
- render browser callback failures for OAuth and OIDC as a styled, no-store recovery page with stable machine-readable codes
- keep explicit JSON clients on JSON responses while preventing provider-controlled error text, profile data, and tokens from being reflected
- add CSP, referrer, content-type, and validated recovery-link protections

## Validation

- `packages/auth`: OAuth client suite — 52 passed, 133 assertions
- `packages/api`: callback browser route suite — 6 passed, 50 assertions
- `packages/api`: nonce-binding + OIDC code-flow suites — 13 passed, 114 assertions
- `packages/api`: OAuth token encryption/provisioning suite — 4 passed, 24 assertions
- forced `@stwd/api...` dependency build — 24/24 packages passed
- Biome check on all changed files passed
- `git diff --check` passed

The ambient-Postgres redirect allowlist suite is intentionally deferred to hosted CI because this isolated lane has no `DATABASE_URL`.

Draft only; do not merge until exact-head hosted checks and independent review are green.