### PR TITLE
fix(ci): align workflow tests with hardened runtime

### DIFF
--- a/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
@@ -229,7 +229,7 @@ describeWithDatabase("OAuth redirect_uri allowlist", () => {
     expect(callbackRes.status).toBe(400);
     const body = (await callbackRes.json()) as { ok: boolean; error: string };
     expect(body.ok).toBe(false);
-    expect(body.error).toContain("redirect_uri is not allowed");
+    expect(body.error).toBe("The application return address is not allowed.");
   });
 
   it("rejects /token when redirectUri is outside the tenant allowlist", async () => {

--- a/packages/api/src/__tests__/provider-case-fixture.ts
+++ b/packages/api/src/__tests__/provider-case-fixture.ts
@@ -17,6 +17,7 @@ import {
   secretRoutes,
   secrets,
   tenants,
+  transactions,
   users,
   userTenants,
   workspaces,
@@ -90,6 +91,7 @@ export async function wipeCase(): Promise<void> {
   await db.delete(approvalQueue);
   await db.delete(providerActionBindings);
   await db.delete(intents);
+  await db.delete(transactions);
   await db.delete(providerGrants);
   await db.delete(providerRoleBindings);
   await db.delete(providerOperations);

--- a/packages/api/src/__tests__/vault-approval-gates.test.ts
+++ b/packages/api/src/__tests__/vault-approval-gates.test.ts
@@ -75,6 +75,8 @@ const AGENT_SOLANA = `approval-solana-${Date.now()}`;
 const SOLANA_RECIPIENT = "7J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg";
 const SOLANA_SIGNATURE =
   "4oL4p7QvN3UH7V5wMGZgW5PuzEk4A9LXLHk9RxAoKjDKuLbQBsfXN8kEvKfj5K1oEJa8wFF6RVp2h7pP9w2f51ZV";
+const ORIGINAL_REDIS_URL = process.env.REDIS_URL;
+const ORIGINAL_REDIS_REQUIRED = process.env.REDIS_REQUIRED;
 
 // One app per auth posture. The approve route reads auth purely from context
 // variables, so a per-test middleware that sets exactly the desired posture is
@@ -269,6 +271,8 @@ function approve(app: Awaited<ReturnType<typeof makeApp>>, agentId: string, txId
 
 describe("vault approval gates (real /approve path)", () => {
   beforeAll(async () => {
+    delete process.env.REDIS_URL;
+    delete process.env.REDIS_REQUIRED;
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_MASTER_PASSWORD = "approval-gate-master-password";
     process.env.STEWARD_JWT_SECRET = "approval-gate-jwt-secret-with-enough-entropy-0123456789";
@@ -354,6 +358,10 @@ describe("vault approval gates (real /approve path)", () => {
 
   afterAll(async () => {
     await closeDb();
+    if (ORIGINAL_REDIS_URL === undefined) delete process.env.REDIS_URL;
+    else process.env.REDIS_URL = ORIGINAL_REDIS_URL;
+    if (ORIGINAL_REDIS_REQUIRED === undefined) delete process.env.REDIS_REQUIRED;
+    else process.env.REDIS_REQUIRED = ORIGINAL_REDIS_REQUIRED;
     delete process.env.STEWARD_PGLITE_MEMORY;
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_EXECUTION_AUTH_SECRET;

--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -163,9 +163,23 @@ describe("vault EVM execution gateway", () => {
 
   it("preserves the legacy Solana sign path without minting an EVM authorization", async () => {
     const beforeRows = await getDb().select().from(executionAuthorizationNonces);
-    const signSpy = spyOn(Vault.prototype, "signTransaction").mockImplementation(async () => {
-      return "solana-signed";
-    });
+    const signSpy = spyOn(Vault.prototype, "signTransaction").mockImplementation(
+      async (request, options) => {
+        // The real Vault signer records the signed transaction before returning.
+        // Preserve that contract while replacing only the cryptographic seam.
+        await getDb().insert(transactions).values({
+          id: options.txId,
+          agentId: request.agentId,
+          status: options.status,
+          toAddress: request.to,
+          value: request.value,
+          data: request.data,
+          chainId: request.chainId,
+          policyResults: options.policyResults,
+        });
+        return "solana-signed";
+      },
+    );
     try {
       const app = await makeApp();
       const res = await app.request(`/vault/${AGENT_ID}/sign`, {
@@ -1070,7 +1084,11 @@ describe("vault EVM execution gateway", () => {
         headers: { "content-type": "application/json" },
         body: "{}",
       });
-      expect(retry.status).toBe(404);
+      expect(retry.status).toBe(409);
+      expect(await retry.json()).toMatchObject({
+        ok: false,
+        error: "Transaction already processed or not found",
+      });
       expect(provider.signCalls).toBe(1);
       expect(writes).toBe(2);
     } finally {

--- a/packages/api/src/__tests__/vault-mfa-sensitive-actions.test.ts
+++ b/packages/api/src/__tests__/vault-mfa-sensitive-actions.test.ts
@@ -35,6 +35,7 @@ const dispatchWebhookMock = mock(() => {});
 
 mock.module("../services/webhook-dispatch", () => ({
   dispatchWebhook: dispatchWebhookMock,
+  dispatchWebhookDurably: mock(async () => {}),
 }));
 
 const TENANT_ID = `vault-mfa-tenant-${Date.now()}`;

--- a/packages/api/src/__tests__/vault-raw-digest-signing.test.ts
+++ b/packages/api/src/__tests__/vault-raw-digest-signing.test.ts
@@ -25,6 +25,7 @@ import type { AppVariables } from "../services/context";
 const dispatchWebhookMock = mock(() => {});
 mock.module("../services/webhook-dispatch", () => ({
   dispatchWebhook: dispatchWebhookMock,
+  dispatchWebhookDurably: mock(async () => {}),
 }));
 
 const TENANT_ID = `raw-digest-tenant-${Date.now()}`;

--- a/packages/api/src/__tests__/vault-user-operation.test.ts
+++ b/packages/api/src/__tests__/vault-user-operation.test.ts
@@ -20,6 +20,7 @@ const dispatchWebhookMock = mock(() => {});
 
 mock.module("../services/webhook-dispatch", () => ({
   dispatchWebhook: dispatchWebhookMock,
+  dispatchWebhookDurably: mock(async () => {}),
 }));
 
 const TENANT_ID = `userop-tenant-${Date.now()}`;

--- a/packages/api/src/__tests__/wallet-actions.test.ts
+++ b/packages/api/src/__tests__/wallet-actions.test.ts
@@ -18,6 +18,8 @@ const TOKEN = "0x4200000000000000000000000000000000000006";
 const ALLOWED_SOLANA = "7J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg";
 const BLOCKED_SOLANA = "8J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg";
 const SOLANA_MINT = "So11111111111111111111111111111111111111112";
+const ORIGINAL_REDIS_URL = process.env.REDIS_URL;
+const ORIGINAL_REDIS_REQUIRED = process.env.REDIS_REQUIRED;
 
 function expectedErc20TransferCalldata(recipient: string, amount: string) {
   return `0xa9059cbb${recipient.toLowerCase().replace(/^0x/, "").padStart(64, "0")}${BigInt(amount).toString(16).padStart(64, "0")}`;
@@ -42,6 +44,8 @@ describe("wallet transfer actions", () => {
   let app: Awaited<ReturnType<typeof makeApp>>;
 
   beforeAll(async () => {
+    delete process.env.REDIS_URL;
+    delete process.env.REDIS_REQUIRED;
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_MASTER_PASSWORD = "wallet-actions-master-password";
     process.env.STEWARD_ALLOW_DEV_SECRETS = "true";
@@ -168,6 +172,10 @@ describe("wallet transfer actions", () => {
 
   afterAll(async () => {
     await closeDb();
+    if (ORIGINAL_REDIS_URL === undefined) delete process.env.REDIS_URL;
+    else process.env.REDIS_URL = ORIGINAL_REDIS_URL;
+    if (ORIGINAL_REDIS_REQUIRED === undefined) delete process.env.REDIS_REQUIRED;
+    else process.env.REDIS_REQUIRED = ORIGINAL_REDIS_REQUIRED;
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_ALLOW_DEV_SECRETS;
   });

--- a/packages/shared/src/security-surface.ts
+++ b/packages/shared/src/security-surface.ts
@@ -529,6 +529,7 @@ export const LEGACY_EVM_SIGN_CALL_SITES = [
  *    unreachable for EVM flows because a nearby invariant guard throws before
  *    it (the Solana primary-sign fallback and the transfer approval-replay
  *    fallback). These are inside the two gateway-migrated routes.
+ *  - "non-evm": a raw signer that is reachable only for a non-EVM chain.
  *  - "legacy": a not-yet-gateway-migrated EVM sign surface, one-for-one with an
  *    entry in LEGACY_EVM_SIGN_CALL_SITES.
  */
@@ -537,7 +538,7 @@ export interface RawEvmSignCallSite {
   /** Stable nearby source marker (route/function/guard string) unique enough to
    *  anchor the call site without brittle line numbers. */
   marker: string;
-  classification: "migrated-invariant-guarded" | "legacy";
+  classification: "migrated-invariant-guarded" | "non-evm" | "legacy";
   reason: string;
 }
 
@@ -552,7 +553,7 @@ export interface RawEvmSignCallSite {
  * entry without removing the call also fails.
  */
 export const RAW_EVM_SIGN_INVENTORY = [
-  // ── packages/api/src/routes/vault.ts (3 raw calls) ──
+  // ── packages/api/src/routes/vault.ts (4 raw calls) ──
   {
     file: "packages/api/src/routes/vault.ts",
     marker: "invariant: primary EVM sign reached raw signer without gateway authorization",
@@ -566,6 +567,13 @@ export const RAW_EVM_SIGN_INVENTORY = [
     classification: "legacy",
     reason:
       "Transfer action EVM sign; separate non-migrated surface. One-for-one with LEGACY_EVM_SIGN_CALL_SITES.",
+  },
+  {
+    file: "packages/api/src/routes/vault.ts",
+    marker: 'transferPayload?.token === "native" && !transactionRow.data',
+    classification: "non-evm",
+    reason:
+      "Native SOL approval recovery path inside the isSolana branch; no EVM request can reach this raw signer.",
   },
   {
     file: "packages/api/src/routes/vault.ts",


### PR DESCRIPTION
## Summary
- isolate PGLite vault tests from CI Redis configuration without weakening production fail-closed behavior
- update webhook mocks, OAuth callback expectations, and gateway signer fixtures for the current runtime contracts
- classify the native-SOL approval signer and clear transaction state before provider-case teardown

## Validation
- `bun run lint`
- `bunx turbo run build --filter=@stwd/shared --filter=@stwd/api`
- `bun scripts/check-ci-test-inventory.ts`
- `actionlint .github/workflows/*.yml`
- `bun test packages/shared` (455 pass)
- focused API suites: execution inventory, vault MFA/raw digest/user operation, wallet actions with CI-like Redis env, approval gates with CI-like Redis env, execution gateway, provider case evidence

The OAuth allowlist and provider snapshot paths require hosted Postgres and are left to the PR integration job.