### PR TITLE
refactor(api): remove the unused process-local SIWE nonce timer

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -31,7 +31,6 @@ import { assertAuthStoresAreSafe, getAuthStoreSources, initAuthStores } from "./
 import {
   API_VERSION,
   type ApiResponse,
-  nonceCleanupTimer,
   RATE_LIMIT_MAX_REQUESTS,
   RATE_LIMIT_WINDOW_MS,
 } from "./services/context";
@@ -439,7 +438,6 @@ const shutdown = async (signal: string) => {
 
   server.stop(true);
   clearInterval(requestLogCleanupTimer);
-  if (nonceCleanupTimer) clearInterval(nonceCleanupTimer);
   if (cancelRetention) cancelRetention();
   if (cancelProviderReservationReconciliation) cancelProviderReservationReconciliation();
   if (cancelTransactionReceiptPolling) cancelTransactionReceiptPolling();

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -244,22 +244,6 @@ export async function verifySessionToken(token: string) {
   }
 }
 
-// ─── SIWE nonce store ─────────────────────────────────────────────────────────
-
-export const nonceStore = new Map<string, { nonce: string; expiresAt: number }>();
-
-export const nonceCleanupTimer = isWorkersRuntime
-  ? undefined
-  : setInterval(
-      () => {
-        const now = Date.now();
-        for (const [key, entry] of nonceStore.entries()) {
-          if (entry.expiresAt <= now) nonceStore.delete(key);
-        }
-      },
-      5 * 60 * 1000,
-    );
-
 // ─── Input validation helpers ─────────────────────────────────────────────────
 
 const AGENT_ID_RE = /^[a-zA-Z0-9_\-.:]{1,128}$/;


### PR DESCRIPTION
Closes #771

Removes the dead process-local SIWE nonce map, its five-minute cleanup timer, and the shutdown-only timer reference. Current SIWE nonce authority remains the configured auth-store backend; no fallback is introduced.

Exact candidate: 20c2b2d1811e9d2b2d9aea355be2df12b8407099 on develop 201c1869d40ffca8a207a32a24eecc7eb6f24cd6.

Validation:
- whole-tree nonceStore / nonceCleanupTimer inventory: empty
- git diff --check: clean
- prior current-base focused semantic audit: pass

Held draft for exact hosted checks and independent review.