### PR TITLE
fix: complete SDK, OAuth, and passkey correctness

### DIFF
--- a/docs/api-reference/agents.mdx
+++ b/docs/api-reference/agents.mdx
@@ -62,10 +62,11 @@ curl -X POST http://localhost:3200/agents \
 
 ## List Agents
 
-Returns all agents for the authenticated tenant.
+Returns a bounded page of agents for the authenticated tenant. The default
+limit is 100 and the maximum is 200.
 
 ```
-GET /agents
+GET /agents?limit=100&offset=0
 ```
 
 **Auth:** Tenant API key
@@ -75,25 +76,28 @@ GET /agents
 ```json
 {
   "ok": true,
-  "data": [
-    {
+  "data": {
+    "agents": [{
       "id": "my-agent",
       "name": "My Trading Agent",
       "tenantId": "your-tenant",
       "walletAddresses": { "evm": "0x742d...", "solana": "7xKXtg..." },
       "createdAt": "2026-03-26T12:00:00.000Z"
-    }
-  ]
+    }],
+    "limit": 100,
+    "offset": 0
+  }
 }
 ```
 
 <CodeGroup>
 ```typescript SDK
 const agents = await steward.listAgents();
+const page = await steward.listAgentsPage({ limit: 100, offset: 0 });
 ```
 
 ```bash cURL
-curl http://localhost:3200/agents \
+curl 'http://localhost:3200/agents?limit=100&offset=0' \
   -H "X-Steward-Key: your-key"
 ```
 </CodeGroup>

--- a/docs/sdk/client.mdx
+++ b/docs/sdk/client.mdx
@@ -45,10 +45,19 @@ const agent = await client.createWallet("my-agent", "My Agent");
 
 ### listAgents
 
-Lists all agents for the authenticated tenant.
+Lists all agents for the authenticated tenant. The SDK walks stable API pages
+at the maximum page size and fails closed on duplicate or non-progressing pages,
+while retaining the historical array return type.
 
 ```typescript
 const agents = await client.listAgents(): Promise<AgentIdentity[]>;
+```
+
+Use the canonical paginated result when the metadata is needed:
+
+```typescript
+const page = await client.listAgentsPage({ limit: 25, offset: 0 });
+// { agents: AgentIdentity[], limit: 25, offset: 0 }
 ```
 
 ### getAgent
@@ -304,7 +313,8 @@ const addresses = await client.getAddresses(
 
 ### getHistory
 
-Gets the transaction history for an agent.
+Gets the complete transaction history for an agent. The SDK walks every bounded
+API page before returning the historical array result.
 
 ```typescript
 const history = await client.getHistory(

--- a/packages/api/src/__tests__/agent-route-scope.test.ts
+++ b/packages/api/src/__tests__/agent-route-scope.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { generateApiKey, signAgentToken } from "@stwd/auth";
-import { agents, auditEvents, getDb, tenants, users, userTenants } from "@stwd/db";
+import { agents, auditEvents, getDb, tenants, transactions, users, userTenants } from "@stwd/db";
+import { StewardClient } from "@stwd/sdk";
 import { and, desc, eq } from "drizzle-orm";
 
 setDefaultTimeout(30000);
@@ -242,6 +243,78 @@ describeWithDatabase("agent route scope enforcement", () => {
     // assert containment rather than exact equality.
     expect(ids).toContain(AGENT_A);
     expect(ids).toContain(AGENT_B);
+  });
+
+  it("serves the canonical paginated response through the production SDK client", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      if (url.origin === "https://sdk-contract.steward.test") {
+        return app.request(`${url.pathname}${url.search}`, init);
+      }
+      return originalFetch(input, init);
+    };
+
+    try {
+      const client = new StewardClient({
+        baseUrl: "https://sdk-contract.steward.test",
+        apiKey,
+        tenantId: TENANT_ID,
+      });
+      const firstPage = await client.listAgentsPage({ limit: 1, offset: 0 });
+      const page = await client.listAgentsPage({ limit: 1, offset: 1 });
+
+      expect(firstPage.agents[0]?.id).toBe(AGENT_A);
+      expect(page.limit).toBe(1);
+      expect(page.offset).toBe(1);
+      expect(page.agents).toHaveLength(1);
+      expect(page.agents[0]?.id).toBe(AGENT_B);
+      expect(page.agents[0]?.createdAt).toBeInstanceOf(Date);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("orders equal-timestamp transaction history by id for stable offset pagination", async () => {
+    const createdAt = new Date("2026-08-20T12:00:00.000Z");
+    await getDb()
+      .insert(transactions)
+      .values([
+        {
+          id: "test-ars-history-a",
+          agentId: AGENT_A,
+          status: "pending",
+          toAddress: "0x1111111111111111111111111111111111111111",
+          value: "1",
+          chainId: 8453,
+          policyResults: [],
+          createdAt,
+        },
+        {
+          id: "test-ars-history-b",
+          agentId: AGENT_A,
+          status: "pending",
+          toAddress: "0x1111111111111111111111111111111111111111",
+          value: "1",
+          chainId: 8453,
+          policyResults: [],
+          createdAt,
+        },
+      ])
+      .onConflictDoNothing();
+
+    const fetchPage = async (offset: number) => {
+      const response = await app.request(`/vault/${AGENT_A}/history?limit=1&offset=${offset}`, {
+        headers: { Authorization: `Bearer ${ownerSessionToken}` },
+      });
+      expect(response.status).toBe(200);
+      return (await response.json()) as {
+        data: { transactions: Array<{ id: string }>; limit: number; offset: number };
+      };
+    };
+
+    expect((await fetchPage(0)).data.transactions[0]?.id).toBe("test-ars-history-b");
+    expect((await fetchPage(1)).data.transactions[0]?.id).toBe("test-ars-history-a");
   });
 
   it("rejects a bare tenant API key for agent-token minting unless explicitly opted in (SEC-209)", async () => {

--- a/packages/api/src/__tests__/auth-oauth-callback-browser.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-callback-browser.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, mock } from "bun:test";
-import { closeDb } from "@stwd/db";
+import { accounts, closeDb, getDb, users } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
 
 const REDIRECT_URI = "https://app.example.test/callback?from=oauth";
 const ORIGINAL_FETCH = globalThis.fetch;
@@ -34,6 +35,8 @@ beforeAll(async () => {
   process.env.NODE_ENV = "test";
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = "oauth-callback-browser-master-password";
+  process.env.STEWARD_JWT_SECRET = "oauth-callback-browser-jwt-secret-with-enough-bytes";
+  process.env.STEWARD_AUDIT_HMAC_KEY = "b".repeat(64);
   const { db, client } = await createPGLiteDb("memory://");
   setPGLiteOverride(db, async () => {
     await client.close();
@@ -55,9 +58,81 @@ afterAll(async () => {
   delete process.env.NODE_ENV;
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_MASTER_PASSWORD;
+  delete process.env.STEWARD_JWT_SECRET;
+  delete process.env.STEWARD_AUDIT_HMAC_KEY;
 });
 
 describe("OAuth browser callback failures", () => {
+  for (const client of [
+    { name: "a browser navigation", suffix: "browser", headers: browserHeaders() },
+    { name: "an explicit JSON client", suffix: "json", headers: { accept: "application/json" } },
+  ]) {
+    it(`completes wallet-backed OAuth for ${client.name} without exposing tokens`, async () => {
+      const { suffix } = client;
+      const state = `successful-${suffix}-state`;
+      const providerAccountId = `google-success-${suffix}`;
+      const email = `oauth-success-${suffix}@example.test`;
+      process.env.APP_URL = "https://api.example.test";
+      process.env.GOOGLE_CLIENT_ID = "google-client";
+      process.env.GOOGLE_CLIENT_SECRET = "google-secret";
+      process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS = REDIRECT_URI;
+      await getAuthChallengeStore().set(
+        `oauth:${state}`,
+        JSON.stringify({
+          provider: "google",
+          redirectUri: REDIRECT_URI,
+          appState: `client-${suffix}-state`,
+        }),
+      );
+      globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "https://oauth2.googleapis.com/token") {
+          return Response.json({
+            access_token: `provider-access-${suffix}`,
+            refresh_token: `provider-refresh-${suffix}`,
+            expires_in: 3600,
+            token_type: "Bearer",
+          });
+        }
+        if (url === "https://www.googleapis.com/oauth2/v3/userinfo") {
+          return Response.json({
+            id: providerAccountId,
+            email,
+            name: `OAuth Success ${suffix}`,
+            verified_email: true,
+          });
+        }
+        return new Response("unexpected provider request", { status: 500 });
+      }) as unknown as typeof fetch;
+
+      const response = await authRoutes.request(
+        `/oauth/google/callback?code=provider-code&state=${state}`,
+        { headers: client.headers },
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location");
+      expect(location).toStartWith(`${REDIRECT_URI}#`);
+      expect(location).toContain(`state=client-${suffix}-state`);
+      expect(location).not.toContain("token=");
+      expect(location).not.toContain(`provider-access-${suffix}`);
+      expect(location).not.toContain(`provider-refresh-${suffix}`);
+
+      const [account] = await getDb()
+        .select({ userId: accounts.userId, accessTokenEncrypted: accounts.accessTokenEncrypted })
+        .from(accounts)
+        .where(eq(accounts.providerAccountId, providerAccountId));
+      expect(account?.accessTokenEncrypted).toBeTruthy();
+      expect(account?.accessTokenEncrypted).not.toBe(`provider-access-${suffix}`);
+      const [user] = await getDb()
+        .select({ walletAddress: users.walletAddress, stewardWalletId: users.stewardWalletId })
+        .from(users)
+        .where(eq(users.id, account?.userId ?? "00000000-0000-0000-0000-000000000000"));
+      expect(user?.walletAddress).toMatch(/^0x[0-9a-f]{40}$/i);
+      expect(user?.stewardWalletId).toBeTruthy();
+    });
+  }
+
   it("renders a non-reflective HTML page for provider errors", async () => {
     const attackerText = '<img src=x onerror="fetch(`https://attacker.test`) ">';
     process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS = REDIRECT_URI;
@@ -104,6 +179,25 @@ describe("OAuth browser callback failures", () => {
       error: "This sign-in attempt is invalid or has expired.",
       code: "oauth_state_expired",
     });
+  });
+
+  it("uses HTML for a navigation with no Accept header", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-no-accept-navigation-state",
+      { headers: { "sec-fetch-mode": "navigate" } },
+    );
+
+    await expectBrowserError(response, { status: 401, code: "oauth_state_expired" });
+  });
+
+  it("keeps JSON with no Accept header when the request is not a navigation", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-no-accept-client-state",
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toMatchObject({ ok: false, code: "oauth_state_expired" });
   });
 
   it("honors an explicit q=0 rejection of HTML even for navigation-shaped requests", async () => {

--- a/packages/api/src/__tests__/auth-oauth-token-encryption.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-token-encryption.test.ts
@@ -1,16 +1,15 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import { accounts, closeDb, tenantConfigs, tenants, users } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { eq } from "drizzle-orm";
-import {
-  authRoutes,
-  clearOAuthTokenKeyStoreForTests,
-  decryptOAuthProviderToken,
-  encryptOAuthProviderTokens,
-} from "../routes/auth";
 
 const MASTER_PASSWORD = "oauth-token-test-master";
 const originalFetch = globalThis.fetch;
+
+let authRoutes: typeof import("../routes/auth").authRoutes;
+let clearOAuthTokenKeyStoreForTests: typeof import("../routes/auth").clearOAuthTokenKeyStoreForTests;
+let decryptOAuthProviderToken: typeof import("../routes/auth").decryptOAuthProviderToken;
+let encryptOAuthProviderTokens: typeof import("../routes/auth").encryptOAuthProviderTokens;
 
 async function setupDb() {
   process.env.STEWARD_PGLITE_MEMORY = "true";
@@ -21,10 +20,24 @@ async function setupDb() {
   return db;
 }
 
+beforeAll(async () => {
+  process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
+  process.env.STEWARD_JWT_SECRET = "oauth-token-test-jwt-secret-with-enough-bytes";
+  process.env.STEWARD_AUDIT_HMAC_KEY = "a".repeat(64);
+  await setupDb();
+  ({
+    authRoutes,
+    clearOAuthTokenKeyStoreForTests,
+    decryptOAuthProviderToken,
+    encryptOAuthProviderTokens,
+  } = await import("../routes/auth"));
+});
+
 describe("OAuth provider token encryption", () => {
   beforeEach(() => {
     process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
-    process.env.JWT_SECRET = "oauth-token-test-jwt-secret-with-enough-bytes";
+    process.env.STEWARD_JWT_SECRET = "oauth-token-test-jwt-secret-with-enough-bytes";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "a".repeat(64);
     process.env.APP_URL = "https://api.example.test";
     process.env.GOOGLE_CLIENT_ID = "google-client";
     process.env.GOOGLE_CLIENT_SECRET = "google-secret";
@@ -38,7 +51,8 @@ describe("OAuth provider token encryption", () => {
     clearOAuthTokenKeyStoreForTests();
     await closeDb().catch(() => {});
     delete process.env.STEWARD_MASTER_PASSWORD;
-    delete process.env.JWT_SECRET;
+    delete process.env.STEWARD_JWT_SECRET;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
     delete process.env.APP_URL;
     delete process.env.GOOGLE_CLIENT_ID;
     delete process.env.GOOGLE_CLIENT_SECRET;

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -4065,6 +4065,9 @@ function escapeOAuthCallbackHtml(value: string): string {
 
 function oauthCallbackPrefersHtml(c: Context): boolean {
   const accept = c.req.header("accept")?.toLowerCase() ?? "";
+  if (!accept.trim()) {
+    return c.req.header("sec-fetch-mode")?.toLowerCase() === "navigate";
+  }
   const qualityFor = (target: "application/json" | "text/html"): number | undefined => {
     const [targetType] = target.split("/");
     let bestMatch: { specificity: number; quality: number } | undefined;

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -5241,7 +5241,7 @@ vaultRoutes.get("/:agentId/history", async (c) => {
     .select()
     .from(transactions)
     .where(eq(transactions.agentId, agentId))
-    .orderBy(desc(transactions.createdAt))
+    .orderBy(desc(transactions.createdAt), desc(transactions.id))
     .limit(limit)
     .offset(offset);
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to `@stwd/react` are documented here.
 - Point example `baseUrl` values in JSDoc (`StewardProvider`, `StewardLogin`) and the README at a self-hosted instance (`http://localhost:3200`) instead of a hosted `api.steward.fi` URL. Steward is self-host-first today; there is no shared hosted API. Docs/comment only, no source behavior change.
 
 ### Tests
+- Replace the passkey-autofill source scaffold with a mounted `StewardLogin`
+  boundary probe that exercises the production component, verifies the email
+  autocomplete contract, and preserves the explicit typed-email passkey flow.
 - Added test coverage for utilities (format, theme, walletPanelRegistry), context hooks (useAuth, useSteward), data hooks (useWallet, useTransactions, useApprovals, usePolicies, useSpend), and SSR branch coverage for the component surface (auth guard, user button, tenant picker, spend dashboard, approval queue, wallet overview, policy controls, email/OAuth callbacks, passkey enrollment). Suite goes from 56 to 195 passing. No source changes.
 - State the StewardLogin hook-order regression as a current invariant instead of change-history narration. Test comment only; no runtime or API change.
 

--- a/packages/react/src/__tests__/StewardLogin.passkeyAutofill.test.tsx
+++ b/packages/react/src/__tests__/StewardLogin.passkeyAutofill.test.tsx
@@ -23,164 +23,53 @@
  *      login with the typed email.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { Window } from "happy-dom";
-import * as React from "react";
-import { createRoot, type Root } from "react-dom/client";
-import { Simulate } from "react-dom/test-utils";
+import { beforeAll, describe, expect, test } from "bun:test";
 
-const window = new Window();
-Object.assign(globalThis, {
-  window,
-  document: window.document,
-  navigator: window.navigator,
-  HTMLElement: window.HTMLElement,
-  HTMLInputElement: window.HTMLInputElement,
-  HTMLButtonElement: window.HTMLButtonElement,
-  Event: window.Event,
-  KeyboardEvent: window.KeyboardEvent,
-  MouseEvent: window.MouseEvent,
-  IS_REACT_ACT_ENVIRONMENT: true,
-});
-
-// Spy on navigator.credentials.get so any conditional-mediation request
-// issued by the component (mount-time or type-time) is detected.
-const credentialsGet = mock(async (..._args: unknown[]) => {
-  throw new Error("navigator.credentials.get must not be called by StewardLogin");
-});
-Object.defineProperty(window.navigator, "credentials", {
-  value: { get: credentialsGet, create: mock(async () => null) },
-  configurable: true,
-});
-
-const { StewardLogin } = await import("../components/StewardLogin.js");
-const { StewardAuthContext } = await import("../provider.js");
-const { registerEvmWalletPanel, registerSolanaWalletPanel } = await import(
-  "../internal/walletPanelRegistry.js"
-);
-
-const loginSource = readFileSync(
-  join(import.meta.dir, "..", "components", "StewardLogin.tsx"),
-  "utf8",
-);
-
-const dummyPanel: React.ComponentType<unknown> = () => null;
-registerEvmWalletPanel({ load: async () => ({ default: dummyPanel }) });
-registerSolanaWalletPanel({ load: async () => ({ default: dummyPanel }) });
-
-const signInWithPasskey = mock(async (_email: string) => ({}));
-
-function baseCtx() {
-  return {
-    isAuthenticated: false,
-    isLoading: false,
-    user: null,
-    session: null,
-    providers: { google: true },
-    isProvidersLoading: false,
-    guestState: { isGuest: false, isExpired: false, expiryMessage: null },
-    signOut: () => {},
-    signInAsGuest: async () => ({}),
-    upgradeGuestWithEmail: async () => ({}),
-    deleteGuest: async () => ({}),
-    getToken: () => null,
-    signInWithPasskey,
-    signInWithEmail: async () => ({}),
-    sendSmsOtp: async () => ({}),
-    verifySmsOtp: async () => ({}),
-    sendWhatsAppOtp: async () => ({}),
-    verifyWhatsAppOtp: async () => ({}),
-    verifyEmailCallback: async () => ({}),
-    signInWithSIWE: async () => ({}),
-    signInWithSolana: async () => ({}),
-    signInWithOAuth: async () => ({}),
-    signInWithTelegram: async () => ({}),
-    signInWithFarcaster: async () => ({}),
-    activeTenantId: null,
-    tenants: null,
-    isTenantsLoading: false,
-    listTenants: async () => [],
-    switchTenant: async () => {},
-    joinTenant: async () => {},
-    leaveTenant: async () => {},
-  };
+interface MountedPasskeyProbe {
+  autocomplete: string | null;
+  credentialsCallsAfterMount: number;
+  credentialsCallsAfterTyping: number;
+  passkeyCallsAfterTyping: string[];
+  passkeyCallsAfterClick: string[];
 }
 
-let container: HTMLDivElement;
-let root: Root | null = null;
+let probe: MountedPasskeyProbe;
 
-async function renderLogin(): Promise<void> {
-  if (root) {
-    await React.act(async () => root?.unmount());
-    root = null;
+beforeAll(async () => {
+  // The mounted probe needs happy-dom and react-dom/client. Run it in a child
+  // process so those browser globals and module-cache choices cannot mutate
+  // the rest of the package's SSR-oriented test process.
+  const fixture = new URL("./fixtures/passkey-autofill-mounted.tsx", import.meta.url).pathname;
+  const child = Bun.spawn(["bun", fixture], {
+    cwd: new URL("../..", import.meta.url).pathname,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: process.env,
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (code !== 0) {
+    throw new Error(`mounted passkey probe failed (${code}):\n${stderr || stdout}`);
   }
-  container = window.document.createElement("div") as unknown as HTMLDivElement;
-  window.document.body.replaceChildren(container as unknown as Node);
-  root = createRoot(container);
-  await React.act(async () => {
-    root?.render(
-      React.createElement(
-        StewardAuthContext.Provider,
-        { value: baseCtx() as unknown as React.ContextType<typeof StewardAuthContext> },
-        React.createElement(StewardLogin, {}),
-      ),
-    );
-  });
-}
-
-function emailInput(): HTMLInputElement {
-  const input = container.querySelector('input[aria-label="email"]');
-  if (!input) throw new Error("email input not found");
-  return input as unknown as HTMLInputElement;
-}
-
-async function typeEmail(value: string): Promise<void> {
-  const input = emailInput();
-  await React.act(async () => {
-    // happy-dom events don't traverse React 18's synthetic event plumbing
-    // for controlled inputs, so drive onChange via Simulate (deterministic
-    // and version-pinned alongside react-dom in this workspace).
-    (input as unknown as { value: string }).value = value;
-    Simulate.change(input as unknown as Element);
-  });
-}
-
-beforeEach(async () => {
-  credentialsGet.mockClear();
-  signInWithPasskey.mockClear();
-  signInWithPasskey.mockImplementation(async () => ({}));
-  await renderLogin();
+  probe = JSON.parse(stdout.trim()) as MountedPasskeyProbe;
 });
 
 describe("passkey conditional-mediation autofill regression", () => {
   test("email input does not carry the webauthn autofill token", () => {
-    const attr = (emailInput() as unknown as Element).getAttribute("autocomplete");
-    expect(attr).toBe("email");
-    expect(attr).not.toContain("webauthn");
-    // Source-level lock: the token must not come back in any casing/order.
-    expect(loginSource).not.toMatch(/autoComplete\s*=\s*"[^"]*webauthn[^"]*"/);
+    expect(probe.autocomplete).toBe("email");
+    expect(probe.autocomplete).not.toContain("webauthn");
   });
 
-  test("no conditional-mediation credentials.get() on mount or while typing a new email", async () => {
-    expect(credentialsGet).toHaveBeenCalledTimes(0);
-    await typeEmail("brand-new-user@example.com");
-    expect(credentialsGet).toHaveBeenCalledTimes(0);
-    // No passkey flow started implicitly either.
-    expect(signInWithPasskey).toHaveBeenCalledTimes(0);
+  test("no conditional-mediation credentials.get() on mount or while typing a new email", () => {
+    expect(probe.credentialsCallsAfterMount).toBe(0);
+    expect(probe.credentialsCallsAfterTyping).toBe(0);
+    expect(probe.passkeyCallsAfterTyping).toEqual([]);
   });
 
-  test("explicit passkey button still initiates email-scoped passkey login", async () => {
-    await typeEmail("brand-new-user@example.com");
-    const btn = [...container.querySelectorAll("button")].find(
-      (b) => b.textContent?.trim() === "passkey",
-    );
-    if (!btn) throw new Error("passkey button not found");
-    await React.act(async () => {
-      (btn as unknown as Element).dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
-    });
-    expect(signInWithPasskey).toHaveBeenCalledTimes(1);
-    expect(signInWithPasskey).toHaveBeenCalledWith("brand-new-user@example.com");
+  test("explicit passkey button still initiates email-scoped passkey login", () => {
+    expect(probe.passkeyCallsAfterClick).toEqual(["brand-new-user@example.com"]);
   });
 });

--- a/packages/react/src/__tests__/fixtures/passkey-autofill-mounted.tsx
+++ b/packages/react/src/__tests__/fixtures/passkey-autofill-mounted.tsx
@@ -1,0 +1,122 @@
+import { Window } from "happy-dom";
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+import { Simulate } from "react-dom/test-utils";
+
+const window = new Window();
+Object.assign(globalThis, {
+  window,
+  document: window.document,
+  navigator: window.navigator,
+  HTMLElement: window.HTMLElement,
+  HTMLInputElement: window.HTMLInputElement,
+  HTMLButtonElement: window.HTMLButtonElement,
+  Event: window.Event,
+  KeyboardEvent: window.KeyboardEvent,
+  MouseEvent: window.MouseEvent,
+  IS_REACT_ACT_ENVIRONMENT: true,
+});
+
+let credentialsCalls = 0;
+Object.defineProperty(window.navigator, "credentials", {
+  value: {
+    get: async () => {
+      credentialsCalls += 1;
+      throw new Error("navigator.credentials.get must not be called by StewardLogin");
+    },
+    create: async () => null,
+  },
+  configurable: true,
+});
+
+const { StewardLogin } = await import("../../components/StewardLogin.js");
+const { StewardAuthContext } = await import("../../provider.js");
+const { registerEvmWalletPanel, registerSolanaWalletPanel } = await import(
+  "../../internal/walletPanelRegistry.js"
+);
+
+const dummyPanel: React.ComponentType<unknown> = () => null;
+registerEvmWalletPanel({ load: async () => ({ default: dummyPanel }) });
+registerSolanaWalletPanel({ load: async () => ({ default: dummyPanel }) });
+
+const passkeyCalls: string[] = [];
+const contextValue = {
+  isAuthenticated: false,
+  isLoading: false,
+  user: null,
+  session: null,
+  providers: { google: true },
+  isProvidersLoading: false,
+  guestState: { isGuest: false, isExpired: false, expiryMessage: null },
+  signOut: () => {},
+  signInAsGuest: async () => ({}),
+  upgradeGuestWithEmail: async () => ({}),
+  deleteGuest: async () => ({}),
+  getToken: () => null,
+  signInWithPasskey: async (email: string) => {
+    passkeyCalls.push(email);
+    return {};
+  },
+  signInWithEmail: async () => ({}),
+  sendSmsOtp: async () => ({}),
+  verifySmsOtp: async () => ({}),
+  sendWhatsAppOtp: async () => ({}),
+  verifyWhatsAppOtp: async () => ({}),
+  verifyEmailCallback: async () => ({}),
+  signInWithSIWE: async () => ({}),
+  signInWithSolana: async () => ({}),
+  signInWithOAuth: async () => ({}),
+  signInWithTelegram: async () => ({}),
+  signInWithFarcaster: async () => ({}),
+  activeTenantId: null,
+  tenants: null,
+  isTenantsLoading: false,
+  listTenants: async () => [],
+  switchTenant: async () => {},
+  joinTenant: async () => {},
+  leaveTenant: async () => {},
+};
+
+const container = window.document.createElement("div") as unknown as HTMLDivElement;
+window.document.body.replaceChildren(container as unknown as Node);
+const root = createRoot(container);
+await React.act(async () => {
+  root.render(
+    React.createElement(
+      StewardAuthContext.Provider,
+      { value: contextValue as unknown as React.ContextType<typeof StewardAuthContext> },
+      React.createElement(StewardLogin, {}),
+    ),
+  );
+});
+
+const input = container.querySelector('input[aria-label="email"]');
+if (!input) throw new Error("email input not found");
+const autocomplete = input.getAttribute("autocomplete");
+const credentialsCallsAfterMount = credentialsCalls;
+
+await React.act(async () => {
+  (input as unknown as { value: string }).value = "brand-new-user@example.com";
+  Simulate.change(input);
+});
+const credentialsCallsAfterTyping = credentialsCalls;
+const passkeyCallsAfterTyping = [...passkeyCalls];
+
+const button = [...container.querySelectorAll("button")].find(
+  (candidate) => candidate.textContent?.trim() === "passkey",
+);
+if (!button) throw new Error("passkey button not found");
+await React.act(async () => {
+  button.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+});
+
+await React.act(async () => root.unmount());
+console.log(
+  JSON.stringify({
+    autocomplete,
+    credentialsCallsAfterMount,
+    credentialsCallsAfterTyping,
+    passkeyCallsAfterTyping,
+    passkeyCallsAfterClick: passkeyCalls,
+  }),
+);

--- a/packages/react/src/components/StewardLogin.tsx
+++ b/packages/react/src/components/StewardLogin.tsx
@@ -725,12 +725,8 @@ export function StewardLogin({
               }
             }}
             disabled={isLoading}
-            // No "webauthn" autofill token here: it arms browser conditional
-            // mediation, which surfaces ANY discoverable passkey for this RP
-            // regardless of the email being typed. That hijacked new-account
-            // signup (typing a brand-new email prompted an existing account's
-            // passkey). Passkey login stays available via the explicit passkey
-            // button, which scopes the ceremony to the typed email.
+            // Keep passkey discovery behind the explicit, email-scoped action;
+            // the `webauthn` token can offer unrelated discoverable credentials.
             autoComplete="email"
             aria-label="email"
           />

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -13,6 +13,12 @@
 - `StewardClient`, `StewardAuth`, and `AgentClient` constructors now REJECT a plaintext non-loopback `baseUrl` (fail closed, SEC-048). These clients transmit platform keys, app secrets, bearer tokens, and HMAC-signed credentials, which must never travel cleartext off-loopback — the CLI has always enforced this. `http://localhost`/`127.0.0.1`/`[::1]` stay allowed for local development; operators on trusted private networks can opt out with the new `allowInsecureBaseUrl: true` config (warns loudly at construction). Previously-working insecure configs must pass the flag or switch to HTTPS.
 - `/accounts` and `/global-wallet` mutations are now HMAC-signed when `requestSigningSecret` is configured, aligning the request-signing prefix list with all eight other SDKs (SEC-049). Servers that enforce signatures on these routes previously saw unsigned mutations from this SDK.
 ### Added
+- Add the public `listAgentsPage({ limit, offset })` API with typed
+  `{ agents, limit, offset }` metadata. The historical `listAgents()` and
+  `getTransactionHistory()` array APIs now exhaust stable, bounded server pages
+  and fail closed on malformed offsets, non-progressing pages, or duplicate
+  agent/transaction identities; transaction-history ordering is stabilized by
+  `createdAt` then `id` for deterministic offset traversal.
 - Expose the SigV4 secret-route strategy/config fields in generated API types for governed, region-bound AWS EC2 operations.
 - Add `approveVaultTransaction()` and its typed result so SDK consumers can execute an approved vault transaction through the policy-revalidating vault route.
 - `StewardAuthConfig.authProxyUrl`: optional same-origin auth proxy prefix (e.g. `/api/auth`) that keeps the long-lived refresh token in an HttpOnly, SameSite=Strict cookie instead of JS-readable storage (SEC-018). When set, sign-in deposits the refresh token with the proxy (failing closed if the deposit cannot be completed), and refresh / revoke / tenant-switch calls go through the proxy — only the short-lived access token is kept in `storage`. Unset keeps the previous behavior unchanged.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -96,10 +96,22 @@ getAgent(agentId: string): Promise<AgentIdentity>
 
 ### `listAgents`
 
-List all agents for the authenticated tenant.
+List all agents for the authenticated tenant. The SDK walks stable API pages at
+the maximum page size and fails closed on duplicate or non-progressing pages,
+while retaining the historical array return type.
 
 ```typescript
 listAgents(): Promise<AgentIdentity[]>
+```
+
+Use `listAgentsPage()` when pagination metadata is needed:
+
+```typescript
+listAgentsPage(options?: { limit?: number; offset?: number }): Promise<{
+  agents: AgentIdentity[];
+  limit: number;
+  offset: number;
+}>
 ```
 
 ---
@@ -264,7 +276,8 @@ const bscBalance = await steward.getBalance('scout-1', 56);
 
 ### `getHistory`
 
-Retrieve signing history for an agent.
+Retrieve complete signing history for an agent. The SDK walks every bounded API
+page before returning the historical array result.
 
 ```typescript
 getHistory(agentId: string): Promise<StewardHistoryEntry[]>

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -193,11 +193,6 @@ const mockAgent = {
   createdAt: new Date("2024-01-01T00:00:00Z").toISOString(),
 };
 
-const mockAgentListResponse = {
-  ok: true,
-  data: { agents: [mockAgent], limit: 100, offset: 0 },
-};
-
 const mockPolicy: PolicyRule = {
   id: "rule-1",
   type: "spending-limit",
@@ -263,11 +258,11 @@ describe("StewardClient construction", () => {
   });
 
   it("strips trailing slash from baseUrl", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     const client = new StewardClient({ baseUrl: "https://api.example.com///" });
     await client.listAgents();
     expect(lastCapture?.url).not.toContain("///agents");
-    expect(lastCapture?.url).toMatch(/\/agents$/);
+    expect(new URL(lastCapture!.url).pathname).toBe("/agents");
   });
 
   it("creates a client with all config options", () => {
@@ -885,26 +880,26 @@ describe("StewardClient webhooks", () => {
 
 describe("Request headers", () => {
   it("always sends Content-Type: application/json", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     await makeClient().listAgents();
     expect(lastCapture?.headers["content-type"]).toBe("application/json");
   });
 
   it("always sends Accept: application/json", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     await makeClient().listAgents();
     expect(lastCapture?.headers.accept).toBe("application/json");
   });
 
   it("sends X-Steward-Key header when apiKey is set", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     const client = makeClient({ apiKey: "my-secret-key" });
     await client.listAgents();
     expect(lastCapture?.headers["x-steward-key"]).toBe("my-secret-key");
   });
 
   it("sends Privy-style app secret Basic auth when app credentials are set", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     const client = makeClient({ appId: "tenant-1/web-prod", appSecret: "stw_app_secret" });
     await client.listAgents();
     expect(lastCapture?.headers["x-steward-app-id"]).toBe("tenant-1/web-prod");
@@ -914,14 +909,14 @@ describe("Request headers", () => {
   });
 
   it("sends Authorization: Bearer header when bearerToken is set", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     const client = makeClient({ bearerToken: "my-jwt-token" });
     await client.listAgents();
     expect(lastCapture?.headers.authorization).toBe("Bearer my-jwt-token");
   });
 
   it("bearerToken takes priority over apiKey when both are set", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     const client = makeClient({
       apiKey: "my-api-key",
       bearerToken: "my-bearer",
@@ -933,7 +928,7 @@ describe("Request headers", () => {
   });
 
   it("sends X-Steward-Tenant header when tenantId is set", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     const client = makeClient({ tenantId: "my-tenant-123" });
     await client.listAgents();
     expect(lastCapture?.headers["x-steward-tenant"]).toBe("my-tenant-123");
@@ -949,7 +944,7 @@ describe("Request headers", () => {
   });
 
   it("does not send auth header when neither apiKey nor bearerToken is set", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     await makeClient().listAgents();
     expect(lastCapture?.headers.authorization).toBeUndefined();
     expect(lastCapture?.headers["x-steward-key"]).toBeUndefined();
@@ -1041,7 +1036,7 @@ describe("Request headers", () => {
   });
 
   it("does not sign non-sensitive requests", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     const client = makeClient({
       requestSigningSecret: "request-signing-secret",
     });
@@ -1077,16 +1072,16 @@ describe("Request headers", () => {
 
 describe("HTTP request building", () => {
   it("refuses redirects so Steward credentials cannot be replayed", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     await makeClient({ apiKey: "tenant-key" }).listAgents();
     expect(lastCapture?.redirect).toBe("error");
   });
 
   it("listAgents → GET /agents", async () => {
-    installMockFetch(mockAgentListResponse);
+    installMockFetch({ ok: true, data: [mockAgent] });
     await makeClient().listAgents();
     expect(lastCapture?.method).toBe("GET");
-    expect(lastCapture?.url).toBe("https://api.steward.example/agents");
+    expect(lastCapture?.url).toBe("https://api.steward.example/agents?limit=200&offset=0");
   });
 
   it("getAgent → GET /agents/:id", async () => {
@@ -3981,7 +3976,9 @@ describe("HTTP request building", () => {
     installMockFetch({ ok: true, data: [] });
     await makeClient().getHistory("agent-1");
     expect(lastCapture?.method).toBe("GET");
-    expect(lastCapture?.url).toBe("https://api.steward.example/vault/agent-1/history");
+    expect(lastCapture?.url).toBe(
+      "https://api.steward.example/vault/agent-1/history?limit=200&offset=0",
+    );
   });
 
   it("listTransactions and getTransaction use first-class transaction endpoints", async () => {
@@ -4849,55 +4846,136 @@ describe("Error handling", () => {
 // ─── Response Parsing Tests ───────────────────────────────────────────────
 
 describe("Response parsing", () => {
-  it("listAgents returns parsed agent array", async () => {
-    installMockFetch({ ok: true, data: { agents: [mockAgent], limit: 100, offset: 0 } });
+  it("listAgents consumes the canonical paginated response and returns parsed agents", async () => {
+    installMockFetch({
+      ok: true,
+      data: { agents: [mockAgent], limit: 25, offset: 0 },
+    });
     const agents = await makeClient().listAgents();
     expect(agents).toHaveLength(1);
     expect(agents[0].id).toBe("agent-1");
     expect(agents[0].name).toBe("Test Agent");
   });
 
-  it("listAgents rejects the obsolete array envelope", async () => {
-    installMockFetch({ ok: true, data: [mockAgent] });
-    await expect(makeClient().listAgents()).rejects.toThrow();
-  });
-
   it("listAgents parses createdAt as Date object", async () => {
-    installMockFetch({ ok: true, data: { agents: [mockAgent], limit: 100, offset: 0 } });
+    installMockFetch({
+      ok: true,
+      data: { agents: [mockAgent], limit: 100, offset: 0 },
+    });
     const agents = await makeClient().listAgents();
     // parseAgentIdentity converts createdAt string to Date
     expect(agents[0].createdAt).toBeInstanceOf(Date);
   });
 
-  it("listAgents exhausts every canonical page", async () => {
-    let calls = 0;
-    global.fetch = async (input) => {
-      const url = String(input);
-      calls += 1;
-      const page =
-        calls === 1
-          ? Array.from({ length: 100 }, (_, index) => ({
-              ...mockAgent,
-              id: `agent-${index}`,
-            }))
-          : [{ ...mockAgent, id: "agent-100" }];
-      expect(url).toBe(
-        calls === 1
-          ? "https://api.steward.example/agents"
-          : "https://api.steward.example/agents?limit=100&offset=100",
-      );
+  it("listAgentsPage preserves canonical pagination metadata and sends page parameters", async () => {
+    installMockFetch({
+      ok: true,
+      data: { agents: [mockAgent], limit: 10, offset: 20 },
+    });
+
+    const page = await makeClient().listAgentsPage({ limit: 10, offset: 20 });
+
+    expect(lastCapture?.url).toBe("https://api.steward.example/agents?limit=10&offset=20");
+    expect(page.limit).toBe(10);
+    expect(page.offset).toBe(20);
+    expect(page.agents[0]?.createdAt).toBeInstanceOf(Date);
+  });
+
+  it("listAgents walks every canonical page before returning the historical array shape", async () => {
+    const requestedUrls: string[] = [];
+    global.fetch = async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      requestedUrls.push(url);
+      const offset = Number(new URL(url).searchParams.get("offset") ?? "0");
+      const pageAgents =
+        offset === 0
+          ? [mockAgent, { ...mockAgent, id: "agent-2" }]
+          : [{ ...mockAgent, id: "agent-3" }];
       return new Response(
         JSON.stringify({
           ok: true,
-          data: { agents: page, limit: 100, offset: calls === 1 ? 0 : 100 },
+          data: { agents: pageAgents, limit: 2, offset },
         }),
-        { headers: { "content-type": "application/json" } },
+        { status: 200, headers: { "Content-Type": "application/json" } },
       );
     };
 
     const agents = await makeClient().listAgents();
-    expect(agents).toHaveLength(101);
-    expect(calls).toBe(2);
+
+    expect(requestedUrls).toEqual([
+      "https://api.steward.example/agents?limit=200&offset=0",
+      "https://api.steward.example/agents?limit=200&offset=2",
+    ]);
+    expect(agents.map((agent) => agent.id)).toEqual(["agent-1", "agent-2", "agent-3"]);
+  });
+
+  it("listAgents fails closed on repeated agents across pages", async () => {
+    global.fetch = async (input: RequestInfo | URL) => {
+      const url = new URL(
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+      );
+      const offset = Number(url.searchParams.get("offset"));
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          data: {
+            agents: offset === 0 ? [mockAgent, { ...mockAgent, id: "agent-2" }] : [mockAgent],
+            limit: 2,
+            offset,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+
+    await expect(makeClient().listAgents()).rejects.toThrow("Duplicate agent");
+  });
+
+  it("getTransactionHistory walks every canonical page", async () => {
+    const requestedUrls: string[] = [];
+    const tx = (id: string) => ({
+      id,
+      agentId: "agent-1",
+      status: "pending",
+      request: {
+        agentId: "agent-1",
+        tenantId: "tenant-1",
+        to: "0x1111111111111111111111111111111111111111",
+        value: "1",
+        chainId: 8453,
+      },
+      policyResults: [],
+      createdAt: "2026-08-20T00:00:00.000Z",
+    });
+    global.fetch = async (input: RequestInfo | URL) => {
+      const url = new URL(
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+      );
+      requestedUrls.push(url.toString());
+      const offset = Number(url.searchParams.get("offset"));
+      const transactions = offset === 0 ? [tx("tx-1"), tx("tx-2")] : [tx("tx-3")];
+      return new Response(JSON.stringify({ ok: true, data: { transactions, limit: 2, offset } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    const transactions = await makeClient().getTransactionHistory("agent-1");
+    expect(requestedUrls).toEqual([
+      "https://api.steward.example/vault/agent-1/history?limit=200&offset=0",
+      "https://api.steward.example/vault/agent-1/history?limit=200&offset=2",
+    ]);
+    expect(transactions.map((transaction) => transaction.id)).toEqual(["tx-1", "tx-2", "tx-3"]);
+  });
+
+  it("listAgents retains compatibility with legacy bare-array responses", async () => {
+    installMockFetch({ ok: true, data: [mockAgent] });
+
+    const page = await makeClient().listAgentsPage();
+
+    expect(page).toMatchObject({ limit: 1, offset: 0 });
+    expect(page.agents[0]?.id).toBe("agent-1");
   });
 
   it("getAgent returns single agent", async () => {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -156,6 +156,30 @@ export interface BatchCreateResult {
   errors: Array<{ id: string; error: string }>;
 }
 
+export interface AgentListOptions {
+  limit?: number;
+  offset?: number;
+}
+
+export interface AgentListResult {
+  agents: AgentIdentity[];
+  limit: number;
+  offset: number;
+}
+
+type DecodedAgentListResult = {
+  result: AgentListResult;
+  legacyArray: boolean;
+};
+
+type DecodedTransactionListResult = {
+  result: TransactionListResult;
+  legacyArray: boolean;
+};
+
+const MAX_LIST_PAGE_SIZE = 200;
+const MAX_LIST_OFFSET = 100_000;
+
 export interface WalletBatchSpec {
   /** Client-side reference id used only for partial-failure reporting. */
   id: string;
@@ -2387,37 +2411,100 @@ export class StewardClient {
     return parseAgentIdentity(response.data);
   }
 
+  /**
+   * List all agents for backwards compatibility, walking every canonical API page.
+   * Use {@link listAgentsPage} when explicit pagination metadata is needed.
+   */
   async listAgents(): Promise<AgentIdentity[]> {
     const agents: AgentIdentity[] = [];
-    let offset = 0;
-    let firstPage = true;
+    const seenAgentIds = new Set<string>();
+    let requestedOffset = 0;
 
-    while (offset <= 100_000) {
-      const response = await this.request<
-        { agents: AgentIdentity[]; limit: number; offset: number },
-        StewardErrorResponse
-      >(firstPage ? "/agents" : `/agents?limit=100&offset=${offset}`);
-
-      if (!response.ok) {
-        throw new StewardApiError(response.error, response.status, response.data);
+    while (true) {
+      const decoded = await this.requestAgentListPage({
+        limit: MAX_LIST_PAGE_SIZE,
+        offset: requestedOffset,
+      });
+      const page = decoded.result;
+      if (!decoded.legacyArray && page.offset !== requestedOffset) {
+        throw new StewardApiError("Invalid agent list pagination response", 0, page);
       }
+      for (const agent of page.agents) {
+        if (seenAgentIds.has(agent.id)) {
+          throw new StewardApiError("Duplicate agent in paginated response", 0, page);
+        }
+        seenAgentIds.add(agent.id);
+        agents.push(agent);
+      }
+
+      if (decoded.legacyArray || page.agents.length === 0 || page.agents.length < page.limit) {
+        return agents;
+      }
+
+      const nextOffset = page.offset + page.agents.length;
       if (
-        !Array.isArray(response.data?.agents) ||
-        !Number.isSafeInteger(response.data.limit) ||
-        response.data.limit < 1 ||
-        response.data.limit > 200 ||
-        response.data.offset !== offset
+        !Number.isSafeInteger(nextOffset) ||
+        nextOffset <= requestedOffset ||
+        nextOffset > MAX_LIST_OFFSET
       ) {
-        throw new Error("Invalid paginated agent-list response");
+        throw new StewardApiError("Invalid agent list pagination response", 0, page);
       }
+      requestedOffset = nextOffset;
+    }
+  }
 
-      agents.push(...response.data.agents.map(parseAgentIdentity));
-      if (response.data.agents.length < response.data.limit) break;
-      offset += response.data.limit;
-      firstPage = false;
+  /** List one page of agents with the canonical API pagination metadata. */
+  async listAgentsPage(options: AgentListOptions = {}): Promise<AgentListResult> {
+    return (await this.requestAgentListPage(options)).result;
+  }
+
+  private async requestAgentListPage(options: AgentListOptions): Promise<DecodedAgentListResult> {
+    const params = new URLSearchParams();
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    if (options.offset !== undefined) params.set("offset", String(options.offset));
+    const query = params.toString();
+    const response = await this.request<AgentIdentity[] | AgentListResult, StewardErrorResponse>(
+      `/agents${query ? `?${query}` : ""}`,
+    );
+
+    if (!response.ok) {
+      throw new StewardApiError(response.error, response.status, response.data);
     }
 
-    return agents;
+    // Steward versions before agent-list pagination returned a bare array.
+    // Keep that response compatibility narrow and expose truthful synthetic
+    // metadata rather than requiring downstream consumers to branch on shape.
+    if (Array.isArray(response.data)) {
+      return {
+        result: {
+          agents: response.data.map(parseAgentIdentity),
+          limit: response.data.length,
+          offset: 0,
+        },
+        legacyArray: true,
+      };
+    }
+
+    if (
+      !Array.isArray(response.data.agents) ||
+      !Number.isSafeInteger(response.data.limit) ||
+      response.data.limit < 1 ||
+      response.data.limit > MAX_LIST_PAGE_SIZE ||
+      response.data.agents.length > response.data.limit ||
+      !Number.isSafeInteger(response.data.offset) ||
+      response.data.offset < 0 ||
+      response.data.offset > MAX_LIST_OFFSET
+    ) {
+      throw new StewardApiError("Invalid agent list response", 0, response.data);
+    }
+
+    return {
+      result: {
+        ...response.data,
+        agents: response.data.agents.map(parseAgentIdentity),
+      },
+      legacyArray: false,
+    };
   }
 
   /**
@@ -2443,16 +2530,82 @@ export class StewardClient {
    * original sign request.
    */
   async getTransactionHistory(agentId: string): Promise<TxRecord[]> {
-    const response = await this.request<TxRecord[] | TransactionListResult, StewardErrorResponse>(
-      `/vault/${encodeURIComponent(agentId)}/history`,
-    );
+    const records: TxRecord[] = [];
+    const seenTransactionIds = new Set<string>();
+    let requestedOffset = 0;
 
+    while (true) {
+      const decoded = await this.requestTransactionHistoryPage(agentId, requestedOffset);
+      const page = decoded.result;
+      if (!decoded.legacyArray && page.offset !== requestedOffset) {
+        throw new StewardApiError("Invalid transaction history pagination response", 0, page);
+      }
+      for (const transaction of page.transactions) {
+        if (seenTransactionIds.has(transaction.id)) {
+          throw new StewardApiError("Duplicate transaction in paginated history", 0, page);
+        }
+        seenTransactionIds.add(transaction.id);
+        records.push(transaction);
+      }
+      if (
+        decoded.legacyArray ||
+        page.transactions.length === 0 ||
+        page.transactions.length < page.limit
+      ) {
+        return records;
+      }
+
+      const nextOffset = page.offset + page.transactions.length;
+      if (
+        !Number.isSafeInteger(nextOffset) ||
+        nextOffset <= requestedOffset ||
+        nextOffset > MAX_LIST_OFFSET
+      ) {
+        throw new StewardApiError("Invalid transaction history pagination response", 0, page);
+      }
+      requestedOffset = nextOffset;
+    }
+  }
+
+  private async requestTransactionHistoryPage(
+    agentId: string,
+    offset: number,
+  ): Promise<DecodedTransactionListResult> {
+    const response = await this.request<TxRecord[] | TransactionListResult, StewardErrorResponse>(
+      `/vault/${encodeURIComponent(agentId)}/history?limit=${MAX_LIST_PAGE_SIZE}&offset=${offset}`,
+    );
     if (!response.ok) {
       throw new StewardApiError(response.error, response.status, response.data);
     }
-
-    const records = Array.isArray(response.data) ? response.data : response.data.transactions;
-    return records.map(parseTxRecord);
+    if (Array.isArray(response.data)) {
+      return {
+        result: {
+          transactions: response.data.map(parseTxRecord),
+          limit: response.data.length,
+          offset: 0,
+        },
+        legacyArray: true,
+      };
+    }
+    if (
+      !Array.isArray(response.data.transactions) ||
+      !Number.isSafeInteger(response.data.limit) ||
+      response.data.limit < 1 ||
+      response.data.limit > MAX_LIST_PAGE_SIZE ||
+      response.data.transactions.length > response.data.limit ||
+      !Number.isSafeInteger(response.data.offset) ||
+      response.data.offset < 0 ||
+      response.data.offset > MAX_LIST_OFFSET
+    ) {
+      throw new StewardApiError("Invalid transaction history response", 0, response.data);
+    }
+    return {
+      result: {
+        ...response.data,
+        transactions: response.data.transactions.map(parseTxRecord),
+      },
+      legacyArray: false,
+    };
   }
 
   async listTransactions(

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -70,6 +70,8 @@ export type {
   AdapterRegistryDescription,
   AdapterTokenRef,
   AdapterUnsignedIntent,
+  AgentListOptions,
+  AgentListResult,
   AgentPolicyRuleCreate,
   AgentPolicyRuleUpdate,
   BatchAgentSpec,

--- a/web/e2e/account-page.spec.ts
+++ b/web/e2e/account-page.spec.ts
@@ -358,8 +358,10 @@ test.describe("Dashboard account management", () => {
         },
       });
     });
-    await page.route(/\/agents$/, async (route) => {
-      await route.fulfill({ json: { ok: true, data: [] } });
+    await page.route(/\/agents(\?.*)?$/, async (route) => {
+      await route.fulfill({
+        json: { ok: true, data: { agents: [], limit: 100, offset: 0 } },
+      });
     });
     await page.route(/\/user\/me\/wallet\/signers(\?.*)?$/, async (route) => {
       await route.fulfill({ json: { ok: true, data: { signers: [] } } });
@@ -547,8 +549,10 @@ test.describe("Dashboard account management", () => {
         },
       });
     });
-    await page.route(/\/agents$/, async (route) => {
-      await route.fulfill({ json: { ok: true, data: [] } });
+    await page.route(/\/agents(\?.*)?$/, async (route) => {
+      await route.fulfill({
+        json: { ok: true, data: { agents: [], limit: 100, offset: 0 } },
+      });
     });
     await page.route(/\/user\/me\/wallet\/signers\/[^/?]+(\?.*)?$/, async (route) => {
       revokeUrl = route.request().url();
@@ -818,7 +822,7 @@ test.describe("Dashboard account management", () => {
         },
       });
     });
-    await page.route(/\/agents$/, async (route) => {
+    await page.route(/\/agents(\?.*)?$/, async (route) => {
       await route.fulfill({
         json: { ok: true, data: { agents, limit: 100, offset: 0 } },
       });

--- a/web/e2e/audit-log-page.spec.ts
+++ b/web/e2e/audit-log-page.spec.ts
@@ -70,8 +70,6 @@ test.describe("Dashboard audit log", () => {
       },
     ];
 
-    await loginWithMagicLink(page, request, email);
-
     await page.route(
       (url) => isApiRequest(url.href) && url.pathname === "/agents",
       async (route) => {
@@ -158,6 +156,8 @@ test.describe("Dashboard audit log", () => {
         });
       },
     );
+
+    await loginWithMagicLink(page, request, email);
 
     await page.goto(`${WEB}/dashboard/audit`);
 

--- a/web/e2e/policies-condition-sets.spec.ts
+++ b/web/e2e/policies-condition-sets.spec.ts
@@ -82,7 +82,9 @@ test.describe("Dashboard condition sets", () => {
     await page.route(
       (url) => url.href.startsWith(API) && /\/agents$/.test(url.pathname),
       async (route) => {
-        await route.fulfill({ json: { ok: true, data: [] } });
+        await route.fulfill({
+          json: { ok: true, data: { agents: [], limit: 100, offset: 0 } },
+        });
       },
     );
     await page.route(

--- a/web/e2e/transaction-history-partial-failure.spec.ts
+++ b/web/e2e/transaction-history-partial-failure.spec.ts
@@ -159,43 +159,90 @@ test("dashboard surfaces partial transaction history without discarding availabl
   await expect(page.getByRole("button", { name: "All1" })).toBeVisible();
 });
 
-test("overview pending counts include agents beyond the former twenty-agent sample", async ({
-  page,
-  request,
-}) => {
-  const agents = Array.from({ length: 21 }, (_, index) => ({
-    id: `agent-${index + 1}`,
-    name: `Agent ${index + 1}`,
-  }));
-
-  await page.route(
-    (url) => url.href.startsWith(API) && url.pathname === "/agents",
-    (route) => route.fulfill({ json: { ok: true, data: agents } }),
-  );
-  await page.route(
-    (url) => url.href.startsWith(API) && /^\/vault\/agent-\d+\/history$/.test(url.pathname),
-    async (route) => {
-      const agentId = new URL(route.request().url()).pathname.split("/")[2];
-      await route.fulfill({
-        json: {
-          ok: true,
-          data: agentId === "agent-21" ? [transaction("tx-agent-21", agentId)] : [],
-        },
-      });
-    },
-  );
-
-  await loginWithMagicLink(page, request, `complete-history-${Date.now()}@example.test`);
-  await page.goto(`${WEB}/dashboard`);
-  const pendingStat = page.getByText("Pending Approvals").locator("..");
-  await expect(pendingStat).toContainText("1");
-  await expect(page.getByRole("link", { name: "Agent 21" })).toBeVisible();
-});
-
 for (const surface of [
   { name: "overview", path: "/dashboard" },
   { name: "transactions", path: "/dashboard/transactions" },
 ] as const) {
+  test(`${surface.name} includes agent and history page-two sentinels in pending counts`, async ({
+    page,
+    request,
+  }) => {
+    const agents = Array.from({ length: 201 }, (_, index) => ({
+      id: `agent-${index + 1}`,
+      name: `Agent ${index + 1}`,
+    }));
+    const agentOffsets: number[] = [];
+    const sentinelHistoryOffsets: number[] = [];
+
+    await page.route(
+      (url) => url.href.startsWith(API) && url.pathname === "/agents",
+      async (route) => {
+        const offset = Number(new URL(route.request().url()).searchParams.get("offset"));
+        agentOffsets.push(offset);
+        await route.fulfill({
+          json: {
+            ok: true,
+            data: { agents: agents.slice(offset, offset + 200), limit: 200, offset },
+          },
+        });
+      },
+    );
+    await page.route(
+      (url) => url.href.startsWith(API) && /^\/vault\/agent-\d+\/history$/.test(url.pathname),
+      async (route) => {
+        const url = new URL(route.request().url());
+        const agentId = url.pathname.split("/")[2];
+        const offset = Number(url.searchParams.get("offset"));
+        if (agentId !== "agent-201") {
+          await route.fulfill({
+            json: { ok: true, data: { transactions: [], limit: 200, offset } },
+          });
+          return;
+        }
+        sentinelHistoryOffsets.push(offset);
+        const transactions =
+          offset === 0
+            ? Array.from({ length: 200 }, (_, index) => ({
+                ...transaction(`sentinel-confirmed-${index}`, agentId),
+                status: "confirmed",
+              }))
+            : [
+                {
+                  ...transaction("sentinel-pending", agentId),
+                  createdAt: "2026-08-21T12:00:00.000Z",
+                },
+              ];
+        await route.fulfill({
+          json: { ok: true, data: { transactions, limit: 200, offset } },
+        });
+      },
+    );
+
+    await loginWithMagicLink(
+      page,
+      request,
+      `complete-history-${surface.name}-${Date.now()}@example.test`,
+    );
+    await page.goto(`${WEB}${surface.path}`);
+    await expect(page.getByRole("link", { name: "Agent 201" }).first()).toBeVisible();
+    if (surface.name === "overview") {
+      await expect(page.getByText("Pending Approvals").locator("..")).toContainText("1");
+    } else {
+      await expect(page.getByRole("button", { name: "All201" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Pending1" })).toBeVisible();
+    }
+    // Optional wallet-provider remounts can repeat a complete load. Every load
+    // must still request exactly one first page and one page-two continuation.
+    expect([...new Set(agentOffsets)]).toEqual([0, 200]);
+    expect(agentOffsets.filter((offset) => offset === 0)).toHaveLength(
+      agentOffsets.filter((offset) => offset === 200).length,
+    );
+    expect([...new Set(sentinelHistoryOffsets)]).toEqual([0, 200]);
+    expect(sentinelHistoryOffsets.filter((offset) => offset === 0)).toHaveLength(
+      sentinelHistoryOffsets.filter((offset) => offset === 200).length,
+    );
+  });
+
   test(`${surface.name} ignores a delayed tenant-A completion after switching to tenant B`, async ({
     page,
     request,
@@ -210,23 +257,41 @@ for (const surface of [
       async (route) => {
         const authorization = route.request().headers().authorization ?? null;
         const tenant = authorization === `Bearer ${tenantBToken}` ? "b" : "a";
+        const offset = Number(new URL(route.request().url()).searchParams.get("offset"));
+        if (tenant === "a" && offset === 200) {
+          delayedTenantA.current = route;
+          return;
+        }
+        const agents =
+          tenant === "a"
+            ? Array.from({ length: 200 }, (_, index) => ({
+                id: `agent-a-${index}`,
+                name: `Tenant A Page One Agent ${index}`,
+              }))
+            : [{ id: "agent-b", name: "Tenant B Agent" }];
         await route.fulfill({
           json: {
             ok: true,
-            data: [{ id: `agent-${tenant}`, name: `Tenant ${tenant.toUpperCase()} Agent` }],
+            data: {
+              agents,
+              limit: 200,
+              offset,
+            },
           },
         });
       },
     );
     await page.route(
-      (url) => url.href.startsWith(API) && url.pathname === "/vault/agent-a/history",
-      (route) => {
-        delayedTenantA.current = route;
+      (url) => url.href.startsWith(API) && /\/vault\/[^/]+\/history$/.test(url.pathname),
+      async (route) => {
+        const agentId = new URL(route.request().url()).pathname.split("/")[2];
+        await route.fulfill({
+          json: {
+            ok: true,
+            data: agentId === "agent-b" ? [transaction("tx-b", "agent-b")] : [],
+          },
+        });
       },
-    );
-    await page.route(
-      (url) => url.href.startsWith(API) && url.pathname === "/vault/agent-b/history",
-      (route) => route.fulfill({ json: { ok: true, data: [transaction("tx-b", "agent-b")] } }),
     );
 
     await loginWithMagicLink(page, request, email);
@@ -236,7 +301,14 @@ for (const surface of [
     await expect(page.getByRole("link", { name: "Tenant B Agent" })).toBeVisible();
 
     await delayedTenantA.current?.fulfill({
-      json: { ok: true, data: [transaction("tx-a", "agent-a")] },
+      json: {
+        ok: true,
+        data: {
+          agents: [{ id: "agent-a", name: "Tenant A Agent" }],
+          limit: 200,
+          offset: 200,
+        },
+      },
     });
     await page.waitForTimeout(250);
     await expect(page.getByRole("link", { name: "Tenant B Agent" })).toBeVisible();
@@ -268,10 +340,14 @@ for (const surface of [
         await route.fulfill({
           json: {
             ok: true,
-            data: [
-              { id: "agent-available", name: availableName },
-              { id: "agent-unavailable", name: "Unavailable Agent" },
-            ],
+            data: {
+              agents: [
+                { id: "agent-available", name: availableName },
+                { id: "agent-unavailable", name: "Unavailable Agent" },
+              ],
+              limit: 100,
+              offset: 0,
+            },
           },
         });
       },


### PR DESCRIPTION
## Summary

- finish partial transaction-history correctness by walking every stable page, preserving successful history and existing tenant/session/retry fences, and failing closed on duplicate/non-progressing responses
- finish the canonical paginated agent-list SDK contract with a public `listAgentsPage()` API and complete `listAgents()` traversal
- restore HTML OAuth/OIDC callback recovery for top-level navigation requests that omit `Accept`, while retaining JSON for programmatic clients and existing explicit media-quality behavior
- replace process-global passkey scaffolding with an isolated mounted production-component probe that proves the email autocomplete boundary and explicit typed-email passkey action
- correct the final passkey test comment so it states the current mounted invariant without stale incident history

## Validation at exact head `c6b0ffea6840f0224e996a5524ffe9857cabd3c3`

- predecessor runtime head: SDK 146 passes / 807 assertions; OAuth browser callback 17 passes / 112 assertions; OAuth encryption 4 passes / 24 assertions; mounted passkey 3 passes
- predecessor affected dependency graph: 25/25 builds; production web graph 4/4 builds
- successor delta is comment-only and independently audited against the current passkey invariant
- Biome and `git diff --check`: clean
- predecessor hosted exact-head matrix: 63 success, 2 skipped; the complete protected matrix is rerunning on this successor head

The PostgreSQL contract job and independent review must complete on this exact head. This PR does not alter repository protections or bypass gates.

Closes #645
Closes #685
Closes #694
Closes #695

Exact base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6