### PR TITLE
fix(auth): accept allowlisted IPv6 loopback OAuth redirects

### DIFF
--- a/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
@@ -109,6 +109,46 @@ describeWithDatabase("OAuth redirect_uri allowlist", () => {
     expect(body.error).toContain("redirect_uri is not allowed");
   });
 
+  it("allows an exact tenant-authorized IPv6 loopback HTTP redirect", async () => {
+    const redirectUri = "http://[::1]:4173/callback";
+    const db = getDb();
+    await db.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TENANT_ID));
+    await db.insert(tenantConfigs).values({
+      tenantId: TENANT_ID,
+      allowedOrigins: [],
+      allowedRedirectUrls: [redirectUri],
+    });
+
+    const res = await authRoutes.request(
+      `/oauth/google/authorize?tenant_id=${TENANT_ID}&redirect_uri=${encodeURIComponent(redirectUri)}${PKCE_QUERY}`,
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toStartWith(
+      "https://accounts.google.com/o/oauth2/v2/auth?",
+    );
+  });
+
+  it("rejects an allowlisted non-loopback HTTP redirect", async () => {
+    const redirectUri = "http://192.0.2.1:4173/callback";
+    const db = getDb();
+    await db.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TENANT_ID));
+    await db.insert(tenantConfigs).values({
+      tenantId: TENANT_ID,
+      allowedOrigins: [],
+      allowedRedirectUrls: [redirectUri],
+    });
+
+    const res = await authRoutes.request(
+      `/oauth/google/authorize?tenant_id=${TENANT_ID}&redirect_uri=${encodeURIComponent(redirectUri)}${PKCE_QUERY}`,
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("must use https except for loopback development origins");
+  });
+
   it("does not allow global OAuth redirects to satisfy a tenant-scoped /authorize request", async () => {
     const db = getDb();
     await db.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TENANT_ID));

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -10882,7 +10882,11 @@ function parseOAuthRedirectUri(redirectUri: string): URL {
   }
 
   if (redirectUrl.protocol === "http:") {
-    const host = redirectUrl.hostname.toLowerCase();
+    const serializedHost = redirectUrl.hostname.toLowerCase();
+    const host =
+      serializedHost.startsWith("[") && serializedHost.endsWith("]")
+        ? serializedHost.slice(1, -1)
+        : serializedHost;
     const isLoopback = host === "localhost" || host === "127.0.0.1" || host === "::1";
     if (!isLoopback) {
       throw new Error("redirect_uri must use https except for loopback development origins");


### PR DESCRIPTION
Closes #779

## Summary
- normalize Bun/WHATWG bracketed IPv6 hostnames before the exact loopback comparison
- accept only the exact allowlisted `[::1]` HTTP callback
- retain rejection for allowlisted non-loopback HTTP origins

## Exact local evidence
- base: `201c1869d40ffca8a207a32a24eecc7eb6f24cd6`
- head: `36e8a62d99a161ce25dbb7fd3d7ec18a1c2af500`
- real PostgreSQL 16 with all 94 migrations on the patch-equivalent pre-rebase tree
- mounted OAuth redirect suite: 11/11
- API dependency build/typecheck: 24/24
- affected Biome and exact rebased diff-check passed

Kept draft pending fresh exact hosted checks and independent review.