### PR TITLE
fix(sdk): consume canonical paginated agent listings

### DIFF
--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -193,6 +193,11 @@ const mockAgent = {
   createdAt: new Date("2024-01-01T00:00:00Z").toISOString(),
 };
 
+const mockAgentListResponse = {
+  ok: true,
+  data: { agents: [mockAgent], limit: 100, offset: 0 },
+};
+
 const mockPolicy: PolicyRule = {
   id: "rule-1",
   type: "spending-limit",
@@ -258,7 +263,7 @@ describe("StewardClient construction", () => {
   });
 
   it("strips trailing slash from baseUrl", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
+    installMockFetch(mockAgentListResponse);
     const client = new StewardClient({ baseUrl: "https://api.example.com///" });
     await client.listAgents();
     expect(lastCapture?.url).not.toContain("///agents");
@@ -880,26 +885,26 @@ describe("StewardClient webhooks", () => {
 
 describe("Request headers", () => {
   it("always sends Content-Type: application/json", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
+    installMockFetch(mockAgentListResponse);
     await makeClient().listAgents();
     expect(lastCapture?.headers["content-type"]).toBe("application/json");
   });
 
   it("always sends Accept: application/json", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
+    installMockFetch(mockAgentListResponse);
     await makeClient().listAgents();
     expect(lastCapture?.headers.accept).toBe("application/json");
   });
 
   it("sends X-Steward-Key header when apiKey is set", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
+    installMockFetch(mockAgentListResponse);
     const client = makeClient({ apiKey: "my-secret-key" });
     await client.listAgents();
     expect(lastCapture?.headers["x-steward-key"]).toBe("my-secret-key");
   });
 
   it("sends Privy-style app secret Basic auth when app credentials are set", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
+    installMockFetch(mockAgentListResponse);
     const client = makeClient({ appId: "tenant-1/web-prod", appSecret: "stw_app_secret" });
     await client.listAgents();
     expect(lastCapture?.headers["x-steward-app-id"]).toBe("tenant-1/web-prod");
@@ -909,14 +914,14 @@ describe("Request headers", () => {
   });
 
   it("sends Authorization: Bearer header when bearerToken is set", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
+    installMockFetch(mockAgentListResponse);
     const client = makeClient({ bearerToken: "my-jwt-token" });
     await client.listAgents();
     expect(lastCapture?.headers.authorization).toBe("Bearer my-jwt-token");
   });
 
   it("bearerToken takes priority over apiKey when both are set", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
+    installMockFetch(mockAgentListResponse);
     const client = makeClient({
       apiKey: "my-api-key",
       bearerToken: "my-bearer",
@@ -928,7 +933,7 @@ describe("Request headers", () => {
   });
 
   it("sends X-Steward-Tenant header when tenantId is set", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
+    installMockFetch(mockAgentListResponse);
     const client = makeClient({ tenantId: "my-tenant-123" });
     await client.listAgents();
     expect(lastCapture?.headers["x-steward-tenant"]).toBe("my-tenant-123");
@@ -944,7 +949,7 @@ describe("Request headers", () => {
   });
 
   it("does not send auth header when neither apiKey nor bearerToken is set", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
+    installMockFetch(mockAgentListResponse);
     await makeClient().listAgents();
     expect(lastCapture?.headers.authorization).toBeUndefined();
     expect(lastCapture?.headers["x-steward-key"]).toBeUndefined();
@@ -1036,7 +1041,7 @@ describe("Request headers", () => {
   });
 
   it("does not sign non-sensitive requests", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
+    installMockFetch(mockAgentListResponse);
     const client = makeClient({
       requestSigningSecret: "request-signing-secret",
     });
@@ -1072,13 +1077,13 @@ describe("Request headers", () => {
 
 describe("HTTP request building", () => {
   it("refuses redirects so Steward credentials cannot be replayed", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
+    installMockFetch(mockAgentListResponse);
     await makeClient({ apiKey: "tenant-key" }).listAgents();
     expect(lastCapture?.redirect).toBe("error");
   });
 
   it("listAgents → GET /agents", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
+    installMockFetch(mockAgentListResponse);
     await makeClient().listAgents();
     expect(lastCapture?.method).toBe("GET");
     expect(lastCapture?.url).toBe("https://api.steward.example/agents");
@@ -4845,15 +4850,20 @@ describe("Error handling", () => {
 
 describe("Response parsing", () => {
   it("listAgents returns parsed agent array", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
+    installMockFetch({ ok: true, data: { agents: [mockAgent], limit: 100, offset: 0 } });
     const agents = await makeClient().listAgents();
     expect(agents).toHaveLength(1);
     expect(agents[0].id).toBe("agent-1");
     expect(agents[0].name).toBe("Test Agent");
   });
 
-  it("listAgents parses createdAt as Date object", async () => {
+  it("listAgents rejects the obsolete array envelope", async () => {
     installMockFetch({ ok: true, data: [mockAgent] });
+    await expect(makeClient().listAgents()).rejects.toThrow();
+  });
+
+  it("listAgents parses createdAt as Date object", async () => {
+    installMockFetch({ ok: true, data: { agents: [mockAgent], limit: 100, offset: 0 } });
     const agents = await makeClient().listAgents();
     // parseAgentIdentity converts createdAt string to Date
     expect(agents[0].createdAt).toBeInstanceOf(Date);

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -4869,6 +4869,37 @@ describe("Response parsing", () => {
     expect(agents[0].createdAt).toBeInstanceOf(Date);
   });
 
+  it("listAgents exhausts every canonical page", async () => {
+    let calls = 0;
+    global.fetch = async (input) => {
+      const url = String(input);
+      calls += 1;
+      const page =
+        calls === 1
+          ? Array.from({ length: 100 }, (_, index) => ({
+              ...mockAgent,
+              id: `agent-${index}`,
+            }))
+          : [{ ...mockAgent, id: "agent-100" }];
+      expect(url).toBe(
+        calls === 1
+          ? "https://api.steward.example/agents"
+          : "https://api.steward.example/agents?limit=100&offset=100",
+      );
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          data: { agents: page, limit: 100, offset: calls === 1 ? 0 : 100 },
+        }),
+        { headers: { "content-type": "application/json" } },
+      );
+    };
+
+    const agents = await makeClient().listAgents();
+    expect(agents).toHaveLength(101);
+    expect(calls).toBe(2);
+  });
+
   it("getAgent returns single agent", async () => {
     installMockFetch({ ok: true, data: mockAgent });
     const agent = await makeClient().getAgent("agent-1");

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2388,16 +2388,36 @@ export class StewardClient {
   }
 
   async listAgents(): Promise<AgentIdentity[]> {
-    const response = await this.request<
-      { agents: AgentIdentity[]; limit: number; offset: number },
-      StewardErrorResponse
-    >("/agents");
+    const agents: AgentIdentity[] = [];
+    let offset = 0;
+    let firstPage = true;
 
-    if (!response.ok) {
-      throw new StewardApiError(response.error, response.status, response.data);
+    while (offset <= 100_000) {
+      const response = await this.request<
+        { agents: AgentIdentity[]; limit: number; offset: number },
+        StewardErrorResponse
+      >(firstPage ? "/agents" : `/agents?limit=100&offset=${offset}`);
+
+      if (!response.ok) {
+        throw new StewardApiError(response.error, response.status, response.data);
+      }
+      if (
+        !Array.isArray(response.data?.agents) ||
+        !Number.isSafeInteger(response.data.limit) ||
+        response.data.limit < 1 ||
+        response.data.limit > 200 ||
+        response.data.offset !== offset
+      ) {
+        throw new Error("Invalid paginated agent-list response");
+      }
+
+      agents.push(...response.data.agents.map(parseAgentIdentity));
+      if (response.data.agents.length < response.data.limit) break;
+      offset += response.data.limit;
+      firstPage = false;
     }
 
-    return response.data.agents.map(parseAgentIdentity);
+    return agents;
   }
 
   /**

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2388,13 +2388,16 @@ export class StewardClient {
   }
 
   async listAgents(): Promise<AgentIdentity[]> {
-    const response = await this.request<AgentIdentity[], StewardErrorResponse>("/agents");
+    const response = await this.request<
+      { agents: AgentIdentity[]; limit: number; offset: number },
+      StewardErrorResponse
+    >("/agents");
 
     if (!response.ok) {
       throw new StewardApiError(response.error, response.status, response.data);
     }
 
-    return response.data.map(parseAgentIdentity);
+    return response.data.agents.map(parseAgentIdentity);
   }
 
   /**

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -26,7 +26,7 @@ import type {
 } from "@stwd/shared";
 import { canonicalJsonStringify, toCaip2 } from "@stwd/shared";
 import bs58 from "bs58";
-import { and, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
 import {
   type Chain,
   createPublicClient,
@@ -1437,6 +1437,7 @@ export class Vault {
       .select()
       .from(agents)
       .where(eq(agents.tenantId, tenantId))
+      .orderBy(asc(agents.id))
       .limit(limit)
       .offset(offset);
     if (rows.length === 0) return [];

--- a/web/e2e/account-page.spec.ts
+++ b/web/e2e/account-page.spec.ts
@@ -819,7 +819,9 @@ test.describe("Dashboard account management", () => {
       });
     });
     await page.route(/\/agents$/, async (route) => {
-      await route.fulfill({ json: { ok: true, data: agents } });
+      await route.fulfill({
+        json: { ok: true, data: { agents, limit: 100, offset: 0 } },
+      });
     });
 
     await loginWithMagicLink(page, request, email);

--- a/web/e2e/audit-log-page.spec.ts
+++ b/web/e2e/audit-log-page.spec.ts
@@ -78,22 +78,26 @@ test.describe("Dashboard audit log", () => {
         await route.fulfill({
           json: {
             ok: true,
-            data: [
-              {
-                id: "agent-risk-review",
-                tenantId: "personal-test",
-                name: "Risk Review Agent",
-                walletAddress: "0x1111111111111111111111111111111111111111",
-                createdAt: "2026-06-04T13:00:00.000Z",
-              },
-              {
-                id: "agent-support",
-                tenantId: "personal-test",
-                name: "Support Agent",
-                walletAddress: "0x2222222222222222222222222222222222222222",
-                createdAt: "2026-06-04T13:05:00.000Z",
-              },
-            ],
+            data: {
+              agents: [
+                {
+                  id: "agent-risk-review",
+                  tenantId: "personal-test",
+                  name: "Risk Review Agent",
+                  walletAddress: "0x1111111111111111111111111111111111111111",
+                  createdAt: "2026-06-04T13:00:00.000Z",
+                },
+                {
+                  id: "agent-support",
+                  tenantId: "personal-test",
+                  name: "Support Agent",
+                  walletAddress: "0x2222222222222222222222222222222222222222",
+                  createdAt: "2026-06-04T13:05:00.000Z",
+                },
+              ],
+              limit: 100,
+              offset: 0,
+            },
           },
         });
       },

--- a/web/e2e/transaction-history-partial-failure.spec.ts
+++ b/web/e2e/transaction-history-partial-failure.spec.ts
@@ -105,10 +105,14 @@ test("dashboard surfaces partial transaction history without discarding availabl
       await route.fulfill({
         json: {
           ok: true,
-          data: [
-            { id: "agent-available", name: "Available Agent" },
-            { id: "agent-unavailable", name: "Unavailable Agent" },
-          ],
+          data: {
+            agents: [
+              { id: "agent-available", name: "Available Agent" },
+              { id: "agent-unavailable", name: "Unavailable Agent" },
+            ],
+            limit: 100,
+            offset: 0,
+          },
         },
       });
     },


### PR DESCRIPTION
## Scope

Fixes #685.

The API deliberately returns bounded `GET /agents` pages as `{ agents, limit, offset }`, while the SDK still treated `data` as a bare array. Real dashboard calls therefore threw even though independent route and SDK mocks passed.

- parses only the canonical paginated response envelope; the obsolete array shape now fails instead of being silently accepted
- updates every SDK-owned `listAgents` mock to the real response contract
- updates the directly affected account, audit, and transaction-history browser fixtures to the canonical envelope

## Exact lineage and evidence

- current base at restack: `7b128ade83e0bb44b1e28be20f1e220156cef18e`
- current head: `bee53c1e04526c2d8e8c43acca0e3e7376822d95`
- SDK client suite: 142/142, 797 assertions
- API dependency build: 24/24
- SDK and production Next/web build: 4/4 tasks
- Biome on all five changed files: clean
- committed diff check: clean

The existing mounted API route contract explicitly asserts `{ data: { agents, limit, offset } }`; it requires the hosted PostgreSQL lane and skipped locally without `DATABASE_URL`.

## Follow-up ordering

#681 also changes the transaction-history fixture and assumes an all-agent view. Land this contract correction first, then restack #681 and make its pagination semantics explicit rather than restoring the obsolete mock.