### PR TITLE
fix(ci): restore honest raw-signer and Docker gates

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,5 @@
 # Build and push Docker image to GitHub Container Registry (GHCR)
-# Triggers on pushes to develop + main branches and version tags (v*)
+# Builds every pull request and publishes pushes to develop/main or version tags (v*).
 #   develop -> :develop image (auto-deployed to STAGING by deploy-staging.yml)
 #   main    -> :main image (promoted to PRODUCTION manually via deploy-railway.yml)
 #   v*      -> :<semver> image (tagged release for production)
@@ -11,13 +11,6 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [develop, main]
-    paths:
-      - "Dockerfile"
-      - ".dockerignore"
-      - "package.json"
-      - "bun.lock"
-      - "packages/**/package.json"
-      - ".github/workflows/docker.yml"
 
 # A branch tag is mutable. Do not let a slower build for an older push finish
 # after a newer build and overwrite `:develop` / `:main` with stale bytes.

--- a/packages/api/src/__tests__/execution-gateway-inventory.test.ts
+++ b/packages/api/src/__tests__/execution-gateway-inventory.test.ts
@@ -79,6 +79,17 @@ function repoRelative(absPath: string): string {
   return REPO_PREFIX + relative(API_ROOT, absPath).split("\\").join("/");
 }
 
+function rawCallAfterMarker(source: string, marker: string) {
+  const markerIndex = source.indexOf(marker);
+  expect(markerIndex, `inventory marker "${marker}" must exist`).toBeGreaterThanOrEqual(0);
+  const match = new RegExp(RAW_SIGN_RE.source).exec(source.slice(markerIndex));
+  expect(match, `inventory marker "${marker}" must anchor a following raw signer`).not.toBeNull();
+  return {
+    markerIndex,
+    rawCallIndex: markerIndex + (match?.index ?? 0),
+  };
+}
+
 /**
  * Classify a single `signTransaction` token occurrence in a production source
  * file into exactly one bucket. Returns a category plus a human-facing note so
@@ -230,17 +241,35 @@ describe("execution gateway raw-signer inventory (repository-wide)", () => {
     for (const site of RAW_EVM_SIGN_INVENTORY) {
       if (site.classification !== "migrated-invariant-guarded") continue;
       if (site.file !== "packages/api/src/routes/vault.ts") continue;
-      // The marker for the guarded sites IS the invariant throw string, which
-      // must appear before the corresponding raw call. Presence is asserted
-      // above; here we assert the invariant strings the runtime relies on exist.
-      expect(vaultSource.includes(site.marker)).toBe(true);
+      const { markerIndex, rawCallIndex } = rawCallAfterMarker(vaultSource, site.marker);
+      const throwIndex = vaultSource.lastIndexOf("throw new Error(", markerIndex);
+      expect(
+        throwIndex,
+        `guard marker "${site.marker}" must be inside the throw immediately before its raw signer`,
+      ).toBeGreaterThanOrEqual(0);
+      const guardToCall = vaultSource.slice(throwIndex, rawCallIndex);
+      expect(guardToCall).toContain(site.marker);
+      expect(guardToCall.length).toBeLessThan(600);
     }
-    // Both primary + approval invariant guards must exist.
-    expect(vaultSource).toContain(
-      "invariant: primary EVM sign reached raw signer without gateway authorization",
+  });
+
+  test("non-EVM raw signers are tied to their explicit Solana branch", () => {
+    const vaultSource = readFileSync(join(SRC_DIR, "routes", "vault.ts"), "utf8");
+    const sites = RAW_EVM_SIGN_INVENTORY.filter(
+      (site) => site.classification === "non-evm-branch-guarded",
     );
-    expect(vaultSource).toContain(
-      "invariant: primary EVM approval reached raw signer without gateway authorization",
-    );
+    expect(sites).toHaveLength(1);
+    for (const site of sites) {
+      expect(site.file).toBe("packages/api/src/routes/vault.ts");
+      const { markerIndex, rawCallIndex } = rawCallAfterMarker(vaultSource, site.marker);
+      const branchIndex = vaultSource.lastIndexOf("if (isSolana) {", markerIndex);
+      expect(
+        branchIndex,
+        `marker "${site.marker}" must be inside the Solana branch`,
+      ).toBeGreaterThanOrEqual(0);
+      const branchToCall = vaultSource.slice(branchIndex, rawCallIndex);
+      expect(branchToCall).toContain(site.marker);
+      expect(branchToCall.length).toBeLessThan(1_200);
+    }
   });
 });

--- a/packages/shared/src/security-surface.ts
+++ b/packages/shared/src/security-surface.ts
@@ -529,6 +529,8 @@ export const LEGACY_EVM_SIGN_CALL_SITES = [
  *    unreachable for EVM flows because a nearby invariant guard throws before
  *    it (the Solana primary-sign fallback and the transfer approval-replay
  *    fallback). These are inside the two gateway-migrated routes.
+ *  - "non-evm-branch-guarded": an intentionally reachable raw signer confined
+ *    to an explicit non-EVM branch inside a gateway-migrated route.
  *  - "legacy": a not-yet-gateway-migrated EVM sign surface, one-for-one with an
  *    entry in LEGACY_EVM_SIGN_CALL_SITES.
  */
@@ -537,7 +539,7 @@ export interface RawEvmSignCallSite {
   /** Stable nearby source marker (route/function/guard string) unique enough to
    *  anchor the call site without brittle line numbers. */
   marker: string;
-  classification: "migrated-invariant-guarded" | "legacy";
+  classification: "migrated-invariant-guarded" | "non-evm-branch-guarded" | "legacy";
   reason: string;
 }
 
@@ -570,7 +572,7 @@ export const RAW_EVM_SIGN_INVENTORY = [
   {
     file: "packages/api/src/routes/vault.ts",
     marker: 'transferPayload?.token === "native" && !transactionRow.data',
-    classification: "migrated-invariant-guarded",
+    classification: "non-evm-branch-guarded",
     reason:
       "Approved native-SOL replay. The enclosing isSolana branch prevents every EVM approval from reaching this raw signer.",
   },


### PR DESCRIPTION
Post-merge corrective for #772.

Summary:
- classify the reachable approved native-SOL raw signer as a non-EVM branch instead of falsely calling it invariant-guarded
- tie each guarded inventory entry to its specific following raw signer and nearby runtime guard
- run the globally required Docker workflow for every pull request so app-pinned build-and-push can always report

Validation:
- git diff --check passes
- actionlint passes for .github/workflows/docker.yml
- exact raw signer count remains four
- local Bun tests were intentionally not run because the shared volume was below the safe disk floor; this draft must remain blocked until exact-head hosted checks, including build-and-push, pass and an independent reviewer approves

Operational note:
- develop classic protection was restored before this PR was opened: strict 62 app-pinned checks, one approval, last-push approval, stale dismissal, conversation resolution, admin enforcement, no force-push/deletion
- the deleted additive ruleset remains a separate provenance incident; historical rule-suite evidence shows classic protection currently enforces the same effective categories plus conversation resolution