### PR TITLE
fix(api): enforce canonical personal-tenant lifecycle

### DIFF
--- a/packages/api/src/__tests__/fixtures/rls-app-role-exercise.ts
+++ b/packages/api/src/__tests__/fixtures/rls-app-role-exercise.ts
@@ -91,7 +91,7 @@ try {
       .onConflictDoNothing();
     await getDb()
       .insert(userTenants)
-      .values({ userId, tenantId: personalTenantId, role: "member" })
+      .values({ userId, tenantId: personalTenantId, role: "owner" })
       .onConflictDoNothing();
   });
   const userToken = await signAccessToken({ address: "", tenantId: personalTenantId, userId });

--- a/packages/api/src/__tests__/platform-identity-graph.test.ts
+++ b/packages/api/src/__tests__/platform-identity-graph.test.ts
@@ -37,6 +37,7 @@ describe("platform global identity graph routes", () => {
         "platform:user:write",
         "platform:user-lifecycle:write",
         "platform:user:delete",
+        "platform:tenant:delete",
         "platform:tenant-user:read",
         "platform:tenant-user:write",
         "platform:gas-spend:read",
@@ -885,5 +886,92 @@ describe("platform global identity graph routes", () => {
       .from(refreshTokens)
       .where(eq(refreshTokens.userId, deleteUser.id));
     expect(deletedRefresh).toHaveLength(0);
+  });
+
+  it("deactivates a personal owner and deletes the tenant before its identity", async () => {
+    const [personalUser] = await getDb()
+      .insert(users)
+      .values({ email: "delete-personal-owner@example.test", emailVerified: true })
+      .returning({ id: users.id });
+    const personalTenantId = `personal-${personalUser.id}`;
+    await getDb().insert(tenants).values({
+      id: personalTenantId,
+      name: "Personal deletion owner",
+      apiKeyHash: "personal-delete-owner-hash",
+    });
+    await getDb().insert(userTenants).values({
+      userId: personalUser.id,
+      tenantId: personalTenantId,
+      role: "owner",
+    });
+
+    const deactivate = await platformRoutes.request(`/users/${personalUser.id}/deactivate`, {
+      method: "PATCH",
+      headers: headers(),
+      body: JSON.stringify({ deactivated: true }),
+    });
+    expect(deactivate.status).toBe(200);
+    const [deactivated] = await getDb()
+      .select({ deactivatedAt: users.deactivatedAt })
+      .from(users)
+      .where(eq(users.id, personalUser.id));
+    expect(deactivated?.deactivatedAt).toBeInstanceOf(Date);
+
+    const prematureRemove = await platformRoutes.request(`/users/${personalUser.id}`, {
+      method: "DELETE",
+      headers: headers(),
+    });
+    expect(prematureRemove.status).toBe(409);
+
+    const removeTenant = await platformRoutes.request(`/tenants/${personalTenantId}`, {
+      method: "DELETE",
+      headers: headers(),
+    });
+    expect(removeTenant.status).toBe(200);
+
+    const remove = await platformRoutes.request(`/users/${personalUser.id}`, {
+      method: "DELETE",
+      headers: headers(),
+    });
+    expect(remove.status).toBe(200);
+    expect(await getDb().select().from(users).where(eq(users.id, personalUser.id))).toHaveLength(0);
+    expect(
+      await getDb().select().from(tenants).where(eq(tenants.id, personalTenantId)),
+    ).toHaveLength(0);
+  });
+
+  it("still refuses lifecycle removal for a sole owner of a shared tenant", async () => {
+    const sharedTenantId = "platform-identity-delete-shared";
+    const [sharedOwner] = await getDb()
+      .insert(users)
+      .values({ email: "delete-shared-owner@example.test", emailVerified: true })
+      .returning({ id: users.id });
+    await getDb().insert(tenants).values({
+      id: sharedTenantId,
+      name: "Shared deletion control",
+      apiKeyHash: "shared-delete-control-hash",
+    });
+    await getDb().insert(userTenants).values({
+      userId: sharedOwner.id,
+      tenantId: sharedTenantId,
+      role: "owner",
+    });
+
+    const deactivate = await platformRoutes.request(`/users/${sharedOwner.id}/deactivate`, {
+      method: "PATCH",
+      headers: headers(),
+      body: JSON.stringify({ deactivated: true }),
+    });
+    expect(deactivate.status).toBe(409);
+
+    const remove = await platformRoutes.request(`/users/${sharedOwner.id}`, {
+      method: "DELETE",
+      headers: headers(),
+    });
+    expect(remove.status).toBe(409);
+    expect(await getDb().select().from(users).where(eq(users.id, sharedOwner.id))).toHaveLength(1);
+    expect(await getDb().select().from(tenants).where(eq(tenants.id, sharedTenantId))).toHaveLength(
+      1,
+    );
   });
 });

--- a/packages/api/src/__tests__/platform-identity-graph.test.ts
+++ b/packages/api/src/__tests__/platform-identity-graph.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 
-import { hashSha256Hex } from "@stwd/auth";
+import { hashSha256Hex, revocationStore } from "@stwd/auth";
 import {
   accounts,
   agents,
@@ -38,6 +38,7 @@ describe("platform global identity graph routes", () => {
         "platform:user-lifecycle:write",
         "platform:user:delete",
         "platform:tenant:delete",
+        "platform:tenant-member:write",
         "platform:tenant-user:read",
         "platform:tenant-user:write",
         "platform:gas-spend:read",
@@ -106,6 +107,79 @@ describe("platform global identity graph routes", () => {
       "Content-Type": "application/json",
       "X-Steward-Platform-Key": PLATFORM_KEY,
     };
+  }
+
+  async function assertMalformedPersonalTenantRejected(extraRole: "member" | "owner") {
+    const [owner, extraUser] = await getDb()
+      .insert(users)
+      .values([
+        {
+          email: `personal-${extraRole}-owner@example.test`,
+          emailVerified: true,
+        },
+        {
+          email: `personal-${extraRole}-extra@example.test`,
+          emailVerified: true,
+        },
+      ])
+      .returning({ id: users.id });
+    const tenantId = `personal-${owner.id}`;
+    await getDb()
+      .insert(tenants)
+      .values({
+        id: tenantId,
+        name: `Malformed personal ${extraRole}`,
+        apiKeyHash: `malformed-personal-${extraRole}-hash`,
+      });
+    await getDb()
+      .insert(userTenants)
+      .values([
+        { userId: owner.id, tenantId, role: "owner" },
+        { userId: extraUser.id, tenantId, role: extraRole },
+      ]);
+    await getDb()
+      .insert(refreshTokens)
+      .values({
+        id: `malformed-personal-${extraRole}-refresh`,
+        userId: owner.id,
+        tenantId,
+        tokenHash: `malformed-personal-${extraRole}-refresh-hash`,
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+    const revokedBefore = await revocationStore.getUserRevokedBefore(owner.id);
+
+    const deactivate = await platformRoutes.request(`/users/${owner.id}/deactivate`, {
+      method: "PATCH",
+      headers: headers(),
+      body: JSON.stringify({ deactivated: true }),
+    });
+    expect(deactivate.status).toBe(409);
+    expect(((await deactivate.json()) as { error: string }).error).toBe(
+      "Personal tenant membership invariant violated",
+    );
+
+    const removeTenant = await platformRoutes.request(`/tenants/${tenantId}`, {
+      method: "DELETE",
+      headers: headers(),
+    });
+    expect(removeTenant.status).toBe(409);
+    expect(((await removeTenant.json()) as { error: string }).error).toBe(
+      "Personal tenant membership invariant violated",
+    );
+
+    const [storedOwner] = await getDb()
+      .select({ deactivatedAt: users.deactivatedAt })
+      .from(users)
+      .where(eq(users.id, owner.id));
+    expect(storedOwner?.deactivatedAt).toBeNull();
+    expect(await revocationStore.getUserRevokedBefore(owner.id)).toBe(revokedBefore);
+    expect(await getDb().select().from(tenants).where(eq(tenants.id, tenantId))).toHaveLength(1);
+    expect(
+      await getDb().select().from(userTenants).where(eq(userTenants.tenantId, tenantId)),
+    ).toHaveLength(2);
+    expect(
+      await getDb().select().from(refreshTokens).where(eq(refreshTokens.userId, owner.id)),
+    ).toHaveLength(1);
   }
 
   it("gets a global user identity with tenant ids and linked accounts", async () => {
@@ -904,6 +978,52 @@ describe("platform global identity graph routes", () => {
       tenantId: personalTenantId,
       role: "owner",
     });
+    await getDb().insert(accounts).values({
+      userId: personalUser.id,
+      provider: "google",
+      providerAccountId: "google-personal-delete-owner",
+    });
+
+    const immutableMembershipRequests = [
+      platformRoutes.request(`/tenants/${personalTenantId}/members`, {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({ email: "personal-extra-member@example.test", role: "member" }),
+      }),
+      platformRoutes.request(`/tenants/${personalTenantId}/members/${personalUser.id}`, {
+        method: "PATCH",
+        headers: headers(),
+        body: JSON.stringify({ role: "member" }),
+      }),
+      platformRoutes.request(`/tenants/${personalTenantId}/members/${personalUser.id}`, {
+        method: "DELETE",
+        headers: headers(),
+      }),
+      platformRoutes.request(`/tenants/${personalTenantId}/invitations`, {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({ email: "personal-invite@example.test" }),
+      }),
+      platformRoutes.request(`/tenants/${personalTenantId}/invitations/${crypto.randomUUID()}`, {
+        method: "DELETE",
+        headers: headers(),
+      }),
+    ];
+    for (const response of await Promise.all(immutableMembershipRequests)) {
+      expect(response.status).toBe(409);
+      expect(((await response.json()) as { error: string }).error).toBe(
+        "Personal tenant membership is immutable",
+      );
+    }
+    expect(
+      await getDb().select().from(userTenants).where(eq(userTenants.tenantId, personalTenantId)),
+    ).toHaveLength(1);
+    expect(
+      await getDb()
+        .select()
+        .from(users)
+        .where(eq(users.email, "personal-extra-member@example.test")),
+    ).toHaveLength(0);
 
     const deactivate = await platformRoutes.request(`/users/${personalUser.id}/deactivate`, {
       method: "PATCH",
@@ -936,8 +1056,22 @@ describe("platform global identity graph routes", () => {
     expect(remove.status).toBe(200);
     expect(await getDb().select().from(users).where(eq(users.id, personalUser.id))).toHaveLength(0);
     expect(
+      await getDb()
+        .select()
+        .from(accounts)
+        .where(eq(accounts.providerAccountId, "google-personal-delete-owner")),
+    ).toHaveLength(0);
+    expect(
       await getDb().select().from(tenants).where(eq(tenants.id, personalTenantId)),
     ).toHaveLength(0);
+  });
+
+  it("rejects a personal tenant with an extra member before lifecycle mutation", async () => {
+    await assertMalformedPersonalTenantRejected("member");
+  });
+
+  it("rejects a personal tenant with an extra owner before lifecycle mutation", async () => {
+    await assertMalformedPersonalTenantRejected("owner");
   });
 
   it("still refuses lifecycle removal for a sole owner of a shared tenant", async () => {

--- a/packages/api/src/__tests__/platform-security-hardening.test.ts
+++ b/packages/api/src/__tests__/platform-security-hardening.test.ts
@@ -526,7 +526,16 @@ describe("platform security hardening", () => {
     expect(rlsMigrationSource).toContain("Cannot deactivate the sole active tenant owner");
     expect(rlsMigrationSource).toContain("Cannot delete the sole active tenant owner");
     expect(personalLifecycleMigrationSource).toContain(
-      "owner_tenant.tenant_id = 'personal-' || p_user_id::text",
+      "personal_tenant_id text := 'personal-' || p_user_id::text",
+    );
+    expect(personalLifecycleMigrationSource).toContain(
+      "count(*) FILTER (WHERE ut.user_id = p_user_id AND ut.role = 'owner')",
+    );
+    expect(personalLifecycleMigrationSource).toContain(
+      "Personal tenant membership invariant violated",
+    );
+    expect(personalLifecycleMigrationSource).toContain(
+      "owner_tenant.tenant_id = personal_tenant_id",
     );
     expect(personalLifecycleMigrationSource).toContain("CONTINUE;");
     expect(platformSource).not.toContain("platform_member_${tenantId}");

--- a/packages/api/src/__tests__/platform-security-hardening.test.ts
+++ b/packages/api/src/__tests__/platform-security-hardening.test.ts
@@ -17,6 +17,10 @@ const rlsMigrationSource = readFileSync(
   join(apiRoot, "..", "..", "db", "drizzle", "0111_tenant_rls_policy_install.sql"),
   "utf8",
 );
+const personalLifecycleMigrationSource = readFileSync(
+  join(apiRoot, "..", "..", "db", "drizzle", "0113_personal_tenant_account_lifecycle.sql"),
+  "utf8",
+);
 
 function expectBefore(first: string, second: string) {
   const firstIndex = platformSource.indexOf(first);
@@ -521,6 +525,10 @@ describe("platform security hardening", () => {
     expect(rlsMigrationSource).toContain("u.deactivated_at IS NULL");
     expect(rlsMigrationSource).toContain("Cannot deactivate the sole active tenant owner");
     expect(rlsMigrationSource).toContain("Cannot delete the sole active tenant owner");
+    expect(personalLifecycleMigrationSource).toContain(
+      "owner_tenant.tenant_id = 'personal-' || p_user_id::text",
+    );
+    expect(personalLifecycleMigrationSource).toContain("CONTINUE;");
     expect(platformSource).not.toContain("platform_member_${tenantId}");
 
     for (const marker of [

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -741,6 +741,16 @@ function errorChainHasExactMessage(error: unknown, expected: string): boolean {
   return false;
 }
 
+function isPersonalTenantId(tenantId: string): boolean {
+  return tenantId.startsWith("personal-");
+}
+
+function canonicalPersonalTenantOwnerId(tenantId: string): string | null {
+  if (!isPersonalTenantId(tenantId)) return null;
+  const ownerId = tenantId.slice("personal-".length);
+  return isValidUserId(ownerId) && tenantId === `personal-${ownerId}` ? ownerId : null;
+}
+
 // ─── Route group ─────────────────────────────────────────────────────────────
 
 const platform = new Hono<{ Variables: AppVariables }>();
@@ -2096,6 +2106,39 @@ platform.delete("/tenants/:id", async (c) => {
         .for("update");
       if (!existing) return { status: "missing" as const };
 
+      const personalOwnerId = canonicalPersonalTenantOwnerId(tenantId);
+      if (isPersonalTenantId(tenantId)) {
+        if (!personalOwnerId) return { status: "blocked_by_personal_membership" as const };
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtextextended(${
+            "platform_user_account_" + personalOwnerId
+          }, 0))`,
+        );
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtextextended(${
+            "tenant_owner_lifecycle_" + tenantId
+          }, 0))`,
+        );
+        const [owner] = await tx
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.id, personalOwnerId))
+          .for("update");
+        const personalMemberships = await tx
+          .select({ userId: userTenants.userId, role: userTenants.role })
+          .from(userTenants)
+          .where(eq(userTenants.tenantId, tenantId))
+          .orderBy(userTenants.userId);
+        if (
+          !owner ||
+          personalMemberships.length !== 1 ||
+          personalMemberships[0]?.userId !== personalOwnerId ||
+          personalMemberships[0]?.role !== "owner"
+        ) {
+          return { status: "blocked_by_personal_membership" as const };
+        }
+      }
+
       const tenantAgents = await tx
         .select({ id: agents.id })
         .from(agents)
@@ -2220,6 +2263,12 @@ platform.delete("/tenants/:id", async (c) => {
   if (result.status === "blocked_by_capability_integrity") {
     return c.json<ApiResponse>(
       { ok: false, error: "Tenant capability authority has cross-tenant references" },
+      409,
+    );
+  }
+  if (result.status === "blocked_by_personal_membership") {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Personal tenant membership invariant violated" },
       409,
     );
   }
@@ -3765,7 +3814,6 @@ platform.patch("/users/:userId/deactivate", async (c) => {
           resourceId: userId,
           ...auditCtx(c),
         });
-        const issuedBefore = await revocationStore.revokeUserTokens(userId);
         const [updated] = rowsFromExecute<{
           user_id: string;
           previous_deactivated_at: Date | null;
@@ -3780,6 +3828,7 @@ platform.patch("/users/:userId/deactivate", async (c) => {
           `),
         );
         if (!updated) throw new Error("User not found");
+        const issuedBefore = await revocationStore.revokeUserTokens(userId);
         await appendRequiredAudit({
           tenantId: PLATFORM_AUDIT_TENANT_ID,
           actorType: "platform",
@@ -3797,12 +3846,18 @@ platform.patch("/users/:userId/deactivate", async (c) => {
     if (errorChainHasExactMessage(err, "Cannot deactivate the sole active tenant owner")) {
       return "Cannot deactivate the sole active tenant owner";
     }
+    if (errorChainHasExactMessage(err, "Personal tenant membership invariant violated")) {
+      return "Personal tenant membership invariant violated";
+    }
     throw err;
   });
   if (result === null) {
     return c.json<ApiResponse>({ ok: false, error: "User not found" }, 404);
   }
   if (result === "Cannot deactivate the sole active tenant owner") {
+    return c.json<ApiResponse>({ ok: false, error: result }, 409);
+  }
+  if (result === "Personal tenant membership invariant violated") {
     return c.json<ApiResponse>({ ok: false, error: result }, 409);
   }
   return c.json<ApiResponse<{ userId: string; deactivatedAt: Date | null }>>({
@@ -3845,13 +3900,13 @@ platform.delete("/users/:userId", async (c) => {
           resourceId: userId,
           ...auditCtx(c),
         });
-        const cutoff = await revocationStore.revokeUserTokens(userId);
         const [deleted] = rowsFromExecute<{ user_id: string }>(
           await tx.execute(sql`
             SELECT * FROM steward_bootstrap.platform_delete_user(${userId}::uuid)
           `),
         );
         if (!deleted) throw new Error("User not found");
+        const cutoff = await revocationStore.revokeUserTokens(userId);
         await appendRequiredAudit({
           tenantId: PLATFORM_AUDIT_TENANT_ID,
           actorType: "platform",
@@ -3869,12 +3924,18 @@ platform.delete("/users/:userId", async (c) => {
     if (errorChainHasExactMessage(error, "Cannot delete the sole active tenant owner")) {
       return "Cannot delete the sole active tenant owner";
     }
+    if (errorChainHasExactMessage(error, "Personal tenant membership invariant violated")) {
+      return "Personal tenant membership invariant violated";
+    }
     throw error;
   });
   if (issuedBefore === null) {
     return c.json<ApiResponse>({ ok: false, error: "User not found" }, 404);
   }
   if (issuedBefore === "Cannot delete the sole active tenant owner") {
+    return c.json<ApiResponse>({ ok: false, error: issuedBefore }, 409);
+  }
+  if (issuedBefore === "Personal tenant membership invariant violated") {
     return c.json<ApiResponse>({ ok: false, error: issuedBefore }, 409);
   }
 
@@ -4692,6 +4753,12 @@ platform.post("/tenants/:id/invitations", async (c) => {
   if (!isValidTenantId(tenantId)) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid tenant id format" }, 400);
   }
+  if (isPersonalTenantId(tenantId)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Personal tenant membership is immutable" },
+      409,
+    );
+  }
 
   const body = await safeJsonParse<{
     email: string;
@@ -4858,6 +4925,12 @@ platform.delete("/tenants/:id/invitations/:invitationId", async (c) => {
   if (!isValidTenantId(tenantId)) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid tenant id format" }, 400);
   }
+  if (isPersonalTenantId(tenantId)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Personal tenant membership is immutable" },
+      409,
+    );
+  }
   if (!isValidUserId(invitationId)) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid invitation id format" }, 400);
   }
@@ -4947,6 +5020,12 @@ platform.post("/tenants/:id/members", async (c) => {
   if (!isValidTenantId(tenantId)) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid tenant id format" }, 400);
   }
+  if (isPersonalTenantId(tenantId)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Personal tenant membership is immutable" },
+      409,
+    );
+  }
 
   const body = await safeJsonParse<{ email: string; role?: string }>(c);
   if (!body || !isNonEmptyString(body.email)) {
@@ -5035,6 +5114,12 @@ platform.delete("/tenants/:id/members/:userId", async (c) => {
 
   if (!isValidTenantId(tenantId)) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid tenant id format" }, 400);
+  }
+  if (isPersonalTenantId(tenantId)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Personal tenant membership is immutable" },
+      409,
+    );
   }
   if (!isValidUserId(userId)) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid user id format" }, 400);
@@ -5131,6 +5216,12 @@ platform.patch("/tenants/:id/members/:userId", async (c) => {
 
   if (!isValidTenantId(tenantId)) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid tenant id format" }, 400);
+  }
+  if (isPersonalTenantId(tenantId)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Personal tenant membership is immutable" },
+      409,
+    );
   }
   if (!isValidUserId(userId)) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid user id format" }, 400);

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -727,6 +727,20 @@ function rowsFromExecute<T>(result: unknown): T[] {
   return (Array.isArray(result) ? result : ((result as { rows?: unknown[] })?.rows ?? [])) as T[];
 }
 
+function errorChainHasExactMessage(error: unknown, expected: string): boolean {
+  const seen = new Set<unknown>();
+  let current = error;
+  for (let depth = 0; depth < 8 && current && !seen.has(current); depth += 1) {
+    seen.add(current);
+    if (current instanceof Error && current.message === expected) return true;
+    current =
+      typeof current === "object" && "cause" in current
+        ? (current as { cause?: unknown }).cause
+        : undefined;
+  }
+  return false;
+}
+
 // ─── Route group ─────────────────────────────────────────────────────────────
 
 const platform = new Hono<{ Variables: AppVariables }>();
@@ -3779,9 +3793,9 @@ platform.patch("/users/:userId/deactivate", async (c) => {
       },
     ),
   ).catch((err: unknown) => {
-    if (err instanceof Error && err.message === "User not found") return null;
-    if (err instanceof Error && err.message === "Cannot deactivate the sole active tenant owner") {
-      return err.message;
+    if (errorChainHasExactMessage(err, "User not found")) return null;
+    if (errorChainHasExactMessage(err, "Cannot deactivate the sole active tenant owner")) {
+      return "Cannot deactivate the sole active tenant owner";
     }
     throw err;
   });
@@ -3851,9 +3865,9 @@ platform.delete("/users/:userId", async (c) => {
       },
     ),
   ).catch((error: unknown) => {
-    if (error instanceof Error && error.message === "User not found") return null;
-    if (error instanceof Error && error.message === "Cannot delete the sole active tenant owner") {
-      return error.message;
+    if (errorChainHasExactMessage(error, "User not found")) return null;
+    if (errorChainHasExactMessage(error, "Cannot delete the sole active tenant owner")) {
+      return "Cannot delete the sole active tenant owner";
     }
     throw error;
   });

--- a/packages/db/drizzle/0113_personal_tenant_account_lifecycle.sql
+++ b/packages/db/drizzle/0113_personal_tenant_account_lifecycle.sql
@@ -1,0 +1,65 @@
+CREATE OR REPLACE FUNCTION "steward_bootstrap"."platform_set_user_deactivation"(
+  p_user_id uuid,
+  p_deactivated boolean
+)
+RETURNS TABLE (
+  user_id uuid, previous_deactivated_at timestamptz,
+  previous_updated_at timestamptz, deactivated_at timestamptz
+)
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  existing public.users%ROWTYPE;
+  owner_tenant record;
+  updated_deactivated_at timestamptz;
+BEGIN
+  IF NULLIF(current_setting('steward.tenant_id', true), '') IS DISTINCT FROM 'platform' THEN
+    RAISE EXCEPTION 'platform lifecycle operation requires reserved platform context';
+  END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended('platform_user_account_' || p_user_id::text, 0));
+  SELECT u.* INTO existing FROM public.users u WHERE u.id = p_user_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'User not found'; END IF;
+
+  IF p_deactivated THEN
+    FOR owner_tenant IN
+      SELECT ut.tenant_id
+      FROM public.user_tenants ut
+      WHERE ut.user_id = p_user_id AND ut.role = 'owner'
+      ORDER BY ut.tenant_id
+    LOOP
+      -- Personal tenants are single-owner by construction. Suspending the
+      -- identity must remain possible; shared tenants retain the strict last
+      -- active owner invariant below.
+      IF owner_tenant.tenant_id = 'personal-' || p_user_id::text THEN
+        CONTINUE;
+      END IF;
+      PERFORM pg_advisory_xact_lock(
+        hashtextextended('tenant_owner_lifecycle_' || owner_tenant.tenant_id, 0)
+      );
+      IF NOT EXISTS (
+        SELECT 1
+        FROM public.user_tenants other
+        JOIN public.users u ON u.id = other.user_id
+        WHERE other.tenant_id = owner_tenant.tenant_id
+          AND other.role = 'owner'
+          AND other.user_id <> p_user_id
+          AND u.deactivated_at IS NULL
+      ) THEN
+        RAISE EXCEPTION 'Cannot deactivate the sole active tenant owner';
+      END IF;
+    END LOOP;
+  END IF;
+
+  UPDATE public.users u
+  SET deactivated_at = CASE WHEN p_deactivated THEN now() ELSE NULL END,
+      updated_at = now()
+  WHERE u.id = p_user_id
+  RETURNING u.deactivated_at INTO updated_deactivated_at;
+  DELETE FROM public.refresh_tokens r WHERE r.user_id = p_user_id;
+  RETURN QUERY SELECT
+    existing.id, existing.deactivated_at, existing.updated_at, updated_deactivated_at;
+END
+$$;

--- a/packages/db/drizzle/0113_personal_tenant_account_lifecycle.sql
+++ b/packages/db/drizzle/0113_personal_tenant_account_lifecycle.sql
@@ -15,6 +15,9 @@ DECLARE
   existing public.users%ROWTYPE;
   owner_tenant record;
   updated_deactivated_at timestamptz;
+  personal_tenant_id text := 'personal-' || p_user_id::text;
+  personal_membership_count bigint;
+  personal_owner_count bigint;
 BEGIN
   IF NULLIF(current_setting('steward.tenant_id', true), '') IS DISTINCT FROM 'platform' THEN
     RAISE EXCEPTION 'platform lifecycle operation requires reserved platform context';
@@ -24,6 +27,22 @@ BEGIN
   IF NOT FOUND THEN RAISE EXCEPTION 'User not found'; END IF;
 
   IF p_deactivated THEN
+    PERFORM pg_advisory_xact_lock(
+      hashtextextended('tenant_owner_lifecycle_' || personal_tenant_id, 0)
+    );
+    PERFORM 1 FROM public.tenants t WHERE t.id = personal_tenant_id FOR UPDATE;
+    IF FOUND THEN
+      SELECT
+        count(*),
+        count(*) FILTER (WHERE ut.user_id = p_user_id AND ut.role = 'owner')
+      INTO personal_membership_count, personal_owner_count
+      FROM public.user_tenants ut
+      WHERE ut.tenant_id = personal_tenant_id;
+      IF personal_membership_count <> 1 OR personal_owner_count <> 1 THEN
+        RAISE EXCEPTION 'Personal tenant membership invariant violated';
+      END IF;
+    END IF;
+
     FOR owner_tenant IN
       SELECT ut.tenant_id
       FROM public.user_tenants ut
@@ -31,9 +50,9 @@ BEGIN
       ORDER BY ut.tenant_id
     LOOP
       -- Personal tenants are single-owner by construction. Suspending the
-      -- identity must remain possible; shared tenants retain the strict last
-      -- active owner invariant below.
-      IF owner_tenant.tenant_id = 'personal-' || p_user_id::text THEN
+      -- identity is allowed only after the exact locked shape check above;
+      -- shared tenants retain the strict last active owner invariant below.
+      IF owner_tenant.tenant_id = personal_tenant_id THEN
         CONTINUE;
       END IF;
       PERFORM pg_advisory_xact_lock(
@@ -61,5 +80,69 @@ BEGIN
   DELETE FROM public.refresh_tokens r WHERE r.user_id = p_user_id;
   RETURN QUERY SELECT
     existing.id, existing.deactivated_at, existing.updated_at, updated_deactivated_at;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION "steward_bootstrap"."platform_delete_user"(p_user_id uuid)
+RETURNS TABLE (user_id uuid)
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  owner_tenant record;
+  personal_tenant_id text := 'personal-' || p_user_id::text;
+  personal_membership_count bigint;
+  personal_owner_count bigint;
+BEGIN
+  IF NULLIF(current_setting('steward.tenant_id', true), '') IS DISTINCT FROM 'platform' THEN
+    RAISE EXCEPTION 'platform lifecycle operation requires reserved platform context';
+  END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended('platform_user_account_' || p_user_id::text, 0));
+  PERFORM 1 FROM public.users u WHERE u.id = p_user_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'User not found'; END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('tenant_owner_lifecycle_' || personal_tenant_id, 0)
+  );
+  PERFORM 1 FROM public.tenants t WHERE t.id = personal_tenant_id FOR UPDATE;
+  IF FOUND THEN
+    SELECT
+      count(*),
+      count(*) FILTER (WHERE ut.user_id = p_user_id AND ut.role = 'owner')
+    INTO personal_membership_count, personal_owner_count
+    FROM public.user_tenants ut
+    WHERE ut.tenant_id = personal_tenant_id;
+    IF personal_membership_count <> 1 OR personal_owner_count <> 1 THEN
+      RAISE EXCEPTION 'Personal tenant membership invariant violated';
+    END IF;
+  END IF;
+
+  FOR owner_tenant IN
+    SELECT ut.tenant_id
+    FROM public.user_tenants ut
+    WHERE ut.user_id = p_user_id AND ut.role = 'owner'
+    ORDER BY ut.tenant_id
+  LOOP
+    PERFORM pg_advisory_xact_lock(
+      hashtextextended('tenant_owner_lifecycle_' || owner_tenant.tenant_id, 0)
+    );
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.user_tenants other
+      JOIN public.users u ON u.id = other.user_id
+      WHERE other.tenant_id = owner_tenant.tenant_id
+        AND other.role = 'owner'
+        AND other.user_id <> p_user_id
+        AND u.deactivated_at IS NULL
+    ) THEN
+      RAISE EXCEPTION 'Cannot delete the sole active tenant owner';
+    END IF;
+  END LOOP;
+
+  DELETE FROM public.refresh_tokens r WHERE r.user_id = p_user_id;
+  DELETE FROM public.users u WHERE u.id = p_user_id;
+  RETURN QUERY SELECT p_user_id;
 END
 $$;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -652,6 +652,13 @@
       "when": 1787203600000,
       "tag": "0112_rls_activation_release_gates",
       "breakpoints": true
+    },
+    {
+      "idx": 113,
+      "version": "7",
+      "when": 1787220000000,
+      "tag": "0113_personal_tenant_account_lifecycle",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
@@ -303,6 +303,80 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
       expect(personalDeactivation[0]?.user_id).toBe(personalOwnerId);
       expect(personalDeactivation[0]?.deactivated_at).toBeInstanceOf(Date);
 
+      for (const extraRole of ["member", "owner"] as const) {
+        const malformedOwnerId = randomUUID();
+        const malformedExtraId = randomUUID();
+        const malformedTenant = `personal-${malformedOwnerId}`;
+        await db`
+          INSERT INTO public.tenants(id, name, api_key_hash)
+          VALUES (
+            ${malformedTenant},
+            ${`Malformed personal ${extraRole}`},
+            ${`malformed-personal-${extraRole}-${suffix}`}
+          )
+        `;
+        await db`
+          INSERT INTO public.users(id, email)
+          VALUES
+            (${malformedOwnerId}::uuid, ${`malformed-${extraRole}-owner-${suffix}@example.test`}),
+            (${malformedExtraId}::uuid, ${`malformed-${extraRole}-extra-${suffix}@example.test`})
+        `;
+        await db`
+          INSERT INTO public.user_tenants(user_id, tenant_id, role)
+          VALUES
+            (${malformedOwnerId}::uuid, ${malformedTenant}, 'owner'),
+            (${malformedExtraId}::uuid, ${malformedTenant}, ${extraRole})
+        `;
+        await db`
+          INSERT INTO public.refresh_tokens(id, user_id, tenant_id, token_hash, expires_at)
+          VALUES (
+            ${`malformed-personal-${extraRole}-${suffix}`},
+            ${malformedOwnerId},
+            ${malformedTenant},
+            ${`malformed-personal-${extraRole}-refresh-${suffix}`},
+            now() + interval '1 hour'
+          )
+        `;
+
+        await expect(
+          db.begin(async (tx) => {
+            await tx.unsafe(`SET LOCAL ROLE ${platformRole}`);
+            await tx`SELECT set_config('steward.tenant_id', 'platform', true)`;
+            await tx`
+              SELECT *
+              FROM steward_bootstrap.platform_set_user_deactivation(
+                ${malformedOwnerId}::uuid,
+                true
+              )
+            `;
+          }),
+        ).rejects.toThrow("Personal tenant membership invariant violated");
+
+        await expect(
+          db.begin(async (tx) => {
+            await tx.unsafe(`SET LOCAL ROLE ${platformRole}`);
+            await tx`SELECT set_config('steward.tenant_id', 'platform', true)`;
+            await tx`
+              SELECT *
+              FROM steward_bootstrap.platform_delete_user(${malformedOwnerId}::uuid)
+            `;
+          }),
+        ).rejects.toThrow("Personal tenant membership invariant violated");
+
+        const [unchangedUser] = await db<{ deactivated_at: Date | null }[]>`
+          SELECT deactivated_at
+          FROM public.users
+          WHERE id = ${malformedOwnerId}::uuid
+        `;
+        expect(unchangedUser?.deactivated_at).toBeNull();
+        const [refreshEvidence] = await db<{ count: number }[]>`
+          SELECT count(*)::int AS count
+          FROM public.refresh_tokens
+          WHERE user_id = ${malformedOwnerId}
+        `;
+        expect(refreshEvidence?.count).toBe(1);
+      }
+
       const platformKey = `rls-platform-key-${suffix}`;
       const appRoleEvidence = await runCommand(
         ["bun", "run", "packages/api/src/__tests__/fixtures/rls-app-role-exercise.ts"],

--- a/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
@@ -289,7 +289,7 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
         VALUES (${personalOwnerId}::uuid, ${personalTenant}, 'owner')
       `;
       const personalDeactivation = await db.begin(async (tx) => {
-        await tx.unsafe(`SET LOCAL ROLE ${appRole}`);
+        await tx.unsafe(`SET LOCAL ROLE ${platformRole}`);
         await tx`SELECT set_config('steward.tenant_id', 'platform', true)`;
         return tx`
           SELECT user_id, deactivated_at

--- a/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
@@ -94,7 +94,7 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
     const firstMigration = await runCommand(["bun", "run", "packages/db/src/migrate.ts"], {
       DATABASE_URL: databaseUrl(databaseName),
     });
-    expect(firstMigration).toContain("0111_tenant_rls_policy_install");
+    expect(firstMigration).toContain("0113_personal_tenant_account_lifecycle");
 
     const db = postgres(databaseUrl(databaseName), { max: 1 });
     try {
@@ -273,6 +273,35 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
           `;
         }),
       ).rejects.toThrow("Cannot deactivate the sole active tenant owner");
+
+      const personalOwnerId = randomUUID();
+      const personalTenant = `personal-${personalOwnerId}`;
+      await db`
+        INSERT INTO public.tenants(id, name, api_key_hash)
+        VALUES (${personalTenant}, 'Personal lifecycle owner', ${`personal-key-${suffix}`})
+      `;
+      await db`
+        INSERT INTO public.users(id, email)
+        VALUES (${personalOwnerId}::uuid, ${`personal-owner-${suffix}@example.test`})
+      `;
+      await db`
+        INSERT INTO public.user_tenants(user_id, tenant_id, role)
+        VALUES (${personalOwnerId}::uuid, ${personalTenant}, 'owner')
+      `;
+      const personalDeactivation = await db.begin(async (tx) => {
+        await tx.unsafe(`SET LOCAL ROLE ${appRole}`);
+        await tx`SELECT set_config('steward.tenant_id', 'platform', true)`;
+        return tx`
+          SELECT user_id, deactivated_at
+          FROM steward_bootstrap.platform_set_user_deactivation(
+            ${personalOwnerId}::uuid,
+            true
+          )
+        `;
+      });
+      expect(personalDeactivation).toHaveLength(1);
+      expect(personalDeactivation[0]?.user_id).toBe(personalOwnerId);
+      expect(personalDeactivation[0]?.deactivated_at).toBeInstanceOf(Date);
 
       const platformKey = `rls-platform-key-${suffix}`;
       const appRoleEvidence = await runCommand(


### PR DESCRIPTION
## Scope

Supersedes the closed, unsafe candidate #675 with the corrected personal-account lifecycle only. This draft does not include signed-artifact retirement or the dependent Solana recovery stack.

- rejects member/invitation writes against `personal-*` tenants
- validates the advisory-locked canonical personal owner and exact sole-owner membership before any external revocation or database deletion
- preserves user, tenant, membership, and refresh authority on malformed extra-member or extra-owner graphs
- keeps the valid Google-backed personal deactivation and deletion flow
- adds immutable migration `0113_personal_tenant_account_lifecycle.sql`

## Exact lineage

- current base at restack: `7b128ade83e0bb44b1e28be20f1e220156cef18e`
- current head: `b082f4242b88d27072a93ed26cea96d8dfa08a37`
- seven-file unique delta; signed-artifact migration `0114` remains unpublished pending #684

## Validation

Exact current head after restack:
- mounted platform identity/security: 44/44, 406 assertions
- API dependency build: 24/24
- Biome on affected TypeScript files and committed diff check: clean
- PGLite applied the complete journal through new migration `0113`

Pre-restack identical seven-file feature tree additionally passed:
- combined mounted/focused lifecycle: 50/50, 515 assertions
- real PostgreSQL 16 operator lifecycle: 1/1, 31 assertions
- API dependency build: 26/26

Hosted exact-head PostgreSQL remains required before readiness.

## Merge order

Review and land this lifecycle first. Then #684 must be audited/restacked and accepted. Signed-artifact retirement follows afterward as migration `0114`.

No production activation or deployment is performed by this draft.