### PR TITLE
fix(sdk): complete bounded agent pagination

### DIFF
--- a/docs/api-reference/agents.mdx
+++ b/docs/api-reference/agents.mdx
@@ -62,10 +62,11 @@ curl -X POST http://localhost:3200/agents \
 
 ## List Agents
 
-Returns all agents for the authenticated tenant.
+Returns a bounded page of agents for the authenticated tenant. The default
+limit is 100 and the maximum is 200.
 
 ```
-GET /agents
+GET /agents?limit=100&offset=0
 ```
 
 **Auth:** Tenant API key
@@ -75,25 +76,28 @@ GET /agents
 ```json
 {
   "ok": true,
-  "data": [
-    {
+  "data": {
+    "agents": [{
       "id": "my-agent",
       "name": "My Trading Agent",
       "tenantId": "your-tenant",
       "walletAddresses": { "evm": "0x742d...", "solana": "7xKXtg..." },
       "createdAt": "2026-03-26T12:00:00.000Z"
-    }
-  ]
+    }],
+    "limit": 100,
+    "offset": 0
+  }
 }
 ```
 
 <CodeGroup>
 ```typescript SDK
 const agents = await steward.listAgents();
+const page = await steward.listAgentsPage({ limit: 100, offset: 0 });
 ```
 
 ```bash cURL
-curl http://localhost:3200/agents \
+curl 'http://localhost:3200/agents?limit=100&offset=0' \
   -H "X-Steward-Key: your-key"
 ```
 </CodeGroup>

--- a/docs/sdk/client.mdx
+++ b/docs/sdk/client.mdx
@@ -45,10 +45,19 @@ const agent = await client.createWallet("my-agent", "My Agent");
 
 ### listAgents
 
-Lists all agents for the authenticated tenant.
+Lists all agents for the authenticated tenant. The SDK walks stable API pages
+at the maximum page size and fails closed on duplicate or non-progressing pages,
+while retaining the historical array return type.
 
 ```typescript
 const agents = await client.listAgents(): Promise<AgentIdentity[]>;
+```
+
+Use the canonical paginated result when the metadata is needed:
+
+```typescript
+const page = await client.listAgentsPage({ limit: 25, offset: 0 });
+// { agents: AgentIdentity[], limit: 25, offset: 0 }
 ```
 
 ### getAgent
@@ -304,7 +313,8 @@ const addresses = await client.getAddresses(
 
 ### getHistory
 
-Gets the transaction history for an agent.
+Gets the complete transaction history for an agent. The SDK walks every bounded
+API page before returning the historical array result.
 
 ```typescript
 const history = await client.getHistory(

--- a/packages/api/src/__tests__/agent-route-scope.test.ts
+++ b/packages/api/src/__tests__/agent-route-scope.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { generateApiKey, signAgentToken } from "@stwd/auth";
-import { agents, auditEvents, getDb, tenants, users, userTenants } from "@stwd/db";
+import { agents, auditEvents, getDb, tenants, transactions, users, userTenants } from "@stwd/db";
+import { StewardClient } from "@stwd/sdk";
 import { and, desc, eq } from "drizzle-orm";
 
 setDefaultTimeout(30000);
@@ -242,6 +243,78 @@ describeWithDatabase("agent route scope enforcement", () => {
     // assert containment rather than exact equality.
     expect(ids).toContain(AGENT_A);
     expect(ids).toContain(AGENT_B);
+  });
+
+  it("serves the canonical paginated response through the production SDK client", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      if (url.origin === "https://sdk-contract.steward.test") {
+        return app.request(`${url.pathname}${url.search}`, init);
+      }
+      return originalFetch(input, init);
+    };
+
+    try {
+      const client = new StewardClient({
+        baseUrl: "https://sdk-contract.steward.test",
+        apiKey,
+        tenantId: TENANT_ID,
+      });
+      const firstPage = await client.listAgentsPage({ limit: 1, offset: 0 });
+      const page = await client.listAgentsPage({ limit: 1, offset: 1 });
+
+      expect(firstPage.agents[0]?.id).toBe(AGENT_A);
+      expect(page.limit).toBe(1);
+      expect(page.offset).toBe(1);
+      expect(page.agents).toHaveLength(1);
+      expect(page.agents[0]?.id).toBe(AGENT_B);
+      expect(page.agents[0]?.createdAt).toBeInstanceOf(Date);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("orders equal-timestamp transaction history by id for stable offset pagination", async () => {
+    const createdAt = new Date("2026-08-20T12:00:00.000Z");
+    await getDb()
+      .insert(transactions)
+      .values([
+        {
+          id: "test-ars-history-a",
+          agentId: AGENT_A,
+          status: "pending",
+          toAddress: "0x1111111111111111111111111111111111111111",
+          value: "1",
+          chainId: 8453,
+          policyResults: [],
+          createdAt,
+        },
+        {
+          id: "test-ars-history-b",
+          agentId: AGENT_A,
+          status: "pending",
+          toAddress: "0x1111111111111111111111111111111111111111",
+          value: "1",
+          chainId: 8453,
+          policyResults: [],
+          createdAt,
+        },
+      ])
+      .onConflictDoNothing();
+
+    const fetchPage = async (offset: number) => {
+      const response = await app.request(`/vault/${AGENT_A}/history?limit=1&offset=${offset}`, {
+        headers: { Authorization: `Bearer ${ownerSessionToken}` },
+      });
+      expect(response.status).toBe(200);
+      return (await response.json()) as {
+        data: { transactions: Array<{ id: string }>; limit: number; offset: number };
+      };
+    };
+
+    expect((await fetchPage(0)).data.transactions[0]?.id).toBe("test-ars-history-b");
+    expect((await fetchPage(1)).data.transactions[0]?.id).toBe("test-ars-history-a");
   });
 
   it("rejects a bare tenant API key for agent-token minting unless explicitly opted in (SEC-209)", async () => {

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -5241,7 +5241,7 @@ vaultRoutes.get("/:agentId/history", async (c) => {
     .select()
     .from(transactions)
     .where(eq(transactions.agentId, agentId))
-    .orderBy(desc(transactions.createdAt))
+    .orderBy(desc(transactions.createdAt), desc(transactions.id))
     .limit(limit)
     .offset(offset);
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -96,10 +96,22 @@ getAgent(agentId: string): Promise<AgentIdentity>
 
 ### `listAgents`
 
-List all agents for the authenticated tenant.
+List all agents for the authenticated tenant. The SDK walks stable API pages at
+the maximum page size and fails closed on duplicate or non-progressing pages,
+while retaining the historical array return type.
 
 ```typescript
 listAgents(): Promise<AgentIdentity[]>
+```
+
+Use `listAgentsPage()` when pagination metadata is needed:
+
+```typescript
+listAgentsPage(options?: { limit?: number; offset?: number }): Promise<{
+  agents: AgentIdentity[];
+  limit: number;
+  offset: number;
+}>
 ```
 
 ---
@@ -264,7 +276,8 @@ const bscBalance = await steward.getBalance('scout-1', 56);
 
 ### `getHistory`
 
-Retrieve signing history for an agent.
+Retrieve complete signing history for an agent. The SDK walks every bounded API
+page before returning the historical array result.
 
 ```typescript
 getHistory(agentId: string): Promise<StewardHistoryEntry[]>

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -193,11 +193,6 @@ const mockAgent = {
   createdAt: new Date("2024-01-01T00:00:00Z").toISOString(),
 };
 
-const mockAgentListResponse = {
-  ok: true,
-  data: { agents: [mockAgent], limit: 100, offset: 0 },
-};
-
 const mockPolicy: PolicyRule = {
   id: "rule-1",
   type: "spending-limit",
@@ -263,11 +258,11 @@ describe("StewardClient construction", () => {
   });
 
   it("strips trailing slash from baseUrl", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     const client = new StewardClient({ baseUrl: "https://api.example.com///" });
     await client.listAgents();
     expect(lastCapture?.url).not.toContain("///agents");
-    expect(lastCapture?.url).toMatch(/\/agents$/);
+    expect(new URL(lastCapture!.url).pathname).toBe("/agents");
   });
 
   it("creates a client with all config options", () => {
@@ -885,26 +880,26 @@ describe("StewardClient webhooks", () => {
 
 describe("Request headers", () => {
   it("always sends Content-Type: application/json", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     await makeClient().listAgents();
     expect(lastCapture?.headers["content-type"]).toBe("application/json");
   });
 
   it("always sends Accept: application/json", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     await makeClient().listAgents();
     expect(lastCapture?.headers.accept).toBe("application/json");
   });
 
   it("sends X-Steward-Key header when apiKey is set", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     const client = makeClient({ apiKey: "my-secret-key" });
     await client.listAgents();
     expect(lastCapture?.headers["x-steward-key"]).toBe("my-secret-key");
   });
 
   it("sends Privy-style app secret Basic auth when app credentials are set", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     const client = makeClient({ appId: "tenant-1/web-prod", appSecret: "stw_app_secret" });
     await client.listAgents();
     expect(lastCapture?.headers["x-steward-app-id"]).toBe("tenant-1/web-prod");
@@ -914,14 +909,14 @@ describe("Request headers", () => {
   });
 
   it("sends Authorization: Bearer header when bearerToken is set", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     const client = makeClient({ bearerToken: "my-jwt-token" });
     await client.listAgents();
     expect(lastCapture?.headers.authorization).toBe("Bearer my-jwt-token");
   });
 
   it("bearerToken takes priority over apiKey when both are set", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     const client = makeClient({
       apiKey: "my-api-key",
       bearerToken: "my-bearer",
@@ -933,7 +928,7 @@ describe("Request headers", () => {
   });
 
   it("sends X-Steward-Tenant header when tenantId is set", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     const client = makeClient({ tenantId: "my-tenant-123" });
     await client.listAgents();
     expect(lastCapture?.headers["x-steward-tenant"]).toBe("my-tenant-123");
@@ -949,7 +944,7 @@ describe("Request headers", () => {
   });
 
   it("does not send auth header when neither apiKey nor bearerToken is set", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     await makeClient().listAgents();
     expect(lastCapture?.headers.authorization).toBeUndefined();
     expect(lastCapture?.headers["x-steward-key"]).toBeUndefined();
@@ -1041,7 +1036,7 @@ describe("Request headers", () => {
   });
 
   it("does not sign non-sensitive requests", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     const client = makeClient({
       requestSigningSecret: "request-signing-secret",
     });
@@ -1077,16 +1072,16 @@ describe("Request headers", () => {
 
 describe("HTTP request building", () => {
   it("refuses redirects so Steward credentials cannot be replayed", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     await makeClient({ apiKey: "tenant-key" }).listAgents();
     expect(lastCapture?.redirect).toBe("error");
   });
 
   it("listAgents → GET /agents", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     await makeClient().listAgents();
     expect(lastCapture?.method).toBe("GET");
-    expect(lastCapture?.url).toBe("https://api.steward.example/agents");
+    expect(lastCapture?.url).toBe("https://api.steward.example/agents?limit=200&offset=0");
   });
 
   it("getAgent → GET /agents/:id", async () => {
@@ -3981,7 +3976,9 @@ describe("HTTP request building", () => {
     installMockFetch({ ok: true, data: [] });
     await makeClient().getHistory("agent-1");
     expect(lastCapture?.method).toBe("GET");
-    expect(lastCapture?.url).toBe("https://api.steward.example/vault/agent-1/history");
+    expect(lastCapture?.url).toBe(
+      "https://api.steward.example/vault/agent-1/history?limit=200&offset=0",
+    );
   });
 
   it("listTransactions and getTransaction use first-class transaction endpoints", async () => {
@@ -4849,55 +4846,136 @@ describe("Error handling", () => {
 // ─── Response Parsing Tests ───────────────────────────────────────────────
 
 describe("Response parsing", () => {
-  it("listAgents returns parsed agent array", async () => {
-    installMockFetch({ ok: true, data: { agents: [mockAgent], limit: 100, offset: 0 } });
+  it("listAgents consumes the canonical paginated response and returns parsed agents", async () => {
+    installMockFetch({
+      ok: true,
+      data: { agents: [mockAgent], limit: 25, offset: 0 },
+    });
     const agents = await makeClient().listAgents();
     expect(agents).toHaveLength(1);
     expect(agents[0].id).toBe("agent-1");
     expect(agents[0].name).toBe("Test Agent");
   });
 
-  it("listAgents rejects the obsolete array envelope", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
-    await expect(makeClient().listAgents()).rejects.toThrow();
-  });
-
   it("listAgents parses createdAt as Date object", async () => {
-    installMockFetch({ ok: true, data: { agents: [mockAgent], limit: 100, offset: 0 } });
+    installMockFetch({
+      ok: true,
+      data: { agents: [mockAgent], limit: 100, offset: 0 },
+    });
     const agents = await makeClient().listAgents();
     // parseAgentIdentity converts createdAt string to Date
     expect(agents[0].createdAt).toBeInstanceOf(Date);
   });
 
-  it("listAgents exhausts every canonical page", async () => {
-    let calls = 0;
-    global.fetch = async (input) => {
-      const url = String(input);
-      calls += 1;
-      const page =
-        calls === 1
-          ? Array.from({ length: 100 }, (_, index) => ({
-              ...mockAgent,
-              id: `agent-${index}`,
-            }))
-          : [{ ...mockAgent, id: "agent-100" }];
-      expect(url).toBe(
-        calls === 1
-          ? "https://api.steward.example/agents"
-          : "https://api.steward.example/agents?limit=100&offset=100",
-      );
+  it("listAgentsPage preserves canonical pagination metadata and sends page parameters", async () => {
+    installMockFetch({
+      ok: true,
+      data: { agents: [mockAgent], limit: 10, offset: 20 },
+    });
+
+    const page = await makeClient().listAgentsPage({ limit: 10, offset: 20 });
+
+    expect(lastCapture?.url).toBe("https://api.steward.example/agents?limit=10&offset=20");
+    expect(page.limit).toBe(10);
+    expect(page.offset).toBe(20);
+    expect(page.agents[0]?.createdAt).toBeInstanceOf(Date);
+  });
+
+  it("listAgents walks every canonical page before returning the historical array shape", async () => {
+    const requestedUrls: string[] = [];
+    global.fetch = async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      requestedUrls.push(url);
+      const offset = Number(new URL(url).searchParams.get("offset") ?? "0");
+      const pageAgents =
+        offset === 0
+          ? [mockAgent, { ...mockAgent, id: "agent-2" }]
+          : [{ ...mockAgent, id: "agent-3" }];
       return new Response(
         JSON.stringify({
           ok: true,
-          data: { agents: page, limit: 100, offset: calls === 1 ? 0 : 100 },
+          data: { agents: pageAgents, limit: 2, offset },
         }),
-        { headers: { "content-type": "application/json" } },
+        { status: 200, headers: { "Content-Type": "application/json" } },
       );
     };
 
     const agents = await makeClient().listAgents();
-    expect(agents).toHaveLength(101);
-    expect(calls).toBe(2);
+
+    expect(requestedUrls).toEqual([
+      "https://api.steward.example/agents?limit=200&offset=0",
+      "https://api.steward.example/agents?limit=200&offset=2",
+    ]);
+    expect(agents.map((agent) => agent.id)).toEqual(["agent-1", "agent-2", "agent-3"]);
+  });
+
+  it("listAgents fails closed on repeated agents across pages", async () => {
+    global.fetch = async (input: RequestInfo | URL) => {
+      const url = new URL(
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+      );
+      const offset = Number(url.searchParams.get("offset"));
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          data: {
+            agents: offset === 0 ? [mockAgent, { ...mockAgent, id: "agent-2" }] : [mockAgent],
+            limit: 2,
+            offset,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+
+    await expect(makeClient().listAgents()).rejects.toThrow("Duplicate agent");
+  });
+
+  it("getTransactionHistory walks every canonical page", async () => {
+    const requestedUrls: string[] = [];
+    const tx = (id: string) => ({
+      id,
+      agentId: "agent-1",
+      status: "pending",
+      request: {
+        agentId: "agent-1",
+        tenantId: "tenant-1",
+        to: "0x1111111111111111111111111111111111111111",
+        value: "1",
+        chainId: 8453,
+      },
+      policyResults: [],
+      createdAt: "2026-08-20T00:00:00.000Z",
+    });
+    global.fetch = async (input: RequestInfo | URL) => {
+      const url = new URL(
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+      );
+      requestedUrls.push(url.toString());
+      const offset = Number(url.searchParams.get("offset"));
+      const transactions = offset === 0 ? [tx("tx-1"), tx("tx-2")] : [tx("tx-3")];
+      return new Response(JSON.stringify({ ok: true, data: { transactions, limit: 2, offset } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    const transactions = await makeClient().getTransactionHistory("agent-1");
+    expect(requestedUrls).toEqual([
+      "https://api.steward.example/vault/agent-1/history?limit=200&offset=0",
+      "https://api.steward.example/vault/agent-1/history?limit=200&offset=2",
+    ]);
+    expect(transactions.map((transaction) => transaction.id)).toEqual(["tx-1", "tx-2", "tx-3"]);
+  });
+
+  it("listAgents retains compatibility with legacy bare-array responses", async () => {
+    installMockFetch({ ok: true, data: [mockAgent] });
+
+    const page = await makeClient().listAgentsPage();
+
+    expect(page).toMatchObject({ limit: 1, offset: 0 });
+    expect(page.agents[0]?.id).toBe("agent-1");
   });
 
   it("getAgent returns single agent", async () => {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -156,6 +156,30 @@ export interface BatchCreateResult {
   errors: Array<{ id: string; error: string }>;
 }
 
+export interface AgentListOptions {
+  limit?: number;
+  offset?: number;
+}
+
+export interface AgentListResult {
+  agents: AgentIdentity[];
+  limit: number;
+  offset: number;
+}
+
+type DecodedAgentListResult = {
+  result: AgentListResult;
+  legacyArray: boolean;
+};
+
+type DecodedTransactionListResult = {
+  result: TransactionListResult;
+  legacyArray: boolean;
+};
+
+const MAX_LIST_PAGE_SIZE = 200;
+const MAX_LIST_OFFSET = 100_000;
+
 export interface WalletBatchSpec {
   /** Client-side reference id used only for partial-failure reporting. */
   id: string;
@@ -2387,37 +2411,100 @@ export class StewardClient {
     return parseAgentIdentity(response.data);
   }
 
+  /**
+   * List all agents for backwards compatibility, walking every canonical API page.
+   * Use {@link listAgentsPage} when explicit pagination metadata is needed.
+   */
   async listAgents(): Promise<AgentIdentity[]> {
     const agents: AgentIdentity[] = [];
-    let offset = 0;
-    let firstPage = true;
+    const seenAgentIds = new Set<string>();
+    let requestedOffset = 0;
 
-    while (offset <= 100_000) {
-      const response = await this.request<
-        { agents: AgentIdentity[]; limit: number; offset: number },
-        StewardErrorResponse
-      >(firstPage ? "/agents" : `/agents?limit=100&offset=${offset}`);
-
-      if (!response.ok) {
-        throw new StewardApiError(response.error, response.status, response.data);
+    while (true) {
+      const decoded = await this.requestAgentListPage({
+        limit: MAX_LIST_PAGE_SIZE,
+        offset: requestedOffset,
+      });
+      const page = decoded.result;
+      if (!decoded.legacyArray && page.offset !== requestedOffset) {
+        throw new StewardApiError("Invalid agent list pagination response", 0, page);
       }
+      for (const agent of page.agents) {
+        if (seenAgentIds.has(agent.id)) {
+          throw new StewardApiError("Duplicate agent in paginated response", 0, page);
+        }
+        seenAgentIds.add(agent.id);
+        agents.push(agent);
+      }
+
+      if (decoded.legacyArray || page.agents.length === 0 || page.agents.length < page.limit) {
+        return agents;
+      }
+
+      const nextOffset = page.offset + page.agents.length;
       if (
-        !Array.isArray(response.data?.agents) ||
-        !Number.isSafeInteger(response.data.limit) ||
-        response.data.limit < 1 ||
-        response.data.limit > 200 ||
-        response.data.offset !== offset
+        !Number.isSafeInteger(nextOffset) ||
+        nextOffset <= requestedOffset ||
+        nextOffset > MAX_LIST_OFFSET
       ) {
-        throw new Error("Invalid paginated agent-list response");
+        throw new StewardApiError("Invalid agent list pagination response", 0, page);
       }
+      requestedOffset = nextOffset;
+    }
+  }
 
-      agents.push(...response.data.agents.map(parseAgentIdentity));
-      if (response.data.agents.length < response.data.limit) break;
-      offset += response.data.limit;
-      firstPage = false;
+  /** List one page of agents with the canonical API pagination metadata. */
+  async listAgentsPage(options: AgentListOptions = {}): Promise<AgentListResult> {
+    return (await this.requestAgentListPage(options)).result;
+  }
+
+  private async requestAgentListPage(options: AgentListOptions): Promise<DecodedAgentListResult> {
+    const params = new URLSearchParams();
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    if (options.offset !== undefined) params.set("offset", String(options.offset));
+    const query = params.toString();
+    const response = await this.request<AgentIdentity[] | AgentListResult, StewardErrorResponse>(
+      `/agents${query ? `?${query}` : ""}`,
+    );
+
+    if (!response.ok) {
+      throw new StewardApiError(response.error, response.status, response.data);
     }
 
-    return agents;
+    // Steward versions before agent-list pagination returned a bare array.
+    // Keep that response compatibility narrow and expose truthful synthetic
+    // metadata rather than requiring downstream consumers to branch on shape.
+    if (Array.isArray(response.data)) {
+      return {
+        result: {
+          agents: response.data.map(parseAgentIdentity),
+          limit: response.data.length,
+          offset: 0,
+        },
+        legacyArray: true,
+      };
+    }
+
+    if (
+      !Array.isArray(response.data.agents) ||
+      !Number.isSafeInteger(response.data.limit) ||
+      response.data.limit < 1 ||
+      response.data.limit > MAX_LIST_PAGE_SIZE ||
+      response.data.agents.length > response.data.limit ||
+      !Number.isSafeInteger(response.data.offset) ||
+      response.data.offset < 0 ||
+      response.data.offset > MAX_LIST_OFFSET
+    ) {
+      throw new StewardApiError("Invalid agent list response", 0, response.data);
+    }
+
+    return {
+      result: {
+        ...response.data,
+        agents: response.data.agents.map(parseAgentIdentity),
+      },
+      legacyArray: false,
+    };
   }
 
   /**
@@ -2443,16 +2530,82 @@ export class StewardClient {
    * original sign request.
    */
   async getTransactionHistory(agentId: string): Promise<TxRecord[]> {
-    const response = await this.request<TxRecord[] | TransactionListResult, StewardErrorResponse>(
-      `/vault/${encodeURIComponent(agentId)}/history`,
-    );
+    const records: TxRecord[] = [];
+    const seenTransactionIds = new Set<string>();
+    let requestedOffset = 0;
 
+    while (true) {
+      const decoded = await this.requestTransactionHistoryPage(agentId, requestedOffset);
+      const page = decoded.result;
+      if (!decoded.legacyArray && page.offset !== requestedOffset) {
+        throw new StewardApiError("Invalid transaction history pagination response", 0, page);
+      }
+      for (const transaction of page.transactions) {
+        if (seenTransactionIds.has(transaction.id)) {
+          throw new StewardApiError("Duplicate transaction in paginated history", 0, page);
+        }
+        seenTransactionIds.add(transaction.id);
+        records.push(transaction);
+      }
+      if (
+        decoded.legacyArray ||
+        page.transactions.length === 0 ||
+        page.transactions.length < page.limit
+      ) {
+        return records;
+      }
+
+      const nextOffset = page.offset + page.transactions.length;
+      if (
+        !Number.isSafeInteger(nextOffset) ||
+        nextOffset <= requestedOffset ||
+        nextOffset > MAX_LIST_OFFSET
+      ) {
+        throw new StewardApiError("Invalid transaction history pagination response", 0, page);
+      }
+      requestedOffset = nextOffset;
+    }
+  }
+
+  private async requestTransactionHistoryPage(
+    agentId: string,
+    offset: number,
+  ): Promise<DecodedTransactionListResult> {
+    const response = await this.request<TxRecord[] | TransactionListResult, StewardErrorResponse>(
+      `/vault/${encodeURIComponent(agentId)}/history?limit=${MAX_LIST_PAGE_SIZE}&offset=${offset}`,
+    );
     if (!response.ok) {
       throw new StewardApiError(response.error, response.status, response.data);
     }
-
-    const records = Array.isArray(response.data) ? response.data : response.data.transactions;
-    return records.map(parseTxRecord);
+    if (Array.isArray(response.data)) {
+      return {
+        result: {
+          transactions: response.data.map(parseTxRecord),
+          limit: response.data.length,
+          offset: 0,
+        },
+        legacyArray: true,
+      };
+    }
+    if (
+      !Array.isArray(response.data.transactions) ||
+      !Number.isSafeInteger(response.data.limit) ||
+      response.data.limit < 1 ||
+      response.data.limit > MAX_LIST_PAGE_SIZE ||
+      response.data.transactions.length > response.data.limit ||
+      !Number.isSafeInteger(response.data.offset) ||
+      response.data.offset < 0 ||
+      response.data.offset > MAX_LIST_OFFSET
+    ) {
+      throw new StewardApiError("Invalid transaction history response", 0, response.data);
+    }
+    return {
+      result: {
+        ...response.data,
+        transactions: response.data.transactions.map(parseTxRecord),
+      },
+      legacyArray: false,
+    };
   }
 
   async listTransactions(

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -70,6 +70,8 @@ export type {
   AdapterRegistryDescription,
   AdapterTokenRef,
   AdapterUnsignedIntent,
+  AgentListOptions,
+  AgentListResult,
   AgentPolicyRuleCreate,
   AgentPolicyRuleUpdate,
   BatchAgentSpec,

--- a/web/e2e/account-page.spec.ts
+++ b/web/e2e/account-page.spec.ts
@@ -359,7 +359,9 @@ test.describe("Dashboard account management", () => {
       });
     });
     await page.route(/\/agents$/, async (route) => {
-      await route.fulfill({ json: { ok: true, data: [] } });
+      await route.fulfill({
+        json: { ok: true, data: { agents: [], limit: 100, offset: 0 } },
+      });
     });
     await page.route(/\/user\/me\/wallet\/signers(\?.*)?$/, async (route) => {
       await route.fulfill({ json: { ok: true, data: { signers: [] } } });
@@ -548,7 +550,9 @@ test.describe("Dashboard account management", () => {
       });
     });
     await page.route(/\/agents$/, async (route) => {
-      await route.fulfill({ json: { ok: true, data: [] } });
+      await route.fulfill({
+        json: { ok: true, data: { agents: [], limit: 100, offset: 0 } },
+      });
     });
     await page.route(/\/user\/me\/wallet\/signers\/[^/?]+(\?.*)?$/, async (route) => {
       revokeUrl = route.request().url();

--- a/web/e2e/audit-log-page.spec.ts
+++ b/web/e2e/audit-log-page.spec.ts
@@ -70,8 +70,6 @@ test.describe("Dashboard audit log", () => {
       },
     ];
 
-    await loginWithMagicLink(page, request, email);
-
     await page.route(
       (url) => isApiRequest(url.href) && url.pathname === "/agents",
       async (route) => {
@@ -158,6 +156,8 @@ test.describe("Dashboard audit log", () => {
         });
       },
     );
+
+    await loginWithMagicLink(page, request, email);
 
     await page.goto(`${WEB}/dashboard/audit`);
 

--- a/web/e2e/policies-condition-sets.spec.ts
+++ b/web/e2e/policies-condition-sets.spec.ts
@@ -82,7 +82,9 @@ test.describe("Dashboard condition sets", () => {
     await page.route(
       (url) => url.href.startsWith(API) && /\/agents$/.test(url.pathname),
       async (route) => {
-        await route.fulfill({ json: { ok: true, data: [] } });
+        await route.fulfill({
+          json: { ok: true, data: { agents: [], limit: 100, offset: 0 } },
+        });
       },
     );
     await page.route(

--- a/web/e2e/transaction-history-partial-failure.spec.ts
+++ b/web/e2e/transaction-history-partial-failure.spec.ts
@@ -159,43 +159,90 @@ test("dashboard surfaces partial transaction history without discarding availabl
   await expect(page.getByRole("button", { name: "All1" })).toBeVisible();
 });
 
-test("overview pending counts include agents beyond the former twenty-agent sample", async ({
-  page,
-  request,
-}) => {
-  const agents = Array.from({ length: 21 }, (_, index) => ({
-    id: `agent-${index + 1}`,
-    name: `Agent ${index + 1}`,
-  }));
-
-  await page.route(
-    (url) => url.href.startsWith(API) && url.pathname === "/agents",
-    (route) => route.fulfill({ json: { ok: true, data: agents } }),
-  );
-  await page.route(
-    (url) => url.href.startsWith(API) && /^\/vault\/agent-\d+\/history$/.test(url.pathname),
-    async (route) => {
-      const agentId = new URL(route.request().url()).pathname.split("/")[2];
-      await route.fulfill({
-        json: {
-          ok: true,
-          data: agentId === "agent-21" ? [transaction("tx-agent-21", agentId)] : [],
-        },
-      });
-    },
-  );
-
-  await loginWithMagicLink(page, request, `complete-history-${Date.now()}@example.test`);
-  await page.goto(`${WEB}/dashboard`);
-  const pendingStat = page.getByText("Pending Approvals").locator("..");
-  await expect(pendingStat).toContainText("1");
-  await expect(page.getByRole("link", { name: "Agent 21" })).toBeVisible();
-});
-
 for (const surface of [
   { name: "overview", path: "/dashboard" },
   { name: "transactions", path: "/dashboard/transactions" },
 ] as const) {
+  test(`${surface.name} includes agent and history page-two sentinels in pending counts`, async ({
+    page,
+    request,
+  }) => {
+    const agents = Array.from({ length: 201 }, (_, index) => ({
+      id: `agent-${index + 1}`,
+      name: `Agent ${index + 1}`,
+    }));
+    const agentOffsets: number[] = [];
+    const sentinelHistoryOffsets: number[] = [];
+
+    await page.route(
+      (url) => url.href.startsWith(API) && url.pathname === "/agents",
+      async (route) => {
+        const offset = Number(new URL(route.request().url()).searchParams.get("offset"));
+        agentOffsets.push(offset);
+        await route.fulfill({
+          json: {
+            ok: true,
+            data: { agents: agents.slice(offset, offset + 200), limit: 200, offset },
+          },
+        });
+      },
+    );
+    await page.route(
+      (url) => url.href.startsWith(API) && /^\/vault\/agent-\d+\/history$/.test(url.pathname),
+      async (route) => {
+        const url = new URL(route.request().url());
+        const agentId = url.pathname.split("/")[2];
+        const offset = Number(url.searchParams.get("offset"));
+        if (agentId !== "agent-201") {
+          await route.fulfill({
+            json: { ok: true, data: { transactions: [], limit: 200, offset } },
+          });
+          return;
+        }
+        sentinelHistoryOffsets.push(offset);
+        const transactions =
+          offset === 0
+            ? Array.from({ length: 200 }, (_, index) => ({
+                ...transaction(`sentinel-confirmed-${index}`, agentId),
+                status: "confirmed",
+              }))
+            : [
+                {
+                  ...transaction("sentinel-pending", agentId),
+                  createdAt: "2026-08-21T12:00:00.000Z",
+                },
+              ];
+        await route.fulfill({
+          json: { ok: true, data: { transactions, limit: 200, offset } },
+        });
+      },
+    );
+
+    await loginWithMagicLink(
+      page,
+      request,
+      `complete-history-${surface.name}-${Date.now()}@example.test`,
+    );
+    await page.goto(`${WEB}${surface.path}`);
+    await expect(page.getByRole("link", { name: "Agent 201" }).first()).toBeVisible();
+    if (surface.name === "overview") {
+      await expect(page.getByText("Pending Approvals").locator("..")).toContainText("1");
+    } else {
+      await expect(page.getByRole("button", { name: "All201" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Pending1" })).toBeVisible();
+    }
+    // Optional wallet-provider remounts can repeat a complete load. Every load
+    // must still request exactly one first page and one page-two continuation.
+    expect([...new Set(agentOffsets)]).toEqual([0, 200]);
+    expect(agentOffsets.filter((offset) => offset === 0)).toHaveLength(
+      agentOffsets.filter((offset) => offset === 200).length,
+    );
+    expect([...new Set(sentinelHistoryOffsets)]).toEqual([0, 200]);
+    expect(sentinelHistoryOffsets.filter((offset) => offset === 0)).toHaveLength(
+      sentinelHistoryOffsets.filter((offset) => offset === 200).length,
+    );
+  });
+
   test(`${surface.name} ignores a delayed tenant-A completion after switching to tenant B`, async ({
     page,
     request,
@@ -210,23 +257,41 @@ for (const surface of [
       async (route) => {
         const authorization = route.request().headers().authorization ?? null;
         const tenant = authorization === `Bearer ${tenantBToken}` ? "b" : "a";
+        const offset = Number(new URL(route.request().url()).searchParams.get("offset"));
+        if (tenant === "a" && offset === 200) {
+          delayedTenantA.current = route;
+          return;
+        }
+        const agents =
+          tenant === "a"
+            ? Array.from({ length: 200 }, (_, index) => ({
+                id: `agent-a-${index}`,
+                name: `Tenant A Page One Agent ${index}`,
+              }))
+            : [{ id: "agent-b", name: "Tenant B Agent" }];
         await route.fulfill({
           json: {
             ok: true,
-            data: [{ id: `agent-${tenant}`, name: `Tenant ${tenant.toUpperCase()} Agent` }],
+            data: {
+              agents,
+              limit: 200,
+              offset,
+            },
           },
         });
       },
     );
     await page.route(
-      (url) => url.href.startsWith(API) && url.pathname === "/vault/agent-a/history",
-      (route) => {
-        delayedTenantA.current = route;
+      (url) => url.href.startsWith(API) && /\/vault\/[^/]+\/history$/.test(url.pathname),
+      async (route) => {
+        const agentId = new URL(route.request().url()).pathname.split("/")[2];
+        await route.fulfill({
+          json: {
+            ok: true,
+            data: agentId === "agent-b" ? [transaction("tx-b", "agent-b")] : [],
+          },
+        });
       },
-    );
-    await page.route(
-      (url) => url.href.startsWith(API) && url.pathname === "/vault/agent-b/history",
-      (route) => route.fulfill({ json: { ok: true, data: [transaction("tx-b", "agent-b")] } }),
     );
 
     await loginWithMagicLink(page, request, email);
@@ -236,7 +301,14 @@ for (const surface of [
     await expect(page.getByRole("link", { name: "Tenant B Agent" })).toBeVisible();
 
     await delayedTenantA.current?.fulfill({
-      json: { ok: true, data: [transaction("tx-a", "agent-a")] },
+      json: {
+        ok: true,
+        data: {
+          agents: [{ id: "agent-a", name: "Tenant A Agent" }],
+          limit: 200,
+          offset: 200,
+        },
+      },
     });
     await page.waitForTimeout(250);
     await expect(page.getByRole("link", { name: "Tenant B Agent" })).toBeVisible();
@@ -268,10 +340,14 @@ for (const surface of [
         await route.fulfill({
           json: {
             ok: true,
-            data: [
-              { id: "agent-available", name: availableName },
-              { id: "agent-unavailable", name: "Unavailable Agent" },
-            ],
+            data: {
+              agents: [
+                { id: "agent-available", name: availableName },
+                { id: "agent-unavailable", name: "Unavailable Agent" },
+              ],
+              limit: 100,
+              offset: 0,
+            },
           },
         });
       },


### PR DESCRIPTION
Closes #685\n\n## Summary\n- expose canonical paged agent metadata while retaining the historical array helper\n- exhaust stable 200-row pages and fail closed at the API offset ceiling\n- validate page length, metadata, duplicate IDs, and forward progress\n- add stable transaction-history pagination and multi-page dashboard fencing coverage\n\n## Exact-head validation\n- focused SDK/API: 146 pass, 13 environment-gated skips, 807 expectations\n- affected dependency build: 24/24\n- git diff --check clean\n\nDraft pending protected CI and independent approval.