### PR TITLE
fix(docker): expose API on container network

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -198,6 +198,11 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 ENV PORT=3200
+# The application defaults to loopback for safe direct/local execution. A
+# container image must accept traffic from the container network (Railway,
+# Kubernetes, Compose, and similar runtimes), so make the published image's
+# network boundary explicit. Operators can still override this at runtime.
+ENV STEWARD_BIND_HOST=0.0.0.0
 
 # Install production dependencies only (no dev/build tools)
 COPY package.json bun.lock turbo.json tsconfig.json ./

--- a/packages/proxy/src/__tests__/deploy-artifacts.test.ts
+++ b/packages/proxy/src/__tests__/deploy-artifacts.test.ts
@@ -21,10 +21,21 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const DEPLOY_DIR = join(import.meta.dir, "..", "..", "..", "..", "deploy");
+const ROOT_DIR = join(DEPLOY_DIR, "..");
 
 function read(name: string): string {
   return readFileSync(join(DEPLOY_DIR, name), "utf8");
 }
+
+describe("published Docker runtime network contract", () => {
+  test("binds the API to the container network instead of loopback", () => {
+    const dockerfile = readFileSync(join(ROOT_DIR, "Dockerfile"), "utf8");
+    const runtime = dockerfile.slice(dockerfile.indexOf(" AS runtime"));
+
+    expect(runtime).toContain("ENV STEWARD_BIND_HOST=0.0.0.0");
+    expect(runtime).toContain('CMD ["bun", "packages/api/src/index.ts"]');
+  });
+});
 
 /**
  * Extract the `steward-proxy:` service block from the compose file (everything


### PR DESCRIPTION
## Summary
- bind the published API container to `0.0.0.0` while preserving the application's safe loopback default outside Docker
- add a deploy-artifact regression test for the runtime network contract

## Failure evidence
- exact-SHA staging deployments `32429173197` and `32429769002` reached Railway `SUCCESS`, then returned `HTTP 000`/live `502` because the image listened only on loopback

## Validation
- `bun test packages/proxy/src/__tests__/deploy-artifacts.test.ts` (47 pass)
- `bun run lint`
- `bun scripts/check-ci-test-inventory.ts`
- `actionlint .github/workflows/*.yml`
- `git diff --check`