### PR TITLE
test(api): sync webhook-dispatch mocks with dispatchWebhookDurably export

### DIFF
--- a/packages/api/src/__tests__/vault-mfa-sensitive-actions.test.ts
+++ b/packages/api/src/__tests__/vault-mfa-sensitive-actions.test.ts
@@ -33,8 +33,10 @@ import type { AppVariables } from "../services/context";
 
 const dispatchWebhookMock = mock(() => {});
 
+const dispatchWebhookDurablyMock = mock(async () => {});
 mock.module("../services/webhook-dispatch", () => ({
   dispatchWebhook: dispatchWebhookMock,
+  dispatchWebhookDurably: dispatchWebhookDurablyMock,
 }));
 
 const TENANT_ID = `vault-mfa-tenant-${Date.now()}`;

--- a/packages/api/src/__tests__/vault-raw-digest-signing.test.ts
+++ b/packages/api/src/__tests__/vault-raw-digest-signing.test.ts
@@ -23,8 +23,10 @@ import { recoverAddress } from "viem";
 import type { AppVariables } from "../services/context";
 
 const dispatchWebhookMock = mock(() => {});
+const dispatchWebhookDurablyMock = mock(async () => {});
 mock.module("../services/webhook-dispatch", () => ({
   dispatchWebhook: dispatchWebhookMock,
+  dispatchWebhookDurably: dispatchWebhookDurablyMock,
 }));
 
 const TENANT_ID = `raw-digest-tenant-${Date.now()}`;

--- a/packages/api/src/__tests__/vault-user-operation.test.ts
+++ b/packages/api/src/__tests__/vault-user-operation.test.ts
@@ -18,8 +18,10 @@ import type { AppVariables, RpcRequest } from "../services/context";
 
 const dispatchWebhookMock = mock(() => {});
 
+const dispatchWebhookDurablyMock = mock(async () => {});
 mock.module("../services/webhook-dispatch", () => ({
   dispatchWebhook: dispatchWebhookMock,
+  dispatchWebhookDurably: dispatchWebhookDurablyMock,
 }));
 
 const TENANT_ID = `userop-tenant-${Date.now()}`;


### PR DESCRIPTION
## What

Three vault integration test files mock `../services/webhook-dispatch` with an object that only exposed `dispatchWebhook`. After #699 (3559ac21) added `dispatchWebhookDurably` as a new named export AND a new named import in `routes/vault.ts`, importing `vaultRoutes` in these tests fails at CI with:

```
SyntaxError: Export named 'dispatchWebhookDurably' not found in module .../services/webhook-dispatch.ts
```

This is the root cause of 3 of the RED files on `Integration Tests (Postgres)` at develop tip 3559ac21:
- packages/api/src/__tests__/vault-raw-digest-signing.test.ts
- packages/api/src/__tests__/vault-mfa-sensitive-actions.test.ts
- packages/api/src/__tests__/vault-user-operation.test.ts

## Why this is a test-sync, not a weakening

`dispatchWebhookDurably` is a real, reviewed, merged export:
- defined/exported at `packages/api/src/services/webhook-dispatch.ts:77` (added by #699)
- imported at `packages/api/src/routes/vault.ts:113` (added by #699)

The mocks simply lagged the new export. The fix adds a `dispatchWebhookDurably` async stub to each mock so the named-import binding resolves. No assertions changed, no `.skip`, no retries, no loosened checks. The 3 files pass locally after the change (7/7, 17/17, 12/12).

## Not addressed here (report-only / HITL)

This PR intentionally does NOT touch the other RED failures in the same job:
- `execution-gateway-inventory` (SECURITY TRIPWIRE — HITL for Shadow/Shaw)
- `auth-oauth-redirect-allowlist` OAuth error-copy drift (product-change verification pending)
- `vault-approval-gates` / `vault-execution-gateway` / `provider-case-snapshot` (real Postgres behavior + agent-delete trigger interactions from #699)
- `wallet-actions` Redis-accounting-backend guard (harness gap)

See CI-TRIAGE-5FAILURES-2026-08-20.md for the full per-failure triage.