### PR TITLE
test(api): isolate generic proxy rate limits

### DIFF
--- a/packages/api/src/__tests__/generic-http-public-boundary-e2e.test.ts
+++ b/packages/api/src/__tests__/generic-http-public-boundary-e2e.test.ts
@@ -165,6 +165,11 @@ describe.skipIf(!process.env.DATABASE_URL)("#201 generic-http true public-bounda
     const proxy = await import("@stwd/proxy/src/handlers/proxy");
     ({ dispatchGovernedExecution } = await import("@stwd/proxy/src/handlers/governed-execution"));
     proxy.__setResolveProxyHostForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
+    proxy.__setCheckProxyRateLimitForTests(async () => ({
+      allowed: true,
+      remaining: Number.POSITIVE_INFINITY,
+      resetMs: 0,
+    }));
     proxy.__setForwardProxyRequestForTests(async (url, method, headers, body) => {
       const bytes = body
         ? new Uint8Array(await new Response(body).arrayBuffer())
@@ -180,6 +185,8 @@ describe.skipIf(!process.env.DATABASE_URL)("#201 generic-http true public-bounda
   });
 
   afterAll(async () => {
+    const proxy = await import("@stwd/proxy/src/handlers/proxy");
+    proxy.__resetProxyHandlerTestHooksForTests();
     // Agent deletion is deliberately guarded while an enabled route can still
     // resolve its secret. Disable first, let the tenant cascade remove all
     // governed authority rows, then remove the non-FK route/secret records.


### PR DESCRIPTION
## Summary

- isolate the generic HTTP public-boundary E2E from Redis rate-limit state left by earlier tests or repeat runs
- keep the real governed dispatch, SSRF resolution, forwarding, approval, evidence, Postgres, and Redis paths intact
- restore every mutable proxy handler dependency after the fixture so the allow-all rate checker cannot leak

## Failure and proof

On reused Redis, the mounted lifecycle reached dispatch but returned upstream 429 (`EXEC_DISPATCH_UPSTREAM_ERROR`) instead of the stubbed success. After pinning only the unrelated rate limiter:

- real Postgres + Redis public-boundary lifecycle: 1/1, then 1/1 again against the same services
- public boundary plus provider-case purity: 3/3, 28 assertions
- API TypeScript build: pass
- repository Biome: 1,373 files clean
- CI inventory: all 47 test-bearing targets covered
- actionlint and committed diff check: clean

## Lineage

- base: `3559ac2108d118730ff99e0b8a2a9fdc55895706`
- head: `99f6e9e56`

Supersedes externally closed, unmerged #698. Draft until exact-head hosted checks and independent approval pass.
