### PR TITLE
fix(ci): repair exact develop workflow failures

### DIFF
--- a/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
@@ -229,7 +229,8 @@ describeWithDatabase("OAuth redirect_uri allowlist", () => {
     expect(callbackRes.status).toBe(400);
     const body = (await callbackRes.json()) as { ok: boolean; error: string };
     expect(body.ok).toBe(false);
-    expect(body.error).toContain("redirect_uri is not allowed");
+    expect(body.error).toBe("The application return address is not allowed.");
+    expect(body.error).not.toContain("redirect_uri");
   });
 
   it("rejects /token when redirectUri is outside the tenant allowlist", async () => {

--- a/packages/api/src/__tests__/provider-case-fixture.ts
+++ b/packages/api/src/__tests__/provider-case-fixture.ts
@@ -17,6 +17,7 @@ import {
   secretRoutes,
   secrets,
   tenants,
+  transactions,
   users,
   userTenants,
   workspaces,
@@ -88,6 +89,7 @@ export async function wipeCase(): Promise<void> {
   await db.execute(sql`DELETE FROM provider_action_audit_outbox`);
   await db.execute(sql`DELETE FROM execution_authorization_nonces`);
   await db.delete(approvalQueue);
+  await db.delete(transactions).where(eq(transactions.agentId, F.AGENT));
   await db.delete(providerActionBindings);
   await db.delete(intents);
   await db.delete(providerGrants);

--- a/packages/api/src/__tests__/provider-case-fixture.ts
+++ b/packages/api/src/__tests__/provider-case-fixture.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  agents,
   approvalQueue,
   getDb,
   intents,
@@ -23,7 +24,7 @@ import {
   workspaces,
 } from "@stwd/db";
 import { buildGithubAction } from "@stwd/provider-github";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
 import { providerActionService } from "../services/provider-action-service";
 import { providerApprovalService } from "../services/provider-approval";
@@ -83,31 +84,55 @@ export async function seedCaseFixture(): Promise<void> {
   ]);
 }
 
-/** Wipe all provider + audit state between tests (audit chain included). */
+/** Wipe only this fixture's provider + audit state between tests. */
 export async function wipeCase(): Promise<void> {
   const db = getDb();
-  await db.execute(sql`DELETE FROM provider_action_audit_outbox`);
-  await db.execute(sql`DELETE FROM execution_authorization_nonces`);
-  await db.delete(approvalQueue);
+  const fixtureTenantIds = [F.TENANT, F.TENANT_B];
+  await db.execute(
+    sql`DELETE FROM provider_action_audit_outbox WHERE tenant_id IN (${sql.join(
+      fixtureTenantIds.map((tenantId) => sql`${tenantId}`),
+      sql`, `,
+    )})`,
+  );
+  await db.execute(
+    sql`DELETE FROM execution_authorization_nonces WHERE tenant_id IN (${sql.join(
+      fixtureTenantIds.map((tenantId) => sql`${tenantId}`),
+      sql`, `,
+    )})`,
+  );
+  await db.delete(approvalQueue).where(eq(approvalQueue.agentId, F.AGENT));
+  await db
+    .delete(providerActionBindings)
+    .where(inArray(providerActionBindings.tenantId, fixtureTenantIds));
+  await db.delete(intents).where(inArray(intents.tenantId, fixtureTenantIds));
+  await db.delete(providerGrants).where(inArray(providerGrants.tenantId, fixtureTenantIds));
+  await db
+    .delete(providerRoleBindings)
+    .where(inArray(providerRoleBindings.tenantId, fixtureTenantIds));
+  await db.delete(providerOperations).where(inArray(providerOperations.tenantId, fixtureTenantIds));
+  await db.delete(providerAccounts).where(inArray(providerAccounts.tenantId, fixtureTenantIds));
+  await db.delete(secretRoutes).where(inArray(secretRoutes.tenantId, fixtureTenantIds));
+  await db.delete(secrets).where(inArray(secrets.tenantId, fixtureTenantIds));
+  await db.delete(workspaces).where(inArray(workspaces.tenantId, fixtureTenantIds));
   await db.delete(transactions).where(eq(transactions.agentId, F.AGENT));
-  await db.delete(providerActionBindings);
-  await db.delete(intents);
-  await db.delete(providerGrants);
-  await db.delete(providerRoleBindings);
-  await db.delete(providerOperations);
-  await db.delete(providerAccounts);
-  await db.delete(secretRoutes);
-  await db.delete(secrets);
-  await db.delete(workspaces);
-  await db.delete(userTenants);
-  await db.delete(users);
-  await db.delete(tenants);
-  await db.execute(sql`DELETE FROM audit_events`);
-  await db.execute(sql`DELETE FROM audit_chain_heads`);
-  // Checkpoints are append-only in production. TRUNCATE is deliberately used
-  // only by this isolated PGLite fixture to reset the shared test database
-  // without weakening the row-level UPDATE/DELETE guard.
-  await db.execute(sql`TRUNCATE TABLE audit_checkpoints RESTART IDENTITY`);
+  await db.delete(agents).where(eq(agents.id, F.AGENT));
+  await db.delete(userTenants).where(inArray(userTenants.tenantId, fixtureTenantIds));
+  await db
+    .delete(users)
+    .where(inArray(users.id, [F.GRANTOR, F.APPROVER, F.APPROVER_2, F.APPROVER_3, F.AGENT_OWNER]));
+  await db.delete(tenants).where(inArray(tenants.id, fixtureTenantIds));
+  await db.execute(
+    sql`DELETE FROM audit_events WHERE tenant_id IN (${sql.join(
+      fixtureTenantIds.map((tenantId) => sql`${tenantId}`),
+      sql`, `,
+    )})`,
+  );
+  await db.execute(
+    sql`DELETE FROM audit_chain_heads WHERE tenant_id IN (${sql.join(
+      fixtureTenantIds.map((tenantId) => sql`${tenantId}`),
+      sql`, `,
+    )})`,
+  );
 }
 
 function idem(seed: string): string {

--- a/packages/api/src/__tests__/provider-case-snapshot-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/provider-case-snapshot-postgres.integration.test.ts
@@ -9,7 +9,15 @@
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { signAccessToken } from "@stwd/auth";
-import { closeDb, createPostgresClient, getDb, providerOperations } from "@stwd/db";
+import {
+  agents,
+  closeDb,
+  createPostgresClient,
+  getDb,
+  providerOperations,
+  tenants,
+  transactions,
+} from "@stwd/db";
 import { eq } from "drizzle-orm";
 import { F } from "./provider-approval-fixture";
 import { createPendingCase, seedCaseFixture, wipeCase } from "./provider-case-fixture";
@@ -18,6 +26,9 @@ const DATABASE_URL = process.env.DATABASE_URL;
 const SKIP = !DATABASE_URL;
 const ORIGINAL_RISK_CLASS = "write";
 const CONCURRENT_RISK_CLASS = "read";
+const SENTINEL_TENANT = "tenant-provider-case-snapshot-sentinel";
+const SENTINEL_AGENT = "agent-provider-case-snapshot-sentinel";
+const SENTINEL_TRANSACTION = "tx-provider-case-snapshot-sentinel";
 
 describe.skipIf(SKIP)("provider-case mounted repeatable-read snapshot (Postgres)", () => {
   let admin: ReturnType<typeof createPostgresClient>;
@@ -35,7 +46,36 @@ describe.skipIf(SKIP)("provider-case mounted repeatable-read snapshot (Postgres)
     process.env.STEWARD_MASTER_PASSWORD ??= "provider-case-snapshot-master-password";
     process.env.STEWARD_JWT_SECRET ??=
       "provider-case-snapshot-jwt-secret-0123456789abcdef0123456789";
+    await getDb()
+      .update(transactions)
+      .set({ status: "failed" })
+      .where(eq(transactions.id, SENTINEL_TRANSACTION));
+    await getDb().delete(tenants).where(eq(tenants.id, SENTINEL_TENANT));
+    await getDb().insert(tenants).values({
+      id: SENTINEL_TENANT,
+      name: "Provider case snapshot cleanup sentinel",
+      apiKeyHash: "provider-case-snapshot-sentinel-hash",
+    });
+    await getDb().insert(agents).values({
+      id: SENTINEL_AGENT,
+      tenantId: SENTINEL_TENANT,
+      name: "Provider case snapshot cleanup sentinel",
+      walletAddress: "0x0000000000000000000000000000000000000001",
+    });
+    await getDb().insert(transactions).values({
+      id: SENTINEL_TRANSACTION,
+      agentId: SENTINEL_AGENT,
+      status: "signed",
+      toAddress: "0x0000000000000000000000000000000000000002",
+      value: "1",
+      chainId: 1,
+    });
     await wipeCase();
+    expect(
+      await getDb().query.transactions.findFirst({
+        where: eq(transactions.id, SENTINEL_TRANSACTION),
+      }),
+    ).toMatchObject({ id: SENTINEL_TRANSACTION, agentId: SENTINEL_AGENT, status: "signed" });
     await seedCaseFixture();
     ({ intentId: caseId } = await createPendingCase("pgsnap01"));
     await getDb()
@@ -55,6 +95,11 @@ describe.skipIf(SKIP)("provider-case mounted repeatable-read snapshot (Postgres)
 
   afterAll(async () => {
     await wipeCase();
+    await getDb()
+      .update(transactions)
+      .set({ status: "failed" })
+      .where(eq(transactions.id, SENTINEL_TRANSACTION));
+    await getDb().delete(tenants).where(eq(tenants.id, SENTINEL_TENANT));
     await Promise.all([admin.end(), locker.end(), writer.end()]);
     await closeDb();
   });

--- a/packages/api/src/__tests__/vault-approval-gates.test.ts
+++ b/packages/api/src/__tests__/vault-approval-gates.test.ts
@@ -52,6 +52,10 @@ import {
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
+
+const ORIGINAL_REDIS_URL = process.env.REDIS_URL;
+const ORIGINAL_REDIS_REQUIRED = process.env.REDIS_REQUIRED;
+
 import {
   executionPayloadDigestForEvmSign,
   policyRevisionHashForPolicySet,
@@ -269,6 +273,8 @@ function approve(app: Awaited<ReturnType<typeof makeApp>>, agentId: string, txId
 
 describe("vault approval gates (real /approve path)", () => {
   beforeAll(async () => {
+    delete process.env.REDIS_URL;
+    delete process.env.REDIS_REQUIRED;
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_MASTER_PASSWORD = "approval-gate-master-password";
     process.env.STEWARD_JWT_SECRET = "approval-gate-jwt-secret-with-enough-entropy-0123456789";
@@ -354,6 +360,10 @@ describe("vault approval gates (real /approve path)", () => {
 
   afterAll(async () => {
     await closeDb();
+    if (ORIGINAL_REDIS_URL === undefined) delete process.env.REDIS_URL;
+    else process.env.REDIS_URL = ORIGINAL_REDIS_URL;
+    if (ORIGINAL_REDIS_REQUIRED === undefined) delete process.env.REDIS_REQUIRED;
+    else process.env.REDIS_REQUIRED = ORIGINAL_REDIS_REQUIRED;
     delete process.env.STEWARD_PGLITE_MEMORY;
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_EXECUTION_AUTH_SECRET;

--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -163,9 +163,24 @@ describe("vault EVM execution gateway", () => {
 
   it("preserves the legacy Solana sign path without minting an EVM authorization", async () => {
     const beforeRows = await getDb().select().from(executionAuthorizationNonces);
-    const signSpy = spyOn(Vault.prototype, "signTransaction").mockImplementation(async () => {
-      return "solana-signed";
-    });
+    const signSpy = spyOn(Vault.prototype, "signTransaction").mockImplementation(
+      async (request, options) => {
+        await getDb()
+          .insert(transactions)
+          .values({
+            id: options.txId,
+            agentId: request.agentId,
+            status: "signed",
+            toAddress: request.to,
+            value: request.value,
+            data: request.data,
+            chainId: request.chainId,
+            actionPayload: { type: "transaction", broadcast: false },
+            policyResults: options.policyResults ?? [],
+          });
+        return "solana-signed";
+      },
+    );
     try {
       const app = await makeApp();
       const res = await app.request(`/vault/${AGENT_ID}/sign`, {
@@ -1070,7 +1085,11 @@ describe("vault EVM execution gateway", () => {
         headers: { "content-type": "application/json" },
         body: "{}",
       });
-      expect(retry.status).toBe(404);
+      expect(retry.status).toBe(409);
+      expect(await retry.json()).toMatchObject({
+        ok: false,
+        error: "Transaction already processed or not found",
+      });
       expect(provider.signCalls).toBe(1);
       expect(writes).toBe(2);
     } finally {

--- a/packages/api/src/__tests__/vault-mfa-sensitive-actions.test.ts
+++ b/packages/api/src/__tests__/vault-mfa-sensitive-actions.test.ts
@@ -35,6 +35,7 @@ const dispatchWebhookMock = mock(() => {});
 
 mock.module("../services/webhook-dispatch", () => ({
   dispatchWebhook: dispatchWebhookMock,
+  dispatchWebhookDurably: mock(async () => {}),
 }));
 
 const TENANT_ID = `vault-mfa-tenant-${Date.now()}`;

--- a/packages/api/src/__tests__/vault-raw-digest-signing.test.ts
+++ b/packages/api/src/__tests__/vault-raw-digest-signing.test.ts
@@ -25,6 +25,7 @@ import type { AppVariables } from "../services/context";
 const dispatchWebhookMock = mock(() => {});
 mock.module("../services/webhook-dispatch", () => ({
   dispatchWebhook: dispatchWebhookMock,
+  dispatchWebhookDurably: mock(async () => {}),
 }));
 
 const TENANT_ID = `raw-digest-tenant-${Date.now()}`;

--- a/packages/api/src/__tests__/vault-user-operation.test.ts
+++ b/packages/api/src/__tests__/vault-user-operation.test.ts
@@ -20,6 +20,7 @@ const dispatchWebhookMock = mock(() => {});
 
 mock.module("../services/webhook-dispatch", () => ({
   dispatchWebhook: dispatchWebhookMock,
+  dispatchWebhookDurably: mock(async () => {}),
 }));
 
 const TENANT_ID = `userop-tenant-${Date.now()}`;

--- a/packages/api/src/__tests__/wallet-actions.test.ts
+++ b/packages/api/src/__tests__/wallet-actions.test.ts
@@ -18,6 +18,8 @@ const TOKEN = "0x4200000000000000000000000000000000000006";
 const ALLOWED_SOLANA = "7J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg";
 const BLOCKED_SOLANA = "8J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg";
 const SOLANA_MINT = "So11111111111111111111111111111111111111112";
+const ORIGINAL_REDIS_URL = process.env.REDIS_URL;
+const ORIGINAL_REDIS_REQUIRED = process.env.REDIS_REQUIRED;
 
 function expectedErc20TransferCalldata(recipient: string, amount: string) {
   return `0xa9059cbb${recipient.toLowerCase().replace(/^0x/, "").padStart(64, "0")}${BigInt(amount).toString(16).padStart(64, "0")}`;
@@ -42,6 +44,8 @@ describe("wallet transfer actions", () => {
   let app: Awaited<ReturnType<typeof makeApp>>;
 
   beforeAll(async () => {
+    delete process.env.REDIS_URL;
+    delete process.env.REDIS_REQUIRED;
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_MASTER_PASSWORD = "wallet-actions-master-password";
     process.env.STEWARD_ALLOW_DEV_SECRETS = "true";
@@ -168,6 +172,10 @@ describe("wallet transfer actions", () => {
 
   afterAll(async () => {
     await closeDb();
+    if (ORIGINAL_REDIS_URL === undefined) delete process.env.REDIS_URL;
+    else process.env.REDIS_URL = ORIGINAL_REDIS_URL;
+    if (ORIGINAL_REDIS_REQUIRED === undefined) delete process.env.REDIS_REQUIRED;
+    else process.env.REDIS_REQUIRED = ORIGINAL_REDIS_REQUIRED;
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_ALLOW_DEV_SECRETS;
   });

--- a/packages/shared/src/security-surface.ts
+++ b/packages/shared/src/security-surface.ts
@@ -552,7 +552,7 @@ export interface RawEvmSignCallSite {
  * entry without removing the call also fails.
  */
 export const RAW_EVM_SIGN_INVENTORY = [
-  // ── packages/api/src/routes/vault.ts (3 raw calls) ──
+  // ── packages/api/src/routes/vault.ts (4 raw calls) ──
   {
     file: "packages/api/src/routes/vault.ts",
     marker: "invariant: primary EVM sign reached raw signer without gateway authorization",
@@ -566,6 +566,13 @@ export const RAW_EVM_SIGN_INVENTORY = [
     classification: "legacy",
     reason:
       "Transfer action EVM sign; separate non-migrated surface. One-for-one with LEGACY_EVM_SIGN_CALL_SITES.",
+  },
+  {
+    file: "packages/api/src/routes/vault.ts",
+    marker: 'transferPayload?.token === "native" && !transactionRow.data',
+    classification: "migrated-invariant-guarded",
+    reason:
+      "Approved native-SOL replay. The enclosing isSolana branch prevents every EVM approval from reaching this raw signer.",
   },
   {
     file: "packages/api/src/routes/vault.ts",


### PR DESCRIPTION
## Summary
- classify the fourth raw signer as native-Solana approval replay
- align OAuth, Redis-isolated vault, gateway, and webhook test fixtures with hardened runtime contracts
- scope provider-case cleanup to fixture tenants and agents
- prove unrelated tenant/agent/transaction state survives cleanup in the real-Postgres snapshot suite

## Exact base and validation
- base: `3559ac2108d118730ff99e0b8a2a9fdc55895706`
- head: `e9754fe6aefba2887c8314ca9e3b51f626c700cf`
- `bunx turbo run build --filter=@stwd/shared --filter=@stwd/api`
- `bun run lint`
- `bun scripts/check-ci-test-inventory.ts`
- `actionlint .github/workflows/*.yml`
- shared: 455/455 tests, 11,287 assertions
- provider-case isolated consumers: 9/9 files
- gateway: 27/27; wallet actions: 10/10; approval gates: 10/10
- MFA/raw-digest/user-operation owning suites green

This supersedes closed draft #725 with tenant-scoped teardown and an unrelated-state sentinel.