### PR TITLE
test(api): sync OAuth /callback rejection copy to #691 sanitized string

### DIFF
--- a/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
@@ -229,7 +229,11 @@ describeWithDatabase("OAuth redirect_uri allowlist", () => {
     expect(callbackRes.status).toBe(400);
     const body = (await callbackRes.json()) as { ok: boolean; error: string };
     expect(body.ok).toBe(false);
-    expect(body.error).toContain("redirect_uri is not allowed");
+    // #691 sanitized the browser /callback rejection copy to a non-reflective,
+    // user-facing string (was the reflected internal "redirect_uri is not
+    // allowed for this tenant" error message). The /token path below still
+    // returns the original copy, which is why only this assertion changed.
+    expect(body.error).toContain("The application return address is not allowed.");
   });
 
   it("rejects /token when redirectUri is outside the tenant allowlist", async () => {


### PR DESCRIPTION
## What

`auth-oauth-redirect-allowlist.test.ts:232` asserted the OLD reflected OAuth /callback rejection copy `"redirect_uri is not allowed"`. #691 (3b764500, `fix(auth): recover OAuth browser callback failures`) **intentionally** replaced the reflected internal error string on the browser /callback path with a sanitized, non-reflective user-facing copy:

```
before: return { error: err.message ... }   // "redirect_uri is not allowed for this tenant"
after:  return oauthCallbackFailure(c, { code: "oauth_redirect_invalid",
          message: "The application return address is not allowed.", status: 400 })
```

## Why this is a test-sync, not a weakening / not a regression

- **Same rejection behavior:** still HTTP 400, still a real allowlist rejection. CI confirmed the callback returned 400 — only the `.toContain` copy assertion failed.
- **Intentional, reviewed, merged:** the new copy is defined at `auth.ts:5338` and `auth.ts:9834`, both added by #691, whose stated purpose is recovering browser callback failures with non-reflective error pages (see the sibling `auth-oauth-callback-browser.test.ts` "renders a **non-reflective** HTML page" tests).
- **Surgical:** only the single **/callback** assertion changed. The **/token** path assertions in the same file (lines 109/129/148/257/283) still return and assert the original `"redirect_uri is not allowed"` copy and are left untouched — proving the /callback copy change was deliberate and localized.

## Verification

Ran the full file against a **real Postgres 16** (matching the `Integration Tests (Postgres)` job): **9/9 pass**, including the untouched /token assertions.

## Scope

Report-only for the remaining RED failures in the same job — see CI-TRIAGE-5FAILURES-2026-08-20.md. In particular the `execution-gateway-inventory` SECURITY TRIPWIRE is HITL for Shadow/Shaw and is deliberately NOT touched.