### PR TITLE
fix(ci): restore honest raw-signer and Docker gates

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,5 @@
 # Build and push Docker image to GitHub Container Registry (GHCR)
-# Triggers on pushes to develop + main branches and version tags (v*)
+# Builds every pull request and publishes pushes to develop/main or version tags (v*).
 #   develop -> :develop image (auto-deployed to STAGING by deploy-staging.yml)
 #   main    -> :main image (promoted to PRODUCTION manually via deploy-railway.yml)
 #   v*      -> :<semver> image (tagged release for production)
@@ -11,13 +11,6 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [develop, main]
-    paths:
-      - "Dockerfile"
-      - ".dockerignore"
-      - "package.json"
-      - "bun.lock"
-      - "packages/**/package.json"
-      - ".github/workflows/docker.yml"
 
 # A branch tag is mutable. Do not let a slower build for an older push finish
 # after a newer build and overwrite `:develop` / `:main` with stale bytes.

--- a/packages/api/src/__tests__/execution-gateway-inventory.test.ts
+++ b/packages/api/src/__tests__/execution-gateway-inventory.test.ts
@@ -79,6 +79,17 @@ function repoRelative(absPath: string): string {
   return REPO_PREFIX + relative(API_ROOT, absPath).split("\\").join("/");
 }
 
+function rawCallAfterMarker(source: string, marker: string) {
+  const markerIndex = source.indexOf(marker);
+  expect(markerIndex, `inventory marker "${marker}" must exist`).toBeGreaterThanOrEqual(0);
+  const match = new RegExp(RAW_SIGN_RE.source).exec(source.slice(markerIndex));
+  expect(match, `inventory marker "${marker}" must anchor a following raw signer`).not.toBeNull();
+  return {
+    markerIndex,
+    rawCallIndex: markerIndex + (match?.index ?? 0),
+  };
+}
+
 /**
  * Classify a single `signTransaction` token occurrence in a production source
  * file into exactly one bucket. Returns a category plus a human-facing note so
@@ -230,17 +241,35 @@ describe("execution gateway raw-signer inventory (repository-wide)", () => {
     for (const site of RAW_EVM_SIGN_INVENTORY) {
       if (site.classification !== "migrated-invariant-guarded") continue;
       if (site.file !== "packages/api/src/routes/vault.ts") continue;
-      // The marker for the guarded sites IS the invariant throw string, which
-      // must appear before the corresponding raw call. Presence is asserted
-      // above; here we assert the invariant strings the runtime relies on exist.
-      expect(vaultSource.includes(site.marker)).toBe(true);
+      const { markerIndex, rawCallIndex } = rawCallAfterMarker(vaultSource, site.marker);
+      const throwIndex = vaultSource.lastIndexOf("throw new Error(", markerIndex);
+      expect(
+        throwIndex,
+        `guard marker "${site.marker}" must be inside the throw immediately before its raw signer`,
+      ).toBeGreaterThanOrEqual(0);
+      const guardToCall = vaultSource.slice(throwIndex, rawCallIndex);
+      expect(guardToCall).toContain(site.marker);
+      expect(guardToCall.length).toBeLessThan(600);
     }
-    // Both primary + approval invariant guards must exist.
-    expect(vaultSource).toContain(
-      "invariant: primary EVM sign reached raw signer without gateway authorization",
+  });
+
+  test("non-EVM raw signers are tied to their explicit Solana branch", () => {
+    const vaultSource = readFileSync(join(SRC_DIR, "routes", "vault.ts"), "utf8");
+    const sites = RAW_EVM_SIGN_INVENTORY.filter(
+      (site) => site.classification === "non-evm-branch-guarded",
     );
-    expect(vaultSource).toContain(
-      "invariant: primary EVM approval reached raw signer without gateway authorization",
-    );
+    expect(sites).toHaveLength(1);
+    for (const site of sites) {
+      expect(site.file).toBe("packages/api/src/routes/vault.ts");
+      const { markerIndex, rawCallIndex } = rawCallAfterMarker(vaultSource, site.marker);
+      const branchIndex = vaultSource.lastIndexOf("if (isSolana) {", markerIndex);
+      expect(
+        branchIndex,
+        `marker "${site.marker}" must be inside the Solana branch`,
+      ).toBeGreaterThanOrEqual(0);
+      const branchToCall = vaultSource.slice(branchIndex, rawCallIndex);
+      expect(branchToCall).toContain(site.marker);
+      expect(branchToCall.length).toBeLessThan(1_200);
+    }
   });
 });

--- a/packages/shared/src/security-surface.ts
+++ b/packages/shared/src/security-surface.ts
@@ -529,6 +529,8 @@ export const LEGACY_EVM_SIGN_CALL_SITES = [
  *    unreachable for EVM flows because a nearby invariant guard throws before
  *    it (the Solana primary-sign fallback and the transfer approval-replay
  *    fallback). These are inside the two gateway-migrated routes.
+ *  - "non-evm-branch-guarded": an intentionally reachable raw signer confined
+ *    to an explicit non-EVM branch inside a gateway-migrated route.
  *  - "legacy": a not-yet-gateway-migrated EVM sign surface, one-for-one with an
  *    entry in LEGACY_EVM_SIGN_CALL_SITES.
  */
@@ -537,7 +539,7 @@ export interface RawEvmSignCallSite {
   /** Stable nearby source marker (route/function/guard string) unique enough to
    *  anchor the call site without brittle line numbers. */
   marker: string;
-  classification: "migrated-invariant-guarded" | "legacy";
+  classification: "migrated-invariant-guarded" | "non-evm-branch-guarded" | "legacy";
   reason: string;
 }
 
@@ -570,7 +572,7 @@ export const RAW_EVM_SIGN_INVENTORY = [
   {
     file: "packages/api/src/routes/vault.ts",
     marker: 'transferPayload?.token === "native" && !transactionRow.data',
-    classification: "migrated-invariant-guarded",
+    classification: "non-evm-branch-guarded",
     reason:
       "Approved native-SOL replay. The enclosing isSolana branch prevents every EVM approval from reaching this raw signer.",
   },


### PR DESCRIPTION
Supersedes closed #773 after #776 advanced develop.

## Summary
- classify the reachable native-SOL raw signer honestly as non-EVM branch guarded
- bind inventory assertions to the specific raw call and nearby invariant/branch instead of vacuous global markers
- run the globally required Docker check for every pull request so protected branches cannot wait forever on a path-filtered status

## Exact local evidence
- base: `201c1869d40ffca8a207a32a24eecc7eb6f24cd6`
- head: `18d2d7218865972feb84351930c11355ed7e9b9c`
- prior patch-equivalent head passed all 62 hosted checks including PostgreSQL and Docker
- exact rebased workflow passes actionlint and diff-check

Kept draft pending fresh exact-head hosted checks and independent review.