### PR TITLE
fix(ci): make Postgres integration DB/webhook mocks deterministic (root-cause the 'flake')

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,8 +467,16 @@ jobs:
           POSTGRES_DB: steward_test
         ports:
           - 5432:5432
+        # pg_isready without -d probes a database named after the connecting
+        # role (steward), which this service never creates (POSTGRES_DB is
+        # steward_test). pg_isready still returns 0 (the server answered), so
+        # the healthcheck passed but the server logged a misleading
+        # `FATAL: database "steward" does not exist` on every 10s probe. Those
+        # log lines were repeatedly misread as a DB-bootstrap race. Point the
+        # probe at the database that actually exists so the container log is
+        # clean and the readiness signal is unambiguous.
         options: >-
-          --health-cmd "pg_isready -U steward"
+          --health-cmd "pg_isready -U steward -d steward_test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/packages/api/src/__tests__/auth-mfa-sms.test.ts
+++ b/packages/api/src/__tests__/auth-mfa-sms.test.ts
@@ -4,6 +4,7 @@ import { closeDb, getDb, users } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { eq } from "drizzle-orm";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import * as actualWebhookDispatch from "../services/webhook-dispatch";
 
 type WebhookDispatch = {
   tenantId: string;
@@ -15,6 +16,10 @@ type WebhookDispatch = {
 const webhookDispatches: WebhookDispatch[] = [];
 
 mock.module("../services/webhook-dispatch", () => ({
+  // Preserve every real export (e.g. dispatchWebhookDurably) and override only
+  // the spied entrypoint; replacing the whole module drops named exports the
+  // routes under test import, surfacing as `Export named 'X' not found`.
+  ...actualWebhookDispatch,
   dispatchWebhook: mock(
     (tenantId: string, agentId: string, type: string, data: Record<string, unknown>) => {
       webhookDispatches.push({ tenantId, agentId, type, data });

--- a/packages/api/src/__tests__/user-embedded-wallet-create-on-login.test.ts
+++ b/packages/api/src/__tests__/user-embedded-wallet-create-on-login.test.ts
@@ -15,9 +15,15 @@ import { and, eq } from "drizzle-orm";
 const APP_TENANT_ID = "embedded-wallet-create-on-login-app";
 const OFF_TENANT_ID = "embedded-wallet-create-on-login-off";
 
+import * as actualWebhookDispatch from "../services/webhook-dispatch";
+
 const dispatchWebhookMock = mock(() => {});
 
 mock.module("../services/webhook-dispatch", () => ({
+  // Preserve every real export (e.g. dispatchWebhookDurably) and override only
+  // the spied entrypoint; replacing the whole module drops named exports the
+  // routes under test import, surfacing as `Export named 'X' not found`.
+  ...actualWebhookDispatch,
   dispatchWebhook: dispatchWebhookMock,
 }));
 

--- a/packages/api/src/__tests__/user-lifecycle-webhooks.test.ts
+++ b/packages/api/src/__tests__/user-lifecycle-webhooks.test.ts
@@ -14,9 +14,15 @@ setDefaultTimeout(30000);
 import { closeDb, getDb, tenantConfigs, tenants, users } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 
+import * as actualWebhookDispatch from "../services/webhook-dispatch";
+
 const dispatchWebhookMock = mock(() => {});
 
 mock.module("../services/webhook-dispatch", () => ({
+  // Preserve every real export (e.g. dispatchWebhookDurably) and override only
+  // the spied entrypoint; replacing the whole module drops named exports the
+  // routes under test import, surfacing as `Export named 'X' not found`.
+  ...actualWebhookDispatch,
   dispatchWebhook: dispatchWebhookMock,
 }));
 

--- a/packages/api/src/__tests__/user-wallet-created-webhook.test.ts
+++ b/packages/api/src/__tests__/user-wallet-created-webhook.test.ts
@@ -17,9 +17,15 @@ import { closeDb, getDb, tenants, users, userTenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { eq } from "drizzle-orm";
 
+import * as actualWebhookDispatch from "../services/webhook-dispatch";
+
 const dispatchWebhookMock = mock(() => {});
 
 mock.module("../services/webhook-dispatch", () => ({
+  // Preserve every real export (e.g. dispatchWebhookDurably) and override only
+  // the spied entrypoint; replacing the whole module drops named exports the
+  // routes under test import, surfacing as `Export named 'X' not found`.
+  ...actualWebhookDispatch,
   dispatchWebhook: dispatchWebhookMock,
 }));
 

--- a/packages/api/src/__tests__/user-wallet-export.test.ts
+++ b/packages/api/src/__tests__/user-wallet-export.test.ts
@@ -11,9 +11,15 @@ const hasDatabaseUrl = Boolean(previousDatabaseUrl);
 const describeWithDatabase = hasDatabaseUrl ? describe : describe.skip;
 process.env.DATABASE_URL ||= "postgres://unused:unused@localhost:5432/unused";
 
+import * as actualWebhookDispatch from "../services/webhook-dispatch";
+
 const dispatchWebhookMock = mock(() => {});
 
 mock.module("../services/webhook-dispatch", () => ({
+  // Preserve every real export (e.g. dispatchWebhookDurably) and override only
+  // the spied entrypoint; replacing the whole module drops named exports the
+  // routes under test import, surfacing as `Export named 'X' not found`.
+  ...actualWebhookDispatch,
   dispatchWebhook: dispatchWebhookMock,
 }));
 

--- a/packages/api/src/__tests__/user-wallet-recovery-setup.test.ts
+++ b/packages/api/src/__tests__/user-wallet-recovery-setup.test.ts
@@ -24,8 +24,14 @@ import { deriveEvmKey, isValidMnemonic } from "@stwd/vault";
 import { eq } from "drizzle-orm";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
+import * as actualWebhookDispatch from "../services/webhook-dispatch";
+
 const dispatchWebhookMock = mock(() => {});
 mock.module("../services/webhook-dispatch", () => ({
+  // Preserve every real export (e.g. dispatchWebhookDurably) and override only
+  // the spied entrypoint; replacing the whole module drops named exports the
+  // routes under test import, surfacing as `Export named 'X' not found`.
+  ...actualWebhookDispatch,
   dispatchWebhook: dispatchWebhookMock,
 }));
 

--- a/packages/api/src/__tests__/vault-mfa-sensitive-actions.test.ts
+++ b/packages/api/src/__tests__/vault-mfa-sensitive-actions.test.ts
@@ -30,10 +30,16 @@ import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
+import * as actualWebhookDispatch from "../services/webhook-dispatch";
 
 const dispatchWebhookMock = mock(() => {});
 
+// Preserve every real export (e.g. dispatchWebhookDurably, dispatchTestWebhook)
+// and override only the spied entrypoint. Replacing the whole module with a
+// bare `{ dispatchWebhook }` object breaks the moment a route this test loads
+// imports another named export, surfacing as `Export named 'X' not found`.
 mock.module("../services/webhook-dispatch", () => ({
+  ...actualWebhookDispatch,
   dispatchWebhook: dispatchWebhookMock,
 }));
 

--- a/packages/api/src/__tests__/vault-raw-digest-signing.test.ts
+++ b/packages/api/src/__tests__/vault-raw-digest-signing.test.ts
@@ -22,8 +22,14 @@ import { Hono } from "hono";
 import { recoverAddress } from "viem";
 import type { AppVariables } from "../services/context";
 
+import * as actualWebhookDispatch from "../services/webhook-dispatch";
+
 const dispatchWebhookMock = mock(() => {});
 mock.module("../services/webhook-dispatch", () => ({
+  // Preserve every real export (e.g. dispatchWebhookDurably) and override only
+  // the spied entrypoint; replacing the whole module drops named exports the
+  // routes under test import, surfacing as `Export named 'X' not found`.
+  ...actualWebhookDispatch,
   dispatchWebhook: dispatchWebhookMock,
 }));
 

--- a/packages/api/src/__tests__/vault-user-operation.test.ts
+++ b/packages/api/src/__tests__/vault-user-operation.test.ts
@@ -16,9 +16,15 @@ import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppVariables, RpcRequest } from "../services/context";
 
+import * as actualWebhookDispatch from "../services/webhook-dispatch";
+
 const dispatchWebhookMock = mock(() => {});
 
 mock.module("../services/webhook-dispatch", () => ({
+  // Preserve every real export (e.g. dispatchWebhookDurably) and override only
+  // the spied entrypoint; replacing the whole module drops named exports the
+  // routes under test import, surfacing as `Export named 'X' not found`.
+  ...actualWebhookDispatch,
   dispatchWebhook: dispatchWebhookMock,
 }));
 


### PR DESCRIPTION
## Root cause (file:line)

The `Integration Tests (Postgres)` job on develop intermittently fails with:

```
SyntaxError: Export named 'dispatchWebhookDurably' not found in module
'.../packages/api/src/services/webhook-dispatch.ts'
```

Nine api test files mock `../services/webhook-dispatch` with a **bare object that only provides `dispatchWebhook`**, e.g. `packages/api/src/__tests__/vault-mfa-sensitive-actions.test.ts:36`:

```js
mock.module("../services/webhook-dispatch", () => ({
  dispatchWebhook: dispatchWebhookMock,
}));
```

`webhook-dispatch.ts` also exports `dispatchWebhookDurably` (line 77), `dispatchTestWebhook` (100), `dispatchReplayWebhook` (128), `redactWebhookSecrets` (23). `packages/api/src/routes/vault.ts:113` imports `{ dispatchWebhook, dispatchWebhookDurably }`. When a test transitively loads `vaultRoutes`, Bun's `mock.module` has already replaced the module with an object that lacks `dispatchWebhookDurably`, so that named import throws at module-evaluation time and the whole file exits 0-pass/1-fail.

It reads as a "flake" because whether a given file trips it depends on the import graph a PR touches (only `vault.ts` currently imports `dispatchWebhookDurably`). It's actually a **deterministic fragility**: the mock silently drops every real export it doesn't re-list.

The oft-cited `FATAL: database "steward" does not exist` in the container log is a **red herring**: `pg_isready -U steward` (no `-d`) probes a DB named after the role, which the service never creates (`POSTGRES_DB=steward_test`). `pg_isready` still returns 0, so the healthcheck passes — those FATALs are just log noise on the 10s probe cadence, not the failure. The job actually fails in the `Integration tests (API)` step (exit 1), not on DB bootstrap.

## The fix (deterministic by construction)

Each of the 9 mocks now spreads the real module and overrides only the spied entrypoint:

```js
import * as actualWebhookDispatch from "../services/webhook-dispatch";
mock.module("../services/webhook-dispatch", () => ({
  ...actualWebhookDispatch,
  dispatchWebhook: dispatchWebhookMock,
}));
```

Adding any future export to `webhook-dispatch.ts` can no longer break these mocks — the failure is impossible by construction, not merely less frequent. No test skipped, no assertion weakened, no coverage reduced.

Also hardened the postgres service healthcheck to `pg_isready -U steward -d steward_test` so the container log stops emitting the misleading `database "steward" does not exist` FATAL that caused this misdiagnosis in the first place.

## Before / after evidence (local, real Postgres matching the CI service)

All 9 previously-broken-or-fragile files, run against `postgres:16-alpine` with the CI env:

| file | before | after |
|---|---|---|
| vault-mfa-sensitive-actions | Export not found → 0 pass / 1 fail | **17 pass / 0 fail** |
| vault-raw-digest-signing | Export not found | **7 pass / 0 fail** |
| vault-user-operation | Export not found | **12 pass / 0 fail** |
| user-embedded-wallet-create-on-login | fragile | **6 pass / 0 fail** |
| user-wallet-created-webhook | fragile | **1 pass / 0 fail** |
| user-wallet-export | fragile | **2 pass / 0 fail** |
| user-wallet-recovery-setup | fragile | **17 pass / 0 fail** |
| user-lifecycle-webhooks | fragile | **4 pass / 0 fail** |
| auth-mfa-sms | fragile (same bare mock) | **4 pass / 0 fail** |

`biome check` clean on all 9 files. `biome format` applied.

## ⚠️ This PR does NOT make the job fully green on its own

While root-causing, I found the develop tip is red for **additional, independent reasons** outside the mock-completeness class — these are real regressions / a deliberate security tripwire that I did **not** touch (they need human/security review, not a CI hack):

- `execution-gateway-inventory.test.ts` — `RAW_EVM_SIGN_INVENTORY` drift: `vault.ts` now has **4** raw `.signTransaction(` call sites, inventory declares **3**. This is an intentional security gate; it must be resolved by classifying the new raw signer or migrating it to `.signTransactionAuthorized(`, **not** by bumping the count.
- `auth-oauth-redirect-allowlist.test.ts` — asserts old error copy `"redirect_uri is not allowed"`; product now returns `"The application return address is not allowed."` (fixture drift).
- `vault-approval-gates.test.ts` (3 fail), `vault-execution-gateway.test.ts` (2 fail) — Solana/EVM concurrent-approval status assertions (200 vs 500, 404 vs 409) tied to the recent `#699` atomicity change.
- `wallet-actions.test.ts` (2 fail) — `Configured Redis accounting backend is unavailable` → 202 vs 500.

I deliberately left those alone per the task constraints (don't weaken/skip tests, don't touch security gates). They're flagged here so the reviewer knows the job needs those addressed separately before develop→staging auto-deploys.

## Did NOT

- Skip / delete / `.skip` any test
- Weaken any assertion or add blanket retries
- Touch migrations, SEC-169 env gates, or the intentional audit-chain negative test
- Merge (open for Shadow/Shaw review)
