### PR TITLE
fix(staging): fail closed on database drift and bounded readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,17 @@ STEWARD_APP_DATABASE_ROLE=steward_app
 STEWARD_PLATFORM_DATABASE_URL=
 STEWARD_PLATFORM_DATABASE_ROLE=steward_platform
 
+# Production API containers must set this and use the restricted DATABASE_URL.
+# Apply the complete core + enabled-plugin release separately first.
+# SKIP_MIGRATIONS=true
+# Release-job credentials only. Keep these out of the API process environment
+# and store them in a separate operator secret scope (for scripts/deploy.sh,
+# /opt/steward/.env.migrate with mode 0600).
+# STEWARD_MIGRATION_DATABASE_URL=
+# STEWARD_OPERATOR_DATABASE_URL=
+# STEWARD_MIGRATION_DATABASE_ROLE=steward_migrator
+# STEWARD_BOOTSTRAP_DATABASE_ROLE=steward_bootstrap_owner
+
 # Production rejects sslmode=require because postgres-js does not authenticate
 # the database peer in that mode. Prefer verify-full. If a legacy provider only
 # supports sslmode=require, this separate acknowledgement opts into the MITM risk.
@@ -396,9 +407,11 @@ STEWARD_PROXY_PORT=8080
 
 # ─── Migrations ───────────────────────────────────────────────────────────────
 
-# Set to "true" to skip automatic migrations on API startup.
-# Useful when running migrations separately via scripts/migrate.sh.
-# SKIP_MIGRATIONS=false
+# Production Postgres APIs must set this to true. Before rollout, a protected
+# release job runs `bun run --cwd packages/api migrate` with the dedicated
+# migration URL, then operator bootstrap and migration-role RLS activation.
+# Local development may leave it false for startup migration behavior.
+# SKIP_MIGRATIONS=true
 
 # ─── Test-account token (DANGEROUS in production) ─────────────────────────────
 # POST /test/token exchanges a tenant's test-account credentials for a real

--- a/.env.example
+++ b/.env.example
@@ -163,6 +163,12 @@ STEWARD_PLATFORM_DATABASE_ROLE=steward_platform
 # STEWARD_MIGRATION_LOCK_TIMEOUT_MS=60000
 # STEWARD_MIGRATION_STATEMENT_TIMEOUT_MS=300000
 # STEWARD_MIGRATION_OVERALL_TIMEOUT_MS=600000
+# Every non-migration pre-listen phase is independently bounded. Override the
+# 30-second default globally or per phase (COMPOSE, RLS, REDIS, AUTH_STORES,
+# SCHEDULERS, CUSTODY). A timeout aborts startup; it never leaves an unlistening
+# container reported as healthy by the deployment control plane.
+# STEWARD_STARTUP_PHASE_TIMEOUT_MS=30000
+# STEWARD_STARTUP_RLS_TIMEOUT_MS=30000
 
 # Production rejects sslmode=require because postgres-js does not authenticate
 # the database peer in that mode. Prefer verify-full. If a legacy provider only

--- a/.env.example
+++ b/.env.example
@@ -156,6 +156,13 @@ STEWARD_PLATFORM_DATABASE_ROLE=steward_platform
 # STEWARD_OPERATOR_DATABASE_URL=
 # STEWARD_MIGRATION_DATABASE_ROLE=steward_migrator
 # STEWARD_BOOTSTRAP_DATABASE_ROLE=steward_bootstrap_owner
+# Bound every migration connection, advisory-lock wait, SQL statement, and
+# complete migration attempt. Values must be positive integers; lock/statement
+# bounds may not exceed the overall bound.
+# STEWARD_MIGRATION_CONNECT_TIMEOUT_SECONDS=15
+# STEWARD_MIGRATION_LOCK_TIMEOUT_MS=60000
+# STEWARD_MIGRATION_STATEMENT_TIMEOUT_MS=300000
+# STEWARD_MIGRATION_OVERALL_TIMEOUT_MS=600000
 
 # Production rejects sslmode=require because postgres-js does not authenticate
 # the database peer in that mode. Prefer verify-full. If a legacy provider only

--- a/docs/RAILWAY-DEPLOY.md
+++ b/docs/RAILWAY-DEPLOY.md
@@ -472,7 +472,7 @@ Common issues:
 
 - Ensure `PORT=3200` is set (Railway uses this to route traffic)
 - Ensure `STEWARD_BIND_HOST=0.0.0.0` (not `127.0.0.1`)
-- The `/ready` endpoint does a deep check (DB + migrations + vault). Use `/health` for the Railway health check (lighter)
+- The `/ready` endpoint does a deep check (DB + exact core and enabled-plugin migration ledgers + vault). Deployment acceptance requires both public `/health` and `/ready` receipts.
 
 ### "Tenant not found" errors
 

--- a/docs/RAILWAY-DEPLOY.md
+++ b/docs/RAILWAY-DEPLOY.md
@@ -502,6 +502,10 @@ curl -sf "$BASE/platform/tenants" \
 | `STEWARD_PLATFORM_DATABASE_URL` | **Yes for destructive platform operations** | — | Separate restricted platform-authority connection. |
 | `STEWARD_PLATFORM_DATABASE_ROLE` | **Yes with platform DB URL** | `steward_platform` | Exact platform login. |
 | `STEWARD_MIGRATION_DATABASE_URL` | **Release job only** | — | Dedicated migrator; never expose to the API. |
+| `STEWARD_MIGRATION_CONNECT_TIMEOUT_SECONDS` | Release job only | `15` | Positive connection deadline in seconds. |
+| `STEWARD_MIGRATION_LOCK_TIMEOUT_MS` | Release job only | `60000` | Positive advisory-lock deadline, no greater than the overall deadline. |
+| `STEWARD_MIGRATION_STATEMENT_TIMEOUT_MS` | Release job only | `300000` | Positive SQL statement deadline, no greater than the overall deadline. |
+| `STEWARD_MIGRATION_OVERALL_TIMEOUT_MS` | Release job only | `600000` | Positive deadline for each complete core or plugin migration attempt. |
 | `STEWARD_OPERATOR_DATABASE_URL` | **Bootstrap job only** | — | Provider-superuser-equivalent; never expose to the API. |
 | `STEWARD_MASTER_PASSWORD` | **Yes** | — | Vault encryption secret. Keep separate from JWT signing material. |
 | `STEWARD_KDF_SALT` | **Yes in production** | — | Stable deployment KDF salt, at least 16 random bytes. Back it up with the encrypted vault data. |

--- a/docs/RAILWAY-DEPLOY.md
+++ b/docs/RAILWAY-DEPLOY.md
@@ -506,6 +506,8 @@ curl -sf "$BASE/platform/tenants" \
 | `STEWARD_MIGRATION_LOCK_TIMEOUT_MS` | Release job only | `60000` | Positive advisory-lock deadline, no greater than the overall deadline. |
 | `STEWARD_MIGRATION_STATEMENT_TIMEOUT_MS` | Release job only | `300000` | Positive SQL statement deadline, no greater than the overall deadline. |
 | `STEWARD_MIGRATION_OVERALL_TIMEOUT_MS` | Release job only | `600000` | Positive deadline for each complete core or plugin migration attempt. |
+| `STEWARD_STARTUP_PHASE_TIMEOUT_MS` | No | `30000` | Positive default deadline for each pre-listen compose/RLS/Redis/auth-store/scheduler/custody phase. |
+| `STEWARD_STARTUP_<PHASE>_TIMEOUT_MS` | No | phase default | Optional exact override; phases are `COMPOSE`, `RLS`, `REDIS`, `AUTH_STORES`, `SCHEDULERS`, and `CUSTODY`. |
 | `STEWARD_OPERATOR_DATABASE_URL` | **Bootstrap job only** | — | Provider-superuser-equivalent; never expose to the API. |
 | `STEWARD_MASTER_PASSWORD` | **Yes** | — | Vault encryption secret. Keep separate from JWT signing material. |
 | `STEWARD_KDF_SALT` | **Yes in production** | — | Stable deployment KDF salt, at least 16 random bytes. Back it up with the encrypted vault data. |

--- a/docs/RAILWAY-DEPLOY.md
+++ b/docs/RAILWAY-DEPLOY.md
@@ -50,14 +50,19 @@ In the Railway dashboard:
 1. Click **+ New** → **Database** → **PostgreSQL**
 2. Click **+ New** → **Database** → **Redis**
 
-Railway auto-provisions `DATABASE_URL` and `REDIS_URL` as shared variables. Reference them in your service env vars with `${{Postgres.DATABASE_URL}}` and `${{Redis.REDIS_URL}}`.
+Railway auto-provisions provider-admin `DATABASE_URL` and `REDIS_URL` values.
+Use the database URL only in the protected bootstrap job; do not reference that
+admin credential from the API. After bootstrap, configure the API with the
+restricted `steward_app` URL. Redis may remain a normal service reference.
 
 ### Option B: External Neon Postgres + Railway Redis
 
 If using Neon:
 
 1. Create a `steward` database in your Neon project (or use the default `neondb`)
-2. Grab the connection string: `postgresql://user:pass@ep-xxx.us-east-2.aws.neon.tech/steward?sslmode=require`
+2. Grab the operator connection string using authenticated TLS, preferably
+   `sslmode=verify-full`; production rejects unverified `sslmode=require` unless
+   its separate risk acknowledgement is explicitly enabled.
 3. Add Railway Redis as above for rate limiting
 
 ---
@@ -75,10 +80,13 @@ NODE_ENV=production
 STEWARD_BIND_HOST=0.0.0.0
 
 # ─── Database ─────────────────────────────────────────────────────────────────
-# If using Railway Postgres:
-DATABASE_URL=${{Postgres.DATABASE_URL}}
+# Use the restricted application login created by the bootstrap job:
+DATABASE_URL=<restricted steward_app connection URL>
 # If using third-party Neon:
-# DATABASE_URL=postgresql://user:pass@ep-xxx.neon.tech/steward?sslmode=require
+# DATABASE_URL=postgresql://steward_app:pass@ep-xxx.neon.tech/steward?sslmode=verify-full
+STEWARD_APP_DATABASE_ROLE=steward_app
+STEWARD_PLATFORM_DATABASE_URL=<restricted steward_platform connection URL>
+STEWARD_PLATFORM_DATABASE_ROLE=steward_platform
 
 # ─── Security (generate these — do NOT reuse across environments) ─────────────
 # Generate each with: openssl rand -hex 32
@@ -128,8 +136,14 @@ PASSKEY_ORIGIN=https://your-app.com
 # TWITTER_CLIENT_SECRET=
 
 # ─── Migrations ──────────────────────────────────────────────────────────────
-SKIP_MIGRATIONS=false
+# The restricted API login must never own or migrate schema objects.
+SKIP_MIGRATIONS=true
 ```
+
+Keep `STEWARD_MIGRATION_DATABASE_URL` and `STEWARD_OPERATOR_DATABASE_URL`
+outside the API service in a separately protected release job. The operator
+must be a provider-superuser-equivalent capable of managing `BYPASSRLS` roles
+and function ownership; ordinary `CREATEROLE` is insufficient.
 
 Review the [custody-posture guide](security/custody-posture.md) before accepting
 local custody in production.
@@ -198,13 +212,30 @@ Railway picks it up automatically. Watch the build in the dashboard.
 railway up
 ```
 
-### First deploy
+### Database release gate
 
-The first deploy will:
-1. Build the multi-stage Docker image (~2-3 min)
-2. Start the API server on port 3200
-3. Run database migrations automatically (unless `SKIP_MIGRATIONS=true`)
-4. Pass the health check at `/health`
+Before every production rollout, run the complete release migrator with the
+same `STEWARD_PLUGINS` selection as the API:
+
+```bash
+DATABASE_URL="$STEWARD_MIGRATION_DATABASE_URL" bun run --cwd packages/api migrate
+psql "$STEWARD_OPERATOR_DATABASE_URL" \
+  -v steward_app_role=steward_app \
+  -v steward_migration_role=steward_migrator \
+  -v steward_bootstrap_role=steward_bootstrap_owner \
+  -v steward_platform_role=steward_platform \
+  -f scripts/postgres/rls-bootstrap.sql
+psql "$STEWARD_MIGRATION_DATABASE_URL" \
+  -v steward_migration_role=steward_migrator \
+  -f scripts/postgres/rls-activate.sql
+```
+
+The API command applies both core and enabled-plugin journals; the DB-only
+migrator is not a complete release. On a brand-new empty database, run the
+initial complete migration with the provider operator as `DATABASE_URL`, then
+bootstrap/provision the three login credentials and activate. Subsequent
+releases use the dedicated migrator. Only after this gate passes may the API
+start with `SKIP_MIGRATIONS=true` and be checked at `/health` and `/ready`.
 
 Watch logs:
 ```bash
@@ -466,7 +497,12 @@ curl -sf "$BASE/platform/tenants" \
 | `PORT` | No | `3200` | API listen port |
 | `STEWARD_BIND_HOST` | No | `127.0.0.1` | Bind host. **Set `0.0.0.0` on Railway** |
 | `NODE_ENV` | No | — | Set `production` |
-| `DATABASE_URL` | **Yes** | — | Postgres connection string |
+| `DATABASE_URL` | **Yes** | — | Restricted, non-owner `steward_app` connection only. |
+| `STEWARD_APP_DATABASE_ROLE` | **Yes in production** | — | Exact role expected on `DATABASE_URL`. |
+| `STEWARD_PLATFORM_DATABASE_URL` | **Yes for destructive platform operations** | — | Separate restricted platform-authority connection. |
+| `STEWARD_PLATFORM_DATABASE_ROLE` | **Yes with platform DB URL** | `steward_platform` | Exact platform login. |
+| `STEWARD_MIGRATION_DATABASE_URL` | **Release job only** | — | Dedicated migrator; never expose to the API. |
+| `STEWARD_OPERATOR_DATABASE_URL` | **Bootstrap job only** | — | Provider-superuser-equivalent; never expose to the API. |
 | `STEWARD_MASTER_PASSWORD` | **Yes** | — | Vault encryption secret. Keep separate from JWT signing material. |
 | `STEWARD_KDF_SALT` | **Yes in production** | — | Stable deployment KDF salt, at least 16 random bytes. Back it up with the encrypted vault data. |
 | `STEWARD_JWT_SECRET` | **Yes** | — | Canonical server-side signing and verification secret for user, session, and agent JWTs. Must be at least 32 characters in production. |
@@ -496,7 +532,7 @@ curl -sf "$BASE/platform/tenants" \
 | `TWITTER_CLIENT_ID` | No | — | Twitter/X OAuth client ID |
 | `TWITTER_CLIENT_SECRET` | No | — | Twitter/X OAuth client secret |
 | `AGENT_TOKEN_EXPIRY` | No | `24h` | Agent JWT token lifetime |
-| `SKIP_MIGRATIONS` | No | `false` | Skip auto-migrations on startup |
+| `SKIP_MIGRATIONS` | **Yes in production** | `false` | Set `true`; the complete release gate must finish first. |
 | `STEWARD_PROXY_PORT` | No | `8080` | Proxy service listen port |
 | `STEWARD_PROXY_REQUEST_SIGNING_SECRET` / `_SECRETS` | **Yes for production proxy traffic** | — | Dedicated HMAC root used by proxy clients to sign requests and by the proxy to verify them. |
 | `STEWARD_PROXY_URL` | No | — | API-side proxy URL used by `/ready` for the optional proxy clock check. |

--- a/docs/deploy/railway-lean-full.md
+++ b/docs/deploy/railway-lean-full.md
@@ -20,7 +20,7 @@ plugins to register. source of truth: `packages/api/src/plugin-config.ts`
 | mode | env | what boots |
 |------|-----|------------|
 | **lean** | `STEWARD_PLUGINS` unset / empty | core only. trading routes NOT mounted, trading module never evaluated, trading migrations NOT run |
-| **full** | `STEWARD_PLUGINS=trading` | core + trading. trading routes mounted, trading migrations run on boot |
+| **full** | `STEWARD_PLUGINS=trading` | core + trading. the release job applies trading migrations before routes mount |
 
 legacy compatibility: `STEWARD_ENABLE_TRADING=true` ALSO enables trading (it
 unions `trading` into the set). prefer `STEWARD_PLUGINS=trading` for new config;
@@ -70,7 +70,11 @@ service where noted, e.g. each service its own DB).
 | `PORT=3200` | required | listen port; `/health` probe targets it | `Dockerfile` (`ENV PORT=3200`), `packages/api/src/index.ts` |
 | `STEWARD_BIND_HOST=0.0.0.0` | required on Railway | default is `127.0.0.1` (loopback only) — Railway's proxy can't reach the container unless it binds `0.0.0.0` | `packages/api/src/index.ts` (`STEWARD_BIND_HOST`) |
 | `STEWARD_TRUSTED_PROXY_HOPS=2` | required on Railway | per-client auth rate limiting: number of trusted proxies APPENDING to `x-forwarded-for` (the entry that many hops from the RIGHT is the client IP). Bare Railway = **2**: `x-forwarded-for` arrives as `<client>, <railway-edge>` and the right-most edge entry rotates between Railway nodes, so `hops=1` scatters a client across buckets while `hops=2` locks onto the stable client entry (verified against prod). Until it is set, auth rate limits fall back to coarse per-host buckets, which are weaker on a directly-exposed (non-Host-locked) service. Never set higher than the real hop count — that re-opens IP spoofing | `packages/api/src/routes/auth.ts` (`trustedClientIp`) |
-| `DATABASE_URL` | **[boot-fatal in prod]** | Postgres connection. boot runs `runMigrations()` blocking before serving; a bad/missing URL fails migration → `process.exit(1)` | `packages/api/src/index.ts`, `packages/db` (`shouldUsePGLite`) |
+| `DATABASE_URL` | **[boot-fatal in prod]** | Restricted, non-owner `steward_app` connection. Migration/operator credentials are forbidden here. | `packages/api/src/index.ts`, `packages/db/src/rls-deployment-safety.ts` |
+| `STEWARD_APP_DATABASE_ROLE=steward_app` | **[boot-fatal in prod]** | Pins the exact restricted login expected on `DATABASE_URL`. | `packages/api/src/index.ts` |
+| `STEWARD_PLATFORM_DATABASE_URL` | required for destructive platform operations | Separate restricted platform-authority login; never reuse the app URL. | `packages/api/src/services/platform-authority-database.ts` |
+| `STEWARD_PLATFORM_DATABASE_ROLE=steward_platform` | required with platform URL | Pins the exact login used by the platform authority pool. | `packages/api/src/services/platform-authority-database.ts` |
+| `SKIP_MIGRATIONS=true` | required | Production API containers start only after the external release gate applies core/plugins, reconciles bootstrap ownership, and activates RLS. | `packages/api/src/index.ts`, `packages/api/src/migrate.ts` |
 | `STEWARD_JWT_SECRET` | **[boot-fatal in prod]** | canonical JWT signing secret. `validateJwtSecretEnv()` runs at module load in `index.ts`; in prod it THROWS if unset or `< 32` chars | `packages/auth/src/jwt.ts` (`getJwtSecret`), called from `packages/api/src/index.ts` |
 | `STEWARD_MASTER_PASSWORD` | **[boot-fatal / ready-gate]** | derives per-agent vault encryption keys. `/ready` reports `vault: not ok` if unset; vault key derivation throws when used | `packages/api/src/index.ts` (`/ready`), `packages/vault/src/keystore.ts` |
 | `STEWARD_KDF_SALT` | **[boot-fatal in prod]** | per-deploy KDF salt for vault key derivation. `keystore.ts` THROWS in production if unset (and requires ≥ 32 hex chars) | `packages/vault/src/keystore.ts` |
@@ -95,9 +99,14 @@ recommended-but-optional (mode-independent), set if the feature is used:
 | `STEWARD_OAUTH_ALLOWED_REDIRECTS` | OAuth redirect allowlist | `packages/api/src` |
 
 leave UNSET in any shared/prod env (dangerous if set): `STEWARD_ALLOW_DEV_SECRETS`,
-`STEWARD_ENABLE_PROD_TEST_ACCOUNT_TOKEN`, `SKIP_MIGRATIONS`, and the
+`STEWARD_ENABLE_PROD_TEST_ACCOUNT_TOKEN`, and the
 `STEWARD_ALLOW_*_EXPORT` / `STEWARD_ALLOW_UNSAFE_*` family — these are dev/break-glass
 escape hatches (`.env.example`, `packages/api/src`, `packages/vault/src`).
+
+Keep `STEWARD_MIGRATION_DATABASE_URL` and `STEWARD_OPERATOR_DATABASE_URL` only
+in a protected release job. Mirror the service's `STEWARD_PLUGINS`, run the API
+package migrator, bootstrap as a provider-superuser-equivalent, and activate as
+the direct migration role before either API service rolls out.
 
 ### trading-only (FULL service only)
 
@@ -211,8 +220,18 @@ openssl rand -hex 32   # STEWARD_MASTER_PASSWORD (long random)
 
 ### B. ship the image
 
+Before either service rolls out, run its protected release job with the same
+`STEWARD_PLUGINS` value. The job uses `STEWARD_MIGRATION_DATABASE_URL` for
+`bun run --cwd packages/api migrate`, the provider-superuser-equivalent
+`STEWARD_OPERATOR_DATABASE_URL` for bootstrap reconciliation, and the direct
+migration login for RLS activation. Never add either privileged URL to a lean or
+full API service.
+
 staging (auto): merge to `develop`. `Docker` builds+pushes
-`:develop`, then `Deploy Staging` deploys it to the staging service(s).
+`:develop`, then `Deploy Staging` deploys it to the staging service(s). The
+image-only workflow does not migrate; enable this automation only when the
+protected release gate is guaranteed to complete first for the same image and
+plugin selection.
 
 production (gated): merge `develop → main` (reviewed), then dispatch
 `Deploy Railway (Production)` from the Actions tab with the image tag (`main` or
@@ -259,11 +278,12 @@ drift — trading routes and trading migrations are always both-on or both-off.
 
 practical consequences when you flip a service:
 
-- **lean → full** (`STEWARD_PLUGINS` unset → `trading`): on the next boot the
-  trading plugin's migrations run (into per-plugin namespaced tables
+- **lean → full** (`STEWARD_PLUGINS` unset → `trading`): before the next boot,
+  the full service's protected release job runs the trading plugin's migrations
+  (into per-plugin namespaced tables
   `drizzle.__drizzle_migrations_plugin_<id>`, isolated from the core's
-  `drizzle.__drizzle_migrations` journal), AFTER the core migrator, then trading
-  routes mount. expect a slightly longer first boot while migrations apply.
+  `drizzle.__drizzle_migrations` journal), after the core migrator. Bootstrap
+  reconciliation and RLS activation must pass before the trading routes mount.
 - **full → lean** (`trading` → unset): trading routes stop mounting immediately.
   the trading TABLES are LEFT IN PLACE — this is harmless: they live in an
   isolated namespaced journal, nothing references them in lean mode, and they are

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -171,7 +171,12 @@ Steward backup.
 | --- | --- | --- | --- |
 | `PORT` | API listen port | `3200` | Must parse as a positive integer. |
 | `STEWARD_BIND_HOST` | API bind address | `127.0.0.1` | Use `0.0.0.0` only behind a firewall/reverse proxy. Compose sets this to `0.0.0.0` inside the container. |
-| `DATABASE_URL` | PostgreSQL connection string | none; PGLite selected when absent/forced in embedded paths | Required by the normal API entry point because `context.ts` calls `requireEnv("DATABASE_URL")`; embedded mode supplies `pglite://embedded` internally. |
+| `DATABASE_URL` | Restricted application PostgreSQL connection | none; PGLite selected when absent/forced in embedded paths | Production requires the non-owner `steward_app` login; never use a migrator, operator, superuser, or `BYPASSRLS` login. |
+| `STEWARD_APP_DATABASE_ROLE` | Exact application database role | none | Required in production and verified at startup. |
+| `STEWARD_PLATFORM_DATABASE_URL` | Restricted platform-authority connection | none | Required for destructive global platform operations; never reuse `DATABASE_URL`. |
+| `STEWARD_PLATFORM_DATABASE_ROLE` | Exact platform database role | `steward_platform` | Must match the login on `STEWARD_PLATFORM_DATABASE_URL`. |
+| `STEWARD_MIGRATION_DATABASE_URL` | Release-job migration connection | none | Keep out of the API environment; applies core/plugin migrations and activates RLS. |
+| `STEWARD_OPERATOR_DATABASE_URL` | Bootstrap operator connection | none | Keep out of the API environment; requires provider-superuser-equivalent authority. |
 | `STEWARD_DB_MODE` | Force database backend | auto | Set to `pglite` to force PGLite. |
 | `STEWARD_PGLITE_PATH` | PGLite persistence directory | `~/.steward/data` | Used only by PGLite. |
 | `STEWARD_PGLITE_MEMORY` | Use in-memory PGLite | `false` | Set exactly `true`; data is discarded on restart. |
@@ -211,7 +216,7 @@ Steward backup.
 | `STEWARD_PROXY_URL` | Proxy URL used by API invoke paths and web/server-side app code | `http://steward-proxy:8080` in root Compose (`http://localhost:8080` for host-side clients) | Use the compose-internal URL inside containers and the published URL outside containers. |
 | `STEWARD_PROXY_REQUEST_SIGNING_SECRET` / `_SECRETS` | HMAC root used by API invoke paths/clients to sign proxy requests and by the proxy to verify them | none | Required for the full API+proxy Compose stack; generate a value distinct from JWT/audit/master secrets. Use plural `_SECRETS` for rotation where supported. |
 | `STEWARD_AGENT_TOKEN` | Agent token for web/server-side routes | none | Required only by app paths that call Steward as an agent. |
-| `SKIP_MIGRATIONS` | Disable API startup migrations | false | Set `true` or `1` only when another process applies migrations. |
+| `SKIP_MIGRATIONS` | Disable API startup migrations | false | Required as `true` or `1` for production Postgres after the release gate completes. |
 | `STEWARD_MONERO_WALLET_RPC_URL` | monero-wallet-rpc sidecar endpoint | none | Empty disables Monero: every Monero endpoint fails closed with 503. In Compose use `http://monero-wallet-rpc:18083/json_rpc`. |
 | `MONERO_WALLET_RPC_PASSWORD` | Password for the sidecar's `--rpc-login` (username `steward`) | none | Required when the `monero` Compose profile is enabled; Compose mounts it into the sidecar as a secret and derives `STEWARD_MONERO_WALLET_RPC_LOGIN` from it. |
 | `STEWARD_MONERO_DAEMON_URL` | Explicit Monero daemon URL used for chain height at wallet creation | — (required when Monero is enabled) | Use HTTPS for remote daemons. Prefer a daemon you operate; a third-party node can correlate your IP with wallet activity. |
@@ -243,13 +248,21 @@ sidecar there); the API fails closed with 503 for Monero endpoints.
 
 ## Migration behavior
 
-Migrations run automatically on startup unless `SKIP_MIGRATIONS=true` or `SKIP_MIGRATIONS=1`.
+Production PostgreSQL API processes set `SKIP_MIGRATIONS=true`. Before rollout,
+a separate job with the same plugin selection runs:
 
-- Normal PostgreSQL mode calls the Drizzle migrator from `packages/db/src/migrate.ts` against `packages/db/drizzle` before the API serves traffic.
+```bash
+DATABASE_URL="$STEWARD_MIGRATION_DATABASE_URL" bun run --cwd packages/api migrate
+```
+
+It applies the core journal and all enabled-plugin journals. The
+provider-superuser-equivalent operator then runs `rls-bootstrap.sql`, followed
+by `rls-activate.sql` through the direct migration login. Neither privileged URL
+may be present in the API environment.
+
+- Development PostgreSQL may retain startup migrations with a suitably privileged local login.
 - PGLite mode does not run the Postgres migrator in `index.ts`. Instead, `packages/db/src/pglite.ts` replays `.sql` files from `packages/db/drizzle` in lexicographic order and tracks applied files in `__steward_migrations`.
 - If a PostgreSQL migration fails at startup, the API exits instead of serving with a partially migrated schema.
-
-Only set `SKIP_MIGRATIONS` when you have a separate migration job and can guarantee it completed before the API starts.
 
 ## Upgrades
 
@@ -269,4 +282,5 @@ docker compose build
 docker compose up -d
 ```
 
-Database migrations auto-apply during API startup. Back up Postgres before upgrades, especially before schema changes that affect vault, auth, or tenant tables.
+Back up Postgres, complete the migration/bootstrap/activation release gate, and
+only then roll out the production API. Do not rely on production API startup to migrate.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -145,8 +145,8 @@ repo configuration. To use them on your own fork/instance, set these GitHub repo
 | name | kind | meaning |
 | --- | --- | --- |
 | `RAILWAY_TOKEN` | secret | Railway API token for your project |
-| `STAGING_RAILWAY_SERVICE_ID` / `_ENV_ID` / `_HEALTH_URL` | vars | your staging service/env/health URL |
-| `PRODUCTION_RAILWAY_SERVICE_ID` / `_ENV_ID` / `_HEALTH_URL` | vars | your production service/env/health URL |
+| `STAGING_RAILWAY_SERVICE_ID` / `_ENV_ID` / `_HEALTH_URL` | vars | your staging service/env and public HTTPS root origin (no path/query/userinfo) |
+| `PRODUCTION_RAILWAY_SERVICE_ID` / `_ENV_ID` / `_HEALTH_URL` | vars | your production service/env and public HTTPS root origin (no path/query/userinfo) |
 
 Branch model the workflows assume: `develop` auto-deploys to **staging** (after a
 green Docker build); `main` is promoted to **production** manually via the gated

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -176,6 +176,10 @@ Steward backup.
 | `STEWARD_PLATFORM_DATABASE_URL` | Restricted platform-authority connection | none | Required for destructive global platform operations; never reuse `DATABASE_URL`. |
 | `STEWARD_PLATFORM_DATABASE_ROLE` | Exact platform database role | `steward_platform` | Must match the login on `STEWARD_PLATFORM_DATABASE_URL`. |
 | `STEWARD_MIGRATION_DATABASE_URL` | Release-job migration connection | none | Keep out of the API environment; applies core/plugin migrations and activates RLS. |
+| `STEWARD_MIGRATION_CONNECT_TIMEOUT_SECONDS` | Migrator connection deadline | `15` | Positive integer; applies to core and plugin migration clients. |
+| `STEWARD_MIGRATION_LOCK_TIMEOUT_MS` | Migrator advisory-lock deadline | `60000` | Positive integer no greater than the overall deadline. |
+| `STEWARD_MIGRATION_STATEMENT_TIMEOUT_MS` | Per-statement migration deadline | `300000` | Positive integer no greater than the overall deadline. |
+| `STEWARD_MIGRATION_OVERALL_TIMEOUT_MS` | Complete core or plugin migration deadline | `600000` | Positive integer; timed-out clients are terminated instead of serving indefinitely. |
 | `STEWARD_OPERATOR_DATABASE_URL` | Bootstrap operator connection | none | Keep out of the API environment; requires provider-superuser-equivalent authority. |
 | `STEWARD_DB_MODE` | Force database backend | auto | Set to `pglite` to force PGLite. |
 | `STEWARD_PGLITE_PATH` | PGLite persistence directory | `~/.steward/data` | Used only by PGLite. |
@@ -258,7 +262,9 @@ DATABASE_URL="$STEWARD_MIGRATION_DATABASE_URL" bun run --cwd packages/api migrat
 It applies the core journal and all enabled-plugin journals. The
 provider-superuser-equivalent operator then runs `rls-bootstrap.sql`, followed
 by `rls-activate.sql` through the direct migration login. Neither privileged URL
-may be present in the API environment.
+may be present in the API environment. The `STEWARD_MIGRATION_*_TIMEOUT_*`
+settings bound connection establishment, advisory-lock acquisition, individual
+statements, and each complete migration attempt.
 
 - Development PostgreSQL may retain startup migrations with a suitably privileged local login.
 - PGLite mode does not run the Postgres migrator in `index.ts`. Instead, `packages/db/src/pglite.ts` replays `.sql` files from `packages/db/drizzle` in lexicographic order and tracks applied files in `__steward_migrations`.

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -189,10 +189,14 @@ first. A PGLite directory archive is not a portable `pg_restore` archive.
    Set files to `0600`. Do not print values in logs or shell tracing.
 6. **Resolve migration compatibility.** First run the recorded release against
    the restored schema. Compare the migration ledger to the checked-out
-   `packages/db/drizzle/` files. Then upgrade one tested release step at a time;
-   normal startup applies forward migrations. Never set `SKIP_MIGRATIONS` unless
-   a separately observed migration job has completed successfully. Never run an
-   older release against a schema already migrated by a newer release.
+   `packages/db/drizzle/` files. Then upgrade one tested release step at a time.
+   Run `DATABASE_URL="$STEWARD_MIGRATION_DATABASE_URL" bun run --cwd packages/api migrate`
+   with the restored plugin selection, reconcile ownership using
+   `rls-bootstrap.sql` through the provider-superuser-equivalent operator, and
+   activate through the direct migration login. Keep both privileged URLs out
+   of the API, set `SKIP_MIGRATIONS=true`, and start it only after all three
+   steps succeed. Never run an older release against a schema already migrated
+   by a newer release.
 7. **Restore or conservatively reset Redis.** Restore the matched snapshot, or
    enforce the documented cold-start hold for spend windows. Redis recovery must
    not delay inspection of durable PostgreSQL state.

--- a/docs/security/database-rls-rollout.mdx
+++ b/docs/security/database-rls-rollout.mdx
@@ -162,8 +162,11 @@ table in future migrations.
 6. Run real-Postgres cross-tenant read/write/upsert/delete/join tests plus
    concurrent pool-reuse and background-job tests against the deployment role.
 
-Create/finalize roles after all migrations in the release have applied (the
-invoking operator needs `CREATEROLE` and schema ownership):
+Create/finalize roles after all migrations in the release have applied. The
+bootstrap creates and maintains a `BYPASSRLS` definer, so the invoking database
+operator must be a PostgreSQL superuser or a provider-controlled equivalent
+that is explicitly allowed to create/alter `BYPASSRLS` roles, change function
+owners, and own the migrated schemas. `CREATEROLE` alone is not sufficient:
 
 ```bash
 psql "$STEWARD_OPERATOR_DATABASE_URL" \
@@ -174,8 +177,9 @@ psql "$STEWARD_OPERATOR_DATABASE_URL" \
   -f scripts/postgres/rls-bootstrap.sql
 ```
 
-`STEWARD_OPERATOR_DATABASE_URL` is a CREATEROLE/schema-owner operator credential;
-never point it at the application login and never expose it to the API process.
+`STEWARD_OPERATOR_DATABASE_URL` is that provider-superuser-equivalent operator
+credential; never point it at the application login and never expose it to the
+API process.
 The app, platform-authority, and migration roles are separate login identities
 asserted `NOSUPERUSER NOBYPASSRLS`; the migration role owns the application
 relations, while the app cannot inherit or assume either privileged login.
@@ -197,8 +201,18 @@ enabled plugin's namespaced journal; invoking only the core package is not a
 complete release migration.
 Do not grant the migrator membership in the BYPASSRLS bootstrap owner. A future
 migration that must replace a bootstrap-owned function requires a separately
-reviewed operator-mediated ownership handoff; applying it directly as the
-migrator must fail rather than widening that authority boundary.
+reviewed, operator-mediated ownership handoff **before** the release migrator
+runs, followed by bootstrap ownership restoration. The generic release command
+does not perform that handoff and must fail rather than silently widening the
+authority boundary. Bootstrap reruns are supported only through the
+provider-superuser-equivalent operator above; a plain schema owner cannot
+reassign functions already owned by the NOLOGIN definer.
+
+On a brand-new empty database, the migration login does not exist yet. Run the
+initial complete API migration entrypoint with the provider operator as
+`DATABASE_URL`, bootstrap the roles, provision the three login credentials
+through the provider, and activate. Every subsequent release uses the dedicated
+migration URL before the operator bootstrap reconciliation.
 
 `bun scripts/generate-rls-policy-manifest.ts` replays the immutable migrations
 and the capabilities plugin migrations, then refreshes the committed exact relation/partition and policy-definition

--- a/docs/security/database-rls-rollout.mdx
+++ b/docs/security/database-rls-rollout.mdx
@@ -189,9 +189,12 @@ functions; only the platform login receives those named grants.
 
 Production API containers must set `SKIP_MIGRATIONS=true`: their `DATABASE_URL`
 is the restricted `steward_app` login and cannot own or create schema objects.
-Run `bun run packages/db/src/migrate.ts` as a separate release job with
+Run `bun run --cwd packages/api migrate` as a separate release job with
 `DATABASE_URL="$STEWARD_MIGRATION_DATABASE_URL"`, wait for it to succeed, rerun
 `rls-bootstrap.sql` with the operator URL, and only then roll out the API.
+The API migration entrypoint applies the exact core journal first and then every
+enabled plugin's namespaced journal; invoking only the core package is not a
+complete release migration.
 Do not grant the migrator membership in the BYPASSRLS bootstrap owner. A future
 migration that must replace a bootstrap-owned function requires a separately
 reviewed operator-mediated ownership handoff; applying it directly as the

--- a/docs/security/database-rls-rollout.mdx
+++ b/docs/security/database-rls-rollout.mdx
@@ -162,11 +162,11 @@ table in future migrations.
 6. Run real-Postgres cross-tenant read/write/upsert/delete/join tests plus
    concurrent pool-reuse and background-job tests against the deployment role.
 
-Create/finalize roles after migration `0112` (the invoking operator needs
-`CREATEROLE` and schema ownership):
+Create/finalize roles after all migrations in the release have applied (the
+invoking operator needs `CREATEROLE` and schema ownership):
 
 ```bash
-psql "$DATABASE_URL" \
+psql "$STEWARD_OPERATOR_DATABASE_URL" \
   -v steward_app_role=steward_app \
   -v steward_migration_role=steward_migrator \
   -v steward_bootstrap_role=steward_bootstrap_owner \
@@ -174,15 +174,28 @@ psql "$DATABASE_URL" \
   -f scripts/postgres/rls-bootstrap.sql
 ```
 
+`STEWARD_OPERATOR_DATABASE_URL` is a CREATEROLE/schema-owner operator credential;
+never point it at the application login and never expose it to the API process.
 The app, platform-authority, and migration roles are separate login identities
 asserted `NOSUPERUSER NOBYPASSRLS`; the migration role owns the application
 relations, while the app cannot inherit or assume either privileged login.
 Supply their credentials through the database provider or `ALTER ROLE` outside
 source control. Set `DATABASE_URL`/`STEWARD_APP_DATABASE_ROLE` to the app login
 and `STEWARD_PLATFORM_DATABASE_URL`/`STEWARD_PLATFORM_DATABASE_ROLE` to the
-platform login. The bootstrap function owner is a non-login `BYPASSRLS` role
+platform login. Keep a separate `STEWARD_MIGRATION_DATABASE_URL` for the
+`steward_migrator` login. The bootstrap function owner is a non-login `BYPASSRLS` role
 with only narrow table privileges. The app loses EXECUTE on destructive global
 functions; only the platform login receives those named grants.
+
+Production API containers must set `SKIP_MIGRATIONS=true`: their `DATABASE_URL`
+is the restricted `steward_app` login and cannot own or create schema objects.
+Run `bun run packages/db/src/migrate.ts` as a separate release job with
+`DATABASE_URL="$STEWARD_MIGRATION_DATABASE_URL"`, wait for it to succeed, rerun
+`rls-bootstrap.sql` with the operator URL, and only then roll out the API.
+Do not grant the migrator membership in the BYPASSRLS bootstrap owner. A future
+migration that must replace a bootstrap-owned function requires a separately
+reviewed operator-mediated ownership handoff; applying it directly as the
+migrator must fail rather than widening that authority boundary.
 
 `bun scripts/generate-rls-policy-manifest.ts` replays the immutable migrations
 and the capabilities plugin migrations, then refreshes the committed exact relation/partition and policy-definition
@@ -197,7 +210,7 @@ After all residual code paths and exact deployment-role tests pass, activate in
 one maintenance transaction:
 
 ```bash
-psql "$DATABASE_URL" \
+psql "$STEWARD_MIGRATION_DATABASE_URL" \
   -v steward_migration_role=steward_migrator \
   -f scripts/postgres/rls-activate.sql
 ```

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "dev": "NODE_ENV=development bun --watch src/index.ts",
     "build": "tsc --noEmit",
+    "migrate": "bun src/migrate.ts",
     "start": "bun src/index.ts",
     "openapi:generate": "bun scripts/generate-openapi.ts",
     "sdk:types": "bun scripts/generate-sdk-types.ts",

--- a/packages/api/src/__tests__/release-migrations.test.ts
+++ b/packages/api/src/__tests__/release-migrations.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { runReleaseMigrations } from "../release-migrations";
+
+describe("out-of-band release migrations", () => {
+  test("applies core before every enabled plugin migration", async () => {
+    const order: string[] = [];
+    const result = await runReleaseMigrations({
+      async runCore() {
+        order.push("core");
+        return { applied: ["0113_personal_tenant_account_lifecycle"] };
+      },
+      async runPlugins() {
+        order.push("plugins");
+        return [
+          {
+            pluginName: "capabilities",
+            id: "capabilities",
+            migrationsTable: "__drizzle_migrations_plugin_capabilities",
+          },
+        ];
+      },
+    });
+
+    expect(order).toEqual(["core", "plugins"]);
+    expect(result.applied).toEqual(["0113_personal_tenant_account_lifecycle"]);
+    expect(result.plugins).toHaveLength(1);
+  });
+
+  test("never starts plugin migrations after a core failure", async () => {
+    let pluginsStarted = false;
+    await expect(
+      runReleaseMigrations({
+        async runCore() {
+          throw new Error("core failed");
+        },
+        async runPlugins() {
+          pluginsStarted = true;
+          return [];
+        },
+      }),
+    ).rejects.toThrow("core failed");
+    expect(pluginsStarted).toBe(false);
+  });
+});

--- a/packages/api/src/__tests__/startup-phase.test.ts
+++ b/packages/api/src/__tests__/startup-phase.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import {
+  resolveStartupPhaseTimeoutMs,
+  runStartupPhase,
+  type StartupPhaseEvent,
+} from "../startup-phase";
+
+describe("bounded pre-listen startup phases", () => {
+  test("uses an exact phase override and rejects invalid bounds", () => {
+    expect(
+      resolveStartupPhaseTimeoutMs("redis", {
+        STEWARD_STARTUP_PHASE_TIMEOUT_MS: "5000",
+        STEWARD_STARTUP_REDIS_TIMEOUT_MS: "17",
+      }),
+    ).toBe(17);
+    expect(() =>
+      resolveStartupPhaseTimeoutMs("custody", { STEWARD_STARTUP_CUSTODY_TIMEOUT_MS: "0" }),
+    ).toThrow(/positive integer/);
+  });
+
+  test("emits ordered fixed diagnostics and rejects a stalled phase", async () => {
+    const events: StartupPhaseEvent[] = [];
+    await expect(
+      runStartupPhase("rls", () => new Promise(() => undefined), {
+        env: { STEWARD_STARTUP_RLS_TIMEOUT_MS: "5" },
+        emit: (event) => events.push(event),
+      }),
+    ).rejects.toThrow('startup phase "rls" exceeded 5ms');
+    expect(events.map(({ phase, state }) => `${phase}:${state}`)).toEqual([
+      "rls:started",
+      "rls:failed",
+    ]);
+    expect(events[1]?.diagnostic).toMatchObject({ errorClass: "Error", errorCode: null });
+  });
+
+  test("does not let a later phase start before its predecessor completes", async () => {
+    const order: string[] = [];
+    await runStartupPhase(
+      "redis",
+      async () => {
+        order.push("redis-operation");
+      },
+      {
+        env: { STEWARD_STARTUP_REDIS_TIMEOUT_MS: "100" },
+        emit: ({ state }) => order.push(`redis-${state}`),
+      },
+    );
+    await runStartupPhase(
+      "auth-stores",
+      async () => {
+        order.push("auth-operation");
+      },
+      {
+        env: { STEWARD_STARTUP_AUTH_STORES_TIMEOUT_MS: "100" },
+        emit: ({ state }) => order.push(`auth-${state}`),
+      },
+    );
+    expect(order).toEqual([
+      "redis-started",
+      "redis-operation",
+      "redis-completed",
+      "auth-started",
+      "auth-operation",
+      "auth-completed",
+    ]);
+  });
+
+  test("does not rethrow provider-controlled diagnostics at top level", async () => {
+    const events: StartupPhaseEvent[] = [];
+    await expect(
+      runStartupPhase("custody", () => Promise.reject(new Error("postgres://user:secret@host")), {
+        env: { STEWARD_STARTUP_CUSTODY_TIMEOUT_MS: "100" },
+        emit: (event) => events.push(event),
+      }),
+    ).rejects.toThrow('startup phase "custody" failed');
+    expect(JSON.stringify(events)).not.toContain("secret");
+  });
+});

--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -1,14 +1,20 @@
 import { expect, spyOn, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import * as databaseModule from "@stwd/db";
 import {
   __resetAuditHmacKeyCacheForTests,
   getDb,
+  getMigrationExpectation,
+  getPluginMigrationLedgerExpectation,
   tenants,
   waitUntilRequestDatabaseTask,
 } from "@stwd/db";
 import { createPGLiteDb } from "@stwd/db/pglite";
 import {
   __setWorkerInitForTests,
+  assertWorkerMigrationReadiness,
   hydrateProcessEnv,
   runWorkerGoogleCredentialLifecycleSweep,
   runWorkerUpstreamCredentialLeaseSweep,
@@ -115,6 +121,50 @@ test("Worker request membrane preserves real Drizzle query execution", async () 
     expect(Array.isArray(rows)).toBe(true);
   } finally {
     await client.close();
+  }
+});
+
+test("Worker boot rejects missing and stale enabled-plugin journals on its request database", async () => {
+  const folder = await mkdtemp(join(tmpdir(), "steward-worker-plugin-ledger-"));
+  const source = { id: "worker-proof", migrationsFolder: folder };
+  try {
+    await mkdir(join(folder, "meta"));
+    await writeFile(
+      join(folder, "meta/_journal.json"),
+      JSON.stringify({ entries: [{ tag: "0000_worker", when: 1_750_000_000_000 }] }),
+    );
+    await writeFile(join(folder, "0000_worker.sql"), "SELECT 1;\n");
+    const core = getMigrationExpectation();
+    const plugin = getPluginMigrationLedgerExpectation(source);
+    let pluginRows: Array<{ hash: string; created_at: number }> = [];
+    let queryIndex = 0;
+    const requestDb = {
+      async execute() {
+        queryIndex += 1;
+        if (queryIndex % 2 === 1) {
+          return [{ database_time_ms: Date.now(), migration_created_at: core.createdAt }];
+        }
+        return pluginRows;
+      },
+    } as unknown as ReturnType<typeof getDb>;
+    const prove = () =>
+      withWorkerRequestDatabase(
+        {
+          DATABASE_URL: "postgresql://worker.invalid/steward",
+          DATABASE_DRIVER: "neon-http",
+          NODE_ENV: "test",
+        },
+        () => assertWorkerMigrationReadiness([{ pluginName: "worker-proof", source }]),
+        { createHttpDb: () => requestDb },
+      );
+
+    await expect(prove()).rejects.toThrow("WORKER_MIGRATION_READINESS_FAILED");
+    pluginRows = [{ hash: "stale", created_at: plugin.entries[0]!.createdAt }];
+    await expect(prove()).rejects.toThrow("WORKER_MIGRATION_READINESS_FAILED");
+    pluginRows = [{ hash: plugin.entries[0]!.hash, created_at: plugin.entries[0]!.createdAt }];
+    await expect(prove()).resolves.toBeUndefined();
+  } finally {
+    await rm(folder, { recursive: true });
   }
 });
 

--- a/packages/api/src/compose.ts
+++ b/packages/api/src/compose.ts
@@ -220,16 +220,14 @@ export async function composeApp(): Promise<Hono<{ Variables: AppVariables }>> {
  * @returns per-plugin results (id + the namespaced table its ledger was written
  *   to). Empty if no opt-in plugin is enabled / declares a migration source.
  */
-export async function runComposedPluginMigrations(): Promise<
-  Array<{ pluginName: string; id: string; migrationsTable: string }>
-> {
+async function buildComposedPluginMigrationHost() {
   // PARITY with composeApp: resolve the SAME enabled set from the SAME resolver,
   // and collect migrations for EXACTLY the plugins composeApp registers. a plugin
   // that is disabled contributes NO migrations (its routes are also not mounted)
   // — the two paths can never drift (both-on or both-off, per plugin).
   const enabled = resolveEnabledPlugins();
   if (enabled.size === 0) {
-    return [];
+    return null;
   }
 
   const ctx = buildPluginContext();
@@ -257,5 +255,17 @@ export async function runComposedPluginMigrations(): Promise<
     host.collectMigrations(wxmrPlugin);
   }
 
-  return host.runMigrations();
+  return host;
+}
+
+export async function getComposedPluginMigrationSources() {
+  const host = await buildComposedPluginMigrationHost();
+  return host ? [...host.pluginMigrationSources] : [];
+}
+
+export async function runComposedPluginMigrations(): Promise<
+  Array<{ pluginName: string; id: string; migrationsTable: string }>
+> {
+  const host = await buildComposedPluginMigrationHost();
+  return host ? host.runMigrations() : [];
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -47,6 +47,7 @@ import {
 } from "./services/upstream-credential-lease-scheduler";
 import { configuredVaultStartupLogLine, getConfiguredVault } from "./services/vault-factory";
 import { startWebhookRetryScheduler } from "./services/webhook-retry-scheduler";
+import { runStartupPhase } from "./startup-phase";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -63,7 +64,7 @@ validateJwtSecretEnv();
 // composeApp() is async because plugin registration may be async + the trading
 // plugin is dynamically imported so the lean core graph never statically pulls
 // in the trading stack. top-level await is supported by the Bun entry.
-const app = await composeApp();
+const app = await runStartupPhase("compose", () => composeApp());
 const capabilitiesEnabled = resolveEnabledPlugins().has("capabilities");
 
 // ─── In-memory rate-limit log + shutdown guard ───────────────────────────────
@@ -346,59 +347,59 @@ if (shouldUsePGLite()) {
 if (process.env.NODE_ENV === "production" && !shouldUsePGLite()) {
   const expectedRole = process.env.STEWARD_APP_DATABASE_ROLE;
   if (!expectedRole) throw new Error("STEWARD_APP_DATABASE_ROLE is required in production");
-  try {
-    await assertRlsDeploymentSafety(getDb(), { expectedRole });
-  } catch (error) {
-    console.error(
-      "[steward] RLS deployment safety assertion failed — cannot start",
-      redactedThrownDiagnostics(error),
-    );
-    process.exit(1);
-  }
+  await runStartupPhase("rls", () => assertRlsDeploymentSafety(getDb(), { expectedRole }));
 }
 
 // ─── Redis + auth stores (blocking — must complete before serving traffic) ──
 
-let redisOk = false;
-try {
-  redisOk = await initRedis();
-} catch (err) {
-  console.warn(
-    "[steward] Redis initialization failed; trying Postgres auth storage",
-    redactedThrownDiagnostics(err),
-  );
-}
+const redisOk = await runStartupPhase("redis", async () => {
+  try {
+    return await initRedis();
+  } catch (err) {
+    console.warn(
+      "[steward] Redis initialization failed; trying Postgres auth storage",
+      redactedThrownDiagnostics(err),
+    );
+    return false;
+  }
+});
 
 // Postgres is the durable fallback for the long-lived server when Redis is not
 // available. buildBackend probes every namespace; the assertion below turns
 // any production fallback to process-local memory into a startup failure.
-await initAuthStores(migrationsRan && !redisOk);
-assertAuthStoresAreSafe();
+await runStartupPhase("auth-stores", async () => {
+  await initAuthStores(migrationsRan && !redisOk);
+  assertAuthStoresAreSafe();
+});
 
 // ─── Data retention scheduler (SOC2 CC2) ────────────────────────────────────
 
-if (migrationsRan) {
-  if (process.env.GOOGLE_PROVIDER_CLIENT_ID && process.env.GOOGLE_PROVIDER_CLIENT_SECRET) {
-    cancelGoogleCredentialLifecycleScheduler = startGoogleCredentialLifecycleScheduler();
+await runStartupPhase("schedulers", async () => {
+  if (migrationsRan) {
+    if (process.env.GOOGLE_PROVIDER_CLIENT_ID && process.env.GOOGLE_PROVIDER_CLIENT_SECRET) {
+      cancelGoogleCredentialLifecycleScheduler = startGoogleCredentialLifecycleScheduler();
+    }
+    if (process.env.X_CLIENT_ID && process.env.X_CLIENT_SECRET) {
+      cancelXCredentialLifecycleScheduler = startXCredentialLifecycleScheduler();
+    }
+    cancelRetention = startRetentionScheduler();
+    if (redisOk) {
+      cancelProviderReservationReconciliation = startProviderReservationReconciliationScheduler();
+    }
+    cancelTransactionReceiptPolling = startTransactionReceiptPollingScheduler();
+    cancelWebhookRetryScheduler = startWebhookRetryScheduler();
+    if (capabilitiesEnabled) {
+      cancelUpstreamCredentialLeaseScheduler = await startUpstreamCredentialLeaseScheduler();
+    }
   }
-  if (process.env.X_CLIENT_ID && process.env.X_CLIENT_SECRET) {
-    cancelXCredentialLifecycleScheduler = startXCredentialLifecycleScheduler();
-  }
-  cancelRetention = startRetentionScheduler();
-  if (redisOk) {
-    cancelProviderReservationReconciliation = startProviderReservationReconciliationScheduler();
-  }
-  cancelTransactionReceiptPolling = startTransactionReceiptPollingScheduler();
-  cancelWebhookRetryScheduler = startWebhookRetryScheduler();
-  if (capabilitiesEnabled) {
-    cancelUpstreamCredentialLeaseScheduler = await startUpstreamCredentialLeaseScheduler();
-  }
-}
+});
 
 // Resolve custody before accepting traffic. A configured backend that cannot
 // initialize throws here, so production never falls back to local AES.
-getConfiguredVault();
-console.log(configuredVaultStartupLogLine());
+await runStartupPhase("custody", () => {
+  getConfiguredVault();
+  console.log(configuredVaultStartupLogLine());
+});
 
 // ─── Server ───────────────────────────────────────────────────────────────────
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -14,18 +14,12 @@
 
 import { createHash, timingSafeEqual } from "node:crypto";
 import { validateJwtSecretEnv } from "@stwd/auth";
-import {
-  assertRlsDeploymentSafety,
-  closeDb,
-  getDb,
-  getMigrationExpectation,
-  getPluginMigrationLedgerExpectation,
-} from "@stwd/db";
+import { assertRlsDeploymentSafety, closeDb, getDb } from "@stwd/db";
 import { shouldUsePGLite } from "@stwd/db/pglite";
 import { redactedThrownDiagnostics } from "@stwd/shared";
-import { sql } from "drizzle-orm";
 import { composeApp, getComposedPluginMigrationSources } from "./compose";
 import { getRedisClient, initRedis, isRedisConfigured, shutdownRedis } from "./middleware/redis";
+import { readMigrationReadiness } from "./migration-readiness";
 import { resolveEnabledPlugins } from "./plugin-config";
 import { assertAuthStoresAreSafe, getAuthStoreSources, initAuthStores } from "./routes/auth";
 import {
@@ -153,99 +147,12 @@ app.get("/ready", async (c) => {
     { ok: boolean; required?: boolean; error?: string; source?: string; detail?: unknown }
   > = {};
 
-  const expectedMigration = getMigrationExpectation();
-  checks.migrations = { ok: false, detail: { expected: expectedMigration.tag } };
-  checks.pluginMigrations = {
-    ok: pluginMigrationSources.length === 0,
-    ...(pluginMigrationSources.length === 0 ? { required: false } : {}),
-  };
-
   try {
     const db = getDb();
-    const pglite = shouldUsePGLite();
-    const result = pglite
-      ? await db.execute(sql`
-          SELECT
-            EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS database_time_ms,
-            EXISTS(
-              SELECT 1 FROM __steward_migrations WHERE tag = ${expectedMigration.tag}
-            ) AS expected_migration_applied
-        `)
-      : await db.execute(sql`
-          SELECT
-            EXTRACT(EPOCH FROM clock_timestamp()) * 1000 AS database_time_ms,
-            (SELECT MAX(created_at) FROM drizzle.__drizzle_migrations) AS migration_created_at
-        `);
-    const rows = Array.isArray(result)
-      ? result
-      : ((result as unknown as { rows?: unknown[] }).rows ?? []);
-    const row = rows[0] as
-      | { database_time_ms?: string | number; migration_created_at?: string | number | null }
-      | undefined;
-    const databaseTimeMs = Number(row?.database_time_ms);
-    const migrationCreatedAt = Number(row?.migration_created_at);
-    const expectedMigrationApplied =
-      (row as { expected_migration_applied?: unknown } | undefined)?.expected_migration_applied ===
-      true;
-    const databaseSkewMs = Math.abs(Date.now() - databaseTimeMs);
-    checks.database = {
-      ok: Number.isFinite(databaseTimeMs) && databaseSkewMs <= 30_000,
-      detail: { clockSkewMs: Math.round(databaseSkewMs), serverTime: new Date().toISOString() },
-    };
-    checks.migrations = {
-      ok:
-        migrationsRan &&
-        (pglite ? expectedMigrationApplied : migrationCreatedAt === expectedMigration.createdAt),
-      detail: {
-        expected: expectedMigration.tag,
-        expectedCreatedAt: expectedMigration.createdAt,
-        ...(pglite
-          ? { expectedMigrationApplied }
-          : { actualCreatedAt: Number.isFinite(migrationCreatedAt) ? migrationCreatedAt : null }),
-      },
-    };
-    if (pluginMigrationSources.length > 0) {
-      try {
-        const pluginDetails: Array<{ plugin: string; ok: boolean; expectedEntries: number }> = [];
-        for (const { pluginName, source } of pluginMigrationSources) {
-          const expectation = getPluginMigrationLedgerExpectation(source);
-          const result = await db.execute(
-            sql.raw(
-              `SELECT hash, created_at FROM drizzle."${expectation.migrationsTable}" ORDER BY id ASC`,
-            ),
-          );
-          const rows = (
-            Array.isArray(result)
-              ? result
-              : ((result as unknown as { rows?: unknown[] }).rows ?? [])
-          ) as Array<{
-            hash?: unknown;
-            created_at?: unknown;
-          }>;
-          const ok =
-            rows.length === expectation.entries.length &&
-            rows.every(
-              (row, index) =>
-                row.hash === expectation.entries[index]?.hash &&
-                Number(row.created_at) === expectation.entries[index]?.createdAt,
-            );
-          pluginDetails.push({
-            plugin: pluginName,
-            ok,
-            expectedEntries: expectation.entries.length,
-          });
-        }
-        checks.pluginMigrations = {
-          ok: pluginDetails.every((plugin) => plugin.ok),
-          detail: pluginDetails,
-        };
-      } catch {
-        checks.pluginMigrations = {
-          ok: false,
-          error: "Enabled plugin migration ledger check failed",
-        };
-      }
-    }
+    Object.assign(
+      checks,
+      await readMigrationReadiness({ db, migrationsRan, pluginMigrationSources }),
+    );
     if (process.env.NODE_ENV === "production") {
       const expectedRole = process.env.STEWARD_APP_DATABASE_ROLE;
       if (!expectedRole) throw new Error("STEWARD_APP_DATABASE_ROLE is required in production");

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -14,11 +14,17 @@
 
 import { createHash, timingSafeEqual } from "node:crypto";
 import { validateJwtSecretEnv } from "@stwd/auth";
-import { assertRlsDeploymentSafety, closeDb, getDb, getMigrationExpectation } from "@stwd/db";
+import {
+  assertRlsDeploymentSafety,
+  closeDb,
+  getDb,
+  getMigrationExpectation,
+  getPluginMigrationLedgerExpectation,
+} from "@stwd/db";
 import { shouldUsePGLite } from "@stwd/db/pglite";
 import { redactedThrownDiagnostics } from "@stwd/shared";
 import { sql } from "drizzle-orm";
-import { composeApp } from "./compose";
+import { composeApp, getComposedPluginMigrationSources } from "./compose";
 import { getRedisClient, initRedis, isRedisConfigured, shutdownRedis } from "./middleware/redis";
 import { resolveEnabledPlugins } from "./plugin-config";
 import { assertAuthStoresAreSafe, getAuthStoreSources, initAuthStores } from "./routes/auth";
@@ -64,7 +70,10 @@ validateJwtSecretEnv();
 // composeApp() is async because plugin registration may be async + the trading
 // plugin is dynamically imported so the lean core graph never statically pulls
 // in the trading stack. top-level await is supported by the Bun entry.
-const app = await runStartupPhase("compose", () => composeApp());
+const { app, pluginMigrationSources } = await runStartupPhase("compose", async () => ({
+  app: await composeApp(),
+  pluginMigrationSources: await getComposedPluginMigrationSources(),
+}));
 const capabilitiesEnabled = resolveEnabledPlugins().has("capabilities");
 
 // ─── In-memory rate-limit log + shutdown guard ───────────────────────────────
@@ -146,6 +155,10 @@ app.get("/ready", async (c) => {
 
   const expectedMigration = getMigrationExpectation();
   checks.migrations = { ok: false, detail: { expected: expectedMigration.tag } };
+  checks.pluginMigrations = {
+    ok: pluginMigrationSources.length === 0,
+    ...(pluginMigrationSources.length === 0 ? { required: false } : {}),
+  };
 
   try {
     const db = getDb();
@@ -191,6 +204,48 @@ app.get("/ready", async (c) => {
           : { actualCreatedAt: Number.isFinite(migrationCreatedAt) ? migrationCreatedAt : null }),
       },
     };
+    if (pluginMigrationSources.length > 0) {
+      try {
+        const pluginDetails: Array<{ plugin: string; ok: boolean; expectedEntries: number }> = [];
+        for (const { pluginName, source } of pluginMigrationSources) {
+          const expectation = getPluginMigrationLedgerExpectation(source);
+          const result = await db.execute(
+            sql.raw(
+              `SELECT hash, created_at FROM drizzle."${expectation.migrationsTable}" ORDER BY id ASC`,
+            ),
+          );
+          const rows = (
+            Array.isArray(result)
+              ? result
+              : ((result as unknown as { rows?: unknown[] }).rows ?? [])
+          ) as Array<{
+            hash?: unknown;
+            created_at?: unknown;
+          }>;
+          const ok =
+            rows.length === expectation.entries.length &&
+            rows.every(
+              (row, index) =>
+                row.hash === expectation.entries[index]?.hash &&
+                Number(row.created_at) === expectation.entries[index]?.createdAt,
+            );
+          pluginDetails.push({
+            plugin: pluginName,
+            ok,
+            expectedEntries: expectation.entries.length,
+          });
+        }
+        checks.pluginMigrations = {
+          ok: pluginDetails.every((plugin) => plugin.ok),
+          detail: pluginDetails,
+        };
+      } catch {
+        checks.pluginMigrations = {
+          ok: false,
+          error: "Enabled plugin migration ledger check failed",
+        };
+      }
+    }
     if (process.env.NODE_ENV === "production") {
       const expectedRole = process.env.STEWARD_APP_DATABASE_ROLE;
       if (!expectedRole) throw new Error("STEWARD_APP_DATABASE_ROLE is required in production");

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -7,20 +7,14 @@
  *
  *   - The in-memory IP rate-limit log (only safe in single-process mode)
  *   - `setInterval` GC for expired entries
- *   - The blocking `runMigrations()` call at boot
+ *   - The blocking release-migration call at boot
  *   - The /ready readiness probe (depends on migration state + DB ping)
  *   - `Bun.serve` plus SIGINT/SIGTERM graceful shutdown
  */
 
 import { createHash, timingSafeEqual } from "node:crypto";
 import { validateJwtSecretEnv } from "@stwd/auth";
-import {
-  assertRlsDeploymentSafety,
-  closeDb,
-  getDb,
-  getMigrationExpectation,
-  runMigrations,
-} from "@stwd/db";
+import { assertRlsDeploymentSafety, closeDb, getDb, getMigrationExpectation } from "@stwd/db";
 import { shouldUsePGLite } from "@stwd/db/pglite";
 import { redactedThrownDiagnostics } from "@stwd/shared";
 import { sql } from "drizzle-orm";
@@ -310,7 +304,8 @@ if (shouldUsePGLite()) {
 } else {
   try {
     console.log("[steward] Running database migrations...");
-    const { applied } = await runMigrations();
+    const { runConfiguredReleaseMigrations } = await import("./migrate");
+    const { applied, plugins: pluginResults } = await runConfiguredReleaseMigrations();
     migrationsRan = true;
     if (applied.length > 0) {
       console.log(`[steward] Applied ${applied.length} migration(s): ${applied.join(", ")}`);
@@ -332,14 +327,9 @@ if (shouldUsePGLite()) {
       console.log("[steward] Migrations already up to date.");
     }
 
-    // Plugin-owned migrations (Phase 2c): applied AFTER the core migrator so a
-    // plugin migration may reference core tables via FK. Each plugin's migrations
-    // land in its OWN namespaced bookkeeping table
-    // (drizzle.__drizzle_migrations_plugin_<id>), totally isolated from the core's
-    // drizzle.__drizzle_migrations journal. Fail-closed: a plugin migration error
-    // aborts boot (we never half-boot with a partially-migrated plugin schema).
-    const { runComposedPluginMigrations } = await import("./compose");
-    const pluginResults = await runComposedPluginMigrations();
+    // The shared release runner applies plugin-owned migrations AFTER core and
+    // uses the same opt-in plugin resolver as app composition. A plugin failure
+    // therefore aborts both this legacy boot path and the out-of-band command.
     if (pluginResults.length > 0) {
       console.log(
         `[steward] Applied plugin migrations: ${pluginResults

--- a/packages/api/src/migrate.ts
+++ b/packages/api/src/migrate.ts
@@ -1,0 +1,28 @@
+import { runMigrations } from "@stwd/db";
+import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runComposedPluginMigrations } from "./compose";
+import { runReleaseMigrations } from "./release-migrations";
+
+/**
+ * Apply the complete database release in load-bearing order. Production API
+ * containers set SKIP_MIGRATIONS and invoke this entrypoint out of band with
+ * the dedicated migration identity.
+ */
+export async function runConfiguredReleaseMigrations() {
+  return runReleaseMigrations({
+    runCore: runMigrations,
+    runPlugins: runComposedPluginMigrations,
+  });
+}
+
+if (import.meta.main) {
+  runConfiguredReleaseMigrations()
+    .then(({ applied, plugins }) => {
+      console.log(`[migrate] Core migrations applied: ${applied.length}`);
+      console.log(`[migrate] Plugin migration ledgers reconciled: ${plugins.length}`);
+    })
+    .catch((error) => {
+      console.error("[migrate] Release migration failed", redactedThrownDiagnostics(error));
+      process.exitCode = 1;
+    });
+}

--- a/packages/api/src/migrate.ts
+++ b/packages/api/src/migrate.ts
@@ -16,13 +16,18 @@ export async function runConfiguredReleaseMigrations() {
 }
 
 if (import.meta.main) {
-  runConfiguredReleaseMigrations()
-    .then(({ applied, plugins }) => {
-      console.log(`[migrate] Core migrations applied: ${applied.length}`);
-      console.log(`[migrate] Plugin migration ledgers reconciled: ${plugins.length}`);
-    })
-    .catch((error) => {
-      console.error("[migrate] Release migration failed", redactedThrownDiagnostics(error));
-      process.exitCode = 1;
-    });
+  try {
+    const { applied, plugins } = await runConfiguredReleaseMigrations();
+    console.log(`[migrate] Core migrations applied: ${applied.length}`);
+    console.log(`[migrate] Plugin migration ledgers reconciled: ${plugins.length}`);
+    // Plugin discovery imports the API composition graph, whose Bun server
+    // compatibility modules own bounded housekeeping timers. The release
+    // command has closed every migration client at this point; terminate
+    // explicitly so those unrelated timers cannot keep a successful release
+    // job alive forever.
+    process.exit(0);
+  } catch (error) {
+    console.error("[migrate] Release migration failed", redactedThrownDiagnostics(error));
+    process.exit(1);
+  }
 }

--- a/packages/api/src/migration-readiness.ts
+++ b/packages/api/src/migration-readiness.ts
@@ -1,0 +1,129 @@
+import { getDb, getMigrationExpectation, getPluginMigrationLedgerExpectation } from "@stwd/db";
+import { shouldUsePGLite } from "@stwd/db/pglite";
+import type { PluginMigrationSource } from "@stwd/shared";
+import { sql } from "drizzle-orm";
+
+export type MigrationReadinessCheck = {
+  ok: boolean;
+  required?: boolean;
+  error?: string;
+  detail?: unknown;
+};
+
+export type EnabledPluginMigrationSource = {
+  pluginName: string;
+  source: PluginMigrationSource;
+};
+
+/**
+ * One exact migration-readiness authority shared by Bun `/ready` and Workers
+ * cold-start. It validates the checked-in core tip and every enabled plugin's
+ * namespaced journal; a core-only database can never serve plugin routes.
+ */
+export async function readMigrationReadiness(options: {
+  db?: ReturnType<typeof getDb>;
+  migrationsRan: boolean;
+  pluginMigrationSources: EnabledPluginMigrationSource[];
+  pglite?: boolean;
+}): Promise<{
+  database: MigrationReadinessCheck;
+  migrations: MigrationReadinessCheck;
+  pluginMigrations: MigrationReadinessCheck;
+}> {
+  const db = options.db ?? getDb();
+  const pglite = options.pglite ?? shouldUsePGLite();
+  const expectedMigration = getMigrationExpectation();
+  const result = pglite
+    ? await db.execute(sql`
+        SELECT
+          EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS database_time_ms,
+          EXISTS(
+            SELECT 1 FROM __steward_migrations WHERE tag = ${expectedMigration.tag}
+          ) AS expected_migration_applied
+      `)
+    : await db.execute(sql`
+        SELECT
+          EXTRACT(EPOCH FROM clock_timestamp()) * 1000 AS database_time_ms,
+          (SELECT MAX(created_at) FROM drizzle.__drizzle_migrations) AS migration_created_at
+      `);
+  const rows = Array.isArray(result)
+    ? result
+    : ((result as unknown as { rows?: unknown[] }).rows ?? []);
+  const row = rows[0] as
+    | {
+        database_time_ms?: string | number;
+        migration_created_at?: string | number | null;
+        expected_migration_applied?: unknown;
+      }
+    | undefined;
+  const databaseTimeMs = Number(row?.database_time_ms);
+  const migrationCreatedAt = Number(row?.migration_created_at);
+  const expectedMigrationApplied = row?.expected_migration_applied === true;
+  const databaseSkewMs = Math.abs(Date.now() - databaseTimeMs);
+  const database: MigrationReadinessCheck = {
+    ok: Number.isFinite(databaseTimeMs) && databaseSkewMs <= 30_000,
+    detail: { clockSkewMs: Math.round(databaseSkewMs), serverTime: new Date().toISOString() },
+  };
+  const migrations: MigrationReadinessCheck = {
+    ok:
+      options.migrationsRan &&
+      (pglite ? expectedMigrationApplied : migrationCreatedAt === expectedMigration.createdAt),
+    detail: {
+      expected: expectedMigration.tag,
+      expectedCreatedAt: expectedMigration.createdAt,
+      ...(pglite
+        ? { expectedMigrationApplied }
+        : { actualCreatedAt: Number.isFinite(migrationCreatedAt) ? migrationCreatedAt : null }),
+    },
+  };
+
+  if (options.pluginMigrationSources.length === 0) {
+    return {
+      database,
+      migrations,
+      pluginMigrations: { ok: true, required: false },
+    };
+  }
+
+  try {
+    const pluginDetails: Array<{ plugin: string; ok: boolean; expectedEntries: number }> = [];
+    for (const { pluginName, source } of options.pluginMigrationSources) {
+      const expectation = getPluginMigrationLedgerExpectation(source);
+      const pluginResult = await db.execute(
+        sql.raw(
+          `SELECT hash, created_at FROM drizzle."${expectation.migrationsTable}" ORDER BY id ASC`,
+        ),
+      );
+      const pluginRows = (
+        Array.isArray(pluginResult)
+          ? pluginResult
+          : ((pluginResult as unknown as { rows?: unknown[] }).rows ?? [])
+      ) as Array<{ hash?: unknown; created_at?: unknown }>;
+      const ok =
+        pluginRows.length === expectation.entries.length &&
+        pluginRows.every(
+          (pluginRow, index) =>
+            pluginRow.hash === expectation.entries[index]?.hash &&
+            Number(pluginRow.created_at) === expectation.entries[index]?.createdAt,
+        );
+      pluginDetails.push({ plugin: pluginName, ok, expectedEntries: expectation.entries.length });
+    }
+    return {
+      database,
+      migrations,
+      pluginMigrations: {
+        ok: pluginDetails.every((plugin) => plugin.ok),
+        detail: pluginDetails,
+      },
+    };
+  } catch {
+    return {
+      database,
+      migrations,
+      pluginMigrations: {
+        ok: false,
+        error: "Enabled plugin migration ledger check failed",
+      },
+    };
+  }
+}

--- a/packages/api/src/release-migrations.ts
+++ b/packages/api/src/release-migrations.ts
@@ -1,0 +1,18 @@
+export interface ReleaseMigrationResult {
+  applied: string[];
+  plugins: Array<{ pluginName: string; id: string; migrationsTable: string }>;
+}
+
+export interface ReleaseMigrationRunners {
+  runCore: () => Promise<{ applied: string[] }>;
+  runPlugins: () => Promise<ReleaseMigrationResult["plugins"]>;
+}
+
+/** Apply the complete release in load-bearing core-then-plugin order. */
+export async function runReleaseMigrations(
+  runners: ReleaseMigrationRunners,
+): Promise<ReleaseMigrationResult> {
+  const { applied } = await runners.runCore();
+  const plugins = await runners.runPlugins();
+  return { applied, plugins };
+}

--- a/packages/api/src/startup-phase.ts
+++ b/packages/api/src/startup-phase.ts
@@ -1,0 +1,103 @@
+import { redactedThrownDiagnostics } from "@stwd/shared";
+
+export const STARTUP_PHASES = [
+  "compose",
+  "rls",
+  "redis",
+  "auth-stores",
+  "schedulers",
+  "custody",
+] as const;
+
+export type StartupPhase = (typeof STARTUP_PHASES)[number];
+
+const DEFAULT_STARTUP_PHASE_TIMEOUT_MS = 30_000;
+
+function positiveInteger(value: string | undefined, fallback: number, name: string): number {
+  if (value === undefined || value.trim() === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`[steward:start] ${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+export function resolveStartupPhaseTimeoutMs(
+  phase: StartupPhase,
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const phaseKey = `STEWARD_STARTUP_${phase.replaceAll("-", "_").toUpperCase()}_TIMEOUT_MS`;
+  const defaultMs = positiveInteger(
+    env.STEWARD_STARTUP_PHASE_TIMEOUT_MS,
+    DEFAULT_STARTUP_PHASE_TIMEOUT_MS,
+    "STEWARD_STARTUP_PHASE_TIMEOUT_MS",
+  );
+  return positiveInteger(env[phaseKey], defaultMs, phaseKey);
+}
+
+export interface StartupPhaseEvent {
+  phase: StartupPhase;
+  state: "started" | "completed" | "failed";
+  timeoutMs: number;
+  elapsedMs?: number;
+  diagnostic?: ReturnType<typeof redactedThrownDiagnostics>;
+}
+
+/**
+ * Bound one pre-listen startup phase. A timeout is terminal: index.ts does not
+ * catch it, so Bun exits instead of leaving a live-but-unlistening container.
+ */
+export async function runStartupPhase<T>(
+  phase: StartupPhase,
+  operation: () => T | Promise<T>,
+  options: {
+    env?: Record<string, string | undefined>;
+    emit?: (event: StartupPhaseEvent) => void;
+  } = {},
+): Promise<T> {
+  const timeoutMs = resolveStartupPhaseTimeoutMs(phase, options.env);
+  const startedAt = Date.now();
+  const emit =
+    options.emit ??
+    ((event: StartupPhaseEvent) => {
+      const detail = event.state === "failed" ? ` ${JSON.stringify(event.diagnostic)}` : "";
+      const elapsed = event.elapsedMs === undefined ? "" : ` elapsedMs=${event.elapsedMs}`;
+      const message =
+        `[steward:start] phase=${event.phase} state=${event.state} timeoutMs=${event.timeoutMs}` +
+        elapsed +
+        detail;
+      if (event.state === "failed") console.error(message);
+      else console.log(message);
+    });
+  emit({ phase, state: "started", timeoutMs });
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  try {
+    const result = await Promise.race([
+      Promise.resolve().then(operation),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          timedOut = true;
+          reject(new Error(`startup phase "${phase}" exceeded ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+    emit({ phase, state: "completed", timeoutMs, elapsedMs: Date.now() - startedAt });
+    return result;
+  } catch (error) {
+    emit({
+      phase,
+      state: "failed",
+      timeoutMs,
+      elapsedMs: Date.now() - startedAt,
+      diagnostic: redactedThrownDiagnostics(error),
+    });
+    // Bun prints uncaught top-level-await errors. Never rethrow a provider or
+    // driver-controlled message after recording its redacted classification.
+    if (timedOut) throw error;
+    throw new Error(`startup phase "${phase}" failed`);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -366,9 +366,30 @@ function validateWorkerSecurityEnv(): void {
   validateJwtSecretEnv();
 }
 
+export async function assertWorkerMigrationReadiness(
+  pluginMigrationSources?: import("./migration-readiness").EnabledPluginMigrationSource[],
+): Promise<void> {
+  const { readMigrationReadiness } = await import("./migration-readiness");
+  const enabledSources =
+    pluginMigrationSources ?? (await import("./compose")).getComposedPluginMigrationSources();
+  const migrationReadiness = await readMigrationReadiness({
+    db: getDb(),
+    migrationsRan: true,
+    pluginMigrationSources: await enabledSources,
+    pglite: false,
+  });
+  if (
+    !migrationReadiness.database.ok ||
+    !migrationReadiness.migrations.ok ||
+    !migrationReadiness.pluginMigrations.ok
+  ) {
+    throw new Error("WORKER_MIGRATION_READINESS_FAILED");
+  }
+}
+
 async function ensureWorkerInit(env: Env): Promise<void> {
   if (workerInit) return workerInit;
-  workerInit = (async () => {
+  const pendingInit = (async () => {
     // Workers bindings are only available inside fetch(). Hydrate process.env
     // before importing app modules that read required env at module init.
     hydrateProcessEnv(env);
@@ -381,6 +402,7 @@ async function ensureWorkerInit(env: Env): Promise<void> {
     if (!expectedRole) {
       throw new Error("STEWARD_APP_DATABASE_ROLE is required on Workers");
     }
+    await assertWorkerMigrationReadiness();
     await assertRlsDeploymentSafety(getDb(), { expectedRole });
     const redisOk = await initRedis(env);
     // Auth stores (passkey challenges, magic-link tokens, SIWE/SIWS nonces)
@@ -430,7 +452,16 @@ async function ensureWorkerInit(env: Env): Promise<void> {
       );
     }
   })();
-  return workerInit;
+  workerInit = pendingInit;
+  try {
+    await pendingInit;
+  } catch (error) {
+    // A release may repair a missing/stale ledger without recycling every
+    // isolate. Keep concurrent callers on the same failed attempt, then allow
+    // the next request to prove the corrected binding/database generation.
+    if (workerInit === pendingInit) workerInit = null;
+    throw error;
+  }
 }
 
 // Compose the deployable app once per isolate: lean core + this repo's opt-in

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -406,6 +406,17 @@ export class PostgresBackend implements StoreBackend {
   private async ensureTable(): Promise<void> {
     if (this.initialized) return;
     const sql = this.getSqlClient();
+    // Numbered release migrations own production DDL. A restricted application
+    // role can use the already-migrated store but must not need CREATE on the
+    // public schema merely because this compatibility fallback is shared with
+    // local development.
+    const [existing] = await sql<{ relation: string | null }[]>`
+      SELECT to_regclass('public.auth_kv_store')::text AS relation
+    `;
+    if (existing?.relation) {
+      this.initialized = true;
+      return;
+    }
     await sql.begin(async (transaction: TransactionSql) => {
       // CREATE TABLE IF NOT EXISTS can still race in PostgreSQL's catalogs when
       // separate fresh backend instances initialize concurrently. Production

--- a/packages/db/src/__tests__/migration-ledger-integrity.test.ts
+++ b/packages/db/src/__tests__/migration-ledger-integrity.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import {
+  assertCoreMigrationLedgerIntegrity,
+  type CoreMigrationLedgerRow,
+  LEGACY_BACKFILL_TIP_TAG,
+} from "../migrate";
+
+interface JournalEntry {
+  idx: number;
+  tag: string;
+  when: number;
+}
+
+const migrations = new URL("../../drizzle/", import.meta.url);
+const journal = JSON.parse(readFileSync(new URL("meta/_journal.json", migrations), "utf8")) as {
+  entries: JournalEntry[];
+};
+
+function row(entry: JournalEntry, id: number): CoreMigrationLedgerRow {
+  const sql = readFileSync(new URL(`${entry.tag}.sql`, migrations));
+  return {
+    id,
+    hash: createHash("sha256").update(sql).digest("hex"),
+    created_at: entry.when,
+  };
+}
+
+function rows(entries: JournalEntry[]): CoreMigrationLedgerRow[] {
+  return entries.map((entry, index) => row(entry, index + 1));
+}
+
+const migratedDatabase = {
+  tenantsExists: true,
+  auditEventsExists: true,
+  publicRelationCount: 250,
+};
+
+describe("core migration ledger integrity", () => {
+  test("accepts a genuinely empty database before the first migration", () => {
+    expect(() =>
+      assertCoreMigrationLedgerIntegrity([], journal, {
+        tenantsExists: false,
+        auditEventsExists: false,
+        publicRelationCount: 0,
+      }),
+    ).not.toThrow();
+  });
+
+  test("accepts a complete Steward journal and the bounded legacy backfill prefix", () => {
+    expect(() =>
+      assertCoreMigrationLedgerIntegrity(rows(journal.entries), journal, migratedDatabase, {
+        requireComplete: true,
+      }),
+    ).not.toThrow();
+
+    const legacyTip = journal.entries.findIndex((entry) => entry.tag === LEGACY_BACKFILL_TIP_TAG);
+    expect(legacyTip).toBeGreaterThan(0);
+    expect(() =>
+      assertCoreMigrationLedgerIntegrity(
+        rows(journal.entries.slice(0, legacyTip + 1)),
+        journal,
+        migratedDatabase,
+      ),
+    ).not.toThrow();
+  });
+
+  test("rejects unrelated and ahead rows before Drizzle can trust their timestamp", () => {
+    const poisoned = [
+      ...rows(journal.entries.slice(0, 3)),
+      { id: 999, hash: "f".repeat(64), created_at: journal.entries.at(-1)!.when + 1 },
+    ];
+    expect(() => assertCoreMigrationLedgerIntegrity(poisoned, journal, migratedDatabase)).toThrow(
+      /not owned by this Steward build/,
+    );
+  });
+
+  test("rejects a missing migration below the recorded cutoff", () => {
+    const missing = rows(
+      journal.entries.filter((entry) => entry.tag !== "0111_tenant_rls_policy_install"),
+    );
+    expect(() => assertCoreMigrationLedgerIntegrity(missing, journal, migratedDatabase)).toThrow(
+      /missing 0111_tenant_rls_policy_install below its recorded cutoff/,
+    );
+  });
+
+  test("rejects wrong, shared, and ambiguous legacy database shapes", () => {
+    expect(() =>
+      assertCoreMigrationLedgerIntegrity(rows(journal.entries), journal, {
+        ...migratedDatabase,
+        tenantsExists: false,
+      }),
+    ).toThrow(/wrong database/);
+    expect(() =>
+      assertCoreMigrationLedgerIntegrity([], journal, {
+        tenantsExists: false,
+        auditEventsExists: false,
+        publicRelationCount: 1,
+      }),
+    ).toThrow(/shared database/);
+
+    // The namespaced core ledger is authoritative. A stale public Drizzle
+    // journal is just another legacy public relation when Steward's own root
+    // and fingerprint prove the bounded psql-era backfill path.
+    expect(() =>
+      assertCoreMigrationLedgerIntegrity([], journal, {
+        tenantsExists: true,
+        auditEventsExists: true,
+        publicRelationCount: 251,
+      }),
+    ).not.toThrow();
+  });
+
+  test("rejects claimed legacy-tip state without its schema fingerprint", () => {
+    expect(() =>
+      assertCoreMigrationLedgerIntegrity(rows(journal.entries), journal, {
+        ...migratedDatabase,
+        auditEventsExists: false,
+      }),
+    ).toThrow(/public\.audit_events is missing/);
+  });
+
+  test("requires the full checked-in journal after the migrator returns", () => {
+    const legacyTip = journal.entries.findIndex((entry) => entry.tag === LEGACY_BACKFILL_TIP_TAG);
+    expect(() =>
+      assertCoreMigrationLedgerIntegrity(
+        rows(journal.entries.slice(0, legacyTip + 1)),
+        journal,
+        migratedDatabase,
+        { requireComplete: true },
+      ),
+    ).toThrow(/returned with an incomplete Steward journal/);
+  });
+});

--- a/packages/db/src/__tests__/migration-ledger-integrity.test.ts
+++ b/packages/db/src/__tests__/migration-ledger-integrity.test.ts
@@ -45,7 +45,7 @@ describe("core migration ledger integrity", () => {
     const validate = source.indexOf(
       "assertCoreMigrationLedgerIntegrity(existingRows, journal, databaseShape)",
     );
-    const mutate = source.indexOf("await client`CREATE SCHEMA drizzle`");
+    const mutate = source.indexOf("await tx.execute(sql`CREATE SCHEMA drizzle`)");
     expect(inspect).toBeGreaterThan(0);
     expect(validate).toBeGreaterThan(inspect);
     expect(mutate).toBeGreaterThan(validate);

--- a/packages/db/src/__tests__/migration-ledger-integrity.test.ts
+++ b/packages/db/src/__tests__/migration-ledger-integrity.test.ts
@@ -35,7 +35,7 @@ const migratedDatabase = {
   tenantsExists: true,
   auditEventsExists: true,
   legacyFingerprintMatches: true,
-  publicRelationCount: 250,
+  userObjectCount: 250,
 };
 
 describe("core migration ledger integrity", () => {
@@ -45,10 +45,14 @@ describe("core migration ledger integrity", () => {
     const validate = source.indexOf(
       "assertCoreMigrationLedgerIntegrity(existingRows, journal, databaseShape)",
     );
-    const mutate = source.indexOf("CREATE SCHEMA IF NOT EXISTS drizzle");
+    const mutate = source.indexOf("await client`CREATE SCHEMA drizzle`");
     expect(inspect).toBeGreaterThan(0);
     expect(validate).toBeGreaterThan(inspect);
     expect(mutate).toBeGreaterThan(validate);
+    expect(source).toContain("FROM pg_namespace candidate");
+    expect(source).toContain("FROM pg_proc object");
+    expect(source).toContain("FROM pg_type object");
+    expect(source).toContain("AS user_object_count");
   });
 
   test("accepts a genuinely empty database before the first migration", () => {
@@ -57,7 +61,7 @@ describe("core migration ledger integrity", () => {
         tenantsExists: false,
         auditEventsExists: false,
         legacyFingerprintMatches: false,
-        publicRelationCount: 0,
+        userObjectCount: 0,
       }),
     ).not.toThrow();
   });
@@ -111,7 +115,7 @@ describe("core migration ledger integrity", () => {
         tenantsExists: false,
         auditEventsExists: false,
         legacyFingerprintMatches: false,
-        publicRelationCount: 1,
+        userObjectCount: 1,
       }),
     ).toThrow(/shared database/);
 
@@ -123,7 +127,7 @@ describe("core migration ledger integrity", () => {
         tenantsExists: true,
         auditEventsExists: true,
         legacyFingerprintMatches: true,
-        publicRelationCount: 251,
+        userObjectCount: 251,
       }),
     ).not.toThrow();
   });
@@ -140,7 +144,7 @@ describe("core migration ledger integrity", () => {
         tenantsExists: true,
         auditEventsExists: true,
         legacyFingerprintMatches: false,
-        publicRelationCount: 2,
+        userObjectCount: 2,
       }),
     ).toThrow(/does not match the complete legacy schema fingerprint/);
   });

--- a/packages/db/src/__tests__/migration-ledger-integrity.test.ts
+++ b/packages/db/src/__tests__/migration-ledger-integrity.test.ts
@@ -49,9 +49,9 @@ describe("core migration ledger integrity", () => {
     expect(inspect).toBeGreaterThan(0);
     expect(validate).toBeGreaterThan(inspect);
     expect(mutate).toBeGreaterThan(validate);
-    expect(source).toContain("FROM pg_namespace candidate");
-    expect(source).toContain("FROM pg_proc object");
-    expect(source).toContain("FROM pg_type object");
+    expect(source).toContain("FROM pg_namespace namespace");
+    expect(source).toContain("FROM pg_proc routine");
+    expect(source).toContain("FROM pg_type type_inventory");
     expect(source).toContain("AS user_object_count");
   });
 
@@ -116,6 +116,17 @@ describe("core migration ledger integrity", () => {
         auditEventsExists: false,
         legacyFingerprintMatches: false,
         userObjectCount: 1,
+        unapprovedObjectCount: 1,
+      }),
+    ).toThrow(/shared database/);
+
+    expect(() =>
+      assertCoreMigrationLedgerIntegrity([], journal, {
+        tenantsExists: false,
+        auditEventsExists: false,
+        legacyFingerprintMatches: false,
+        userObjectCount: 0,
+        unapprovedObjectCount: 1,
       }),
     ).toThrow(/shared database/);
 
@@ -130,6 +141,32 @@ describe("core migration ledger integrity", () => {
         userObjectCount: 251,
       }),
     ).not.toThrow();
+  });
+
+  test("rejects a malformed namespaced ledger before trusting its rows", () => {
+    expect(() =>
+      assertCoreMigrationLedgerIntegrity([], journal, {
+        tenantsExists: false,
+        auditEventsExists: false,
+        legacyFingerprintMatches: false,
+        userObjectCount: 0,
+        unapprovedObjectCount: 0,
+        coreLedgerExists: true,
+        coreLedgerShapeMatches: false,
+      }),
+    ).toThrow(/does not match Steward's migration-ledger shape/);
+  });
+
+  test("rejects foreign inventory even beside an otherwise valid Steward ledger", () => {
+    expect(() =>
+      assertCoreMigrationLedgerIntegrity(rows(journal.entries), journal, {
+        ...migratedDatabase,
+        unapprovedObjectCount: 1,
+        alwaysRejectedObjectCount: 1,
+        coreLedgerExists: true,
+        coreLedgerShapeMatches: true,
+      }),
+    ).toThrow(/outside the verified Steward and provider inventories/);
   });
 
   test("rejects claimed legacy-tip state without its complete schema fingerprint", () => {

--- a/packages/db/src/__tests__/migration-ledger-integrity.test.ts
+++ b/packages/db/src/__tests__/migration-ledger-integrity.test.ts
@@ -34,6 +34,7 @@ function rows(entries: JournalEntry[]): CoreMigrationLedgerRow[] {
 const migratedDatabase = {
   tenantsExists: true,
   auditEventsExists: true,
+  legacyFingerprintMatches: true,
   publicRelationCount: 250,
 };
 
@@ -55,6 +56,7 @@ describe("core migration ledger integrity", () => {
       assertCoreMigrationLedgerIntegrity([], journal, {
         tenantsExists: false,
         auditEventsExists: false,
+        legacyFingerprintMatches: false,
         publicRelationCount: 0,
       }),
     ).not.toThrow();
@@ -108,6 +110,7 @@ describe("core migration ledger integrity", () => {
       assertCoreMigrationLedgerIntegrity([], journal, {
         tenantsExists: false,
         auditEventsExists: false,
+        legacyFingerprintMatches: false,
         publicRelationCount: 1,
       }),
     ).toThrow(/shared database/);
@@ -119,18 +122,48 @@ describe("core migration ledger integrity", () => {
       assertCoreMigrationLedgerIntegrity([], journal, {
         tenantsExists: true,
         auditEventsExists: true,
+        legacyFingerprintMatches: true,
         publicRelationCount: 251,
       }),
     ).not.toThrow();
   });
 
-  test("rejects claimed legacy-tip state without its schema fingerprint", () => {
+  test("rejects claimed legacy-tip state without its complete schema fingerprint", () => {
     expect(() =>
       assertCoreMigrationLedgerIntegrity(rows(journal.entries), journal, {
         ...migratedDatabase,
         auditEventsExists: false,
       }),
-    ).toThrow(/public\.audit_events is missing/);
+    ).toThrow(/complete legacy schema fingerprint does not match/);
+    expect(() =>
+      assertCoreMigrationLedgerIntegrity([], journal, {
+        tenantsExists: true,
+        auditEventsExists: true,
+        legacyFingerprintMatches: false,
+        publicRelationCount: 2,
+      }),
+    ).toThrow(/does not match the complete legacy schema fingerprint/);
+  });
+
+  test("validates explicit positive migration timeout bounds", async () => {
+    const { resolveMigrationTimeouts } = await import("../migrate");
+    expect(
+      resolveMigrationTimeouts({
+        STEWARD_MIGRATION_CONNECT_TIMEOUT_SECONDS: "3",
+        STEWARD_MIGRATION_LOCK_TIMEOUT_MS: "4000",
+        STEWARD_MIGRATION_STATEMENT_TIMEOUT_MS: "5000",
+        STEWARD_MIGRATION_OVERALL_TIMEOUT_MS: "6000",
+      }),
+    ).toEqual({ connectSeconds: 3, advisoryLockMs: 4000, statementMs: 5000, overallMs: 6000 });
+    expect(() =>
+      resolveMigrationTimeouts({ STEWARD_MIGRATION_CONNECT_TIMEOUT_SECONDS: "0" }),
+    ).toThrow(/positive integer/);
+    expect(() =>
+      resolveMigrationTimeouts({
+        STEWARD_MIGRATION_LOCK_TIMEOUT_MS: "7000",
+        STEWARD_MIGRATION_OVERALL_TIMEOUT_MS: "6000",
+      }),
+    ).toThrow(/must not exceed/);
   });
 
   test("requires the full checked-in journal after the migrator returns", () => {

--- a/packages/db/src/__tests__/migration-ledger-integrity.test.ts
+++ b/packages/db/src/__tests__/migration-ledger-integrity.test.ts
@@ -38,6 +38,18 @@ const migratedDatabase = {
 };
 
 describe("core migration ledger integrity", () => {
+  test("inspects and rejects the target before creating migration bookkeeping", () => {
+    const source = readFileSync(new URL("../migrate.ts", import.meta.url), "utf8");
+    const inspect = source.indexOf("to_regclass('drizzle.__drizzle_migrations')");
+    const validate = source.indexOf(
+      "assertCoreMigrationLedgerIntegrity(existingRows, journal, databaseShape)",
+    );
+    const mutate = source.indexOf("CREATE SCHEMA IF NOT EXISTS drizzle");
+    expect(inspect).toBeGreaterThan(0);
+    expect(validate).toBeGreaterThan(inspect);
+    expect(mutate).toBeGreaterThan(validate);
+  });
+
   test("accepts a genuinely empty database before the first migration", () => {
     expect(() =>
       assertCoreMigrationLedgerIntegrity([], journal, {

--- a/packages/db/src/__tests__/migration-target-inventory-postgres.test.ts
+++ b/packages/db/src/__tests__/migration-target-inventory-postgres.test.ts
@@ -1,0 +1,192 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import postgres from "postgres";
+
+const rootDatabaseUrl = process.env.DATABASE_URL;
+const describeWithPostgres = rootDatabaseUrl ? describe : describe.skip;
+const repositoryRoot = new URL("../../../../", import.meta.url).pathname;
+const databaseNames = new Set<string>();
+let admin: ReturnType<typeof postgres> | undefined;
+
+function databaseUrl(name: string): string {
+  const url = new URL(rootDatabaseUrl as string);
+  url.pathname = `/${name}`;
+  return url.toString();
+}
+
+async function createTarget(prefix: string): Promise<{
+  name: string;
+  url: string;
+  client: ReturnType<typeof postgres>;
+}> {
+  const name = `steward_${prefix}_${process.pid}_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
+  await admin!`CREATE DATABASE ${admin!(name)}`;
+  databaseNames.add(name);
+  const url = databaseUrl(name);
+  return { name, url, client: postgres(url, { max: 1 }) };
+}
+
+async function runMigrator(url: string): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const child = Bun.spawn(["bun", "run", "packages/db/src/migrate.ts"], {
+    cwd: repositoryRoot,
+    env: {
+      ...process.env,
+      DATABASE_URL: url,
+      DATABASE_DRIVER: "postgres-js",
+      STEWARD_MIGRATION_CONNECT_TIMEOUT_SECONDS: "10",
+      STEWARD_MIGRATION_LOCK_TIMEOUT_MS: "10000",
+      STEWARD_MIGRATION_STATEMENT_TIMEOUT_MS: "120000",
+      STEWARD_MIGRATION_OVERALL_TIMEOUT_MS: "180000",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+async function expectRejectedWithoutMutation(
+  target: ReturnType<typeof postgres>,
+  result: Awaited<ReturnType<typeof runMigrator>>,
+): Promise<void> {
+  expect(result.exitCode).not.toBe(0);
+  // Entrypoint diagnostics intentionally redact error messages. The durable
+  // proof is that the migrator failed and did not create even its schema.
+  const [shape] = await target<Array<{ drizzle_schema_exists: boolean; ledger_exists: boolean }>>`
+    SELECT
+      to_regnamespace('drizzle') IS NOT NULL AS drizzle_schema_exists,
+      to_regclass('drizzle.__drizzle_migrations') IS NOT NULL AS ledger_exists
+  `;
+  expect(shape).toEqual({ drizzle_schema_exists: false, ledger_exists: false });
+}
+
+describeWithPostgres("migration target inventory (real Postgres)", () => {
+  beforeAll(() => {
+    const maintenanceUrl = new URL(rootDatabaseUrl as string);
+    maintenanceUrl.pathname = "/postgres";
+    admin = postgres(maintenanceUrl.toString(), { max: 1 });
+  });
+
+  afterAll(async () => {
+    try {
+      for (const name of databaseNames) {
+        await admin!`DROP DATABASE IF EXISTS ${admin!(name)} WITH (FORCE)`;
+      }
+    } finally {
+      await admin?.end({ timeout: 5 });
+    }
+  });
+
+  test("rejects a foreign table in a custom schema before any mutation", async () => {
+    const target = await createTarget("foreign_schema");
+    try {
+      await target.client`CREATE SCHEMA foreign_application`;
+      await target.client`
+        CREATE FOREIGN DATA WRAPPER inventory_test_fdw NO HANDLER NO VALIDATOR
+      `;
+      await target.client`
+        CREATE SERVER inventory_test_server FOREIGN DATA WRAPPER inventory_test_fdw
+      `;
+      await target.client`
+        CREATE FOREIGN TABLE foreign_application.customer_records (id integer)
+          SERVER inventory_test_server
+      `;
+
+      await expectRejectedWithoutMutation(target.client, await runMigrator(target.url));
+      const [foreignTable] = await target.client<Array<{ exists: boolean }>>`
+        SELECT to_regclass('foreign_application.customer_records') IS NOT NULL AS exists
+      `;
+      expect(foreignTable?.exists).toBe(true);
+    } finally {
+      await target.client.end({ timeout: 5 });
+    }
+  });
+
+  test("rejects a public view-only target before any mutation", async () => {
+    const target = await createTarget("public_view");
+    try {
+      await target.client`CREATE VIEW public.foreign_view AS SELECT 1 AS id`;
+
+      await expectRejectedWithoutMutation(target.client, await runMigrator(target.url));
+      const [view] = await target.client<Array<{ exists: boolean }>>`
+        SELECT to_regclass('public.foreign_view') IS NOT NULL AS exists
+      `;
+      expect(view?.exists).toBe(true);
+    } finally {
+      await target.client.end({ timeout: 5 });
+    }
+  });
+
+  test("rejects standalone public routines and types before any mutation", async () => {
+    const target = await createTarget("public_code");
+    try {
+      await target.client`CREATE TYPE public.foreign_status AS ENUM ('active')`;
+      await target.client`
+        CREATE FUNCTION public.foreign_identity(value integer)
+        RETURNS integer LANGUAGE sql IMMUTABLE AS 'SELECT value'
+      `;
+
+      await expectRejectedWithoutMutation(target.client, await runMigrator(target.url));
+    } finally {
+      await target.client.end({ timeout: 5 });
+    }
+  });
+
+  test("accepts explicit Neon schema and trusted extension metadata", async () => {
+    const target = await createTarget("provider_metadata");
+    try {
+      await target.client`CREATE SCHEMA neon`;
+      await target.client`CREATE SCHEMA drizzle`;
+      await target.client`CREATE SCHEMA steward_rls`;
+      await target.client`CREATE SCHEMA steward_bootstrap`;
+      await target.client`CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public`;
+
+      const result = await runMigrator(target.url);
+      expect(result.exitCode, result.stderr || result.stdout).toBe(0);
+      const [shape] = await target.client<
+        Array<{ neon_schema_exists: boolean; extension_exists: boolean; migration_count: number }>
+      >`
+        SELECT
+          to_regnamespace('neon') IS NOT NULL AS neon_schema_exists,
+          EXISTS (
+            SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements'
+          ) AS extension_exists,
+          (
+            SELECT count(*)::int FROM drizzle.__drizzle_migrations
+          ) AS migration_count
+      `;
+      expect(shape?.neon_schema_exists).toBe(true);
+      expect(shape?.extension_exists).toBe(true);
+      expect(shape?.migration_count).toBeGreaterThan(0);
+
+      await target.client`
+        CREATE TABLE drizzle.__drizzle_migrations_plugin_capabilities (
+          id serial PRIMARY KEY,
+          hash text NOT NULL,
+          created_at bigint
+        )
+      `;
+      const cleanRetry = await runMigrator(target.url);
+      expect(cleanRetry.exitCode, cleanRetry.stderr || cleanRetry.stdout).toBe(0);
+
+      await target.client`CREATE SCHEMA shared_application`;
+      await target.client`CREATE TABLE shared_application.foreign_records (id integer)`;
+      const sharedResult = await runMigrator(target.url);
+      expect(sharedResult.exitCode).not.toBe(0);
+      const [afterRejection] = await target.client<Array<{ migration_count: number }>>`
+        SELECT count(*)::int AS migration_count FROM drizzle.__drizzle_migrations
+      `;
+      expect(afterRejection?.migration_count).toBe(shape?.migration_count);
+    } finally {
+      await target.client.end({ timeout: 5 });
+    }
+  }, 200_000);
+});

--- a/packages/db/src/__tests__/migration-target-inventory-postgres.test.ts
+++ b/packages/db/src/__tests__/migration-target-inventory-postgres.test.ts
@@ -189,4 +189,108 @@ describeWithPostgres("migration target inventory (real Postgres)", () => {
       await target.client.end({ timeout: 5 });
     }
   }, 200_000);
+
+  test("rejects ordinary extra objects even with a complete valid core ledger", async () => {
+    const target = await createTarget("valid_ledger_drift");
+    try {
+      const migrated = await runMigrator(target.url);
+      expect(migrated.exitCode, migrated.stderr || migrated.stdout).toBe(0);
+      const [before] = await target.client<Array<{ migration_count: number }>>`
+        SELECT count(*)::int AS migration_count FROM drizzle.__drizzle_migrations
+      `;
+
+      await target.client`CREATE TABLE public.foreign_customer_records (id integer)`;
+      await target.client`CREATE SEQUENCE public.foreign_customer_sequence`;
+      await target.client`CREATE TYPE public.foreign_customer_status AS ENUM ('active')`;
+      await target.client`
+        CREATE FUNCTION public.foreign_customer_identity(value integer)
+        RETURNS integer LANGUAGE sql IMMUTABLE AS 'SELECT value'
+      `;
+
+      const rejected = await runMigrator(target.url);
+      expect(rejected.exitCode).not.toBe(0);
+      const [after] = await target.client<Array<{ migration_count: number }>>`
+        SELECT count(*)::int AS migration_count FROM drizzle.__drizzle_migrations
+      `;
+      expect(after?.migration_count).toBe(before?.migration_count);
+    } finally {
+      await target.client.end({ timeout: 5 });
+    }
+  }, 200_000);
+
+  test("rejects malformed and unknown plugin ledgers on a valid core target", async () => {
+    const target = await createTarget("plugin_ledger_drift");
+    try {
+      const migrated = await runMigrator(target.url);
+      expect(migrated.exitCode, migrated.stderr || migrated.stdout).toBe(0);
+
+      await target.client`
+        CREATE TABLE drizzle.__drizzle_migrations_plugin_capabilities (
+          id serial PRIMARY KEY,
+          hash text NOT NULL,
+          created_at bigint
+        )
+      `;
+      await target.client`
+        INSERT INTO drizzle.__drizzle_migrations_plugin_capabilities(hash, created_at)
+        VALUES ('not-a-checked-in-hash', 1782800000000)
+      `;
+      const malformed = await runMigrator(target.url);
+      expect(malformed.exitCode).not.toBe(0);
+
+      await target.client`DROP TABLE drizzle.__drizzle_migrations_plugin_capabilities`;
+      await target.client`
+        CREATE TABLE drizzle.__drizzle_migrations_plugin_unknown (
+          id serial PRIMARY KEY,
+          hash text NOT NULL,
+          created_at bigint
+        )
+      `;
+      const unknown = await runMigrator(target.url);
+      expect(unknown.exitCode).not.toBe(0);
+    } finally {
+      await target.client.end({ timeout: 5 });
+    }
+  }, 200_000);
+
+  test("rolls back migrations when non-cooperating DDL lands during the migration", async () => {
+    const target = await createTarget("concurrent_ddl");
+    try {
+      const migration = runMigrator(target.url);
+      const deadline = Date.now() + 30_000;
+      let migrationTransactionObserved = false;
+      while (Date.now() < deadline) {
+        const [activity] = await target.client<Array<{ observed: boolean }>>`
+          SELECT EXISTS (
+            SELECT 1
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+              AND pid <> pg_backend_pid()
+              AND xact_start IS NOT NULL
+              AND clock_timestamp() - xact_start > interval '250 milliseconds'
+          ) AS observed
+        `;
+        if (activity?.observed) {
+          migrationTransactionObserved = true;
+          break;
+        }
+        await Bun.sleep(25);
+      }
+      expect(migrationTransactionObserved).toBe(true);
+
+      await target.client`CREATE TABLE public.concurrent_foreign_records (id integer)`;
+      const result = await migration;
+      expect(result.exitCode).not.toBe(0);
+      const [shape] = await target.client<
+        Array<{ ledger_exists: boolean; foreign_table_exists: boolean }>
+      >`
+        SELECT
+          to_regclass('drizzle.__drizzle_migrations') IS NOT NULL AS ledger_exists,
+          to_regclass('public.concurrent_foreign_records') IS NOT NULL AS foreign_table_exists
+      `;
+      expect(shape).toEqual({ ledger_exists: false, foreign_table_exists: true });
+    } finally {
+      await target.client.end({ timeout: 5 });
+    }
+  }, 200_000);
 });

--- a/packages/db/src/__tests__/plugin-migrate.test.ts
+++ b/packages/db/src/__tests__/plugin-migrate.test.ts
@@ -15,6 +15,7 @@ import { migrate as pgliteMigrate } from "drizzle-orm/pglite/migrator";
 
 import { createPGLiteDb } from "../pglite";
 import {
+  getPluginMigrationLedgerExpectation,
   pluginMigrationsTable,
   runPluginMigrations,
   sanitizePluginMigrationId,
@@ -49,6 +50,19 @@ async function makeMigrationsFolder(tag: string, sql: string): Promise<string> {
 }
 
 describe("plugin migrations: namespaced-journal isolation", () => {
+  test("derives the exact enabled-plugin readiness ledger from checked-in bytes", async () => {
+    const folder = await makeMigrationsFolder("0000_readiness", "SELECT 1;");
+    const expectation = getPluginMigrationLedgerExpectation({
+      id: "readiness-plugin",
+      migrationsFolder: folder,
+    });
+    expect(expectation.id).toBe("readiness-plugin");
+    expect(expectation.migrationsTable).toBe("__drizzle_migrations_plugin_readiness_plugin");
+    expect(expectation.entries).toHaveLength(1);
+    expect(expectation.entries[0]?.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(Number.isSafeInteger(expectation.entries[0]?.createdAt)).toBe(true);
+  });
+
   test("sanitizePluginMigrationId is injection-safe and fail-closed on empty", () => {
     expect(sanitizePluginMigrationId("Trading")).toBe("trading");
     expect(sanitizePluginMigrationId("a-b.c/d")).toBe("a_b_c_d");

--- a/packages/db/src/__tests__/rls-deployment-safety.test.ts
+++ b/packages/db/src/__tests__/rls-deployment-safety.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { assertRlsDeploymentSafety } from "../rls-deployment-safety";
 import {
   EXPECTED_PUBLIC_RELATIONS,
@@ -11,11 +12,13 @@ function database(options?: {
   relationDrift?: boolean;
   capabilities?: boolean;
   partialCapabilities?: boolean;
+  onExecute?: (query: unknown, queryIndex: number) => void;
 }) {
   let query = 0;
   return {
-    async execute() {
+    async execute(statement: unknown) {
       query += 1;
+      options?.onExecute?.(statement, query);
       if (query === 1) {
         return [
           {
@@ -72,6 +75,25 @@ function database(options?: {
 }
 
 describe("RLS deployment safety gate", () => {
+  test("binds the protected relation inventory as a PostgreSQL text array", async () => {
+    let roleQuery: { sql: string; params: unknown[] } | undefined;
+    await assertRlsDeploymentSafety(
+      database({
+        onExecute(statement, queryIndex) {
+          if (queryIndex === 1) roleQuery = new PgDialect().sqlToQuery(statement as never);
+        },
+      }),
+      { expectedRole: "steward_app" },
+    );
+
+    expect(roleQuery?.sql).toContain("relation.relname = ANY(ARRAY[");
+    expect(roleQuery?.sql).toContain("]::text[])");
+    expect(roleQuery?.sql).not.toContain("relation.relname = ANY(($");
+    expect(roleQuery?.params).toEqual([
+      ...new Set(EXPECTED_RLS_POLICY_DEFINITIONS.map((policy) => policy.relation_name)),
+    ]);
+  });
+
   test("accepts only the exact safe role, relation/partition shape, and policies", async () => {
     await expect(
       assertRlsDeploymentSafety(database(), { expectedRole: "steward_app" }),

--- a/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import postgres from "postgres";
 
@@ -35,8 +35,8 @@ function platformDatabaseUrl(): string {
   return url.toString();
 }
 
-function migrationDatabaseUrl(): string {
-  const url = new URL(databaseUrl(databaseName));
+function migrationDatabaseUrl(database = databaseName): string {
+  const url = new URL(databaseUrl(database));
   url.username = migrationRole;
   url.password = migrationRolePassword;
   return url.toString();
@@ -96,7 +96,7 @@ async function reserveLoopbackPort(): Promise<number> {
   return port;
 }
 
-async function proveRestrictedApiStartupReadiness(platformKey: string) {
+async function proveRestrictedApiStartupReadiness(platformKey: string, expectedStatus = 200) {
   const port = await reserveLoopbackPort();
   const probeToken = `rls-ready-${suffix}`;
   const child = Bun.spawn(["bun", "run", "packages/api/src/index.ts"], {
@@ -112,7 +112,7 @@ async function proveRestrictedApiStartupReadiness(platformKey: string) {
       STEWARD_APP_DATABASE_ROLE: appRole,
       STEWARD_PLATFORM_DATABASE_URL: platformDatabaseUrl(),
       STEWARD_PLATFORM_DATABASE_ROLE: platformRole,
-      STEWARD_PLUGINS: "",
+      STEWARD_PLUGINS: "capabilities",
       STEWARD_ENABLE_TRADING: "false",
       STEWARD_REDIS_REQUIRED: "false",
       REDIS_URL: "",
@@ -152,7 +152,7 @@ async function proveRestrictedApiStartupReadiness(platformKey: string) {
           headers: { "x-steward-probe-token": probeToken },
           signal: AbortSignal.timeout(1_000),
         });
-        if (response.status === 200) {
+        if (response.status === expectedStatus) {
           proof = (await response.json()) as typeof proof;
           break;
         }
@@ -175,9 +175,19 @@ async function proveRestrictedApiStartupReadiness(platformKey: string) {
 
 describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", () => {
   const admin = postgres(process.env.DATABASE_URL as string, { max: 1 });
+  const hostileSchemaDatabase = `steward_foreign_schema_${suffix}`;
+  const hostileObjectDatabase = `steward_foreign_object_${suffix}`;
+
+  beforeAll(async () => {
+    await admin.unsafe(
+      `CREATE ROLE ${migrationRole} LOGIN PASSWORD '${migrationRolePassword}' NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE NOREPLICATION`,
+    );
+  });
 
   afterAll(async () => {
     await admin.unsafe(`DROP DATABASE IF EXISTS ${databaseName} WITH (FORCE)`);
+    await admin.unsafe(`DROP DATABASE IF EXISTS ${hostileSchemaDatabase} WITH (FORCE)`);
+    await admin.unsafe(`DROP DATABASE IF EXISTS ${hostileObjectDatabase} WITH (FORCE)`);
     await admin.unsafe(`DROP ROLE IF EXISTS ${appRole}`);
     await admin.unsafe(`DROP ROLE IF EXISTS ${migrationRole}`);
     await admin.unsafe(`DROP ROLE IF EXISTS ${definerRole}`);
@@ -185,25 +195,69 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
     await admin.end();
   });
 
+  async function provisionMigrationTarget(targetDatabase: string) {
+    await admin.unsafe(`CREATE DATABASE ${targetDatabase}`);
+    const target = postgres(databaseUrl(targetDatabase), { max: 1 });
+    try {
+      await target.unsafe(`ALTER SCHEMA public OWNER TO ${migrationRole}`);
+      await target.unsafe(`CREATE SCHEMA drizzle AUTHORIZATION ${migrationRole}`);
+      await target.unsafe(`CREATE SCHEMA steward_rls AUTHORIZATION ${migrationRole}`);
+      await target.unsafe(`CREATE SCHEMA steward_bootstrap AUTHORIZATION ${migrationRole}`);
+      // Immutable migration 0111 executes CREATE SCHEMA IF NOT EXISTS; PostgreSQL
+      // requires database CREATE even when the admin already provisioned those
+      // exact schemas. Bound the grant to the release and revoke it below before
+      // any runtime role is activated. NOCREATEDB remains unchanged throughout.
+      await target.unsafe(
+        `GRANT CONNECT, CREATE ON DATABASE ${targetDatabase} TO ${migrationRole}`,
+      );
+    } finally {
+      await target.end();
+    }
+  }
+
+  test("rejects foreign schemas and non-table public objects before creating a ledger", async () => {
+    for (const [targetDatabase, hostileSql] of [
+      [hostileSchemaDatabase, "CREATE SCHEMA unrelated"],
+      [hostileObjectDatabase, "CREATE VIEW public.unrelated_view AS SELECT 1 AS value"],
+    ] as const) {
+      await provisionMigrationTarget(targetDatabase);
+      const target = postgres(databaseUrl(targetDatabase), { max: 1 });
+      try {
+        await target.unsafe(hostileSql);
+      } finally {
+        await target.end();
+      }
+      let rejected: unknown;
+      try {
+        await runCommand(["bun", "run", "--cwd", "packages/api", "migrate"], {
+          DATABASE_URL: migrationDatabaseUrl(targetDatabase),
+          STEWARD_PLUGINS: "capabilities",
+          STEWARD_ENABLE_TRADING: "false",
+          STEWARD_MASTER_PASSWORD: `restricted-migrator-master-${suffix}`,
+        });
+      } catch (error) {
+        rejected = error;
+      }
+      expect(rejected).toBeInstanceOf(Error);
+      const inspect = postgres(databaseUrl(targetDatabase), { max: 1 });
+      try {
+        await inspect.unsafe(`REVOKE CREATE ON DATABASE ${targetDatabase} FROM ${migrationRole}`);
+        const [ledger] = await inspect<{ ledger: string | null }[]>`
+          SELECT to_regclass('drizzle.__drizzle_migrations')::text AS ledger
+        `;
+        expect(ledger?.ledger).toBeNull();
+      } finally {
+        await inspect.end();
+      }
+    }
+  });
+
   test("bootstraps, activates, rolls back, reactivates, and reruns the migrator", async () => {
     const [adminRole] = await admin<{ rolsuper: boolean }[]>`
       SELECT rolsuper FROM pg_roles WHERE rolname = current_user
     `;
     expect(adminRole?.rolsuper).toBe(true);
-    await admin.unsafe(
-      `CREATE ROLE ${migrationRole} LOGIN PASSWORD '${migrationRolePassword}' NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE NOREPLICATION`,
-    );
-    await admin.unsafe(`CREATE DATABASE ${databaseName}`);
-
-    const emptyDatabase = postgres(databaseUrl(databaseName), { max: 1 });
-    try {
-      await emptyDatabase.unsafe(
-        `GRANT CONNECT, CREATE ON DATABASE ${databaseName} TO ${migrationRole}`,
-      );
-      await emptyDatabase.unsafe(`GRANT USAGE, CREATE ON SCHEMA public TO ${migrationRole}`);
-    } finally {
-      await emptyDatabase.end();
-    }
+    await provisionMigrationTarget(databaseName);
 
     const firstMigration = await runCommand(["bun", "run", "--cwd", "packages/api", "migrate"], {
       DATABASE_URL: migrationDatabaseUrl(),
@@ -216,6 +270,7 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
 
     const db = postgres(databaseUrl(databaseName), { max: 1 });
     try {
+      await db.unsafe(`REVOKE CREATE ON DATABASE ${databaseName} FROM ${migrationRole}`);
       const [restrictedRelease] = await db<
         {
           core_rows: number;
@@ -223,6 +278,10 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
           migrator_super: boolean;
           migrator_bypassrls: boolean;
           migrator_createrole: boolean;
+          migrator_createdb: boolean;
+          migrator_database_create: boolean;
+          migrator_public_create: boolean;
+          migrator_drizzle_create: boolean;
         }[]
       >`
         SELECT
@@ -233,7 +292,11 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
           ) AS plugin_rows,
           role.rolsuper AS migrator_super,
           role.rolbypassrls AS migrator_bypassrls,
-          role.rolcreaterole AS migrator_createrole
+          role.rolcreaterole AS migrator_createrole,
+          role.rolcreatedb AS migrator_createdb,
+          has_database_privilege(${migrationRole}, current_database(), 'CREATE') AS migrator_database_create,
+          has_schema_privilege(${migrationRole}, 'public', 'CREATE') AS migrator_public_create,
+          has_schema_privilege(${migrationRole}, 'drizzle', 'CREATE') AS migrator_drizzle_create
         FROM pg_roles role
         WHERE role.rolname = ${migrationRole}
       `;
@@ -243,6 +306,10 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
         migrator_super: false,
         migrator_bypassrls: false,
         migrator_createrole: false,
+        migrator_createdb: false,
+        migrator_database_create: false,
+        migrator_public_create: true,
+        migrator_drizzle_create: true,
       });
 
       const [installed] = await db<{ relations: number; policies: number }[]>`
@@ -292,6 +359,71 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
         rolcanlogin: true,
         rolbypassrls: false,
         rolsuper: false,
+      });
+      const [schemaBoundary] = await db<
+        {
+          app_schema_create: boolean;
+          platform_schema_create: boolean;
+          public_schema_create: boolean;
+          migrator_public_create: boolean;
+          migrator_drizzle_create: boolean;
+          migrator_rls_create: boolean;
+          migrator_bootstrap_create: boolean;
+          migrator_other_schema_create: boolean;
+          wrong_relation_owner_count: number;
+        }[]
+      >`
+        SELECT
+          EXISTS (
+            SELECT 1 FROM pg_namespace namespace
+            WHERE namespace.nspname IN ('public', 'drizzle', 'steward_rls', 'steward_bootstrap')
+              AND has_schema_privilege(${appRole}, namespace.nspname, 'CREATE')
+          ) AS app_schema_create,
+          EXISTS (
+            SELECT 1 FROM pg_namespace namespace
+            WHERE namespace.nspname IN ('public', 'drizzle', 'steward_rls', 'steward_bootstrap')
+              AND has_schema_privilege(${platformRole}, namespace.nspname, 'CREATE')
+          ) AS platform_schema_create,
+          EXISTS (
+            SELECT 1 FROM pg_namespace namespace
+            CROSS JOIN LATERAL aclexplode(COALESCE(namespace.nspacl, '{}'::aclitem[])) privilege
+            WHERE namespace.nspname IN ('public', 'drizzle', 'steward_rls', 'steward_bootstrap')
+              AND privilege.grantee = 0
+              AND privilege.privilege_type = 'CREATE'
+          ) AS public_schema_create,
+          has_schema_privilege(${migrationRole}, 'public', 'CREATE') AS migrator_public_create,
+          has_schema_privilege(${migrationRole}, 'drizzle', 'CREATE') AS migrator_drizzle_create,
+          has_schema_privilege(${migrationRole}, 'steward_rls', 'CREATE') AS migrator_rls_create,
+          has_schema_privilege(${migrationRole}, 'steward_bootstrap', 'CREATE') AS migrator_bootstrap_create,
+          EXISTS (
+            SELECT 1 FROM pg_namespace namespace
+            WHERE namespace.nspname NOT IN (
+              'public', 'drizzle', 'steward_rls', 'steward_bootstrap',
+              'pg_catalog', 'information_schema'
+            )
+              AND namespace.nspname !~ '^pg_(toast|temp|toast_temp)'
+              AND has_schema_privilege(${migrationRole}, namespace.nspname, 'CREATE')
+          ) AS migrator_other_schema_create,
+          (
+            SELECT count(*)::int
+            FROM pg_class relation
+            JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+            JOIN pg_roles owner ON owner.oid = relation.relowner
+            WHERE namespace.nspname IN ('public', 'drizzle')
+              AND relation.relkind IN ('r', 'p', 'S')
+              AND owner.rolname <> ${migrationRole}
+          ) AS wrong_relation_owner_count
+      `;
+      expect(schemaBoundary).toEqual({
+        app_schema_create: false,
+        platform_schema_create: false,
+        public_schema_create: false,
+        migrator_public_create: true,
+        migrator_drizzle_create: true,
+        migrator_rls_create: true,
+        migrator_bootstrap_create: false,
+        migrator_other_schema_create: false,
+        wrong_relation_owner_count: 0,
       });
       const appReadinessDb = postgres(appDatabaseUrl(), { max: 1 });
       try {
@@ -359,14 +491,80 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
         WHERE n.nspname = 'public' AND p.polname LIKE 'steward_%'
       `;
       expect(activated).toEqual({ enabled: 74, forced: 74, maintenance: 74 });
+      const [maintenanceBoundary] = await db<{ wrong_role_count: number }[]>`
+        SELECT count(*)::int AS wrong_role_count
+        FROM pg_policy policy
+        WHERE policy.polname = 'steward_migration_maintenance'
+          AND policy.polroles <> ARRAY[(SELECT oid FROM pg_roles WHERE rolname = ${migrationRole})]
+      `;
+      expect(maintenanceBoundary?.wrong_role_count).toBe(0);
+
+      const restrictedMigrator = postgres(migrationDatabaseUrl(), { max: 1 });
+      try {
+        for (const forbiddenSql of [
+          `CREATE DATABASE forbidden_${suffix}`,
+          `CREATE ROLE forbidden_${suffix}`,
+          "CREATE EXTENSION hstore SCHEMA public",
+        ]) {
+          let forbiddenError: unknown;
+          try {
+            await restrictedMigrator.unsafe(forbiddenSql);
+          } catch (error) {
+            forbiddenError = error;
+          }
+          expect(forbiddenError).toBeInstanceOf(Error);
+        }
+      } finally {
+        await restrictedMigrator.end();
+      }
 
       const startupPlatformKey = `rls-startup-platform-key-${suffix}`;
       const startupProof = await proveRestrictedApiStartupReadiness(startupPlatformKey);
       expect(startupProof.status).toBe("ready");
       expect(startupProof.checks?.database?.ok).toBe(true);
       expect(startupProof.checks?.migrations?.ok).toBe(true);
+      expect(startupProof.checks?.pluginMigrations?.ok).toBe(true);
       expect(startupProof.checks?.rlsDeployment?.ok).toBe(true);
       expect(startupProof.checks?.authStores?.ok).toBe(true);
+
+      const pluginLedgerRows = await db<
+        { id: number; hash: string; created_at: string | number }[]
+      >`
+        SELECT id, hash, created_at
+        FROM drizzle.__drizzle_migrations_plugin_capabilities
+        ORDER BY id
+      `;
+      expect(pluginLedgerRows.length).toBeGreaterThan(1);
+      await db`TRUNCATE drizzle.__drizzle_migrations_plugin_capabilities`;
+      const missingPluginProof = await proveRestrictedApiStartupReadiness(
+        `${startupPlatformKey}-missing`,
+        503,
+      );
+      expect(missingPluginProof.status).toBe("not_ready");
+      expect(missingPluginProof.checks?.database?.ok).toBe(true);
+      expect(missingPluginProof.checks?.pluginMigrations?.ok).toBe(false);
+      for (const row of pluginLedgerRows) {
+        await db`
+          INSERT INTO drizzle.__drizzle_migrations_plugin_capabilities(id, hash, created_at)
+          VALUES (${row.id}, ${row.hash}, ${row.created_at})
+        `;
+      }
+      const stalePluginRow = pluginLedgerRows.at(-1)!;
+      await db`
+        DELETE FROM drizzle.__drizzle_migrations_plugin_capabilities
+        WHERE id = ${stalePluginRow.id}
+      `;
+      const stalePluginProof = await proveRestrictedApiStartupReadiness(
+        `${startupPlatformKey}-stale`,
+        503,
+      );
+      expect(stalePluginProof.status).toBe("not_ready");
+      expect(stalePluginProof.checks?.database?.ok).toBe(true);
+      expect(stalePluginProof.checks?.pluginMigrations?.ok).toBe(false);
+      await db`
+        INSERT INTO drizzle.__drizzle_migrations_plugin_capabilities(id, hash, created_at)
+        VALUES (${stalePluginRow.id}, ${stalePluginRow.hash}, ${stalePluginRow.created_at})
+      `;
 
       const refreshUserId = randomUUID();
       const sourceTenant = `source-${suffix}`;
@@ -610,10 +808,15 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
       expect(rolledBack).toEqual({ enabled: 0, forced: 0 });
 
       await runOperatorScript("rls-activate.sql");
-      const rerun = await runCommand(["bun", "run", "packages/db/src/migrate.ts"], {
-        DATABASE_URL: migrationDatabaseUrl(),
-      });
-      expect(rerun).toContain("Already up to date");
+      const rerun = await runCommand(
+        [
+          "bun",
+          "-e",
+          'import { runMigrations } from "./packages/db/src/migrate.ts"; console.log(JSON.stringify(await runMigrations()));',
+        ],
+        { DATABASE_URL: migrationDatabaseUrl() },
+      );
+      expect(rerun).toContain('"applied":[]');
     } finally {
       await db.end();
     }

--- a/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
@@ -85,6 +85,90 @@ async function runOperatorScript(name: string, includeRoles = false) {
   return runCommand(command);
 }
 
+async function reserveLoopbackPort(): Promise<number> {
+  const listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: { data() {} },
+  });
+  const port = listener.port;
+  await listener.stop(true);
+  return port;
+}
+
+async function proveRestrictedApiStartupReadiness(platformKey: string) {
+  const port = await reserveLoopbackPort();
+  const probeToken = `rls-ready-${suffix}`;
+  const child = Bun.spawn(["bun", "run", "packages/api/src/index.ts"], {
+    cwd: new URL("../../../../", import.meta.url).pathname,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      STEWARD_BIND_HOST: "127.0.0.1",
+      NODE_ENV: "production",
+      SKIP_MIGRATIONS: "true",
+      DATABASE_DRIVER: "postgres-js",
+      DATABASE_URL: appDatabaseUrl(),
+      STEWARD_APP_DATABASE_ROLE: appRole,
+      STEWARD_PLATFORM_DATABASE_URL: platformDatabaseUrl(),
+      STEWARD_PLATFORM_DATABASE_ROLE: platformRole,
+      STEWARD_PLUGINS: "",
+      STEWARD_ENABLE_TRADING: "false",
+      STEWARD_REDIS_REQUIRED: "false",
+      REDIS_URL: "",
+      STEWARD_REDIS_URL: "",
+      APP_URL: `http://127.0.0.1:${port}`,
+      STEWARD_JWT_SECRET: `rls-startup-jwt-${suffix}-0123456789abcdef`,
+      STEWARD_KDF_SALT: "ab".repeat(32),
+      STEWARD_AUDIT_HMAC_KEY: "cd".repeat(32),
+      STEWARD_DEFAULT_TENANT_KEY: `rls-startup-default-${suffix}`,
+      STEWARD_MASTER_PASSWORD: `rls-startup-master-${suffix}`,
+      STEWARD_PLATFORM_KEYS: platformKey,
+      STEWARD_PLATFORM_KEY_SCOPES: JSON.stringify({ [platformKey]: ["platform:*"] }),
+      STEWARD_READY_PROBE_TOKEN: probeToken,
+      STEWARD_ACK_LOCAL_CUSTODY: "true",
+      STEWARD_ALLOW_MEMORY_AUTH_STORES: "false",
+      STEWARD_ALLOW_INSECURE_AUTH_STORES: "false",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdoutPromise = new Response(child.stdout).text();
+  const stderrPromise = new Response(child.stderr).text();
+  let proof: {
+    status?: string;
+    checks?: Record<string, { ok?: boolean; source?: string }>;
+  } | null = null;
+
+  try {
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline && child.exitCode === null) {
+      try {
+        const response = await fetch(`http://127.0.0.1:${port}/ready`, {
+          headers: { "x-steward-probe-token": probeToken },
+          signal: AbortSignal.timeout(1_000),
+        });
+        if (response.status === 200) {
+          proof = (await response.json()) as typeof proof;
+          break;
+        }
+      } catch {
+        // The real entrypoint is still starting. Keep polling within the bound.
+      }
+      await Bun.sleep(100);
+    }
+  } finally {
+    if (child.exitCode === null) child.kill("SIGTERM");
+    await child.exited;
+  }
+
+  const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
+  if (!proof) {
+    throw new Error(`restricted API did not become ready:\n${stderr || stdout}`);
+  }
+  return proof;
+}
+
 describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", () => {
   const admin = postgres(process.env.DATABASE_URL as string, { max: 1 });
 
@@ -218,6 +302,14 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
         WHERE n.nspname = 'public' AND p.polname LIKE 'steward_%'
       `;
       expect(activated).toEqual({ enabled: 71, forced: 71, maintenance: 71 });
+
+      const startupPlatformKey = `rls-startup-platform-key-${suffix}`;
+      const startupProof = await proveRestrictedApiStartupReadiness(startupPlatformKey);
+      expect(startupProof.status).toBe("ready");
+      expect(startupProof.checks?.database?.ok).toBe(true);
+      expect(startupProof.checks?.migrations?.ok).toBe(true);
+      expect(startupProof.checks?.rlsDeployment?.ok).toBe(true);
+      expect(startupProof.checks?.authStores?.ok).toBe(true);
 
       const refreshUserId = randomUUID();
       const sourceTenant = `source-${suffix}`;

--- a/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
@@ -117,6 +117,10 @@ async function proveRestrictedApiStartupReadiness(platformKey: string) {
       STEWARD_REDIS_REQUIRED: "false",
       REDIS_URL: "",
       STEWARD_REDIS_URL: "",
+      KV_REST_API_URL: "",
+      KV_REST_API_TOKEN: "",
+      UPSTASH_REDIS_REST_URL: "",
+      UPSTASH_REDIS_REST_TOKEN: "",
       APP_URL: `http://127.0.0.1:${port}`,
       STEWARD_JWT_SECRET: `rls-startup-jwt-${suffix}-0123456789abcdef`,
       STEWARD_KDF_SALT: "ab".repeat(32),
@@ -186,15 +190,61 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
       SELECT rolsuper FROM pg_roles WHERE rolname = current_user
     `;
     expect(adminRole?.rolsuper).toBe(true);
+    await admin.unsafe(
+      `CREATE ROLE ${migrationRole} LOGIN PASSWORD '${migrationRolePassword}' NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE NOREPLICATION`,
+    );
     await admin.unsafe(`CREATE DATABASE ${databaseName}`);
 
-    const firstMigration = await runCommand(["bun", "run", "packages/db/src/migrate.ts"], {
-      DATABASE_URL: databaseUrl(databaseName),
+    const emptyDatabase = postgres(databaseUrl(databaseName), { max: 1 });
+    try {
+      await emptyDatabase.unsafe(
+        `GRANT CONNECT, CREATE ON DATABASE ${databaseName} TO ${migrationRole}`,
+      );
+      await emptyDatabase.unsafe(`GRANT USAGE, CREATE ON SCHEMA public TO ${migrationRole}`);
+    } finally {
+      await emptyDatabase.end();
+    }
+
+    const firstMigration = await runCommand(["bun", "run", "--cwd", "packages/api", "migrate"], {
+      DATABASE_URL: migrationDatabaseUrl(),
+      STEWARD_PLUGINS: "capabilities",
+      STEWARD_ENABLE_TRADING: "false",
+      STEWARD_MASTER_PASSWORD: `restricted-migrator-master-${suffix}`,
     });
-    expect(firstMigration).toContain("0113_personal_tenant_account_lifecycle");
+    expect(firstMigration).toMatch(/\[migrate\] Core migrations applied: [1-9][0-9]*/);
+    expect(firstMigration).toContain("Plugin migration ledgers reconciled: 1");
 
     const db = postgres(databaseUrl(databaseName), { max: 1 });
     try {
+      const [restrictedRelease] = await db<
+        {
+          core_rows: number;
+          plugin_rows: number;
+          migrator_super: boolean;
+          migrator_bypassrls: boolean;
+          migrator_createrole: boolean;
+        }[]
+      >`
+        SELECT
+          (SELECT count(*)::int FROM drizzle.__drizzle_migrations) AS core_rows,
+          (
+            SELECT count(*)::int
+            FROM drizzle.__drizzle_migrations_plugin_capabilities
+          ) AS plugin_rows,
+          role.rolsuper AS migrator_super,
+          role.rolbypassrls AS migrator_bypassrls,
+          role.rolcreaterole AS migrator_createrole
+        FROM pg_roles role
+        WHERE role.rolname = ${migrationRole}
+      `;
+      expect(restrictedRelease?.core_rows).toBeGreaterThan(0);
+      expect(restrictedRelease?.plugin_rows).toBeGreaterThan(0);
+      expect(restrictedRelease).toMatchObject({
+        migrator_super: false,
+        migrator_bypassrls: false,
+        migrator_createrole: false,
+      });
+
       const [installed] = await db<{ relations: number; policies: number }[]>`
         SELECT count(DISTINCT c.relname)::int AS relations, count(*)::int AS policies
         FROM pg_policy p
@@ -202,11 +252,13 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = 'public'
       `;
-      expect(installed).toEqual({ relations: 71, policies: 73 });
+      // Core contributes 71 policy-bearing relations/73 policies; the enabled
+      // capabilities plugin contributes its three independently journaled
+      // tenant-scoped relations and policies in the same restricted release.
+      expect(installed).toEqual({ relations: 74, policies: 76 });
 
       await runOperatorScript("rls-bootstrap.sql", true);
       await admin.unsafe(`ALTER ROLE ${appRole} PASSWORD '${appRolePassword}'`);
-      await admin.unsafe(`ALTER ROLE ${migrationRole} PASSWORD '${migrationRolePassword}'`);
       await admin.unsafe(`ALTER ROLE ${platformRole} PASSWORD '${platformRolePassword}'`);
       const roleRows = await db<
         {
@@ -248,12 +300,17 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
           FROM drizzle.__drizzle_migrations
         `;
         expect(Number(readiness?.migration_created_at)).toBeGreaterThan(0);
-        await expect(
-          appReadinessDb`
+        let deniedError: unknown;
+        try {
+          await appReadinessDb`
             DELETE FROM drizzle.__drizzle_migrations
             WHERE false
-          `,
-        ).rejects.toThrow(/permission denied/i);
+          `;
+        } catch (error) {
+          deniedError = error;
+        }
+        expect(deniedError).toBeInstanceOf(Error);
+        expect((deniedError as Error).message).toMatch(/permission denied/i);
       } finally {
         await appReadinessDb.end();
       }
@@ -301,7 +358,7 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = 'public' AND p.polname LIKE 'steward_%'
       `;
-      expect(activated).toEqual({ enabled: 71, forced: 71, maintenance: 71 });
+      expect(activated).toEqual({ enabled: 74, forced: 74, maintenance: 74 });
 
       const startupPlatformKey = `rls-startup-platform-key-${suffix}`;
       const startupProof = await proveRestrictedApiStartupReadiness(startupPlatformKey);

--- a/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import postgres from "postgres";
 
 const describeWithPostgres = process.env.DATABASE_URL ? describe : describe.skip;
-setDefaultTimeout(180_000);
+setDefaultTimeout(360_000);
 
 const suffix = randomUUID().replaceAll("-", "").slice(0, 16);
 const databaseName = `steward_rls_${suffix}`;

--- a/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
@@ -12,6 +12,7 @@ const migrationRole = `steward_migrator_${suffix}`;
 const definerRole = `steward_definer_${suffix}`;
 const platformRole = `steward_platform_${suffix}`;
 const appRolePassword = randomUUID().replaceAll("-", "");
+const migrationRolePassword = randomUUID().replaceAll("-", "");
 const platformRolePassword = randomUUID().replaceAll("-", "");
 
 function databaseUrl(database: string): string {
@@ -34,6 +35,13 @@ function platformDatabaseUrl(): string {
   return url.toString();
 }
 
+function migrationDatabaseUrl(): string {
+  const url = new URL(databaseUrl(databaseName));
+  url.username = migrationRole;
+  url.password = migrationRolePassword;
+  return url.toString();
+}
+
 async function runCommand(command: string[], env: Record<string, string | undefined> = {}) {
   const child = Bun.spawn(command, {
     cwd: new URL("../../../../", import.meta.url).pathname,
@@ -53,7 +61,12 @@ async function runCommand(command: string[], env: Record<string, string | undefi
 }
 
 async function runOperatorScript(name: string, includeRoles = false) {
-  const command = ["psql", "--no-psqlrc", "--dbname", databaseUrl(databaseName)];
+  const command = [
+    "psql",
+    "--no-psqlrc",
+    "--dbname",
+    name === "rls-activate.sql" ? migrationDatabaseUrl() : databaseUrl(databaseName),
+  ];
   if (includeRoles) {
     command.push(
       "-v",
@@ -109,6 +122,7 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
 
       await runOperatorScript("rls-bootstrap.sql", true);
       await admin.unsafe(`ALTER ROLE ${appRole} PASSWORD '${appRolePassword}'`);
+      await admin.unsafe(`ALTER ROLE ${migrationRole} PASSWORD '${migrationRolePassword}'`);
       await admin.unsafe(`ALTER ROLE ${platformRole} PASSWORD '${platformRolePassword}'`);
       const roleRows = await db<
         {
@@ -143,6 +157,22 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
         rolbypassrls: false,
         rolsuper: false,
       });
+      const appReadinessDb = postgres(appDatabaseUrl(), { max: 1 });
+      try {
+        const [readiness] = await appReadinessDb<{ migration_created_at: number }[]>`
+          SELECT MAX(created_at) AS migration_created_at
+          FROM drizzle.__drizzle_migrations
+        `;
+        expect(Number(readiness?.migration_created_at)).toBeGreaterThan(0);
+        await expect(
+          appReadinessDb`
+            DELETE FROM drizzle.__drizzle_migrations
+            WHERE false
+          `,
+        ).rejects.toThrow(/permission denied/i);
+      } finally {
+        await appReadinessDb.end();
+      }
       const [platformRlsPrivileges] = await db<
         {
           schema_usage: boolean;
@@ -432,7 +462,7 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
 
       await runOperatorScript("rls-activate.sql");
       const rerun = await runCommand(["bun", "run", "packages/db/src/migrate.ts"], {
-        DATABASE_URL: databaseUrl(databaseName),
+        DATABASE_URL: migrationDatabaseUrl(),
       });
       expect(rerun).toContain("Already up to date");
     } finally {

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -152,11 +152,36 @@ export function assertDatabaseUrlTls(
   );
 }
 
-export function createPostgresClient(connectionString = getDatabaseUrl()) {
+export interface PostgresClientTimeoutOptions {
+  max?: number;
+  connectTimeoutSeconds?: number;
+  statementTimeoutMs?: number;
+  lockTimeoutMs?: number;
+  idleInTransactionTimeoutMs?: number;
+}
+
+export function createPostgresClient(
+  connectionString = getDatabaseUrl(),
+  options: PostgresClientTimeoutOptions = {},
+) {
   assertDatabaseUrlTls(connectionString);
   return postgres(connectionString, {
-    max: 10,
+    max: options.max ?? 10,
     prepare: false,
+    ...(options.connectTimeoutSeconds ? { connect_timeout: options.connectTimeoutSeconds } : {}),
+    ...(options.statementTimeoutMs || options.lockTimeoutMs || options.idleInTransactionTimeoutMs
+      ? {
+          connection: {
+            ...(options.statementTimeoutMs
+              ? { statement_timeout: options.statementTimeoutMs }
+              : {}),
+            ...(options.lockTimeoutMs ? { lock_timeout: options.lockTimeoutMs } : {}),
+            ...(options.idleInTransactionTimeoutMs
+              ? { idle_in_transaction_session_timeout: options.idleInTransactionTimeoutMs }
+              : {}),
+          },
+        }
+      : {}),
   });
 }
 
@@ -296,8 +321,11 @@ export async function withDatabaseDeadline<T>(
 
 // ─── postgres-js (Bun/Node) ───────────────────────────────────────────────────
 
-export function createDb(connectionString = getDatabaseUrl()) {
-  const client = createPostgresClient(connectionString);
+export function createDb(
+  connectionString = getDatabaseUrl(),
+  options: PostgresClientTimeoutOptions = {},
+) {
+  const client = createPostgresClient(connectionString, options);
   const db = drizzlePostgres(client, { schema: FULL_SCHEMA });
 
   return { client, db };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -47,6 +47,8 @@ export { runMigrations } from "./migrate";
 export { getMigrationExpectation, type MigrationExpectation } from "./migration-status";
 export { encryptOAuthAccountPlaintextTokens } from "./oauth-token-encryption";
 export {
+  getPluginMigrationLedgerExpectation,
+  type PluginMigrationLedgerExpectation,
   pluginAdvisoryLockKey,
   pluginMigrationsTable,
   type RunPluginMigrationsOptions,

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -33,7 +33,7 @@ interface CoreMigrationDatabaseShape {
   tenantsExists: boolean;
   auditEventsExists: boolean;
   legacyFingerprintMatches: boolean;
-  publicRelationCount: number;
+  userObjectCount: number;
 }
 
 export interface MigrationTimeouts {
@@ -146,9 +146,9 @@ export function assertCoreMigrationLedgerIntegrity(
       "[migrate] Non-empty database resembles Steward but does not match the complete legacy schema fingerprint; refusing to create migration bookkeeping",
     );
   }
-  if (rows.length === 0 && !database.tenantsExists && database.publicRelationCount > 0) {
+  if (rows.length === 0 && !database.tenantsExists && database.userObjectCount > 0) {
     throw new Error(
-      "[migrate] Non-empty public schema has no Steward migration history; refusing a shared database",
+      "[migrate] Non-empty user schema has no Steward migration history; refusing a shared database",
     );
   }
   const auditMigrationIndex = journal.entries.findIndex(
@@ -280,6 +280,9 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
       const ledgerExists = (await client`
         SELECT to_regclass('drizzle.__drizzle_migrations') AS r
       `) as Array<{ r: string | null }>;
+      const drizzleSchemaExists = (await client`
+        SELECT to_regnamespace('drizzle') AS r
+      `) as Array<{ r: string | null }>;
       const tenantsExists = (await client`
         SELECT to_regclass('public.tenants') AS r
       `) as Array<{ r: string | null }>;
@@ -288,9 +291,27 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
       `) as Array<{ r: string | null }>;
       const databaseInventory = (await client`
         SELECT
-          count(*) FILTER (
-            WHERE namespace.nspname = 'public' AND relation.relkind IN ('r', 'p')
-          )::int AS public_relation_count,
+          (
+            SELECT count(*) FROM pg_namespace candidate
+            WHERE candidate.nspname NOT IN (
+              'public', 'drizzle', 'steward_rls', 'steward_bootstrap',
+              'pg_catalog', 'information_schema'
+            )
+              AND candidate.nspname !~ '^pg_(toast|temp|toast_temp)'
+          ) + (
+            SELECT count(*) FROM pg_class object
+            JOIN pg_namespace candidate ON candidate.oid = object.relnamespace
+            WHERE candidate.nspname IN ('public', 'drizzle', 'steward_rls', 'steward_bootstrap')
+          ) + (
+            SELECT count(*) FROM pg_proc object
+            JOIN pg_namespace candidate ON candidate.oid = object.pronamespace
+            WHERE candidate.nspname IN ('public', 'drizzle', 'steward_rls', 'steward_bootstrap')
+          ) + (
+            SELECT count(*) FROM pg_type object
+            JOIN pg_namespace candidate ON candidate.oid = object.typnamespace
+            WHERE candidate.nspname IN ('public', 'drizzle', 'steward_rls', 'steward_bootstrap')
+              AND object.typtype IN ('c', 'd', 'e', 'm', 'r')
+          ) AS user_object_count,
           (
             SELECT count(*) = 28
             FROM (VALUES
@@ -339,12 +360,12 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
           ) AS legacy_fingerprint_matches
         FROM pg_class relation
         JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
-      `) as Array<{ public_relation_count: number; legacy_fingerprint_matches: boolean }>;
+      `) as Array<{ user_object_count: number; legacy_fingerprint_matches: boolean }>;
       const databaseShape: CoreMigrationDatabaseShape = {
         tenantsExists: Boolean(tenantsExists[0]?.r),
         auditEventsExists: Boolean(auditEventsExists[0]?.r),
         legacyFingerprintMatches: databaseInventory[0]?.legacy_fingerprint_matches === true,
-        publicRelationCount: databaseInventory[0]?.public_relation_count ?? 0,
+        userObjectCount: databaseInventory[0]?.user_object_count ?? 0,
       };
       let existingRows: CoreMigrationLedgerRow[] = [];
       if (ledgerExists[0]?.r) {
@@ -353,16 +374,30 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
         `) as CoreMigrationLedgerRow[];
       }
       assertCoreMigrationLedgerIntegrity(existingRows, journal, databaseShape);
+      if (existingRows.length === journal.entries.length) {
+        assertCoreMigrationLedgerIntegrity(existingRows, journal, databaseShape, {
+          requireComplete: true,
+        });
+        return { applied: [] };
+      }
 
       // Only a verified empty/legacy Steward target may receive the ledger.
-      await client`CREATE SCHEMA IF NOT EXISTS drizzle`;
-      await client`
-        CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations (
-          id SERIAL PRIMARY KEY,
-          hash text NOT NULL,
-          created_at bigint
-        )
-      `;
+      // Avoid even idempotent CREATE statements once admin topology/the ledger
+      // exists: PostgreSQL requires database/schema CREATE before checking IF
+      // NOT EXISTS, which would make an already-complete runtime migration
+      // probe depend on a release-only privilege.
+      if (!drizzleSchemaExists[0]?.r) {
+        await client`CREATE SCHEMA drizzle`;
+      }
+      if (!ledgerExists[0]?.r) {
+        await client`
+          CREATE TABLE drizzle.__drizzle_migrations (
+            id SERIAL PRIMARY KEY,
+            hash text NOT NULL,
+            created_at bigint
+          )
+        `;
+      }
 
       // Backfill: legacy DB previously migrated by the psql loop.
       if (existingRows.length === 0 && tenantsExists[0]?.r) {
@@ -460,16 +495,14 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
             ) AS required(index_name)
             WHERE to_regclass('public.' || required.index_name) IS NOT NULL
           ) AS legacy_fingerprint_matches,
-          count(*) FILTER (
-            WHERE namespace.nspname = 'public' AND relation.relkind IN ('r', 'p')
-          )::int AS public_relation_count
+          0::int AS user_object_count
         FROM pg_class relation
         JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
       `) as Array<{
         tenants_exists: boolean;
         audit_events_exists: boolean;
         legacy_fingerprint_matches: boolean;
-        public_relation_count: number;
+        user_object_count: number;
       }>;
       assertCoreMigrationLedgerIntegrity(
         afterRows,
@@ -478,7 +511,7 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
           tenantsExists: postMigrationShape?.tenants_exists ?? false,
           auditEventsExists: postMigrationShape?.audit_events_exists ?? false,
           legacyFingerprintMatches: postMigrationShape?.legacy_fingerprint_matches ?? false,
-          publicRelationCount: postMigrationShape?.public_relation_count ?? 0,
+          userObjectCount: postMigrationShape?.user_object_count ?? 0,
         },
         {
           requireComplete: true,

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -199,20 +199,13 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
     try {
       const journal = readJournal();
 
-      // Ensure schema + table exist so we can inspect before drizzle's migrator runs.
-      await client`CREATE SCHEMA IF NOT EXISTS drizzle`;
-      await client`
-        CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations (
-          id SERIAL PRIMARY KEY,
-          hash text NOT NULL,
-          created_at bigint
-        )
-      `;
-
-      let existingRows = (await client`
-        SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id ASC
-      `) as CoreMigrationLedgerRow[];
-
+      // Inspect without writing first. A privileged migration URL can be
+      // misconfigured to point at an unrelated/shared database; even creating
+      // our bookkeeping schema there would be an unacceptable mutation before
+      // the fail-closed target check runs.
+      const ledgerExists = (await client`
+        SELECT to_regclass('drizzle.__drizzle_migrations') AS r
+      `) as Array<{ r: string | null }>;
       const tenantsExists = (await client`
         SELECT to_regclass('public.tenants') AS r
       `) as Array<{ r: string | null }>;
@@ -231,7 +224,23 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
         auditEventsExists: Boolean(auditEventsExists[0]?.r),
         publicRelationCount: databaseInventory[0]?.public_relation_count ?? 0,
       };
+      let existingRows: CoreMigrationLedgerRow[] = [];
+      if (ledgerExists[0]?.r) {
+        existingRows = (await client`
+          SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id ASC
+        `) as CoreMigrationLedgerRow[];
+      }
       assertCoreMigrationLedgerIntegrity(existingRows, journal, databaseShape);
+
+      // Only a verified empty/legacy Steward target may receive the ledger.
+      await client`CREATE SCHEMA IF NOT EXISTS drizzle`;
+      await client`
+        CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations (
+          id SERIAL PRIMARY KEY,
+          hash text NOT NULL,
+          created_at bigint
+        )
+      `;
 
       // Backfill: legacy DB previously migrated by the psql loop.
       if (existingRows.length === 0 && tenantsExists[0]?.r) {

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -6,6 +6,7 @@ import { createDb } from "./client";
 
 declare const process: {
   argv: string[];
+  env: Record<string, string | undefined>;
   exitCode?: number;
 };
 
@@ -31,7 +32,55 @@ export interface CoreMigrationLedgerRow {
 interface CoreMigrationDatabaseShape {
   tenantsExists: boolean;
   auditEventsExists: boolean;
+  legacyFingerprintMatches: boolean;
   publicRelationCount: number;
+}
+
+export interface MigrationTimeouts {
+  connectSeconds: number;
+  advisoryLockMs: number;
+  statementMs: number;
+  overallMs: number;
+}
+
+function positiveInteger(value: string | undefined, fallback: number, name: string): number {
+  if (value === undefined || value.trim() === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`[migrate] ${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+export function resolveMigrationTimeouts(
+  env: Record<string, string | undefined> = process.env,
+): MigrationTimeouts {
+  const connectSeconds = positiveInteger(
+    env.STEWARD_MIGRATION_CONNECT_TIMEOUT_SECONDS,
+    15,
+    "STEWARD_MIGRATION_CONNECT_TIMEOUT_SECONDS",
+  );
+  const advisoryLockMs = positiveInteger(
+    env.STEWARD_MIGRATION_LOCK_TIMEOUT_MS,
+    60_000,
+    "STEWARD_MIGRATION_LOCK_TIMEOUT_MS",
+  );
+  const statementMs = positiveInteger(
+    env.STEWARD_MIGRATION_STATEMENT_TIMEOUT_MS,
+    300_000,
+    "STEWARD_MIGRATION_STATEMENT_TIMEOUT_MS",
+  );
+  const overallMs = positiveInteger(
+    env.STEWARD_MIGRATION_OVERALL_TIMEOUT_MS,
+    600_000,
+    "STEWARD_MIGRATION_OVERALL_TIMEOUT_MS",
+  );
+  if (advisoryLockMs > overallMs || statementMs > overallMs) {
+    throw new Error(
+      "[migrate] migration lock/statement timeouts must not exceed the overall timeout",
+    );
+  }
+  return { connectSeconds, advisoryLockMs, statementMs, overallMs };
 }
 
 /**
@@ -92,6 +141,11 @@ export function assertCoreMigrationLedgerIntegrity(
       "[migrate] Core migration journal exists without public.tenants; refusing the wrong database",
     );
   }
+  if (rows.length === 0 && database.tenantsExists && !database.legacyFingerprintMatches) {
+    throw new Error(
+      "[migrate] Non-empty database resembles Steward but does not match the complete legacy schema fingerprint; refusing to create migration bookkeeping",
+    );
+  }
   if (rows.length === 0 && !database.tenantsExists && database.publicRelationCount > 0) {
     throw new Error(
       "[migrate] Non-empty public schema has no Steward migration history; refusing a shared database",
@@ -103,10 +157,10 @@ export function assertCoreMigrationLedgerIntegrity(
   if (
     auditMigrationIndex !== -1 &&
     recordedIndices.some((index) => index >= auditMigrationIndex) &&
-    !database.auditEventsExists
+    (!database.auditEventsExists || !database.legacyFingerprintMatches)
   ) {
     throw new Error(
-      `[migrate] Journal claims ${LEGACY_BACKFILL_TIP_TAG} but ${LEGACY_BACKFILL_FINGERPRINT_TABLE} is missing`,
+      `[migrate] Journal claims ${LEGACY_BACKFILL_TIP_TAG} but the complete legacy schema fingerprint does not match`,
     );
   }
 
@@ -140,9 +194,10 @@ export function assertCoreMigrationLedgerIntegrity(
 export const LEGACY_BACKFILL_TIP_TAG = "0024_audit_events";
 
 /**
- * Fingerprint proving a legacy DB actually reached the psql-era tip: the
- * newest table 0024 created. `public.tenants` (0000) alone says nothing about
- * how far the psql loop got before the DB was frozen.
+ * The newest table created by the legacy psql-era tip. Before backfilling its
+ * ledger, runMigrations additionally verifies the complete 0000-0024 relation,
+ * migration-specific column, and critical-index fingerprint; this sentinel is
+ * retained for the explicit tip lookup and diagnostics.
  */
 export const LEGACY_BACKFILL_FINGERPRINT_TABLE = "public.audit_events";
 
@@ -182,19 +237,38 @@ function hashMigration(tag: string): string {
  * used to `psql -f` each .sql by hand), we backfill `drizzle.__drizzle_migrations`
  * from the journal so the migrator doesn't try to re-apply non-idempotent DDL.
  * Heuristic: if `__drizzle_migrations` is empty AND `tenants` exists (was
- * created by 0000), the DB came from the psql loop. We then FINGERPRINT the
- * psql-era tip (`LEGACY_BACKFILL_FINGERPRINT_TABLE`, created by 0024) and seed
- * only the entries through that tip — seeding the whole current journal would
- * silently skip every migration between the DB's true tip and now, including
- * constraint-only hardening migrations whose absence produces no runtime error.
+ * created by 0000), the DB may have come from the psql loop. Before accepting
+ * it, verify the complete 0000-0024 relation, migration-specific column, and
+ * critical-index fingerprint. Then seed only entries through that tip —
+ * seeding the whole current journal would silently skip every migration
+ * between the DB's true tip and now, including constraint-only hardening
+ * migrations whose absence produces no runtime error.
  */
 export async function runMigrations(): Promise<{ applied: string[] }> {
-  const { client, db } = createDb();
+  const timeouts = resolveMigrationTimeouts();
+  const { client, db } = createDb(undefined, {
+    max: 1,
+    connectTimeoutSeconds: timeouts.connectSeconds,
+    statementTimeoutMs: timeouts.statementMs,
+    lockTimeoutMs: timeouts.advisoryLockMs,
+    idleInTransactionTimeoutMs: timeouts.statementMs,
+  });
+  let overallTimedOut = false;
+  let deadlineClose: Promise<void> | undefined;
+  const overallTimer = setTimeout(() => {
+    overallTimedOut = true;
+    deadlineClose = client.end({ timeout: 0 });
+    void deadlineClose.catch(() => undefined);
+  }, timeouts.overallMs);
+  let advisoryLockHeld = false;
 
   try {
     // Session-scoped advisory lock spans the whole migrator (which uses its
-    // own transaction). pg_advisory_lock blocks until acquired.
+    // own transaction). Give this wait its own shorter server-side bound.
+    await client`SELECT set_config('statement_timeout', ${`${timeouts.advisoryLockMs}ms`}, false)`;
     await client`SELECT pg_advisory_lock(hashtextextended(${ADVISORY_LOCK_KEY}, 0))`;
+    advisoryLockHeld = true;
+    await client`SELECT set_config('statement_timeout', ${`${timeouts.statementMs}ms`}, false)`;
 
     try {
       const journal = readJournal();
@@ -213,15 +287,63 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
         SELECT to_regclass(${LEGACY_BACKFILL_FINGERPRINT_TABLE}) AS r
       `) as Array<{ r: string | null }>;
       const databaseInventory = (await client`
-        SELECT count(*) FILTER (
-          WHERE namespace.nspname = 'public' AND relation.relkind IN ('r', 'p')
-        )::int AS public_relation_count
+        SELECT
+          count(*) FILTER (
+            WHERE namespace.nspname = 'public' AND relation.relkind IN ('r', 'p')
+          )::int AS public_relation_count,
+          (
+            SELECT count(*) = 28
+            FROM (VALUES
+              ('agents'), ('approval_queue'), ('encrypted_keys'), ('policies'),
+              ('tenants'), ('transactions'), ('accounts'), ('authenticators'), ('sessions'),
+              ('user_tenants'), ('users'), ('agent_wallets'), ('encrypted_chain_keys'),
+              ('webhook_deliveries'), ('secrets'), ('secret_routes'), ('proxy_audit_log'),
+              ('tenant_configs'), ('webhook_configs'), ('auto_approval_rules'),
+              ('auth_kv_store'), ('refresh_tokens'), ('policy_templates'),
+              ('agent_registrations'), ('reputation_cache'), ('registry_index'),
+              ('trade_sessions'), ('audit_events')
+            ) AS required(relation_name)
+            WHERE to_regclass('public.' || required.relation_name) IS NOT NULL
+          ) AND (
+            SELECT count(*) = 21
+            FROM (VALUES
+              ('agents', 'owner_user_id'), ('agents', 'wallet_type'),
+              ('tenant_configs', 'allowed_origins'), ('tenant_configs', 'join_mode'),
+              ('tenant_configs', 'email_config'), ('users', 'wallet_chain'),
+              ('proxy_audit_log', 'reason'),
+              ('accounts', 'access_token_iv'), ('accounts', 'access_token_tag'),
+              ('accounts', 'access_token_salt'), ('accounts', 'refresh_token_iv'),
+              ('accounts', 'refresh_token_tag'), ('accounts', 'refresh_token_salt'),
+              ('encrypted_chain_keys', 'venue'), ('encrypted_chain_keys', 'purpose'),
+              ('agent_wallets', 'venue'),
+              ('audit_events', 'tenant_id'), ('audit_events', 'seq'),
+              ('audit_events', 'prev_hash'), ('audit_events', 'hmac'),
+              ('audit_events', 'action')
+            ) AS required(relation_name, column_name)
+            WHERE EXISTS (
+              SELECT 1
+              FROM information_schema.columns column_inventory
+              WHERE column_inventory.table_schema = 'public'
+                AND column_inventory.table_name = required.relation_name
+                AND column_inventory.column_name = required.column_name
+            )
+          ) AND (
+            SELECT count(*) = 6
+            FROM (VALUES
+              ('auth_kv_store_expires_idx'), ('refresh_tokens_token_hash_idx'),
+              ('agent_registrations_tenant_agent_chain_idx'),
+              ('encrypted_chain_keys_agent_chain_venue_idx'),
+              ('trade_sessions_agent_venue_status_idx'), ('audit_events_tenant_seq_idx')
+            ) AS required(index_name)
+            WHERE to_regclass('public.' || required.index_name) IS NOT NULL
+          ) AS legacy_fingerprint_matches
         FROM pg_class relation
         JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
-      `) as Array<{ public_relation_count: number }>;
+      `) as Array<{ public_relation_count: number; legacy_fingerprint_matches: boolean }>;
       const databaseShape: CoreMigrationDatabaseShape = {
         tenantsExists: Boolean(tenantsExists[0]?.r),
         auditEventsExists: Boolean(auditEventsExists[0]?.r),
+        legacyFingerprintMatches: databaseInventory[0]?.legacy_fingerprint_matches === true,
         publicRelationCount: databaseInventory[0]?.public_relation_count ?? 0,
       };
       let existingRows: CoreMigrationLedgerRow[] = [];
@@ -292,6 +414,52 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
         SELECT
           to_regclass('public.tenants') IS NOT NULL AS tenants_exists,
           to_regclass(${LEGACY_BACKFILL_FINGERPRINT_TABLE}) IS NOT NULL AS audit_events_exists,
+          (
+            SELECT count(*) = 28
+            FROM (VALUES
+              ('agents'), ('approval_queue'), ('encrypted_keys'), ('policies'),
+              ('tenants'), ('transactions'), ('accounts'), ('authenticators'), ('sessions'),
+              ('user_tenants'), ('users'), ('agent_wallets'), ('encrypted_chain_keys'),
+              ('webhook_deliveries'), ('secrets'), ('secret_routes'), ('proxy_audit_log'),
+              ('tenant_configs'), ('webhook_configs'), ('auto_approval_rules'),
+              ('auth_kv_store'), ('refresh_tokens'), ('policy_templates'),
+              ('agent_registrations'), ('reputation_cache'), ('registry_index'),
+              ('trade_sessions'), ('audit_events')
+            ) AS required(relation_name)
+            WHERE to_regclass('public.' || required.relation_name) IS NOT NULL
+          ) AND (
+            SELECT count(*) = 21
+            FROM (VALUES
+              ('agents', 'owner_user_id'), ('agents', 'wallet_type'),
+              ('tenant_configs', 'allowed_origins'), ('tenant_configs', 'join_mode'),
+              ('tenant_configs', 'email_config'), ('users', 'wallet_chain'),
+              ('proxy_audit_log', 'reason'),
+              ('accounts', 'access_token_iv'), ('accounts', 'access_token_tag'),
+              ('accounts', 'access_token_salt'), ('accounts', 'refresh_token_iv'),
+              ('accounts', 'refresh_token_tag'), ('accounts', 'refresh_token_salt'),
+              ('encrypted_chain_keys', 'venue'), ('encrypted_chain_keys', 'purpose'),
+              ('agent_wallets', 'venue'),
+              ('audit_events', 'tenant_id'), ('audit_events', 'seq'),
+              ('audit_events', 'prev_hash'), ('audit_events', 'hmac'),
+              ('audit_events', 'action')
+            ) AS required(relation_name, column_name)
+            WHERE EXISTS (
+              SELECT 1
+              FROM information_schema.columns column_inventory
+              WHERE column_inventory.table_schema = 'public'
+                AND column_inventory.table_name = required.relation_name
+                AND column_inventory.column_name = required.column_name
+            )
+          ) AND (
+            SELECT count(*) = 6
+            FROM (VALUES
+              ('auth_kv_store_expires_idx'), ('refresh_tokens_token_hash_idx'),
+              ('agent_registrations_tenant_agent_chain_idx'),
+              ('encrypted_chain_keys_agent_chain_venue_idx'),
+              ('trade_sessions_agent_venue_status_idx'), ('audit_events_tenant_seq_idx')
+            ) AS required(index_name)
+            WHERE to_regclass('public.' || required.index_name) IS NOT NULL
+          ) AS legacy_fingerprint_matches,
           count(*) FILTER (
             WHERE namespace.nspname = 'public' AND relation.relkind IN ('r', 'p')
           )::int AS public_relation_count
@@ -300,6 +468,7 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
       `) as Array<{
         tenants_exists: boolean;
         audit_events_exists: boolean;
+        legacy_fingerprint_matches: boolean;
         public_relation_count: number;
       }>;
       assertCoreMigrationLedgerIntegrity(
@@ -308,6 +477,7 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
         {
           tenantsExists: postMigrationShape?.tenants_exists ?? false,
           auditEventsExists: postMigrationShape?.audit_events_exists ?? false,
+          legacyFingerprintMatches: postMigrationShape?.legacy_fingerprint_matches ?? false,
           publicRelationCount: postMigrationShape?.public_relation_count ?? 0,
         },
         {
@@ -322,10 +492,21 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
 
       return { applied };
     } finally {
-      await client`SELECT pg_advisory_unlock(hashtextextended(${ADVISORY_LOCK_KEY}, 0))`;
+      if (advisoryLockHeld && !overallTimedOut) {
+        await client`SELECT pg_advisory_unlock(hashtextextended(${ADVISORY_LOCK_KEY}, 0))`;
+      }
     }
+  } catch (error) {
+    if (overallTimedOut) {
+      throw new Error(`[migrate] Migration exceeded the ${timeouts.overallMs}ms overall timeout`, {
+        cause: error,
+      });
+    }
+    throw error;
   } finally {
-    await client.end();
+    clearTimeout(overallTimer);
+    if (deadlineClose) await deadlineClose.catch(() => undefined);
+    else await client.end({ timeout: 0 });
   }
 }
 

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from "node:fs";
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 
 import { createDb } from "./client";
@@ -252,6 +254,395 @@ function hashMigration(tag: string): string {
   return crypto.createHash("sha256").update(sql).digest("hex");
 }
 
+type MigrationQueryExecutor = {
+  execute(query: ReturnType<typeof sql>): Promise<unknown>;
+};
+
+function queryRows<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  return ((result as { rows?: T[] } | undefined)?.rows ?? []) as T[];
+}
+
+/**
+ * Exact checked-in ownership boundary for catalog objects created by the core
+ * and bundled plugin migrations. Indexes, constraints, triggers, and policies
+ * are subordinate to these relations; standalone schemas, relations,
+ * routines, types, and other namespaced catalog objects are not.
+ *
+ * Run this immediately before the first write and again before commit. The
+ * second check closes the inspection-to-migration gap even for DDL writers
+ * that do not participate in Steward's advisory-lock convention.
+ */
+async function assertExactMigrationObjectInventory(db: MigrationQueryExecutor): Promise<void> {
+  const result = await db.execute(sql`
+    WITH
+    allowed_extensions(extname) AS (
+      VALUES ('neon'), ('pg_stat_statements')
+    ),
+    allowed_relations(schema_name, relation_name, relation_kind) AS (
+      VALUES
+        ('public', 'accounts', 'r'),
+        ('public', 'agent_key_quorums', 'r'),
+        ('public', 'agent_policies', 'r'),
+        ('public', 'agent_registrations', 'r'),
+        ('public', 'agent_signers', 'r'),
+        ('public', 'agent_wallets', 'r'),
+        ('public', 'agents', 'r'),
+        ('public', 'approval_queue', 'r'),
+        ('public', 'audit_archive_chunks', 'r'),
+        ('public', 'audit_archives', 'r'),
+        ('public', 'audit_chain_heads', 'r'),
+        ('public', 'audit_checkpoints', 'r'),
+        ('public', 'audit_events', 'r'),
+        ('public', 'audit_retention_policies', 'r'),
+        ('public', 'auth_kv_store', 'r'),
+        ('public', 'authenticators', 'r'),
+        ('public', 'auto_approval_rules', 'r'),
+        ('public', 'condition_set_items', 'r'),
+        ('public', 'condition_sets', 'r'),
+        ('public', 'digital_asset_account_aggregations', 'r'),
+        ('public', 'digital_asset_account_wallets', 'r'),
+        ('public', 'digital_asset_accounts', 'r'),
+        ('public', 'encrypted_chain_keys', 'r'),
+        ('public', 'encrypted_keys', 'r'),
+        ('public', 'evm_wallet_nonce_inflight', 'r'),
+        ('public', 'evm_wallet_nonce_owners', 'r'),
+        ('public', 'evm_wallet_nonces', 'r'),
+        ('public', 'execution_authorization_nonces', 'r'),
+        ('public', 'global_wallet_action_confirmations', 'r'),
+        ('public', 'intents', 'r'),
+        ('public', 'operator_transfer_reservations', 'r'),
+        ('public', 'pending_proxy_requests', 'r'),
+        ('public', 'policies', 'r'),
+        ('public', 'policy_templates', 'r'),
+        ('public', 'provider_accounts', 'r'),
+        ('public', 'provider_action_approvals', 'r'),
+        ('public', 'provider_action_audit_outbox', 'r'),
+        ('public', 'provider_action_bindings', 'r'),
+        ('public', 'provider_action_reservation_generations', 'r'),
+        ('public', 'provider_agent_budgets', 'r'),
+        ('public', 'provider_authority_tenant_state', 'r'),
+        ('public', 'provider_google_credential_lifecycles', 'r'),
+        ('public', 'provider_grants', 'r'),
+        ('public', 'provider_operations', 'r'),
+        ('public', 'provider_role_bindings', 'r'),
+        ('public', 'provider_x_credential_lifecycles', 'r'),
+        ('public', 'proxy_audit_log', 'r'),
+        ('public', 'refresh_tokens', 'r'),
+        ('public', 'registry_index', 'r'),
+        ('public', 'reputation_cache', 'r'),
+        ('public', 'secret_routes', 'r'),
+        ('public', 'secrets', 'r'),
+        ('public', 'session_signers', 'r'),
+        ('public', 'sessions', 'r'),
+        ('public', 'sponsored_gas_events', 'r'),
+        ('public', 'tenant_app_client_secrets', 'r'),
+        ('public', 'tenant_app_clients', 'r'),
+        ('public', 'tenant_configs', 'r'),
+        ('public', 'tenant_invitations', 'r'),
+        ('public', 'tenant_request_signing_keys', 'r'),
+        ('public', 'tenant_saml_assertion_replays', 'r'),
+        ('public', 'tenant_saml_authn_requests', 'r'),
+        ('public', 'tenant_saml_sso_configs', 'r'),
+        ('public', 'tenant_sso_domains', 'r'),
+        ('public', 'tenants', 'r'),
+        ('public', 'trade_sessions', 'r'),
+        ('public', 'transactions', 'r'),
+        ('public', 'upstream_credential_lease_events', 'r'),
+        ('public', 'upstream_credential_leases', 'r'),
+        ('public', 'user_push_subscriptions', 'r'),
+        ('public', 'user_tenants', 'r'),
+        ('public', 'user_wallet_app_consents', 'r'),
+        ('public', 'users', 'r'),
+        ('public', 'vault_signing_freezes', 'r'),
+        ('public', 'webhook_configs', 'r'),
+        ('public', 'webhook_deliveries', 'r'),
+        ('public', 'workspaces', 'r'),
+        ('public', 'agent_registrations_id_seq', 'S'),
+        ('public', 'audit_checkpoints_id_seq', 'S'),
+        ('public', 'audit_events_id_seq', 'S'),
+        ('public', 'registry_index_id_seq', 'S'),
+        ('public', 'reputation_cache_id_seq', 'S'),
+        -- Bundled plugin-owned objects are accepted only with their exact names.
+        ('public', 'capabilities', 'r'),
+        ('public', 'capability_grants', 'r'),
+        ('public', 'capability_invocations', 'r'),
+        ('public', 'example_log', 'r'),
+        ('public', 'example_log_id_seq', 'S')
+    ),
+    allowed_routines(schema_name, routine_identity) AS (
+      VALUES
+        ('public', 'steward_bump_provider_agent_budget_revision()'),
+        ('public', 'steward_bump_secret_route_authority_revision()'),
+        ('public', 'steward_fence_agent_authority_creation()'),
+        ('public', 'steward_fence_provider_action_agent()'),
+        ('public', 'steward_fence_provider_action_intent_tenant()'),
+        ('public', 'steward_fence_upstream_lease_workspace()'),
+        ('public', 'steward_guard_agent_delete()'),
+        ('public', 'steward_guard_audit_archive_immutability()'),
+        ('public', 'steward_guard_audit_checkpoint_immutability()'),
+        ('public', 'steward_guard_workspace_delete()'),
+        ('public', 'steward_lock_tenant_deletion(target_tenant text)'),
+        ('public', 'steward_provider_action_binding_guard()'),
+        ('public', 'steward_provider_reservation_generation_guard()'),
+        ('public', 'steward_reject_provider_scope_move()'),
+        ('public', 'steward_reject_upstream_lease_evidence_mutation()'),
+        ('public', 'capability_grants_agent_fence()'),
+        ('public', 'capability_grants_guard_agent_delete()'),
+        ('steward_rls', 'tenant_id()'),
+        ('steward_rls', 'user_id()'),
+        ('steward_bootstrap', 'agent_subject(p_agent_id text, p_tenant_id text, p_jti text)'),
+        ('steward_bootstrap', 'agent_tenant_subject(p_agent_id text)'),
+        ('steward_bootstrap', 'app_client_subject(p_tenant_id text, p_client_id text)'),
+        ('steward_bootstrap', 'auth_app_clients_subject(p_tenant_id text)'),
+        ('steward_bootstrap', 'auth_refresh_subject(p_token_hash text)'),
+        ('steward_bootstrap', 'auth_sso_discovery_subject(p_domain text)'),
+        ('steward_bootstrap', 'auth_sso_domain_subject(p_tenant_id text, p_domain text)'),
+        ('steward_bootstrap', 'auth_tenant_config_subject(p_tenant_id text)'),
+        ('steward_bootstrap', 'auth_tenant_subject(p_tenant_id text, p_user_id uuid)'),
+        ('steward_bootstrap', 'auth_rotate_refresh_token(p_source_token_hash text, p_target_tenant_id text, p_successor_id text, p_successor_token_hash text, p_successor_expires_at timestamp with time zone)'),
+        ('steward_bootstrap', 'ensure_default_tenant(p_api_key_hash text)'),
+        ('steward_bootstrap', 'ensure_platform_tenant()'),
+        ('steward_bootstrap', 'ensure_system_tenant()'),
+        ('steward_bootstrap', 'platform_delete_user(p_user_id uuid)'),
+        ('steward_bootstrap', 'platform_revoke_user_refresh_tokens(p_user_id uuid)'),
+        ('steward_bootstrap', 'platform_set_user_deactivation(p_user_id uuid, p_deactivated boolean)'),
+        ('steward_bootstrap', 'platform_stats()'),
+        ('steward_bootstrap', 'platform_tenants(p_limit integer, p_offset integer)'),
+        ('steward_bootstrap', 'platform_user_tenant_ids(p_user_id uuid)'),
+        ('steward_bootstrap', 'retention_delete_deactivated_users(p_days integer)'),
+        ('steward_bootstrap', 'session_subject(p_user_id uuid, p_tenant_id text)'),
+        ('steward_bootstrap', 'tenant_api_key_subject(p_tenant_id text)'),
+        ('steward_bootstrap', 'tenant_ids_for_internal_job()')
+    ),
+    allowed_types(type_name) AS (
+      VALUES
+        ('approval_queue_status'), ('chain_family'), ('execution_authorization_status'),
+        ('pending_proxy_request_status'), ('policy_type'), ('provider_authority_status'),
+        ('provider_environment'), ('provider_principal_type'), ('provider_risk_class'),
+        ('provider_role'), ('secret_route_authority_mode'), ('transaction_status'),
+        ('webhook_delivery_status')
+    ),
+    unexpected(kind, identity) AS (
+      SELECT 'schema', namespace.nspname
+      FROM pg_namespace namespace
+      WHERE namespace.nspname <> 'information_schema'
+        AND namespace.nspname NOT LIKE 'pg\\_%' ESCAPE '\\'
+        AND namespace.nspname NOT IN (
+          'public', 'drizzle', 'neon', 'steward_rls', 'steward_bootstrap'
+        )
+
+      UNION ALL
+
+      SELECT 'relation', format('%I.%I', namespace.nspname, relation.relname)
+      FROM pg_class relation
+      JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+      WHERE namespace.nspname <> 'information_schema'
+        AND namespace.nspname NOT LIKE 'pg\\_%' ESCAPE '\\'
+        AND relation.relkind IN ('r', 'p', 'v', 'm', 'S', 'f', 'c')
+        AND NOT EXISTS (
+          SELECT 1 FROM allowed_relations allowed
+          WHERE allowed.schema_name = namespace.nspname
+            AND allowed.relation_name = relation.relname
+            AND allowed.relation_kind = relation.relkind::text
+        )
+        AND NOT (
+          namespace.nspname = 'drizzle'
+          AND (
+            relation.relname IN (
+              '__drizzle_migrations',
+              '__drizzle_migrations_plugin_capabilities',
+              '__drizzle_migrations_plugin_example'
+            )
+            OR relation.relname IN (
+              '__drizzle_migrations_id_seq',
+              '__drizzle_migrations_plugin_capabilities_id_seq',
+              '__drizzle_migrations_plugin_example_id_seq'
+            )
+          )
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM pg_depend dependency
+          JOIN pg_extension extension_inventory ON extension_inventory.oid = dependency.refobjid
+          JOIN allowed_extensions allowed ON allowed.extname = extension_inventory.extname
+          WHERE dependency.classid = 'pg_class'::regclass
+            AND dependency.objid = relation.oid
+            AND dependency.objsubid = 0
+            AND dependency.refclassid = 'pg_extension'::regclass
+            AND dependency.deptype = 'e'
+        )
+
+      UNION ALL
+
+      SELECT 'routine', format('%I.%s', namespace.nspname,
+        routine.proname || '(' || pg_get_function_identity_arguments(routine.oid) || ')')
+      FROM pg_proc routine
+      JOIN pg_namespace namespace ON namespace.oid = routine.pronamespace
+      WHERE namespace.nspname <> 'information_schema'
+        AND namespace.nspname NOT LIKE 'pg\\_%' ESCAPE '\\'
+        AND NOT EXISTS (
+          SELECT 1 FROM allowed_routines allowed
+          WHERE allowed.schema_name = namespace.nspname
+            AND allowed.routine_identity =
+              routine.proname || '(' || pg_get_function_identity_arguments(routine.oid) || ')'
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM pg_depend dependency
+          JOIN pg_extension extension_inventory ON extension_inventory.oid = dependency.refobjid
+          JOIN allowed_extensions allowed ON allowed.extname = extension_inventory.extname
+          WHERE dependency.classid = 'pg_proc'::regclass
+            AND dependency.objid = routine.oid
+            AND dependency.refclassid = 'pg_extension'::regclass
+            AND dependency.deptype = 'e'
+        )
+
+      UNION ALL
+
+      SELECT 'type', format('%I.%I', namespace.nspname, type_inventory.typname)
+      FROM pg_type type_inventory
+      JOIN pg_namespace namespace ON namespace.oid = type_inventory.typnamespace
+      WHERE namespace.nspname <> 'information_schema'
+        AND namespace.nspname NOT LIKE 'pg\\_%' ESCAPE '\\'
+        AND type_inventory.typrelid = 0
+        AND type_inventory.typelem = 0
+        AND type_inventory.typtype IN ('d', 'e', 'r', 'm')
+        AND NOT (
+          namespace.nspname = 'public'
+          AND EXISTS (SELECT 1 FROM allowed_types allowed WHERE allowed.type_name = type_inventory.typname)
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM pg_depend dependency
+          JOIN pg_extension extension_inventory ON extension_inventory.oid = dependency.refobjid
+          JOIN allowed_extensions allowed ON allowed.extname = extension_inventory.extname
+          WHERE dependency.classid = 'pg_type'::regclass
+            AND dependency.objid = type_inventory.oid
+            AND dependency.refclassid = 'pg_extension'::regclass
+            AND dependency.deptype = 'e'
+        )
+
+      UNION ALL SELECT 'extension', extension_inventory.extname
+      FROM pg_extension extension_inventory
+      WHERE extension_inventory.extname <> 'plpgsql'
+        AND NOT EXISTS (
+          SELECT 1 FROM allowed_extensions allowed WHERE allowed.extname = extension_inventory.extname
+        )
+      UNION ALL SELECT 'foreign data wrapper', wrapper.fdwname FROM pg_foreign_data_wrapper wrapper
+      WHERE NOT EXISTS (
+        SELECT 1 FROM pg_depend dependency
+        JOIN pg_extension extension_inventory ON extension_inventory.oid = dependency.refobjid
+        JOIN allowed_extensions allowed ON allowed.extname = extension_inventory.extname
+        WHERE dependency.classid = 'pg_foreign_data_wrapper'::regclass
+          AND dependency.objid = wrapper.oid
+          AND dependency.refclassid = 'pg_extension'::regclass
+          AND dependency.deptype = 'e'
+      )
+      UNION ALL SELECT 'foreign server', server.srvname FROM pg_foreign_server server
+      UNION ALL SELECT 'event trigger', trigger.evtname FROM pg_event_trigger trigger
+      UNION ALL SELECT 'publication', publication.pubname FROM pg_publication publication
+      UNION ALL SELECT 'large object', large_object.oid::text FROM pg_largeobject_metadata large_object
+    )
+    SELECT count(*)::int AS unexpected_count,
+      min(kind || ':' || identity) AS first_unexpected
+    FROM unexpected
+  `);
+  const [row] = queryRows<{ unexpected_count: number; first_unexpected: string | null }>(result);
+  if ((row?.unexpected_count ?? 0) > 0) {
+    throw new Error(
+      `[migrate] Database contains catalog object outside the checked-in Steward inventory (${row?.first_unexpected ?? "unknown"}); refusing a shared database`,
+    );
+  }
+}
+
+async function assertBundledPluginLedgerIntegrity(db: MigrationQueryExecutor): Promise<void> {
+  const bundledPlugins = [
+    {
+      id: "capabilities",
+      migrationsFolder: new URL("../../plugin-capabilities/drizzle", import.meta.url).pathname,
+      ownedRelations: ["capabilities", "capability_grants", "capability_invocations"],
+    },
+    {
+      id: "example",
+      migrationsFolder: new URL("../../plugin-example/drizzle", import.meta.url).pathname,
+      ownedRelations: ["example_log"],
+    },
+  ];
+
+  for (const plugin of bundledPlugins) {
+    const pluginJournal = JSON.parse(
+      readFileSync(`${plugin.migrationsFolder}/meta/_journal.json`, "utf8"),
+    ) as { entries?: Array<{ tag?: unknown; when?: unknown }> };
+    if (!Array.isArray(pluginJournal.entries) || pluginJournal.entries.length === 0) {
+      throw new Error(`[migrate] Bundled plugin ${plugin.id} journal is malformed`);
+    }
+    const crypto = require("node:crypto") as typeof import("node:crypto");
+    const expectedEntries = pluginJournal.entries.map((entry) => {
+      if (typeof entry.tag !== "string" || !Number.isSafeInteger(entry.when)) {
+        throw new Error(`[migrate] Bundled plugin ${plugin.id} journal is malformed`);
+      }
+      return {
+        createdAt: entry.when as number,
+        hash: crypto
+          .createHash("sha256")
+          .update(readFileSync(`${plugin.migrationsFolder}/${entry.tag}.sql`))
+          .digest("hex"),
+      };
+    });
+    const migrationsTable = `__drizzle_migrations_plugin_${plugin.id}`;
+    const [shape] = queryRows<{ ledger_exists: boolean; owned_objects_exist: boolean }>(
+      await db.execute(sql`
+        SELECT
+          to_regclass(${`drizzle.${migrationsTable}`}) IS NOT NULL AS ledger_exists,
+          EXISTS (
+            SELECT 1
+            FROM pg_class relation
+            JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+            WHERE namespace.nspname = 'public'
+              AND relation.relname IN (${sql.join(
+                plugin.ownedRelations.map((name) => sql`${name}`),
+                sql`, `,
+              )})
+              AND relation.relkind IN ('r', 'p')
+          ) AS owned_objects_exist
+      `),
+    );
+    if (!shape?.ledger_exists) {
+      if (shape?.owned_objects_exist) {
+        throw new Error(
+          `[migrate] Bundled plugin ${plugin.id} objects exist without their checked-in migration ledger`,
+        );
+      }
+      continue;
+    }
+
+    const rows = queryRows<{ hash: string; created_at: string | number | null }>(
+      await db.execute(sql`
+        SELECT hash, created_at
+        FROM ${sql.identifier("drizzle")}.${sql.identifier(migrationsTable)}
+        ORDER BY id ASC
+      `),
+    );
+    if (rows.length > expectedEntries.length) {
+      throw new Error(`[migrate] Bundled plugin ${plugin.id} ledger is ahead of this build`);
+    }
+    for (const [index, row] of rows.entries()) {
+      const expected = expectedEntries[index];
+      if (row.hash !== expected?.hash || Number(row.created_at) !== expected.createdAt) {
+        throw new Error(
+          `[migrate] Bundled plugin ${plugin.id} ledger is malformed or not owned by this build`,
+        );
+      }
+    }
+    if (shape.owned_objects_exist && rows.length === 0) {
+      throw new Error(
+        `[migrate] Bundled plugin ${plugin.id} objects exist without an applied checked-in migration`,
+      );
+    }
+  }
+}
+
 /**
  * Run drizzle-kit migrations under a Postgres advisory session lock so
  * concurrent API replicas don't race on startup. Returns the tags of
@@ -281,8 +672,9 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
   let deadlineClose: Promise<void> | undefined;
   const overallTimer = setTimeout(() => {
     overallTimedOut = true;
-    deadlineClose = client.end({ timeout: 0 });
-    void deadlineClose.catch(() => undefined);
+    const close = client.end({ timeout: 0 });
+    deadlineClose = close;
+    void close.catch(() => undefined);
   }, timeouts.overallMs);
   let advisoryLockHeld = false;
 
@@ -296,6 +688,8 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
 
     try {
       const journal = readJournal();
+      await assertExactMigrationObjectInventory(db);
+      await assertBundledPluginLedgerIntegrity(db);
 
       // Inspect without writing first. A privileged migration URL can be
       // misconfigured to point at an unrelated/shared database; even creating
@@ -303,9 +697,6 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
       // the fail-closed target check runs.
       const ledgerExists = (await client`
         SELECT to_regclass('drizzle.__drizzle_migrations') AS r
-      `) as Array<{ r: string | null }>;
-      const drizzleSchemaExists = (await client`
-        SELECT to_regnamespace('drizzle') AS r
       `) as Array<{ r: string | null }>;
       const tenantsExists = (await client`
         SELECT to_regclass('public.tenants') AS r
@@ -779,71 +1170,127 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
         return { applied: [] };
       }
 
-      // Only a verified empty/legacy Steward target may receive the ledger.
-      // Avoid even idempotent CREATE statements once admin topology/the ledger
-      // exists: PostgreSQL requires database/schema CREATE before checking IF
-      // NOT EXISTS, which would make an already-complete runtime migration
-      // probe depend on a release-only privilege.
-      if (!drizzleSchemaExists[0]?.r) {
-        await client`CREATE SCHEMA drizzle`;
-      }
-      if (!ledgerExists[0]?.r) {
-        await client`
+      // Repeat the ownership and ledger checks inside the transaction that
+      // performs the migration. The earlier inspection guarantees we do not
+      // write to an already-wrong target; this one prevents a concurrent DDL
+      // writer from changing the target between inspection and mutation.
+      return await db.transaction(async (tx) => {
+        await assertExactMigrationObjectInventory(tx);
+        await assertBundledPluginLedgerIntegrity(tx);
+        const txDrizzleSchemaExists = queryRows<{ r: string | null }>(
+          await tx.execute(sql`SELECT to_regnamespace('drizzle') AS r`),
+        );
+        const txLedgerExists = queryRows<{ r: string | null }>(
+          await tx.execute(sql`SELECT to_regclass('drizzle.__drizzle_migrations') AS r`),
+        );
+        const txTenantsExists = queryRows<{ r: string | null }>(
+          await tx.execute(sql`SELECT to_regclass('public.tenants') AS r`),
+        );
+        let transactionalRows: CoreMigrationLedgerRow[] = [];
+        if (txLedgerExists[0]?.r) {
+          transactionalRows = queryRows<CoreMigrationLedgerRow>(
+            await tx.execute(
+              sql`SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id ASC`,
+            ),
+          );
+        }
+        assertCoreMigrationLedgerIntegrity(transactionalRows, journal, {
+          ...databaseShape,
+          tenantsExists: Boolean(txTenantsExists[0]?.r),
+          coreLedgerExists: Boolean(txLedgerExists[0]?.r),
+        });
+
+        // Only a verified empty/legacy Steward target may receive the ledger.
+        // Avoid even idempotent CREATE statements once admin topology/the ledger
+        // exists: PostgreSQL requires database/schema CREATE before checking IF
+        // NOT EXISTS, which would make an already-complete runtime migration
+        // probe depend on a release-only privilege.
+        if (!txDrizzleSchemaExists[0]?.r) {
+          await tx.execute(sql`CREATE SCHEMA drizzle`);
+        }
+        if (!txLedgerExists[0]?.r) {
+          await tx.execute(sql`
           CREATE TABLE drizzle.__drizzle_migrations (
             id SERIAL PRIMARY KEY,
             hash text NOT NULL,
             created_at bigint
           )
-        `;
-      }
-
-      // Backfill: legacy DB previously migrated by the psql loop.
-      if (existingRows.length === 0 && tenantsExists[0]?.r) {
-        // Fingerprint the psql-era tip before trusting the heuristic: a DB
-        // frozen at an older tip must fail loudly here, not be seeded with
-        // migrations it never applied.
-        if (!databaseShape.auditEventsExists) {
-          throw new Error(
-            `[migrate] Legacy DB detected (public.tenants exists) but fingerprint table ` +
-              `${LEGACY_BACKFILL_FINGERPRINT_TABLE} is missing — the DB predates migration ` +
-              `${LEGACY_BACKFILL_TIP_TAG}. Refusing to seed __drizzle_migrations: entries past ` +
-              `the DB's true tip would be silently skipped (including security-hardening ` +
-              `migrations). Reconcile the schema manually, then re-run migrations.`,
-          );
+        `);
         }
-        const backfillEntries = selectLegacyBackfillEntries(journal);
-        console.log(
-          `[migrate] Legacy DB detected — seeding __drizzle_migrations with ${backfillEntries.length} ` +
-            `entries through ${LEGACY_BACKFILL_TIP_TAG}; the migrator will apply the remaining ` +
-            `${journal.entries.length - backfillEntries.length} journal entrie(s) normally`,
-        );
-        for (const entry of backfillEntries) {
-          const hash = hashMigration(entry.tag);
-          await client`
+
+        // Backfill: legacy DB previously migrated by the psql loop.
+        if (transactionalRows.length === 0 && txTenantsExists[0]?.r) {
+          // Fingerprint the psql-era tip before trusting the heuristic: a DB
+          // frozen at an older tip must fail loudly here, not be seeded with
+          // migrations it never applied.
+          if (!databaseShape.auditEventsExists) {
+            throw new Error(
+              `[migrate] Legacy DB detected (public.tenants exists) but fingerprint table ` +
+                `${LEGACY_BACKFILL_FINGERPRINT_TABLE} is missing — the DB predates migration ` +
+                `${LEGACY_BACKFILL_TIP_TAG}. Refusing to seed __drizzle_migrations: entries past ` +
+                `the DB's true tip would be silently skipped (including security-hardening ` +
+                `migrations). Reconcile the schema manually, then re-run migrations.`,
+            );
+          }
+          const backfillEntries = selectLegacyBackfillEntries(journal);
+          console.log(
+            `[migrate] Legacy DB detected — seeding __drizzle_migrations with ${backfillEntries.length} ` +
+              `entries through ${LEGACY_BACKFILL_TIP_TAG}; the migrator will apply the remaining ` +
+              `${journal.entries.length - backfillEntries.length} journal entrie(s) normally`,
+          );
+          for (const entry of backfillEntries) {
+            const hash = hashMigration(entry.tag);
+            await tx.execute(sql`
             INSERT INTO drizzle.__drizzle_migrations ("hash", "created_at")
             VALUES (${hash}, ${entry.when})
-          `;
+          `);
+          }
+          transactionalRows = queryRows<CoreMigrationLedgerRow>(
+            await tx.execute(
+              sql`SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id ASC`,
+            ),
+          );
+          assertCoreMigrationLedgerIntegrity(transactionalRows, journal, databaseShape);
         }
-        existingRows = (await client`
-          SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id ASC
-        `) as CoreMigrationLedgerRow[];
-        assertCoreMigrationLedgerIntegrity(existingRows, journal, databaseShape);
-      }
 
-      const beforeCount = (
-        (await client`SELECT count(*)::int AS n FROM drizzle.__drizzle_migrations`) as Array<{
-          n: number;
-        }>
-      )[0].n;
+        const beforeCount = queryRows<{ n: number }>(
+          await tx.execute(sql`SELECT count(*)::int AS n FROM drizzle.__drizzle_migrations`),
+        )[0].n;
 
-      await migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+        // The postgres-js migrator normally opens its own transaction. We are
+        // already inside the ownership-check transaction, so give it the same
+        // dialect with a transaction-local session whose nested transaction is
+        // the current atomic unit. The migrator only requires execute/all/
+        // transaction from this session.
+        const txInternals = tx as unknown as {
+          dialect: unknown;
+        };
+        const migrationDb = {
+          dialect: txInternals.dialect,
+          session: {
+            execute: (query: ReturnType<typeof sql>) => tx.execute(query),
+            all: async (query: ReturnType<typeof sql>) => queryRows(await tx.execute(query)),
+            transaction: async <T>(use: (migrationTx: typeof tx) => Promise<T>) => use(tx),
+          },
+        } as unknown as PostgresJsDatabase<Record<string, unknown>>;
+        await migrate(migrationDb, {
+          migrationsFolder: MIGRATIONS_FOLDER,
+        });
 
-      const afterRows = (await client`
-        SELECT id, hash, created_at
-        FROM drizzle.__drizzle_migrations
-        ORDER BY id ASC
-      `) as CoreMigrationLedgerRow[];
-      const [postMigrationShape] = (await client`
+        const afterRows = queryRows<CoreMigrationLedgerRow>(
+          await tx.execute(sql`
+          SELECT id, hash, created_at
+          FROM drizzle.__drizzle_migrations
+          ORDER BY id ASC
+        `),
+        );
+        const [postMigrationShape] = queryRows<{
+          tenants_exists: boolean;
+          audit_events_exists: boolean;
+          legacy_fingerprint_matches: boolean;
+          user_object_count: number;
+        }>(
+          await tx.execute(sql`
         SELECT
           to_regclass('public.tenants') IS NOT NULL AS tenants_exists,
           to_regclass(${LEGACY_BACKFILL_FINGERPRINT_TABLE}) IS NOT NULL AS audit_events_exists,
@@ -896,32 +1343,31 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
           0::int AS user_object_count
         FROM pg_class relation
         JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
-      `) as Array<{
-        tenants_exists: boolean;
-        audit_events_exists: boolean;
-        legacy_fingerprint_matches: boolean;
-        user_object_count: number;
-      }>;
-      assertCoreMigrationLedgerIntegrity(
-        afterRows,
-        journal,
-        {
-          tenantsExists: postMigrationShape?.tenants_exists ?? false,
-          auditEventsExists: postMigrationShape?.audit_events_exists ?? false,
-          legacyFingerprintMatches: postMigrationShape?.legacy_fingerprint_matches ?? false,
-          userObjectCount: postMigrationShape?.user_object_count ?? 0,
-        },
-        {
-          requireComplete: true,
-        },
-      );
+      `),
+        );
+        assertCoreMigrationLedgerIntegrity(
+          afterRows,
+          journal,
+          {
+            tenantsExists: postMigrationShape?.tenants_exists ?? false,
+            auditEventsExists: postMigrationShape?.audit_events_exists ?? false,
+            legacyFingerprintMatches: postMigrationShape?.legacy_fingerprint_matches ?? false,
+            userObjectCount: postMigrationShape?.user_object_count ?? 0,
+          },
+          {
+            requireComplete: true,
+          },
+        );
 
-      const newRows = afterRows.slice(beforeCount);
-      const tagByHash = new Map<string, string>();
-      for (const entry of journal.entries) tagByHash.set(hashMigration(entry.tag), entry.tag);
-      const applied = newRows.map((r) => tagByHash.get(r.hash) ?? r.hash);
+        const newRows = afterRows.slice(beforeCount);
+        const tagByHash = new Map<string, string>();
+        for (const entry of journal.entries) tagByHash.set(hashMigration(entry.tag), entry.tag);
+        const applied = newRows.map((r) => tagByHash.get(r.hash) ?? r.hash);
 
-      return { applied };
+        await assertExactMigrationObjectInventory(tx);
+        await assertBundledPluginLedgerIntegrity(tx);
+        return { applied };
+      });
     } finally {
       if (advisoryLockHeld && !overallTimedOut) {
         await client`SELECT pg_advisory_unlock(hashtextextended(${ADVISORY_LOCK_KEY}, 0))`;

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -22,6 +22,115 @@ interface Journal {
   entries: JournalEntry[];
 }
 
+export interface CoreMigrationLedgerRow {
+  id: number;
+  hash: string;
+  created_at: string | number | null;
+}
+
+interface CoreMigrationDatabaseShape {
+  tenantsExists: boolean;
+  auditEventsExists: boolean;
+  publicRelationCount: number;
+}
+
+/**
+ * Drizzle trusts only the greatest `created_at` in its journal. An unrelated
+ * row with a future timestamp therefore makes every Steward migration appear
+ * applied. Validate the entire ledger against this repository before Drizzle
+ * is allowed to use that cutoff.
+ */
+export function assertCoreMigrationLedgerIntegrity(
+  rows: readonly CoreMigrationLedgerRow[],
+  journal: Journal,
+  database: CoreMigrationDatabaseShape,
+  options: { requireComplete?: boolean } = {},
+): void {
+  const expected = journal.entries.map((entry) => ({
+    ...entry,
+    hash: hashMigration(entry.tag),
+  }));
+  const expectedByIdentity = new Map(
+    expected.map((entry, index) => [`${entry.when}:${entry.hash}`, { entry, index }]),
+  );
+  if (expectedByIdentity.size !== expected.length) {
+    throw new Error("[migrate] Checked-in migration journal contains duplicate identities");
+  }
+
+  const recordedIndices: number[] = [];
+  const recordedIdentities = new Set<string>();
+  for (const row of rows) {
+    const createdAt = Number(row.created_at);
+    if (!Number.isSafeInteger(createdAt) || createdAt < 0 || !row.hash) {
+      throw new Error("[migrate] Core migration journal contains a malformed row");
+    }
+    const identity = `${createdAt}:${row.hash}`;
+    const match = expectedByIdentity.get(identity);
+    if (!match) {
+      throw new Error(
+        "[migrate] Core migration journal contains an entry not owned by this Steward build; " +
+          "refusing to trust a possibly shared or ahead database",
+      );
+    }
+    if (recordedIdentities.has(identity)) {
+      throw new Error("[migrate] Core migration journal contains a duplicate Steward entry");
+    }
+    recordedIdentities.add(identity);
+    recordedIndices.push(match.index);
+  }
+
+  if (
+    recordedIndices.some(
+      (index, position) => position > 0 && index <= recordedIndices[position - 1],
+    )
+  ) {
+    throw new Error("[migrate] Core migration journal is not in checked-in Steward order");
+  }
+
+  if (rows.length > 0 && !database.tenantsExists) {
+    throw new Error(
+      "[migrate] Core migration journal exists without public.tenants; refusing the wrong database",
+    );
+  }
+  if (rows.length === 0 && !database.tenantsExists && database.publicRelationCount > 0) {
+    throw new Error(
+      "[migrate] Non-empty public schema has no Steward migration history; refusing a shared database",
+    );
+  }
+  const auditMigrationIndex = journal.entries.findIndex(
+    (entry) => entry.tag === LEGACY_BACKFILL_TIP_TAG,
+  );
+  if (
+    auditMigrationIndex !== -1 &&
+    recordedIndices.some((index) => index >= auditMigrationIndex) &&
+    !database.auditEventsExists
+  ) {
+    throw new Error(
+      `[migrate] Journal claims ${LEGACY_BACKFILL_TIP_TAG} but ${LEGACY_BACKFILL_FINGERPRINT_TABLE} is missing`,
+    );
+  }
+
+  if (recordedIndices.length > 0) {
+    const greatestRecordedWhen = Math.max(
+      ...recordedIndices.map((index) => journal.entries[index].when),
+    );
+    const silentlySkipped = expected.filter(
+      (entry) =>
+        entry.when <= greatestRecordedWhen &&
+        !recordedIdentities.has(`${entry.when}:${entry.hash}`),
+    );
+    if (silentlySkipped.length > 0) {
+      throw new Error(
+        `[migrate] Core migration journal is missing ${silentlySkipped[0].tag} below its recorded cutoff`,
+      );
+    }
+  }
+
+  if (options.requireComplete && recordedIdentities.size !== expected.length) {
+    throw new Error("[migrate] Core migrator returned with an incomplete Steward journal");
+  }
+}
+
 /**
  * The legacy `psql -f` deploy loop was retired when this migrator was
  * introduced; the journal tip at that moment was 0024_audit_events. A legacy
@@ -100,23 +209,36 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
         )
       `;
 
-      const existingRows = (await client`
-        SELECT created_at FROM drizzle.__drizzle_migrations
-      `) as Array<{ created_at: string | number | null }>;
+      let existingRows = (await client`
+        SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id ASC
+      `) as CoreMigrationLedgerRow[];
 
       const tenantsExists = (await client`
         SELECT to_regclass('public.tenants') AS r
       `) as Array<{ r: string | null }>;
+      const auditEventsExists = (await client`
+        SELECT to_regclass(${LEGACY_BACKFILL_FINGERPRINT_TABLE}) AS r
+      `) as Array<{ r: string | null }>;
+      const databaseInventory = (await client`
+        SELECT count(*) FILTER (
+          WHERE namespace.nspname = 'public' AND relation.relkind IN ('r', 'p')
+        )::int AS public_relation_count
+        FROM pg_class relation
+        JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+      `) as Array<{ public_relation_count: number }>;
+      const databaseShape: CoreMigrationDatabaseShape = {
+        tenantsExists: Boolean(tenantsExists[0]?.r),
+        auditEventsExists: Boolean(auditEventsExists[0]?.r),
+        publicRelationCount: databaseInventory[0]?.public_relation_count ?? 0,
+      };
+      assertCoreMigrationLedgerIntegrity(existingRows, journal, databaseShape);
 
       // Backfill: legacy DB previously migrated by the psql loop.
       if (existingRows.length === 0 && tenantsExists[0]?.r) {
         // Fingerprint the psql-era tip before trusting the heuristic: a DB
         // frozen at an older tip must fail loudly here, not be seeded with
         // migrations it never applied.
-        const fingerprint = (await client`
-          SELECT to_regclass(${LEGACY_BACKFILL_FINGERPRINT_TABLE}) AS r
-        `) as Array<{ r: string | null }>;
-        if (!fingerprint[0]?.r) {
+        if (!databaseShape.auditEventsExists) {
           throw new Error(
             `[migrate] Legacy DB detected (public.tenants exists) but fingerprint table ` +
               `${LEGACY_BACKFILL_FINGERPRINT_TABLE} is missing — the DB predates migration ` +
@@ -138,6 +260,10 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
             VALUES (${hash}, ${entry.when})
           `;
         }
+        existingRows = (await client`
+          SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id ASC
+        `) as CoreMigrationLedgerRow[];
+        assertCoreMigrationLedgerIntegrity(existingRows, journal, databaseShape);
       }
 
       const beforeCount = (
@@ -149,10 +275,36 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
       await migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
 
       const afterRows = (await client`
-        SELECT hash, created_at
+        SELECT id, hash, created_at
         FROM drizzle.__drizzle_migrations
         ORDER BY id ASC
-      `) as Array<{ hash: string; created_at: string | number | null }>;
+      `) as CoreMigrationLedgerRow[];
+      const [postMigrationShape] = (await client`
+        SELECT
+          to_regclass('public.tenants') IS NOT NULL AS tenants_exists,
+          to_regclass(${LEGACY_BACKFILL_FINGERPRINT_TABLE}) IS NOT NULL AS audit_events_exists,
+          count(*) FILTER (
+            WHERE namespace.nspname = 'public' AND relation.relkind IN ('r', 'p')
+          )::int AS public_relation_count
+        FROM pg_class relation
+        JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+      `) as Array<{
+        tenants_exists: boolean;
+        audit_events_exists: boolean;
+        public_relation_count: number;
+      }>;
+      assertCoreMigrationLedgerIntegrity(
+        afterRows,
+        journal,
+        {
+          tenantsExists: postMigrationShape?.tenants_exists ?? false,
+          auditEventsExists: postMigrationShape?.audit_events_exists ?? false,
+          publicRelationCount: postMigrationShape?.public_relation_count ?? 0,
+        },
+        {
+          requireComplete: true,
+        },
+      );
 
       const newRows = afterRows.slice(beforeCount);
       const tagByHash = new Map<string, string>();

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -34,6 +34,16 @@ interface CoreMigrationDatabaseShape {
   auditEventsExists: boolean;
   legacyFingerprintMatches: boolean;
   userObjectCount: number;
+  /**
+   * Objects that cannot belong to a fresh Steward target. This inventory is
+   * deliberately broader than `public` tables: schema-separated shared
+   * databases, views, sequences, routines, and user-defined types must all
+   * fail before migration bookkeeping is created.
+   */
+  unapprovedObjectCount?: number;
+  alwaysRejectedObjectCount?: number;
+  coreLedgerExists?: boolean;
+  coreLedgerShapeMatches?: boolean;
 }
 
 export interface MigrationTimeouts {
@@ -95,6 +105,11 @@ export function assertCoreMigrationLedgerIntegrity(
   database: CoreMigrationDatabaseShape,
   options: { requireComplete?: boolean } = {},
 ): void {
+  if ((database.alwaysRejectedObjectCount ?? 0) > 0) {
+    throw new Error(
+      "[migrate] Database contains objects outside the verified Steward and provider inventories; refusing a shared database",
+    );
+  }
   const expected = journal.entries.map((entry) => ({
     ...entry,
     hash: hashMigration(entry.tag),
@@ -141,14 +156,23 @@ export function assertCoreMigrationLedgerIntegrity(
       "[migrate] Core migration journal exists without public.tenants; refusing the wrong database",
     );
   }
+  if (database.coreLedgerExists && !database.coreLedgerShapeMatches) {
+    throw new Error(
+      "[migrate] drizzle.__drizzle_migrations does not match Steward's migration-ledger shape; refusing the wrong database",
+    );
+  }
   if (rows.length === 0 && database.tenantsExists && !database.legacyFingerprintMatches) {
     throw new Error(
       "[migrate] Non-empty database resembles Steward but does not match the complete legacy schema fingerprint; refusing to create migration bookkeeping",
     );
   }
-  if (rows.length === 0 && !database.tenantsExists && database.userObjectCount > 0) {
+  if (
+    rows.length === 0 &&
+    !database.tenantsExists &&
+    (database.unapprovedObjectCount ?? database.userObjectCount) > 0
+  ) {
     throw new Error(
-      "[migrate] Non-empty user schema has no Steward migration history; refusing a shared database",
+      "[migrate] Non-empty database has no Steward migration history; refusing a shared database",
     );
   }
   const auditMigrationIndex = journal.entries.findIndex(
@@ -290,28 +314,388 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
         SELECT to_regclass(${LEGACY_BACKFILL_FINGERPRINT_TABLE}) AS r
       `) as Array<{ r: string | null }>;
       const databaseInventory = (await client`
-        SELECT
-          (
-            SELECT count(*) FROM pg_namespace candidate
-            WHERE candidate.nspname NOT IN (
-              'public', 'drizzle', 'steward_rls', 'steward_bootstrap',
-              'pg_catalog', 'information_schema'
+        WITH
+        allowed_extensions(extname) AS (
+          VALUES ('neon'), ('pg_stat_statements')
+        ),
+        ledger_shape AS (
+          SELECT
+            to_regclass('drizzle.__drizzle_migrations') IS NOT NULL AS ledger_exists,
+            (
+              NOT EXISTS (
+                SELECT 1
+                FROM pg_class relation
+                JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+                WHERE namespace.nspname = 'drizzle'
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM pg_proc routine
+                JOIN pg_namespace namespace ON namespace.oid = routine.pronamespace
+                WHERE namespace.nspname = 'drizzle'
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM pg_type type_inventory
+                JOIN pg_namespace namespace ON namespace.oid = type_inventory.typnamespace
+                WHERE namespace.nspname = 'drizzle'
+                  AND type_inventory.typrelid = 0
+                  AND type_inventory.typelem = 0
+              )
+            ) AS ledger_schema_empty,
+            (
+              EXISTS (
+                SELECT 1
+                FROM pg_class relation
+                JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+                WHERE namespace.nspname = 'drizzle'
+                  AND relation.relname = '__drizzle_migrations'
+                  AND relation.relkind = 'r'
+              )
+              AND (
+                SELECT count(*) = 3
+                  AND bool_or(
+                    column_inventory.column_name = 'id'
+                    AND column_inventory.data_type = 'integer'
+                    AND column_inventory.is_nullable = 'NO'
+                    AND column_inventory.column_default =
+                      'nextval(''drizzle.__drizzle_migrations_id_seq''::regclass)'
+                  )
+                  AND bool_or(
+                    column_inventory.column_name = 'hash'
+                    AND column_inventory.data_type = 'text'
+                    AND column_inventory.is_nullable = 'NO'
+                  )
+                  AND bool_or(
+                    column_inventory.column_name = 'created_at'
+                    AND column_inventory.data_type = 'bigint'
+                    AND column_inventory.is_nullable = 'YES'
+                  )
+                FROM information_schema.columns column_inventory
+                WHERE column_inventory.table_schema = 'drizzle'
+                  AND column_inventory.table_name = '__drizzle_migrations'
+              )
+              AND EXISTS (
+                SELECT 1
+                FROM pg_constraint constraint_inventory
+                WHERE constraint_inventory.conrelid =
+                    to_regclass('drizzle.__drizzle_migrations')
+                  AND constraint_inventory.contype = 'p'
+                  AND pg_get_constraintdef(constraint_inventory.oid) = 'PRIMARY KEY (id)'
+              )
+              AND pg_get_serial_sequence(
+                'drizzle.__drizzle_migrations',
+                'id'
+              ) = 'drizzle.__drizzle_migrations_id_seq'
+              AND NOT EXISTS (
+                SELECT 1
+                FROM pg_class relation
+                JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+                WHERE namespace.nspname = 'drizzle'
+                  AND relation.relkind IN ('r', 'p', 'v', 'm', 'S', 'f', 'c')
+                  AND NOT (
+                    (relation.relname = '__drizzle_migrations' AND relation.relkind = 'r')
+                    OR (
+                      relation.relkind = 'r'
+                      AND relation.relname ~ '^__drizzle_migrations_plugin_[a-z0-9_]+$'
+                      AND (
+                        SELECT count(*) = 3
+                          AND bool_or(
+                            column_inventory.column_name = 'id'
+                            AND column_inventory.data_type = 'integer'
+                            AND column_inventory.is_nullable = 'NO'
+                          )
+                          AND bool_or(
+                            column_inventory.column_name = 'hash'
+                            AND column_inventory.data_type = 'text'
+                            AND column_inventory.is_nullable = 'NO'
+                          )
+                          AND bool_or(
+                            column_inventory.column_name = 'created_at'
+                            AND column_inventory.data_type = 'bigint'
+                            AND column_inventory.is_nullable = 'YES'
+                          )
+                        FROM information_schema.columns column_inventory
+                        WHERE column_inventory.table_schema = 'drizzle'
+                          AND column_inventory.table_name = relation.relname
+                      )
+                      AND EXISTS (
+                        SELECT 1
+                        FROM pg_constraint constraint_inventory
+                        WHERE constraint_inventory.conrelid = relation.oid
+                          AND constraint_inventory.contype = 'p'
+                          AND pg_get_constraintdef(constraint_inventory.oid) =
+                            'PRIMARY KEY (id)'
+                      )
+                      AND pg_get_serial_sequence(
+                        format('%I.%I', namespace.nspname, relation.relname),
+                        'id'
+                      ) IS NOT NULL
+                    )
+                    OR (
+                      relation.relkind = 'S'
+                      AND EXISTS (
+                        SELECT 1
+                        FROM pg_depend dependency
+                        JOIN pg_class ledger_table
+                          ON ledger_table.oid = dependency.refobjid
+                        JOIN pg_namespace ledger_namespace
+                          ON ledger_namespace.oid = ledger_table.relnamespace
+                        JOIN pg_attribute ledger_column
+                          ON ledger_column.attrelid = ledger_table.oid
+                          AND ledger_column.attnum = dependency.refobjsubid
+                        WHERE dependency.classid = 'pg_class'::regclass
+                          AND dependency.objid = relation.oid
+                          AND dependency.refclassid = 'pg_class'::regclass
+                          AND dependency.deptype = 'a'
+                          AND ledger_namespace.nspname = 'drizzle'
+                          AND ledger_column.attname = 'id'
+                          AND (
+                            ledger_table.relname = '__drizzle_migrations'
+                            OR ledger_table.relname ~
+                              '^__drizzle_migrations_plugin_[a-z0-9_]+$'
+                          )
+                      )
+                    )
+                  )
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM pg_proc routine
+                JOIN pg_namespace namespace ON namespace.oid = routine.pronamespace
+                WHERE namespace.nspname = 'drizzle'
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM pg_type type_inventory
+                JOIN pg_namespace namespace ON namespace.oid = type_inventory.typnamespace
+                WHERE namespace.nspname = 'drizzle'
+                  AND type_inventory.typrelid = 0
+                  AND type_inventory.typelem = 0
+                  AND type_inventory.typtype IN ('d', 'e', 'r', 'm')
+              )
+            ) AS ledger_shape_matches
+        ),
+        namespaced_catalog_objects(classid, object_oid, namespace_oid, kind, identity) AS (
+          SELECT 'pg_collation'::regclass::oid, oid, collnamespace, 'collation', collname
+          FROM pg_collation
+          UNION ALL
+          SELECT 'pg_conversion'::regclass::oid, oid, connamespace, 'conversion', conname
+          FROM pg_conversion
+          UNION ALL
+          SELECT 'pg_operator'::regclass::oid, oid, oprnamespace, 'operator', oprname
+          FROM pg_operator
+          UNION ALL
+          SELECT 'pg_opclass'::regclass::oid, oid, opcnamespace, 'operator class', opcname
+          FROM pg_opclass
+          UNION ALL
+          SELECT 'pg_opfamily'::regclass::oid, oid, opfnamespace, 'operator family', opfname
+          FROM pg_opfamily
+          UNION ALL
+          SELECT 'pg_ts_config'::regclass::oid, oid, cfgnamespace, 'text search config', cfgname
+          FROM pg_ts_config
+          UNION ALL
+          SELECT 'pg_ts_dict'::regclass::oid, oid, dictnamespace, 'text search dictionary', dictname
+          FROM pg_ts_dict
+          UNION ALL
+          SELECT 'pg_ts_parser'::regclass::oid, oid, prsnamespace, 'text search parser', prsname
+          FROM pg_ts_parser
+          UNION ALL
+          SELECT 'pg_ts_template'::regclass::oid, oid, tmplnamespace, 'text search template', tmplname
+          FROM pg_ts_template
+        ),
+        unapproved_objects(kind, identity, always_reject) AS (
+          SELECT 'schema', namespace.nspname, true
+          FROM pg_namespace namespace
+          CROSS JOIN ledger_shape
+          WHERE namespace.nspname <> 'information_schema'
+            AND namespace.nspname NOT LIKE 'pg\\_%' ESCAPE '\\'
+            AND namespace.nspname NOT IN (
+              'public', 'neon', 'steward_rls', 'steward_bootstrap'
             )
-              AND candidate.nspname !~ '^pg_(toast|temp|toast_temp)'
-          ) + (
-            SELECT count(*) FROM pg_class object
-            JOIN pg_namespace candidate ON candidate.oid = object.relnamespace
-            WHERE candidate.nspname IN ('public', 'drizzle', 'steward_rls', 'steward_bootstrap')
-          ) + (
-            SELECT count(*) FROM pg_proc object
-            JOIN pg_namespace candidate ON candidate.oid = object.pronamespace
-            WHERE candidate.nspname IN ('public', 'drizzle', 'steward_rls', 'steward_bootstrap')
-          ) + (
-            SELECT count(*) FROM pg_type object
-            JOIN pg_namespace candidate ON candidate.oid = object.typnamespace
-            WHERE candidate.nspname IN ('public', 'drizzle', 'steward_rls', 'steward_bootstrap')
-              AND object.typtype IN ('c', 'd', 'e', 'm', 'r')
-          ) AS user_object_count,
+            AND NOT (
+              namespace.nspname = 'drizzle'
+              AND (
+                ledger_shape.ledger_shape_matches
+                OR ledger_shape.ledger_schema_empty
+              )
+            )
+
+          UNION ALL
+
+          SELECT
+            'relation',
+            format('%I.%I', namespace.nspname, relation.relname),
+            namespace.nspname = 'neon'
+              OR namespace.nspname NOT IN (
+                'public', 'drizzle', 'steward_rls', 'steward_bootstrap'
+              )
+              OR (
+                namespace.nspname = 'public'
+                AND relation.relkind IN ('v', 'm', 'f', 'c')
+              )
+          FROM pg_class relation
+          JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+          CROSS JOIN ledger_shape
+          WHERE namespace.nspname <> 'information_schema'
+            AND namespace.nspname NOT LIKE 'pg\\_%' ESCAPE '\\'
+            AND relation.relkind IN ('r', 'p', 'v', 'm', 'S', 'f', 'c')
+            AND NOT (
+              namespace.nspname = 'drizzle'
+              AND ledger_shape.ledger_shape_matches
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM pg_depend dependency
+              JOIN pg_extension extension_inventory
+                ON extension_inventory.oid = dependency.refobjid
+              JOIN allowed_extensions allowed
+                ON allowed.extname = extension_inventory.extname
+              WHERE dependency.classid = 'pg_class'::regclass
+                AND dependency.objid = relation.oid
+                AND dependency.objsubid = 0
+                AND dependency.refclassid = 'pg_extension'::regclass
+                AND dependency.deptype = 'e'
+            )
+
+          UNION ALL
+
+          SELECT
+            'routine',
+            format('%I.%I', namespace.nspname, routine.proname),
+            namespace.nspname = 'neon'
+              OR namespace.nspname NOT IN (
+                'public', 'steward_rls', 'steward_bootstrap'
+              )
+          FROM pg_proc routine
+          JOIN pg_namespace namespace ON namespace.oid = routine.pronamespace
+          WHERE namespace.nspname <> 'information_schema'
+            AND namespace.nspname NOT LIKE 'pg\\_%' ESCAPE '\\'
+            AND NOT EXISTS (
+              SELECT 1
+              FROM pg_depend dependency
+              JOIN pg_extension extension_inventory
+                ON extension_inventory.oid = dependency.refobjid
+              JOIN allowed_extensions allowed
+                ON allowed.extname = extension_inventory.extname
+              WHERE dependency.classid = 'pg_proc'::regclass
+                AND dependency.objid = routine.oid
+                AND dependency.objsubid = 0
+                AND dependency.refclassid = 'pg_extension'::regclass
+                AND dependency.deptype = 'e'
+            )
+
+          UNION ALL
+
+          SELECT
+            'type',
+            format('%I.%I', namespace.nspname, type_inventory.typname),
+            namespace.nspname = 'neon'
+              OR namespace.nspname NOT IN (
+                'public', 'steward_rls', 'steward_bootstrap'
+              )
+          FROM pg_type type_inventory
+          JOIN pg_namespace namespace ON namespace.oid = type_inventory.typnamespace
+          WHERE namespace.nspname <> 'information_schema'
+            AND namespace.nspname NOT LIKE 'pg\\_%' ESCAPE '\\'
+            AND type_inventory.typrelid = 0
+            AND type_inventory.typelem = 0
+            AND type_inventory.typtype IN ('d', 'e', 'r', 'm')
+            AND NOT EXISTS (
+              SELECT 1
+              FROM pg_depend dependency
+              JOIN pg_extension extension_inventory
+                ON extension_inventory.oid = dependency.refobjid
+              JOIN allowed_extensions allowed
+                ON allowed.extname = extension_inventory.extname
+              WHERE dependency.classid = 'pg_type'::regclass
+                AND dependency.objid = type_inventory.oid
+                AND dependency.objsubid = 0
+                AND dependency.refclassid = 'pg_extension'::regclass
+                AND dependency.deptype = 'e'
+            )
+
+          UNION ALL
+
+          SELECT
+            catalog_object.kind,
+            format('%I.%I', namespace.nspname, catalog_object.identity),
+            namespace.nspname = 'neon'
+              OR namespace.nspname NOT IN (
+                'public', 'steward_rls', 'steward_bootstrap'
+              )
+          FROM namespaced_catalog_objects catalog_object
+          JOIN pg_namespace namespace ON namespace.oid = catalog_object.namespace_oid
+          WHERE namespace.nspname <> 'information_schema'
+            AND namespace.nspname NOT LIKE 'pg\\_%' ESCAPE '\\'
+            AND NOT EXISTS (
+              SELECT 1
+              FROM pg_depend dependency
+              JOIN pg_extension extension_inventory
+                ON extension_inventory.oid = dependency.refobjid
+              JOIN allowed_extensions allowed
+                ON allowed.extname = extension_inventory.extname
+              WHERE dependency.classid = catalog_object.classid
+                AND dependency.objid = catalog_object.object_oid
+                AND dependency.objsubid = 0
+                AND dependency.refclassid = 'pg_extension'::regclass
+                AND dependency.deptype = 'e'
+            )
+
+          UNION ALL
+
+          SELECT 'extension', extension_inventory.extname, true
+          FROM pg_extension extension_inventory
+          WHERE extension_inventory.extname <> 'plpgsql'
+            AND NOT EXISTS (
+              SELECT 1
+              FROM allowed_extensions allowed
+              WHERE allowed.extname = extension_inventory.extname
+            )
+
+          UNION ALL
+
+          SELECT 'foreign data wrapper', wrapper.fdwname, true
+          FROM pg_foreign_data_wrapper wrapper
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM pg_depend dependency
+            JOIN pg_extension extension_inventory
+              ON extension_inventory.oid = dependency.refobjid
+            JOIN allowed_extensions allowed
+              ON allowed.extname = extension_inventory.extname
+            WHERE dependency.classid = 'pg_foreign_data_wrapper'::regclass
+              AND dependency.objid = wrapper.oid
+              AND dependency.objsubid = 0
+              AND dependency.refclassid = 'pg_extension'::regclass
+              AND dependency.deptype = 'e'
+          )
+
+          UNION ALL
+
+          SELECT 'foreign server', server.srvname, true FROM pg_foreign_server server
+
+          UNION ALL
+
+          SELECT 'event trigger', trigger.evtname, true FROM pg_event_trigger trigger
+
+          UNION ALL
+
+          SELECT 'publication', publication.pubname, true FROM pg_publication publication
+
+          UNION ALL
+
+          SELECT 'large object', large_object.oid::text, true
+          FROM pg_largeobject_metadata large_object
+        )
+        SELECT
+          (SELECT count(*)::int FROM unapproved_objects) AS user_object_count,
+          (SELECT ledger_exists FROM ledger_shape) AS ledger_exists,
+          (SELECT ledger_shape_matches FROM ledger_shape) AS ledger_shape_matches,
+          (SELECT count(*)::int FROM unapproved_objects) AS unapproved_object_count,
+          (
+            SELECT count(*)::int FROM unapproved_objects WHERE always_reject
+          ) AS always_rejected_object_count,
           (
             SELECT count(*) = 28
             FROM (VALUES
@@ -358,16 +742,30 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
             ) AS required(index_name)
             WHERE to_regclass('public.' || required.index_name) IS NOT NULL
           ) AS legacy_fingerprint_matches
-        FROM pg_class relation
-        JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
-      `) as Array<{ user_object_count: number; legacy_fingerprint_matches: boolean }>;
+      `) as Array<{
+        user_object_count: number;
+        ledger_exists: boolean;
+        ledger_shape_matches: boolean;
+        unapproved_object_count: number;
+        always_rejected_object_count: number;
+        legacy_fingerprint_matches: boolean;
+      }>;
       const databaseShape: CoreMigrationDatabaseShape = {
         tenantsExists: Boolean(tenantsExists[0]?.r),
         auditEventsExists: Boolean(auditEventsExists[0]?.r),
         legacyFingerprintMatches: databaseInventory[0]?.legacy_fingerprint_matches === true,
         userObjectCount: databaseInventory[0]?.user_object_count ?? 0,
+        unapprovedObjectCount: databaseInventory[0]?.unapproved_object_count ?? 0,
+        alwaysRejectedObjectCount: databaseInventory[0]?.always_rejected_object_count ?? 0,
+        coreLedgerExists: databaseInventory[0]?.ledger_exists ?? false,
+        coreLedgerShapeMatches: databaseInventory[0]?.ledger_shape_matches ?? false,
       };
       let existingRows: CoreMigrationLedgerRow[] = [];
+      if (databaseShape.coreLedgerExists && !databaseShape.coreLedgerShapeMatches) {
+        throw new Error(
+          "[migrate] drizzle.__drizzle_migrations does not match Steward's migration-ledger shape; refusing the wrong database",
+        );
+      }
       if (ledgerExists[0]?.r) {
         existingRows = (await client`
           SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id ASC

--- a/packages/db/src/plugin-migrate.ts
+++ b/packages/db/src/plugin-migrate.ts
@@ -46,6 +46,7 @@ import type { PluginMigrationSource } from "@stwd/shared";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 
 import { createDb } from "./client";
+import { resolveMigrationTimeouts } from "./migrate";
 
 /** the schema the per-plugin bookkeeping table lives in (same as core's). */
 const PLUGIN_MIGRATIONS_SCHEMA = "drizzle";
@@ -202,12 +203,31 @@ export async function runPluginMigrations(
   let ownsClient = false;
   let db = options.db;
   let client = options.client;
+  const timeouts = resolveMigrationTimeouts();
   if (!db) {
-    const created = createDb();
+    const created = createDb(undefined, {
+      max: 1,
+      connectTimeoutSeconds: timeouts.connectSeconds,
+      statementTimeoutMs: timeouts.statementMs,
+      lockTimeoutMs: timeouts.advisoryLockMs,
+      idleInTransactionTimeoutMs: timeouts.statementMs,
+    });
     db = created.db;
     client = created.client;
     ownsClient = true;
   }
+
+  let overallTimedOut = false;
+  let deadlineClose: Promise<void> | undefined;
+  const overallTimer = ownsClient
+    ? setTimeout(() => {
+        overallTimedOut = true;
+        const close = client.end({ timeout: 0 });
+        deadlineClose = close;
+        void close.catch(() => undefined);
+      }, timeouts.overallMs)
+    : undefined;
+  let advisoryLockHeld = false;
 
   try {
     if (useAdvisoryLock) {
@@ -217,7 +237,14 @@ export async function runPluginMigrations(
             "but no SQL client was provided. Pass `client` or set useAdvisoryLock:false.",
         );
       }
+      if (ownsClient) {
+        await client`SELECT set_config('statement_timeout', ${`${timeouts.advisoryLockMs}ms`}, false)`;
+      }
       await client`SELECT pg_advisory_lock(hashtextextended(${lockKey}, 0))`;
+      advisoryLockHeld = true;
+      if (ownsClient) {
+        await client`SELECT set_config('statement_timeout', ${`${timeouts.statementMs}ms`}, false)`;
+      }
     }
 
     try {
@@ -230,15 +257,25 @@ export async function runPluginMigrations(
         migrationsSchema: PLUGIN_MIGRATIONS_SCHEMA,
       });
     } finally {
-      if (useAdvisoryLock && client) {
+      if (advisoryLockHeld && client && !overallTimedOut) {
         await client`SELECT pg_advisory_unlock(hashtextextended(${lockKey}, 0))`;
       }
     }
 
     return { id: source.id, migrationsTable };
+  } catch (error) {
+    if (overallTimedOut) {
+      throw new Error(
+        `plugin migration "${source.id}" exceeded the ${timeouts.overallMs}ms overall timeout`,
+        { cause: error },
+      );
+    }
+    throw error;
   } finally {
+    if (overallTimer) clearTimeout(overallTimer);
     if (ownsClient && client && typeof client.end === "function") {
-      await client.end();
+      if (deadlineClose) await deadlineClose.catch(() => undefined);
+      else await client.end({ timeout: 0 });
     }
   }
 }

--- a/packages/db/src/plugin-migrate.ts
+++ b/packages/db/src/plugin-migrate.ts
@@ -42,6 +42,8 @@
  * nothing.
  */
 
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import type { PluginMigrationSource } from "@stwd/shared";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 
@@ -120,6 +122,36 @@ export function pluginMigrationsTable(id: string): string {
  */
 export function pluginAdvisoryLockKey(id: string): string {
   return `steward_plugin_migrations_${boundedPluginMigrationId(id)}`;
+}
+
+export interface PluginMigrationLedgerExpectation {
+  id: string;
+  migrationsTable: string;
+  entries: Array<{ hash: string; createdAt: number }>;
+}
+
+/** Exact checked-in identities required for an enabled plugin to be ready. */
+export function getPluginMigrationLedgerExpectation(
+  source: PluginMigrationSource,
+): PluginMigrationLedgerExpectation {
+  const journal = JSON.parse(
+    readFileSync(`${source.migrationsFolder}/meta/_journal.json`, "utf8"),
+  ) as { entries?: Array<{ tag?: unknown; when?: unknown }> };
+  if (!Array.isArray(journal.entries) || journal.entries.length === 0) {
+    throw new Error(`plugin migration journal "${source.id}" is empty or malformed`);
+  }
+  const entries = journal.entries.map((entry) => {
+    if (typeof entry.tag !== "string" || !Number.isSafeInteger(entry.when)) {
+      throw new Error(`plugin migration journal "${source.id}" contains a malformed entry`);
+    }
+    return {
+      createdAt: entry.when as number,
+      hash: createHash("sha256")
+        .update(readFileSync(`${source.migrationsFolder}/${entry.tag}.sql`))
+        .digest("hex"),
+    };
+  });
+  return { id: source.id, migrationsTable: pluginMigrationsTable(source.id), entries };
 }
 
 /**

--- a/packages/db/src/rls-deployment-safety.ts
+++ b/packages/db/src/rls-deployment-safety.ts
@@ -14,6 +14,13 @@ function stable(value: unknown): string {
   return JSON.stringify(value);
 }
 
+function boundTextArray(values: readonly string[]) {
+  return sql`ARRAY[${sql.join(
+    values.map((value) => sql`${value}`),
+    sql`, `,
+  )}]::text[]`;
+}
+
 /**
  * Load-bearing production gate for the SEC-169 deployment role and catalog.
  * It deliberately runs through the exact application connection before traffic
@@ -39,7 +46,9 @@ export async function assertRlsDeploymentSafety(
           SELECT 1 FROM pg_class relation
           JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
           WHERE namespace.nspname = 'public'
-            AND relation.relname = ANY(${[...new Set(EXPECTED_RLS_POLICY_DEFINITIONS.map((p) => p.relation_name))]})
+            AND relation.relname = ANY(${boundTextArray([
+              ...new Set(EXPECTED_RLS_POLICY_DEFINITIONS.map((p) => p.relation_name)),
+            ])})
             AND relation.relowner = role.oid
         ) AS owns_rls_relation
       FROM pg_roles role WHERE role.rolname = current_user

--- a/scripts/__tests__/railway-deploy.test.ts
+++ b/scripts/__tests__/railway-deploy.test.ts
@@ -161,7 +161,7 @@ describe("Railway staging deployment", () => {
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain("Health check attempt 2: HTTP 000");
     expect(result.output).toContain("Health check passed");
-  });
+  }, 15_000);
 
   test("prints Railway diagnostics when health never becomes ready", async () => {
     const result = await fakeRailwayRun(999, 2);
@@ -179,5 +179,5 @@ describe("Railway staging deployment", () => {
     expect(result.output).not.toContain("oauth-code-secret");
     expect(result.output).toContain("state=public-state");
     expect(result.output).toContain("…REDACTED…");
-  });
+  }, 15_000);
 });

--- a/scripts/__tests__/railway-deploy.test.ts
+++ b/scripts/__tests__/railway-deploy.test.ts
@@ -32,6 +32,7 @@ async function fakeRailwayRun(
   healthTimeout = 4,
   readyAfter = 1,
   healthUrl: string | null = "https://example.test",
+  remoteIp = "1.1.1.1",
 ) {
   const dir = await mkdtemp(join(tmpdir(), "steward-railway-deploy-"));
   temporaryDirectories.push(dir);
@@ -52,14 +53,14 @@ case "$args" in
     [ ! -f "$FAKE_HEALTH_STATE" ] || count=$(cat "$FAKE_HEALTH_STATE")
     count=$((count + 1))
     echo "$count" > "$FAKE_HEALTH_STATE"
-    if [ "$count" -ge "$FAKE_HEALTHY_AFTER" ]; then printf 200; else printf 000; fi
+    if [ "$count" -ge "$FAKE_HEALTHY_AFTER" ]; then printf '200 %s' "$FAKE_REMOTE_IP"; else printf '000 '; fi
     ;;
   *example.test/ready*)
     count=0
     [ ! -f "$FAKE_READY_STATE" ] || count=$(cat "$FAKE_READY_STATE")
     count=$((count + 1))
     echo "$count" > "$FAKE_READY_STATE"
-    if [ "$count" -ge "$FAKE_READY_AFTER" ]; then printf 200; else printf 503; fi
+    if [ "$count" -ge "$FAKE_READY_AFTER" ]; then printf '200 %s' "$FAKE_REMOTE_IP"; else printf '503 %s' "$FAKE_REMOTE_IP"; fi
     ;;
   *serviceInstanceUpdate*) printf '%s\n' '{"data":{"serviceInstanceUpdate":true}}' ;;
   *serviceInstanceDeployV2*) printf '%s\n' '{"data":{"serviceInstanceDeployV2":"deployment-test"}}' ;;
@@ -84,6 +85,7 @@ esac
       FAKE_CURL_LOG: curlLog,
       FAKE_HEALTHY_AFTER: String(healthyAfter),
       FAKE_READY_AFTER: String(readyAfter),
+      FAKE_REMOTE_IP: remoteIp,
       RAILWAY_TOKEN: "test-token",
       RAILWAY_SERVICE_ID: "test-service",
       RAILWAY_ENV_ID: "test-environment",
@@ -99,7 +101,7 @@ esac
     new Response(process.stdout).text(),
     new Response(process.stderr).text(),
   ]);
-  const curlArguments = await Bun.file(curlLog).text();
+  const curlArguments = (await Bun.file(curlLog).exists()) ? await Bun.file(curlLog).text() : "";
   return { exitCode, output: stdout + stderr, curlArguments };
 }
 
@@ -181,8 +183,29 @@ describe("Railway staging deployment", () => {
     const result = await fakeRailwayRun(1, 2, 1, null);
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain("RAILWAY_HEALTH_URL is required for deployment acceptance");
-    expect(result.output).toContain("refusing to skip public /health and /ready receipts");
+    expect(result.curlArguments).not.toContain("serviceInstanceUpdate");
   }, 15_000);
+
+  for (const invalidOrigin of [
+    "http://example.test",
+    "https://user:secret@example.test",
+    "https://example.test/private",
+    "https://example.test?token=secret",
+    "https://localhost",
+    "https://127.0.0.1",
+    "https://10.0.0.1",
+    "https://169.254.1.1",
+    "https://[::1]",
+    "https://[fc00::1]",
+  ]) {
+    test(`rejects ${invalidOrigin.split(":")[0]} invalid probe authority before mutation`, async () => {
+      const result = await fakeRailwayRun(1, 2, 1, invalidOrigin);
+      expect(result.exitCode).toBe(1);
+      expect(result.curlArguments).not.toContain("serviceInstanceUpdate");
+      expect(result.curlArguments).not.toContain("serviceInstanceDeployV2");
+      expect(result.output).not.toContain("secret");
+    });
+  }
 
   test("waits through delayed health before accepting the deployment", async () => {
     const result = await fakeRailwayRun(3);
@@ -196,6 +219,12 @@ describe("Railway staging deployment", () => {
       expect(call).toContain("--connect-timeout 5");
       expect(call).toContain("--max-time 20");
     }
+  }, 15_000);
+
+  test("rejects a public-looking authority whose successful probe resolves privately", async () => {
+    const result = await fakeRailwayRun(1, 2, 1, "https://example.test", "10.0.0.8");
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("Health check failed");
   }, 15_000);
 
   test("rejects a live deployment whose durable readiness never passes", async () => {

--- a/scripts/__tests__/railway-deploy.test.ts
+++ b/scripts/__tests__/railway-deploy.test.ts
@@ -27,7 +27,12 @@ function redact(input: string): string {
   );
 }
 
-async function fakeRailwayRun(healthyAfter: number, healthTimeout = 4, readyAfter = 1) {
+async function fakeRailwayRun(
+  healthyAfter: number,
+  healthTimeout = 4,
+  readyAfter = 1,
+  healthUrl: string | null = "https://example.test",
+) {
   const dir = await mkdtemp(join(tmpdir(), "steward-railway-deploy-"));
   temporaryDirectories.push(dir);
   const stateFile = join(dir, "health-attempts");
@@ -82,7 +87,7 @@ esac
       RAILWAY_TOKEN: "test-token",
       RAILWAY_SERVICE_ID: "test-service",
       RAILWAY_ENV_ID: "test-environment",
-      RAILWAY_HEALTH_URL: "https://example.test",
+      RAILWAY_HEALTH_URL: healthUrl ?? "",
       RAILWAY_HEALTH_TIMEOUT: String(healthTimeout),
       RAILWAY_HEALTH_INTERVAL: "1",
     },
@@ -172,6 +177,13 @@ describe("SEC-129 redact_secrets filter", () => {
 });
 
 describe("Railway staging deployment", () => {
+  test("rejects deployment acceptance when no public probe authority is configured", async () => {
+    const result = await fakeRailwayRun(1, 2, 1, null);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("RAILWAY_HEALTH_URL is required for deployment acceptance");
+    expect(result.output).toContain("refusing to skip public /health and /ready receipts");
+  }, 15_000);
+
   test("waits through delayed health before accepting the deployment", async () => {
     const result = await fakeRailwayRun(3);
     expect(result.exitCode).toBe(0);

--- a/scripts/__tests__/railway-deploy.test.ts
+++ b/scripts/__tests__/railway-deploy.test.ts
@@ -27,10 +27,11 @@ function redact(input: string): string {
   );
 }
 
-async function fakeRailwayRun(healthyAfter: number, healthTimeout = 4) {
+async function fakeRailwayRun(healthyAfter: number, healthTimeout = 4, readyAfter = 1) {
   const dir = await mkdtemp(join(tmpdir(), "steward-railway-deploy-"));
   temporaryDirectories.push(dir);
   const stateFile = join(dir, "health-attempts");
+  const readyStateFile = join(dir, "ready-attempts");
   const curlLog = join(dir, "curl-arguments");
   const fakeCurl = join(dir, "curl");
   const fakeSleep = join(dir, "sleep");
@@ -47,6 +48,13 @@ case "$args" in
     count=$((count + 1))
     echo "$count" > "$FAKE_HEALTH_STATE"
     if [ "$count" -ge "$FAKE_HEALTHY_AFTER" ]; then printf 200; else printf 000; fi
+    ;;
+  *example.test/ready*)
+    count=0
+    [ ! -f "$FAKE_READY_STATE" ] || count=$(cat "$FAKE_READY_STATE")
+    count=$((count + 1))
+    echo "$count" > "$FAKE_READY_STATE"
+    if [ "$count" -ge "$FAKE_READY_AFTER" ]; then printf 200; else printf 503; fi
     ;;
   *serviceInstanceUpdate*) printf '%s\n' '{"data":{"serviceInstanceUpdate":true}}' ;;
   *serviceInstanceDeployV2*) printf '%s\n' '{"data":{"serviceInstanceDeployV2":"deployment-test"}}' ;;
@@ -67,8 +75,10 @@ esac
       ...Bun.env,
       PATH: `${dir}:${Bun.env.PATH ?? ""}`,
       FAKE_HEALTH_STATE: stateFile,
+      FAKE_READY_STATE: readyStateFile,
       FAKE_CURL_LOG: curlLog,
       FAKE_HEALTHY_AFTER: String(healthyAfter),
+      FAKE_READY_AFTER: String(readyAfter),
       RAILWAY_TOKEN: "test-token",
       RAILWAY_SERVICE_ID: "test-service",
       RAILWAY_ENV_ID: "test-environment",
@@ -167,12 +177,20 @@ describe("Railway staging deployment", () => {
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain("Health check attempt 2: HTTP 000");
     expect(result.output).toContain("Health check passed");
+    expect(result.output).toContain("Readiness check passed");
     for (const call of result.curlArguments
       .split("\n")
       .filter((line) => line.includes("graphql"))) {
       expect(call).toContain("--connect-timeout 5");
       expect(call).toContain("--max-time 20");
     }
+  }, 15_000);
+
+  test("rejects a live deployment whose durable readiness never passes", async () => {
+    const result = await fakeRailwayRun(1, 2, 999);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toMatch(/Readiness check failed after [1-9][0-9]* attempts? \/ 2s/);
+    expect(result.output).toContain("Railway deployment diagnostics");
   }, 15_000);
 
   test("prints Railway diagnostics when health never becomes ready", async () => {

--- a/scripts/__tests__/railway-deploy.test.ts
+++ b/scripts/__tests__/railway-deploy.test.ts
@@ -1,18 +1,23 @@
 /**
- * SEC-129 regression tests — railway-deploy.sh must fail closed by default
- * and redact secrets from dumped Railway logs.
- *
- * The fail-closed default is asserted as a source contract (the script is not
- * safely sourceable — it performs API calls at runtime). The redact_secrets
- * filter is extracted from the real script and exercised behaviorally.
+ * SEC-129 regression tests — railway-deploy.sh must fail closed by default,
+ * redact secrets from dumped Railway logs, and wait for a delayed healthy
+ * container without accepting an unreachable deployment.
  */
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 
-const SCRIPT = join(import.meta.dir, "..", "railway-deploy.sh");
+const repoRoot = resolve(import.meta.dir, "../..");
+const SCRIPT = join(repoRoot, "scripts/railway-deploy.sh");
 const source = readFileSync(SCRIPT, "utf8");
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((dir) => rm(dir, { recursive: true })));
+});
 
 function redact(input: string): string {
   return execFileSync(
@@ -22,13 +27,67 @@ function redact(input: string): string {
   );
 }
 
+async function fakeRailwayRun(healthyAfter: number, healthTimeout = 4) {
+  const dir = await mkdtemp(join(tmpdir(), "steward-railway-deploy-"));
+  temporaryDirectories.push(dir);
+  const stateFile = join(dir, "health-attempts");
+  const fakeCurl = join(dir, "curl");
+  const fakeSleep = join(dir, "sleep");
+
+  await writeFile(
+    fakeCurl,
+    `#!/bin/sh
+args="$*"
+case "$args" in
+  *example.test/health*)
+    count=0
+    [ ! -f "$FAKE_HEALTH_STATE" ] || count=$(cat "$FAKE_HEALTH_STATE")
+    count=$((count + 1))
+    echo "$count" > "$FAKE_HEALTH_STATE"
+    if [ "$count" -ge "$FAKE_HEALTHY_AFTER" ]; then printf 200; else printf 000; fi
+    ;;
+  *serviceInstanceUpdate*) printf '%s\n' '{"data":{"serviceInstanceUpdate":true}}' ;;
+  *serviceInstanceDeployV2*) printf '%s\n' '{"data":{"serviceInstanceDeployV2":"deployment-test"}}' ;;
+  *'deployments(input:'*) printf '%s\n' '{"data":{"deployments":{"edges":[{"node":{"id":"deployment-test","status":"SUCCESS","createdAt":"2026-01-01T00:00:00Z"}}]}}}' ;;
+  *'deployment(id:'*) printf '%s\n' '{"data":{"deployment":{"id":"deployment-test","status":"SUCCESS"}}}' ;;
+  *buildLogs*) printf '%s\n' '{"data":{"buildLogs":[{"message":"build diagnostic"}]}}' ;;
+  *deploymentLogs*) printf '%s\n' '{"data":{"deploymentLogs":[{"message":"runtime diagnostic {\\"STEWARD_JWT_SECRET\\":\\"abc123def456\\"} STEWARD_MASTER_PASSWORD: hunter2 RAILWAY_TOKEN = token123 STEWARD_API_KEY=\\u0027single secret value\\u0027"}]}}' ;;
+  *) printf '%s\n' '{}' ;;
+esac
+`,
+  );
+  await writeFile(fakeSleep, '#!/bin/sh\n[ "$1" = "10" ] && exit 0\nexec /bin/sleep "$@"\n');
+  await Promise.all([chmod(fakeCurl, 0o755), chmod(fakeSleep, 0o755)]);
+
+  const process = Bun.spawn(["bash", SCRIPT, "sha-test"], {
+    cwd: repoRoot,
+    env: {
+      ...Bun.env,
+      PATH: `${dir}:${Bun.env.PATH ?? ""}`,
+      FAKE_HEALTH_STATE: stateFile,
+      FAKE_HEALTHY_AFTER: String(healthyAfter),
+      RAILWAY_TOKEN: "test-token",
+      RAILWAY_SERVICE_ID: "test-service",
+      RAILWAY_ENV_ID: "test-environment",
+      RAILWAY_HEALTH_URL: "https://example.test",
+      RAILWAY_HEALTH_TIMEOUT: String(healthTimeout),
+      RAILWAY_HEALTH_INTERVAL: "1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ]);
+  return { exitCode, output: stdout + stderr };
+}
+
 describe("SEC-129 railway-deploy.sh fails closed by default", () => {
   test("no-log control-plane rejection is a hard failure unless explicitly downgraded", () => {
-    // LOGS_EMPTY=1 must fail even when RAILWAY_STRICT is not set, so CI cannot
-    // green on a deploy that never happened.
     expect(source).not.toContain("RAILWAY_STRICT");
     expect(source).toContain("RAILWAY_ALLOW_REJECTED_DEPLOY:-false");
-    // finish_failure must exit 1 on the default path.
     const finish = source.match(/finish_failure\(\) \{([\s\S]*?)\n\}/)?.[1] ?? "";
     expect(finish).toContain("exit 0");
     expect(finish.trim().endsWith("exit 1")).toBe(true);
@@ -41,12 +100,16 @@ describe("SEC-129 railway-deploy.sh fails closed by default", () => {
 });
 
 describe("SEC-129 redact_secrets filter", () => {
-  test("redacts postgres DSN passwords, bearer tokens, KEY= assignments, stw_ keys, long hex", () => {
+  test("redacts postgres DSNs, bearer tokens, structured assignments, stw_ keys, and long hex", () => {
     const out = redact(
       [
         "connecting to postgresql://steward:hunter2@db.internal:5432/steward",
         "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig",
         "STEWARD_JWT_SECRET=abc123def456",
+        '{"STEWARD_JWT_SECRET":"json-secret-value"}',
+        "STEWARD_MASTER_PASSWORD: yaml-secret-value",
+        "RAILWAY_TOKEN = spaced-secret-value",
+        "STEWARD_API_KEY='single quoted secret value'",
         "tenant key stw_9f8e7d6c5b4a issued",
         "master 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef done",
         "ordinary log line stays",
@@ -55,9 +118,35 @@ describe("SEC-129 redact_secrets filter", () => {
     expect(out).not.toContain("hunter2");
     expect(out).not.toContain("eyJhbGciOiJIUzI1NiJ9.payload.sig");
     expect(out).not.toContain("abc123def456");
+    expect(out).not.toContain("json-secret-value");
+    expect(out).not.toContain("yaml-secret-value");
+    expect(out).not.toContain("spaced-secret-value");
+    expect(out).not.toContain("single quoted secret value");
     expect(out).not.toContain("9f8e7d6c5b4a");
     expect(out).not.toContain("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
     expect(out).toContain("postgresql://steward:");
     expect(out).toContain("ordinary log line stays");
+  });
+});
+
+describe("Railway staging deployment", () => {
+  test("waits through delayed health before accepting the deployment", async () => {
+    const result = await fakeRailwayRun(3);
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("Health check attempt 2: HTTP 000");
+    expect(result.output).toContain("Health check passed");
+  });
+
+  test("prints Railway diagnostics when health never becomes ready", async () => {
+    const result = await fakeRailwayRun(999, 2);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("Health check failed after 2 attempts / 2s");
+    expect(result.output).toContain("Railway deployment diagnostics");
+    expect(result.output).toContain("runtime diagnostic");
+    expect(result.output).not.toContain("abc123def456");
+    expect(result.output).not.toContain("hunter2");
+    expect(result.output).not.toContain("token123");
+    expect(result.output).not.toContain("single secret value");
+    expect(result.output).toContain("…REDACTED…");
   });
 });

--- a/scripts/__tests__/railway-deploy.test.ts
+++ b/scripts/__tests__/railway-deploy.test.ts
@@ -31,6 +31,7 @@ async function fakeRailwayRun(healthyAfter: number, healthTimeout = 4) {
   const dir = await mkdtemp(join(tmpdir(), "steward-railway-deploy-"));
   temporaryDirectories.push(dir);
   const stateFile = join(dir, "health-attempts");
+  const curlLog = join(dir, "curl-arguments");
   const fakeCurl = join(dir, "curl");
   const fakeSleep = join(dir, "sleep");
 
@@ -38,6 +39,7 @@ async function fakeRailwayRun(healthyAfter: number, healthTimeout = 4) {
     fakeCurl,
     `#!/bin/sh
 args="$*"
+printf '%s\n' "$args" >> "$FAKE_CURL_LOG"
 case "$args" in
   *example.test/health*)
     count=0
@@ -65,6 +67,7 @@ esac
       ...Bun.env,
       PATH: `${dir}:${Bun.env.PATH ?? ""}`,
       FAKE_HEALTH_STATE: stateFile,
+      FAKE_CURL_LOG: curlLog,
       FAKE_HEALTHY_AFTER: String(healthyAfter),
       RAILWAY_TOKEN: "test-token",
       RAILWAY_SERVICE_ID: "test-service",
@@ -81,7 +84,8 @@ esac
     new Response(process.stdout).text(),
     new Response(process.stderr).text(),
   ]);
-  return { exitCode, output: stdout + stderr };
+  const curlArguments = await Bun.file(curlLog).text();
+  return { exitCode, output: stdout + stderr, curlArguments };
 }
 
 describe("SEC-129 railway-deploy.sh fails closed by default", () => {
@@ -108,6 +112,7 @@ describe("SEC-129 redact_secrets filter", () => {
         "rediss cache rediss://:encoded%40password@cache.internal:6380/0",
         "broker amqps://worker:broker-password@mq.internal/vhost",
         "callback https://agent:http-password@example.test/callback",
+        "token-user https://opaque-access-token@example.test/private",
         "signed https://objects.example.test/item?X-Amz-Credential=aws-credential&X-Amz-Signature=aws-signature&safe=visible",
         "oauth https://example.test/callback?code=oauth-code&state=visible-state&access_token=oauth-token",
         'CACHE_URL="redis://default:quoted-url-secret@cache.internal:6379/0"',
@@ -131,6 +136,7 @@ describe("SEC-129 redact_secrets filter", () => {
     expect(out).not.toContain("encoded%40password");
     expect(out).not.toContain("broker-password");
     expect(out).not.toContain("http-password");
+    expect(out).not.toContain("opaque-access-token");
     expect(out).not.toContain("aws-credential");
     expect(out).not.toContain("aws-signature");
     expect(out).not.toContain("oauth-code");
@@ -161,6 +167,12 @@ describe("Railway staging deployment", () => {
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain("Health check attempt 2: HTTP 000");
     expect(result.output).toContain("Health check passed");
+    for (const call of result.curlArguments
+      .split("\n")
+      .filter((line) => line.includes("graphql"))) {
+      expect(call).toContain("--connect-timeout 5");
+      expect(call).toContain("--max-time 20");
+    }
   }, 15_000);
 
   test("prints Railway diagnostics when health never becomes ready", async () => {
@@ -179,5 +191,12 @@ describe("Railway staging deployment", () => {
     expect(result.output).not.toContain("oauth-code-secret");
     expect(result.output).toContain("state=public-state");
     expect(result.output).toContain("…REDACTED…");
+    expect(result.output).not.toContain('Response: {"data"');
+    for (const call of result.curlArguments
+      .split("\n")
+      .filter((line) => line.includes("graphql"))) {
+      expect(call).toContain("--connect-timeout 5");
+      expect(call).toContain("--max-time 20");
+    }
   }, 15_000);
 });

--- a/scripts/__tests__/railway-deploy.test.ts
+++ b/scripts/__tests__/railway-deploy.test.ts
@@ -9,6 +9,7 @@ import { readFileSync } from "node:fs";
 import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { isPublicIp, resolvePublicHttpsOrigin } from "../validate-public-origin.mjs";
 
 const repoRoot = resolve(import.meta.dir, "../..");
 const SCRIPT = join(repoRoot, "scripts/railway-deploy.sh");
@@ -33,6 +34,7 @@ async function fakeRailwayRun(
   readyAfter = 1,
   healthUrl: string | null = "https://example.test",
   remoteIp = "1.1.1.1",
+  dnsAnswers = "1.1.1.1",
 ) {
   const dir = await mkdtemp(join(tmpdir(), "steward-railway-deploy-"));
   temporaryDirectories.push(dir);
@@ -40,6 +42,7 @@ async function fakeRailwayRun(
   const readyStateFile = join(dir, "ready-attempts");
   const curlLog = join(dir, "curl-arguments");
   const fakeCurl = join(dir, "curl");
+  const fakeNode = join(dir, "node");
   const fakeSleep = join(dir, "sleep");
 
   await writeFile(
@@ -72,10 +75,27 @@ case "$args" in
 esac
 `,
   );
+  await writeFile(
+    fakeNode,
+    `#!/bin/sh
+if [ "\${2:-}" = "--resolve-origin" ]; then
+  origin=$($REAL_NODE "$1" "$3") || exit 1
+  old_ifs=$IFS
+  IFS=,
+  for address in $FAKE_DNS_ANSWERS; do
+    "$REAL_NODE" "$1" --ip "$address" >/dev/null 2>&1 || exit 1
+  done
+  IFS=$old_ifs
+  printf %s "$origin"
+  exit 0
+fi
+exec "$REAL_NODE" "$@"
+`,
+  );
   await writeFile(fakeSleep, '#!/bin/sh\n[ "$1" = "10" ] && exit 0\nexec /bin/sleep "$@"\n');
-  await Promise.all([chmod(fakeCurl, 0o755), chmod(fakeSleep, 0o755)]);
+  await Promise.all([chmod(fakeCurl, 0o755), chmod(fakeNode, 0o755), chmod(fakeSleep, 0o755)]);
 
-  const process = Bun.spawn(["bash", SCRIPT, "sha-test"], {
+  const child = Bun.spawn(["bash", SCRIPT, "sha-test"], {
     cwd: repoRoot,
     env: {
       ...Bun.env,
@@ -86,6 +106,8 @@ esac
       FAKE_HEALTHY_AFTER: String(healthyAfter),
       FAKE_READY_AFTER: String(readyAfter),
       FAKE_REMOTE_IP: remoteIp,
+      FAKE_DNS_ANSWERS: dnsAnswers,
+      REAL_NODE: process.execPath,
       RAILWAY_TOKEN: "test-token",
       RAILWAY_SERVICE_ID: "test-service",
       RAILWAY_ENV_ID: "test-environment",
@@ -97,9 +119,9 @@ esac
     stderr: "pipe",
   });
   const [exitCode, stdout, stderr] = await Promise.all([
-    process.exited,
-    new Response(process.stdout).text(),
-    new Response(process.stderr).text(),
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
   ]);
   const curlArguments = (await Bun.file(curlLog).exists()) ? await Bun.file(curlLog).text() : "";
   return { exitCode, output: stdout + stderr, curlArguments };
@@ -195,8 +217,12 @@ describe("Railway staging deployment", () => {
     "https://127.0.0.1",
     "https://10.0.0.1",
     "https://169.254.1.1",
+    "https://192.88.99.1",
     "https://[::1]",
     "https://[fc00::1]",
+    "https://[2001:2::1]",
+    "https://[2001:10::1]",
+    "https://[3fff::1]",
   ]) {
     test(`rejects ${invalidOrigin.split(":")[0]} invalid probe authority before mutation`, async () => {
       const result = await fakeRailwayRun(1, 2, 1, invalidOrigin);
@@ -206,6 +232,20 @@ describe("Railway staging deployment", () => {
       expect(result.output).not.toContain("secret");
     });
   }
+
+  test("rejects any private DNS answer before the first deployment mutation", async () => {
+    const result = await fakeRailwayRun(
+      1,
+      2,
+      1,
+      "https://example.test",
+      "1.1.1.1",
+      "1.1.1.1,10.0.0.8",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.curlArguments).not.toContain("serviceInstanceUpdate");
+    expect(result.curlArguments).not.toContain("serviceInstanceDeployV2");
+  });
 
   test("waits through delayed health before accepting the deployment", async () => {
     const result = await fakeRailwayRun(3);
@@ -258,4 +298,37 @@ describe("Railway staging deployment", () => {
       expect(call).toContain("--max-time 20");
     }
   }, 15_000);
+});
+
+describe("public deployment authority classification", () => {
+  test("conservatively rejects special-purpose IPv4 and IPv6 registries", () => {
+    for (const address of [
+      "192.88.99.1",
+      "2001:2::1",
+      "2001:10::1",
+      "2001:db8::1",
+      "3fff::1",
+      "fc00::1",
+    ]) {
+      expect(isPublicIp(address)).toBe(false);
+    }
+    for (const address of ["1.1.1.1", "8.8.8.8", "2606:4700:4700::1111"]) {
+      expect(isPublicIp(address)).toBe(true);
+    }
+  });
+
+  test("rejects a hostname when any resolved address is non-public", async () => {
+    await expect(
+      resolvePublicHttpsOrigin("https://health.example", async () => [
+        { address: "1.1.1.1", family: 4 },
+        { address: "2001:10::1", family: 6 },
+      ]),
+    ).rejects.toThrow("non-public");
+    await expect(
+      resolvePublicHttpsOrigin("https://health.example", async () => [
+        { address: "1.1.1.1", family: 4 },
+        { address: "2606:4700:4700::1111", family: 6 },
+      ]),
+    ).resolves.toBe("https://health.example");
+  });
 });

--- a/scripts/__tests__/railway-deploy.test.ts
+++ b/scripts/__tests__/railway-deploy.test.ts
@@ -51,7 +51,7 @@ case "$args" in
   *'deployments(input:'*) printf '%s\n' '{"data":{"deployments":{"edges":[{"node":{"id":"deployment-test","status":"SUCCESS","createdAt":"2026-01-01T00:00:00Z"}}]}}}' ;;
   *'deployment(id:'*) printf '%s\n' '{"data":{"deployment":{"id":"deployment-test","status":"SUCCESS"}}}' ;;
   *buildLogs*) printf '%s\n' '{"data":{"buildLogs":[{"message":"build diagnostic"}]}}' ;;
-  *deploymentLogs*) printf '%s\n' '{"data":{"deploymentLogs":[{"message":"runtime diagnostic {\\"STEWARD_JWT_SECRET\\":\\"abc123def456\\"} STEWARD_MASTER_PASSWORD: hunter2 RAILWAY_TOKEN = token123 STEWARD_API_KEY=\\u0027single secret value\\u0027"}]}}' ;;
+  *deploymentLogs*) printf '%s\n' '{"data":{"deploymentLogs":[{"message":"runtime diagnostic {\\"STEWARD_JWT_SECRET\\":\\"abc123def456\\",\\"CACHE_URL\\":\\"rediss://default:redis-json-secret@cache.internal:6380/0\\"} STEWARD_MASTER_PASSWORD: hunter2 RAILWAY_TOKEN = token123 STEWARD_API_KEY=\\u0027single secret value\\u0027 BROKER_URI=amqps://worker:broker-secret@mq.internal/vhost WEBHOOK_URL=https://hooks.example.test/webhook-path-secret callback=https://example.test/callback?code=oauth-code-secret&state=public-state"}]}}' ;;
   *) printf '%s\n' '{}' ;;
 esac
 `,
@@ -100,10 +100,21 @@ describe("SEC-129 railway-deploy.sh fails closed by default", () => {
 });
 
 describe("SEC-129 redact_secrets filter", () => {
-  test("redacts postgres DSNs, bearer tokens, structured assignments, stw_ keys, and long hex", () => {
+  test("redacts credential-bearing URIs, sensitive query parameters, structured assignments, stw_ keys, and long hex", () => {
     const out = redact(
       [
         "connecting to postgresql://steward:hunter2@db.internal:5432/steward",
+        "redis cache redis://default:redis-password@cache.internal:6379/0",
+        "rediss cache rediss://:encoded%40password@cache.internal:6380/0",
+        "broker amqps://worker:broker-password@mq.internal/vhost",
+        "callback https://agent:http-password@example.test/callback",
+        "signed https://objects.example.test/item?X-Amz-Credential=aws-credential&X-Amz-Signature=aws-signature&safe=visible",
+        "oauth https://example.test/callback?code=oauth-code&state=visible-state&access_token=oauth-token",
+        'CACHE_URL="redis://default:quoted-url-secret@cache.internal:6379/0"',
+        "BROKER_URI='amqps://worker:single-url-secret@mq.internal/vhost'",
+        '{"DATABASE_DSN":"postgresql://steward:json-url-secret@db.internal/steward"}',
+        "UPSTREAM_URL: https://user:yaml-url-secret@example.test/path",
+        "WEBHOOK_URL=https://hooks.example.test/unguessable-path-secret",
         "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig",
         "STEWARD_JWT_SECRET=abc123def456",
         '{"STEWARD_JWT_SECRET":"json-secret-value"}',
@@ -116,6 +127,19 @@ describe("SEC-129 redact_secrets filter", () => {
       ].join("\n"),
     );
     expect(out).not.toContain("hunter2");
+    expect(out).not.toContain("redis-password");
+    expect(out).not.toContain("encoded%40password");
+    expect(out).not.toContain("broker-password");
+    expect(out).not.toContain("http-password");
+    expect(out).not.toContain("aws-credential");
+    expect(out).not.toContain("aws-signature");
+    expect(out).not.toContain("oauth-code");
+    expect(out).not.toContain("oauth-token");
+    expect(out).not.toContain("quoted-url-secret");
+    expect(out).not.toContain("single-url-secret");
+    expect(out).not.toContain("json-url-secret");
+    expect(out).not.toContain("yaml-url-secret");
+    expect(out).not.toContain("unguessable-path-secret");
     expect(out).not.toContain("eyJhbGciOiJIUzI1NiJ9.payload.sig");
     expect(out).not.toContain("abc123def456");
     expect(out).not.toContain("json-secret-value");
@@ -125,6 +149,8 @@ describe("SEC-129 redact_secrets filter", () => {
     expect(out).not.toContain("9f8e7d6c5b4a");
     expect(out).not.toContain("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
     expect(out).toContain("postgresql://steward:");
+    expect(out).toContain("safe=visible");
+    expect(out).toContain("state=visible-state");
     expect(out).toContain("ordinary log line stays");
   });
 });
@@ -140,13 +166,18 @@ describe("Railway staging deployment", () => {
   test("prints Railway diagnostics when health never becomes ready", async () => {
     const result = await fakeRailwayRun(999, 2);
     expect(result.exitCode).toBe(1);
-    expect(result.output).toContain("Health check failed after 2 attempts / 2s");
+    expect(result.output).toMatch(/Health check failed after [1-9][0-9]* attempts? \/ 2s/);
     expect(result.output).toContain("Railway deployment diagnostics");
     expect(result.output).toContain("runtime diagnostic");
     expect(result.output).not.toContain("abc123def456");
     expect(result.output).not.toContain("hunter2");
     expect(result.output).not.toContain("token123");
     expect(result.output).not.toContain("single secret value");
+    expect(result.output).not.toContain("redis-json-secret");
+    expect(result.output).not.toContain("broker-secret");
+    expect(result.output).not.toContain("webhook-path-secret");
+    expect(result.output).not.toContain("oauth-code-secret");
+    expect(result.output).toContain("state=public-state");
     expect(result.output).toContain("…REDACTED…");
   });
 });

--- a/scripts/__tests__/runtime-error-log-safety.test.ts
+++ b/scripts/__tests__/runtime-error-log-safety.test.ts
@@ -418,5 +418,5 @@ describe("runtime error logging", () => {
       }
     }
     expect(failures).toEqual([]);
-  });
+  }, 15_000);
 });

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -67,6 +67,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 REMOTE_DIR="/opt/steward"
+REMOTE_MIGRATION_ENV="${REMOTE_DIR}/.env.migrate"
 BUN="/root/.bun/bin/bun"
 
 # Host-key checking: TOFU (accept-new) at minimum — never "no" (SEC-019).
@@ -115,16 +116,39 @@ fi
 # 3. Migrations
 # ---------------------------------------------------------------------------
 if $DO_MIGRATE; then
-  log "Running migrations on $NODE_IP via drizzle migrator ..."
+  log "Running complete release migrations on $NODE_IP ..."
 
-  # Source DATABASE_URL from remote .env and run the in-app migrator. This uses
-  # drizzle's __drizzle_migrations tracking table, acquires an advisory lock
-  # for multi-replica safety, and backfills the tracking table on first run
-  # against a DB that was previously migrated by the old psql loop.
-  if remote "cd $REMOTE_DIR && set -a && . ./.env && set +a && $BUN packages/db/src/migrate.ts"; then
-    ok "Migrations complete"
+  # Privileged database URLs must live in the root-only migration environment,
+  # never in the API service's .env. Apply core + enabled-plugin journals as the
+  # dedicated migrator, then restore bootstrap ownership/ACLs as the provider
+  # operator, and finally activate the exact RLS inventory as the migrator.
+  # rls-bootstrap.sql requires a PostgreSQL superuser or provider-equivalent
+  # able to create/alter BYPASSRLS roles; CREATEROLE alone is insufficient.
+  MIGRATION_COMMAND=$(cat <<EOF
+cd $REMOTE_DIR &&
+test -f '.env' &&
+test -f '$REMOTE_MIGRATION_ENV' &&
+test -O '$REMOTE_MIGRATION_ENV' &&
+test "\$(stat -c '%a' '$REMOTE_MIGRATION_ENV')" = 600 &&
+set -a && . '.env' && . '$REMOTE_MIGRATION_ENV' && set +a &&
+: "\${STEWARD_MIGRATION_DATABASE_URL:?missing STEWARD_MIGRATION_DATABASE_URL}" &&
+: "\${STEWARD_OPERATOR_DATABASE_URL:?missing STEWARD_OPERATOR_DATABASE_URL}" &&
+DATABASE_URL="\$STEWARD_MIGRATION_DATABASE_URL" $BUN run --cwd packages/api migrate &&
+PGDATABASE="\$STEWARD_OPERATOR_DATABASE_URL" psql --no-psqlrc \
+  -v steward_app_role="\${STEWARD_APP_DATABASE_ROLE:-steward_app}" \
+  -v steward_migration_role="\${STEWARD_MIGRATION_DATABASE_ROLE:-steward_migrator}" \
+  -v steward_bootstrap_role="\${STEWARD_BOOTSTRAP_DATABASE_ROLE:-steward_bootstrap_owner}" \
+  -v steward_platform_role="\${STEWARD_PLATFORM_DATABASE_ROLE:-steward_platform}" \
+  -f scripts/postgres/rls-bootstrap.sql &&
+PGDATABASE="\$STEWARD_MIGRATION_DATABASE_URL" psql --no-psqlrc \
+  -v steward_migration_role="\${STEWARD_MIGRATION_DATABASE_ROLE:-steward_migrator}" \
+  -f scripts/postgres/rls-activate.sql
+EOF
+)
+  if remote "$MIGRATION_COMMAND"; then
+    ok "Core/plugin migrations, bootstrap reconciliation, and RLS activation complete"
   else
-    fail "Migration failed, aborting"
+    fail "Release migration/bootstrap/activation failed, aborting"
     exit 1
   fi
 fi

--- a/scripts/postgres/rls-activate.sql
+++ b/scripts/postgres/rls-activate.sql
@@ -20,6 +20,11 @@ DO $$
 DECLARE
   relation_name text;
 BEGIN
+  IF current_user <> current_setting('steward.activation.migration_role')
+     OR session_user <> current_setting('steward.activation.migration_role') THEN
+    RAISE EXCEPTION 'SEC-169 activation must connect directly as the migration role';
+  END IF;
+
   FOR relation_name IN
     SELECT inventory.relation_name
     FROM steward_expected_rls_policies inventory

--- a/scripts/postgres/rls-bootstrap.sql
+++ b/scripts/postgres/rls-bootstrap.sql
@@ -74,6 +74,8 @@ REVOKE ALL ON ALL FUNCTIONS IN SCHEMA steward_rls FROM PUBLIC;
 SELECT format('GRANT %I TO %I', :'steward_migration_role', current_user) \gexec
 SELECT format('GRANT USAGE, CREATE ON SCHEMA public TO %I', :'steward_migration_role') \gexec
 SELECT format('GRANT USAGE ON SCHEMA public, steward_bootstrap, steward_rls TO %I', :'steward_app_role') \gexec
+SELECT format('GRANT USAGE ON SCHEMA drizzle TO %I', :'steward_app_role') \gexec
+SELECT format('GRANT SELECT ON TABLE drizzle.__drizzle_migrations TO %I', :'steward_app_role') \gexec
 SELECT format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA steward_bootstrap, steward_rls TO %I', :'steward_app_role') \gexec
 SELECT format(
   'REVOKE EXECUTE ON FUNCTION '
@@ -212,6 +214,19 @@ BEGIN
      OR has_schema_privilege(current_setting('steward.bootstrap.app_role'), 'steward_bootstrap', 'CREATE')
      OR has_schema_privilege(current_setting('steward.bootstrap.app_role'), 'steward_rls', 'CREATE') THEN
     RAISE EXCEPTION 'SEC-169 app role must not create schema objects';
+  END IF;
+  IF NOT has_schema_privilege(
+       current_setting('steward.bootstrap.app_role'), 'drizzle', 'USAGE'
+     ) OR NOT has_table_privilege(
+       current_setting('steward.bootstrap.app_role'),
+       'drizzle.__drizzle_migrations',
+       'SELECT'
+     ) OR has_table_privilege(
+       current_setting('steward.bootstrap.app_role'),
+       'drizzle.__drizzle_migrations',
+       'INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
+     ) THEN
+    RAISE EXCEPTION 'SEC-169 app role must have read-only migration readiness access';
   END IF;
   IF NOT has_schema_privilege(
        current_setting('steward.bootstrap.platform_role'), 'steward_rls', 'USAGE'

--- a/scripts/postgres/rls-bootstrap.sql
+++ b/scripts/postgres/rls-bootstrap.sql
@@ -76,6 +76,13 @@ SELECT format('GRANT USAGE, CREATE ON SCHEMA public TO %I', :'steward_migration_
 SELECT format('GRANT USAGE ON SCHEMA public, steward_bootstrap, steward_rls TO %I', :'steward_app_role') \gexec
 SELECT format('GRANT USAGE ON SCHEMA drizzle TO %I', :'steward_app_role') \gexec
 SELECT format('GRANT SELECT ON TABLE drizzle.__drizzle_migrations TO %I', :'steward_app_role') \gexec
+SELECT format('GRANT SELECT ON TABLE %I.%I TO %I', n.nspname, c.relname, :'steward_app_role')
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'drizzle'
+  AND c.relkind IN ('r', 'p')
+  AND c.relname LIKE '__drizzle_migrations_plugin\_%' ESCAPE '\'
+ORDER BY c.relname \gexec
 SELECT format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA steward_bootstrap, steward_rls TO %I', :'steward_app_role') \gexec
 SELECT format(
   'REVOKE EXECUTE ON FUNCTION '

--- a/scripts/railway-deploy.sh
+++ b/scripts/railway-deploy.sh
@@ -20,6 +20,8 @@ set -euo pipefail
 #   DEPLOY_TIMEOUT      (optional) max seconds to wait for deploy, default: 300
 #   RAILWAY_HEALTH_TIMEOUT  (optional) max seconds to wait for health, default: 120
 #   RAILWAY_HEALTH_INTERVAL (optional) seconds between health probes, default: 5
+#   RAILWAY_API_CONNECT_TIMEOUT (optional) GraphQL connect bound, default: 5
+#   RAILWAY_API_TIMEOUT (optional) GraphQL request bound, default: 20
 #   RAILWAY_ALLOW_REJECTED_DEPLOY (optional, default: fail closed) when "true",
 #                       a deployment Railway rejected before any container ran
 #                       (no build/deploy logs) degrades to a non-fatal warning
@@ -54,6 +56,8 @@ HEALTH_URL="${RAILWAY_HEALTH_URL:-}"
 TIMEOUT="${DEPLOY_TIMEOUT:-300}"
 HEALTH_TIMEOUT="${RAILWAY_HEALTH_TIMEOUT:-120}"
 HEALTH_INTERVAL="${RAILWAY_HEALTH_INTERVAL:-5}"
+API_CONNECT_TIMEOUT="${RAILWAY_API_CONNECT_TIMEOUT:-5}"
+API_TIMEOUT="${RAILWAY_API_TIMEOUT:-20}"
 API="https://backboard.railway.com/graphql/v2"
 
 DRY_RUN=false
@@ -97,8 +101,10 @@ fi
 
 if [[ ! "$TIMEOUT" =~ ^[1-9][0-9]*$ ||
       ! "$HEALTH_TIMEOUT" =~ ^[1-9][0-9]*$ ||
-      ! "$HEALTH_INTERVAL" =~ ^[1-9][0-9]*$ ]]; then
-  fail "DEPLOY_TIMEOUT, RAILWAY_HEALTH_TIMEOUT, and RAILWAY_HEALTH_INTERVAL must be positive integers"
+      ! "$HEALTH_INTERVAL" =~ ^[1-9][0-9]*$ ||
+      ! "$API_CONNECT_TIMEOUT" =~ ^[1-9][0-9]*$ ||
+      ! "$API_TIMEOUT" =~ ^[1-9][0-9]*$ ]]; then
+  fail "deploy, health, and Railway API timeouts must be positive integers"
   exit 1
 fi
 
@@ -117,12 +123,55 @@ fi
 
 FULL_IMAGE="${IMAGE_REPO}:${IMAGE_TAG}"
 
+# Redact every externally supplied diagnostic before it reaches CI. This covers
+# credential-bearing URLs (Postgres, Redis, brokers, generic HTTP userinfo),
+# sensitive query parameters, structured assignments, bearer tokens, Steward
+# keys, and long cryptographic material.
+redact_secrets() {
+  sed -E \
+    -e 's#([A-Za-z][A-Za-z0-9+.-]*://[^/@[:space:]:]*:)[^@/[:space:]]+@#\1…REDACTED…@#g' \
+    -e 's#([A-Za-z][A-Za-z0-9+.-]*://)[^/:@[:space:]]+@#\1…REDACTED…@#g' \
+    -e 's#([?&](access_key|access_token|api_key|apikey|auth|authorization|client_secret|code|credential|key|password|passwd|pwd|secret|signature|sig|token|x-amz-credential|x-amz-security-token|x-amz-signature)=)[^&#"'"'"'[:space:]]+#\1…REDACTED…#gI' \
+    -e 's/(Bearer )[A-Za-z0-9._~+/-]+/\1…REDACTED…/g' \
+    -e 's/(([A-Za-z_][A-Za-z0-9_]*_(URL|URI|DSN)|URL|URI|DSN)"[[:space:]]*:[[:space:]]*")[^"]*/\1…REDACTED…/gI' \
+    -e 's/(([A-Za-z_][A-Za-z0-9_]*_(URL|URI|DSN)|URL|URI|DSN)[[:space:]]*[:=][[:space:]]*")[^"]*/\1…REDACTED…/gI' \
+    -e "s/(([A-Za-z_][A-Za-z0-9_]*_(URL|URI|DSN)|URL|URI|DSN)[[:space:]]*[:=][[:space:]]*')[^']*/\1…REDACTED…/gI" \
+    -e 's/(([A-Za-z_][A-Za-z0-9_]*_(URL|URI|DSN)|URL|URI|DSN)[[:space:]]*[:=][[:space:]]*)[^[:space:],}]+/\1…REDACTED…/gI' \
+    -e 's/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*"[[:space:]]*:[[:space:]]*")[^"]*/\1…REDACTED…/g' \
+    -e 's/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*[[:space:]]*[:=][[:space:]]*")[^"]*/\1…REDACTED…/g' \
+    -e "s/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*[[:space:]]*[:=][[:space:]]*')[^']*/\1…REDACTED…/g" \
+    -e 's/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*[[:space:]]*[:=][[:space:]]*)[^[:space:],}]+/\1…REDACTED…/g' \
+    -e 's/(^|[^A-Za-z0-9_])stw_[A-Za-z0-9]+/\1stw_…REDACTED…/g' \
+    -e 's/(^|[^0-9a-fA-F])[0-9a-fA-F]{48,}([^0-9a-fA-F]|$)/\1…REDACTED…\2/g'
+}
+
+redacted_text() {
+  printf '%s' "${1:-}" | redact_secrets
+}
+
+# Never print a raw GraphQL response: arbitrary provider messages can echo
+# request variables or deployment environment values. Keep only error code and
+# redacted message when the response is valid JSON.
+graphql_diagnostic() {
+  local response="${1:-}"
+  local diagnostic
+  diagnostic=$(printf '%s' "$response" | jq -c \
+    '[.errors[]? | {code: (.extensions.code // "UNKNOWN"), message: (.message // "request failed")}]' \
+    2>/dev/null) || diagnostic=""
+  if [[ -n "$diagnostic" && "$diagnostic" != "[]" ]]; then
+    redacted_text "$diagnostic"
+  else
+    printf '%s' '<no safe GraphQL diagnostic available>'
+  fi
+}
+
 # ---------------------------------------------------------------------------
 # Helper: GraphQL request
 # ---------------------------------------------------------------------------
 gql() {
   local query="$1"
-  curl -sf -X POST "$API" \
+  curl -sf --connect-timeout "$API_CONNECT_TIMEOUT" --max-time "$API_TIMEOUT" \
+    -X POST "$API" \
     -H "Authorization: Bearer ${RAILWAY_TOKEN}" \
     -H "Content-Type: application/json" \
     -d "$query"
@@ -170,13 +219,13 @@ START_TS=$(date -u +%s)
 
 CONNECT_RESULT=$(gql "$CONNECT_PAYLOAD" 2>&1) || {
   fail "serviceInstanceUpdate mutation failed"
-  fail "Response: $CONNECT_RESULT"
+  fail "Response: $(graphql_diagnostic "$CONNECT_RESULT")"
   exit 1
 }
 
 # Check for GraphQL errors
 if echo "$CONNECT_RESULT" | jq -e '.errors' >/dev/null 2>&1; then
-  fail "GraphQL error: $(echo "$CONNECT_RESULT" | jq -r '.errors[0].message')"
+  fail "GraphQL error: $(graphql_diagnostic "$CONNECT_RESULT")"
   exit 1
 fi
 
@@ -195,7 +244,7 @@ DEPLOY_PAYLOAD=$(jq -n \
 
 DEPLOY_TRIGGER=$(gql "$DEPLOY_PAYLOAD" 2>&1) || DEPLOY_TRIGGER=""
 if echo "$DEPLOY_TRIGGER" | jq -e '.errors' >/dev/null 2>&1; then
-  warn "serviceInstanceDeploy returned an error (service may auto-deploy on connect): $(echo "$DEPLOY_TRIGGER" | jq -r '.errors[0].message' 2>/dev/null)"
+  warn "serviceInstanceDeploy returned an error (service may auto-deploy on connect): $(graphql_diagnostic "$DEPLOY_TRIGGER")"
 else
   TRIGGER_DEPLOY_ID=$(echo "$DEPLOY_TRIGGER" | jq -r '.data.serviceInstanceDeployV2 // ""' 2>/dev/null) || TRIGGER_DEPLOY_ID=""
   [[ -n "$TRIGGER_DEPLOY_ID" ]] && ok "Triggered deployment ${TRIGGER_DEPLOY_ID}"
@@ -222,10 +271,11 @@ DEPLOY_ID=""
 # missing required env var on the Railway service) or an image-pull error — the
 # logs below are what tell the operator which. Uses a non-failing curl (the
 # normal gql() helper uses `curl -sf`, which drops the body on any HTTP error)
-# and prints RAW responses so a wrong field name / auth-scope problem is still
-# visible rather than silently swallowed.
+# and reports only whitelisted/redacted diagnostics; raw GraphQL responses may
+# contain echoed variables or provider secrets and are never printed.
 gql_raw() {
-  curl -s -X POST "$API" \
+  curl -s --connect-timeout "$API_CONNECT_TIMEOUT" --max-time "$API_TIMEOUT" \
+    -X POST "$API" \
     -H "Authorization: Bearer ${RAILWAY_TOKEN}" \
     -H "Content-Type: application/json" \
     -d "$1" 2>/dev/null
@@ -237,26 +287,6 @@ gql_raw() {
 # app/code regression). 0 when the container actually produced output (a real
 # crash/health failure that SHOULD fail the pipeline).
 LOGS_EMPTY=0
-
-# Redact obvious secret shapes before printing build/deploy logs to CI
-# stderr: a crash-looped container may have echoed config (DATABASE_URL,
-# STEWARD_* secrets, Bearer tokens) to its logs (SEC-129).
-redact_secrets() {
-  sed -E \
-    -e 's#([A-Za-z][A-Za-z0-9+.-]*://[^/@[:space:]:]*:)[^@/[:space:]]+@#\1…REDACTED…@#g' \
-    -e 's#([?&](access_key|access_token|api_key|apikey|auth|authorization|client_secret|code|credential|key|password|passwd|pwd|secret|signature|sig|token|x-amz-credential|x-amz-security-token|x-amz-signature)=)[^&#"'"'"'[:space:]]+#\1…REDACTED…#gI' \
-    -e 's/(Bearer )[A-Za-z0-9._~+/-]+/\1…REDACTED…/g' \
-    -e 's/(([A-Za-z_][A-Za-z0-9_]*_(URL|URI|DSN)|URL|URI|DSN)"[[:space:]]*:[[:space:]]*")[^"]*/\1…REDACTED…/gI' \
-    -e 's/(([A-Za-z_][A-Za-z0-9_]*_(URL|URI|DSN)|URL|URI|DSN)[[:space:]]*[:=][[:space:]]*")[^"]*/\1…REDACTED…/gI' \
-    -e "s/(([A-Za-z_][A-Za-z0-9_]*_(URL|URI|DSN)|URL|URI|DSN)[[:space:]]*[:=][[:space:]]*')[^']*/\1…REDACTED…/gI" \
-    -e 's/(([A-Za-z_][A-Za-z0-9_]*_(URL|URI|DSN)|URL|URI|DSN)[[:space:]]*[:=][[:space:]]*)[^[:space:],}]+/\1…REDACTED…/gI' \
-    -e 's/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*"[[:space:]]*:[[:space:]]*")[^"]*/\1…REDACTED…/g' \
-    -e 's/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*[[:space:]]*[:=][[:space:]]*")[^"]*/\1…REDACTED…/g' \
-    -e "s/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*[[:space:]]*[:=][[:space:]]*')[^']*/\1…REDACTED…/g" \
-    -e 's/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*[[:space:]]*[:=][[:space:]]*)[^[:space:],}]+/\1…REDACTED…/g' \
-    -e 's/(^|[^A-Za-z0-9_])stw_[A-Za-z0-9]+/\1stw_…REDACTED…/g' \
-    -e 's/(^|[^0-9a-fA-F])[0-9a-fA-F]{48,}([^0-9a-fA-F]|$)/\1…REDACTED…\2/g'
-}
 
 dump_failure() {
   LOGS_EMPTY=0
@@ -276,7 +306,10 @@ dump_failure() {
   q=$(jq -n --arg id "$DEPLOY_ID" \
     '{query: "query($id: String!) { deployment(id: $id) { id status createdAt staticUrl url canRedeploy } }", variables: {id: $id}}')
   resp=$(gql_raw "$q")
-  fail "deployment: ${resp:-<empty response>}"
+  local deployment_summary
+  deployment_summary=$(printf '%s' "${resp:-}" | jq -c \
+    '.data.deployment | {id, status, createdAt, canRedeploy}' 2>/dev/null) || deployment_summary=""
+  fail "deployment: ${deployment_summary:-$(graphql_diagnostic "$resp")}"
 
   q=$(jq -n --arg id "$DEPLOY_ID" \
     '{query: "query($id: String!) { buildLogs(deploymentId: $id, limit: 200) { message } }", variables: {id: $id}}')
@@ -286,7 +319,7 @@ dump_failure() {
   if [[ -n "$build_logs" ]]; then
     echo "$build_logs" | redact_secrets >&2
   else
-    fail "${resp:-<empty response>}"
+    fail "$(graphql_diagnostic "$resp")"
   fi
 
   q=$(jq -n --arg id "$DEPLOY_ID" \
@@ -297,7 +330,7 @@ dump_failure() {
   if [[ -n "$deploy_logs" ]]; then
     echo "$deploy_logs" | redact_secrets >&2
   else
-    fail "${resp:-<empty response>}"
+    fail "$(graphql_diagnostic "$resp")"
   fi
   fail "----------------------------------------"
 

--- a/scripts/railway-deploy.sh
+++ b/scripts/railway-deploy.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 #   RAILWAY_ENV_ID      (REQUIRED) the deployer's own Railway environment id
 #   RAILWAY_IMAGE_REPO  (optional) default: ghcr.io/steward-fi/steward (the
 #                                  canonical published OSS image)
-#   RAILWAY_HEALTH_URL  (optional) the deployer's own /health URL to verify
+#   RAILWAY_HEALTH_URL  (required) the deployer's public HTTPS root origin
 #   DEPLOY_TIMEOUT      (optional) max seconds to wait for deploy, default: 300
 #   RAILWAY_HEALTH_TIMEOUT  (optional) max seconds to wait for health, default: 120
 #   RAILWAY_HEALTH_INTERVAL (optional) seconds between health probes, default: 5
@@ -53,7 +53,6 @@ SERVICE_ID="${RAILWAY_SERVICE_ID:-}"
 ENV_ID="${RAILWAY_ENV_ID:-}"
 IMAGE_REPO="${RAILWAY_IMAGE_REPO:-ghcr.io/steward-fi/steward}"
 HEALTH_URL="${RAILWAY_HEALTH_URL:-}"
-HEALTH_URL="${HEALTH_URL%/}"
 TIMEOUT="${DEPLOY_TIMEOUT:-300}"
 HEALTH_TIMEOUT="${RAILWAY_HEALTH_TIMEOUT:-120}"
 HEALTH_INTERVAL="${RAILWAY_HEALTH_INTERVAL:-5}"
@@ -123,6 +122,18 @@ if [[ -z "${RAILWAY_TOKEN:-}" ]]; then
 fi
 
 FULL_IMAGE="${IMAGE_REPO}:${IMAGE_TAG}"
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+# Validate the probe authority before the first control-plane request. Never
+# print the untrusted input: it may contain userinfo or query credentials.
+if [[ -z "$HEALTH_URL" ]]; then
+  fail "RAILWAY_HEALTH_URL is required for deployment acceptance"
+  exit 1
+fi
+if ! HEALTH_URL=$(node "$SCRIPT_DIR/validate-public-origin.mjs" "$HEALTH_URL"); then
+  fail "RAILWAY_HEALTH_URL must be a credential-free public HTTPS root origin"
+  exit 1
+fi
 
 # Redact every externally supplied diagnostic before it reaches CI. This covers
 # credential-bearing URLs (Postgres, Redis, brokers, generic HTTP userinfo),
@@ -422,15 +433,12 @@ fi
 # A Railway SUCCESS state only proves control-plane rollout. Deployment
 # acceptance requires an explicit public probe authority plus both liveness and
 # durable readiness receipts; absent authority must never look shipped.
-if [[ -z "$HEALTH_URL" ]]; then
-  fail "RAILWAY_HEALTH_URL is required for deployment acceptance; refusing to skip public /health and /ready receipts."
-  exit 1
-fi
-
 verify_public_probe() {
   local path="$1"
   local label="$2"
+  local probe_result="000 "
   local http_code="000"
+  local remote_ip=""
   local attempt=0
   local started=$SECONDS
   local elapsed=0
@@ -441,13 +449,15 @@ verify_public_probe() {
     local remaining=$((HEALTH_TIMEOUT - elapsed))
     local request_timeout=$((remaining < 10 ? remaining : 10))
     local connect_timeout=$((request_timeout < 5 ? request_timeout : 5))
-    http_code=$(curl -sS \
+    probe_result=$(curl -sS \
       --connect-timeout "$connect_timeout" \
       --max-time "$request_timeout" \
       -o /dev/null \
-      -w "%{http_code}" \
-      "${HEALTH_URL}${path}" 2>/dev/null) || http_code="000"
-    if [[ "$http_code" == "200" ]]; then
+      -w "%{http_code} %{remote_ip}" \
+      "${HEALTH_URL}${path}" 2>/dev/null) || probe_result="000 "
+    read -r http_code remote_ip <<< "$probe_result"
+    if [[ "$http_code" == "200" ]] &&
+       node "$SCRIPT_DIR/validate-public-origin.mjs" --ip "$remote_ip" >/dev/null 2>&1; then
       ok "${label} check passed"
       return 0
     fi

--- a/scripts/railway-deploy.sh
+++ b/scripts/railway-deploy.sh
@@ -243,8 +243,13 @@ LOGS_EMPTY=0
 # STEWARD_* secrets, Bearer tokens) to its logs (SEC-129).
 redact_secrets() {
   sed -E \
-    -e 's#(postgres(ql)?://[^:/@]+:)[^@]+@#\1…REDACTED…@#g' \
+    -e 's#([A-Za-z][A-Za-z0-9+.-]*://[^/@[:space:]:]*:)[^@/[:space:]]+@#\1…REDACTED…@#g' \
+    -e 's#([?&](access_key|access_token|api_key|apikey|auth|authorization|client_secret|code|credential|key|password|passwd|pwd|secret|signature|sig|token|x-amz-credential|x-amz-security-token|x-amz-signature)=)[^&#"'"'"'[:space:]]+#\1…REDACTED…#gI' \
     -e 's/(Bearer )[A-Za-z0-9._~+/-]+/\1…REDACTED…/g' \
+    -e 's/(([A-Za-z_][A-Za-z0-9_]*_(URL|URI|DSN)|URL|URI|DSN)"[[:space:]]*:[[:space:]]*")[^"]*/\1…REDACTED…/gI' \
+    -e 's/(([A-Za-z_][A-Za-z0-9_]*_(URL|URI|DSN)|URL|URI|DSN)[[:space:]]*[:=][[:space:]]*")[^"]*/\1…REDACTED…/gI' \
+    -e "s/(([A-Za-z_][A-Za-z0-9_]*_(URL|URI|DSN)|URL|URI|DSN)[[:space:]]*[:=][[:space:]]*')[^']*/\1…REDACTED…/gI" \
+    -e 's/(([A-Za-z_][A-Za-z0-9_]*_(URL|URI|DSN)|URL|URI|DSN)[[:space:]]*[:=][[:space:]]*)[^[:space:],}]+/\1…REDACTED…/gI' \
     -e 's/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*"[[:space:]]*:[[:space:]]*")[^"]*/\1…REDACTED…/g' \
     -e 's/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*[[:space:]]*[:=][[:space:]]*")[^"]*/\1…REDACTED…/g' \
     -e "s/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*[[:space:]]*[:=][[:space:]]*')[^']*/\1…REDACTED…/g" \

--- a/scripts/railway-deploy.sh
+++ b/scripts/railway-deploy.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 #                                  canonical published OSS image)
 #   RAILWAY_HEALTH_URL  (optional) the deployer's own /health URL to verify
 #   DEPLOY_TIMEOUT      (optional) max seconds to wait for deploy, default: 300
+#   RAILWAY_HEALTH_TIMEOUT  (optional) max seconds to wait for health, default: 120
+#   RAILWAY_HEALTH_INTERVAL (optional) seconds between health probes, default: 5
 #   RAILWAY_ALLOW_REJECTED_DEPLOY (optional, default: fail closed) when "true",
 #                       a deployment Railway rejected before any container ran
 #                       (no build/deploy logs) degrades to a non-fatal warning
@@ -50,6 +52,8 @@ ENV_ID="${RAILWAY_ENV_ID:-}"
 IMAGE_REPO="${RAILWAY_IMAGE_REPO:-ghcr.io/steward-fi/steward}"
 HEALTH_URL="${RAILWAY_HEALTH_URL:-}"
 TIMEOUT="${DEPLOY_TIMEOUT:-300}"
+HEALTH_TIMEOUT="${RAILWAY_HEALTH_TIMEOUT:-120}"
+HEALTH_INTERVAL="${RAILWAY_HEALTH_INTERVAL:-5}"
 API="https://backboard.railway.com/graphql/v2"
 
 DRY_RUN=false
@@ -88,6 +92,13 @@ done
 
 if [[ -z "$IMAGE_TAG" ]]; then
   fail "Image tag required. Usage: $0 <image-tag>"
+  exit 1
+fi
+
+if [[ ! "$TIMEOUT" =~ ^[1-9][0-9]*$ ||
+      ! "$HEALTH_TIMEOUT" =~ ^[1-9][0-9]*$ ||
+      ! "$HEALTH_INTERVAL" =~ ^[1-9][0-9]*$ ]]; then
+  fail "DEPLOY_TIMEOUT, RAILWAY_HEALTH_TIMEOUT, and RAILWAY_HEALTH_INTERVAL must be positive integers"
   exit 1
 fi
 
@@ -234,7 +245,10 @@ redact_secrets() {
   sed -E \
     -e 's#(postgres(ql)?://[^:/@]+:)[^@]+@#\1…REDACTED…@#g' \
     -e 's/(Bearer )[A-Za-z0-9._~+/-]+/\1…REDACTED…/g' \
-    -e 's/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*=)[^[:space:]]+/\1…REDACTED…/g' \
+    -e 's/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*"[[:space:]]*:[[:space:]]*")[^"]*/\1…REDACTED…/g' \
+    -e 's/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*[[:space:]]*[:=][[:space:]]*")[^"]*/\1…REDACTED…/g' \
+    -e "s/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*[[:space:]]*[:=][[:space:]]*')[^']*/\1…REDACTED…/g" \
+    -e 's/((SECRET|SECRETS|PASSWORD|PASS|SALT|TOKEN|KEY|KEYS|HMAC|PRIVATE)[A-Z_]*[[:space:]]*[:=][[:space:]]*)[^[:space:],}]+/\1…REDACTED…/g' \
     -e 's/(^|[^A-Za-z0-9_])stw_[A-Za-z0-9]+/\1stw_…REDACTED…/g' \
     -e 's/(^|[^0-9a-fA-F])[0-9a-fA-F]{48,}([^0-9a-fA-F]|$)/\1…REDACTED…\2/g'
 }
@@ -376,25 +390,41 @@ fi
 
 log "Verifying health endpoint: ${HEALTH_URL}/health"
 
-# Give the service a moment to start accepting traffic
-sleep 5
-
 HEALTH_OK=false
-for i in 1 2 3; do
-  HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" "${HEALTH_URL}/health" 2>/dev/null) || HTTP_CODE="000"
+HTTP_CODE="000"
+HEALTH_ATTEMPT=0
+HEALTH_STARTED=$SECONDS
+HEALTH_ELAPSED=0
+while [[ $HEALTH_ELAPSED -lt $HEALTH_TIMEOUT ]]; do
+  HEALTH_ATTEMPT=$((HEALTH_ATTEMPT + 1))
+  HEALTH_REMAINING=$((HEALTH_TIMEOUT - HEALTH_ELAPSED))
+  REQUEST_TIMEOUT=$((HEALTH_REMAINING < 10 ? HEALTH_REMAINING : 10))
+  CONNECT_TIMEOUT=$((REQUEST_TIMEOUT < 5 ? REQUEST_TIMEOUT : 5))
+  HTTP_CODE=$(curl -sS \
+    --connect-timeout "$CONNECT_TIMEOUT" \
+    --max-time "$REQUEST_TIMEOUT" \
+    -o /dev/null \
+    -w "%{http_code}" \
+    "${HEALTH_URL}/health" 2>/dev/null) || HTTP_CODE="000"
   if [[ "$HTTP_CODE" == "200" ]]; then
     HEALTH_OK=true
     break
   fi
-  warn "  Health check attempt $i: HTTP ${HTTP_CODE}"
-  sleep 5
+  HEALTH_ELAPSED=$((SECONDS - HEALTH_STARTED))
+  warn "  Health check attempt ${HEALTH_ATTEMPT}: HTTP ${HTTP_CODE} (${HEALTH_ELAPSED}s elapsed)"
+  HEALTH_REMAINING=$((HEALTH_TIMEOUT - HEALTH_ELAPSED))
+  if [[ $HEALTH_REMAINING -gt 0 ]]; then
+    sleep "$((HEALTH_REMAINING < HEALTH_INTERVAL ? HEALTH_REMAINING : HEALTH_INTERVAL))"
+  fi
+  HEALTH_ELAPSED=$((SECONDS - HEALTH_STARTED))
 done
 
 if $HEALTH_OK; then
   ok "Health check passed"
 else
-  fail "Health check failed after 3 attempts (last HTTP: ${HTTP_CODE})"
-  fail "Service may still be starting. Check ${HEALTH_URL}/health manually."
+  fail "Health check failed after ${HEALTH_ATTEMPT} attempts / ${HEALTH_TIMEOUT}s (last HTTP: ${HTTP_CODE})"
+  fail "Collecting Railway logs for deployment ${DEPLOY_ID} before failing."
+  dump_failure
   exit 1
 fi
 

--- a/scripts/railway-deploy.sh
+++ b/scripts/railway-deploy.sh
@@ -419,12 +419,12 @@ fi
 # ---------------------------------------------------------------------------
 # Step 3: Health check
 # ---------------------------------------------------------------------------
-# Skip when no health URL is configured; otherwise a deployer who only set the
-# required service/env IDs would have the service image updated and THEN see the
-# deploy marked failed against a bare "/health" URL.
+# A Railway SUCCESS state only proves control-plane rollout. Deployment
+# acceptance requires an explicit public probe authority plus both liveness and
+# durable readiness receipts; absent authority must never look shipped.
 if [[ -z "$HEALTH_URL" ]]; then
-  ok "Service image updated. Skipping health check (RAILWAY_HEALTH_URL not set)."
-  exit 0
+  fail "RAILWAY_HEALTH_URL is required for deployment acceptance; refusing to skip public /health and /ready receipts."
+  exit 1
 fi
 
 verify_public_probe() {
@@ -481,4 +481,5 @@ ok "  Railway Deploy Complete"
 ok "  Image:   ${FULL_IMAGE}"
 ok "  Service: ${SERVICE_ID}"
 ok "  Health:  ${HEALTH_URL}/health ✓"
+ok "  Ready:   ${HEALTH_URL}/ready ✓"
 ok "=========================================="

--- a/scripts/railway-deploy.sh
+++ b/scripts/railway-deploy.sh
@@ -130,7 +130,7 @@ if [[ -z "$HEALTH_URL" ]]; then
   fail "RAILWAY_HEALTH_URL is required for deployment acceptance"
   exit 1
 fi
-if ! HEALTH_URL=$(node "$SCRIPT_DIR/validate-public-origin.mjs" "$HEALTH_URL"); then
+if ! HEALTH_URL=$(node "$SCRIPT_DIR/validate-public-origin.mjs" --resolve-origin "$HEALTH_URL"); then
   fail "RAILWAY_HEALTH_URL must be a credential-free public HTTPS root origin"
   exit 1
 fi

--- a/scripts/railway-deploy.sh
+++ b/scripts/railway-deploy.sh
@@ -53,6 +53,7 @@ SERVICE_ID="${RAILWAY_SERVICE_ID:-}"
 ENV_ID="${RAILWAY_ENV_ID:-}"
 IMAGE_REPO="${RAILWAY_IMAGE_REPO:-ghcr.io/steward-fi/steward}"
 HEALTH_URL="${RAILWAY_HEALTH_URL:-}"
+HEALTH_URL="${HEALTH_URL%/}"
 TIMEOUT="${DEPLOY_TIMEOUT:-300}"
 HEALTH_TIMEOUT="${RAILWAY_HEALTH_TIMEOUT:-120}"
 HEALTH_INTERVAL="${RAILWAY_HEALTH_INTERVAL:-5}"
@@ -426,45 +427,50 @@ if [[ -z "$HEALTH_URL" ]]; then
   exit 0
 fi
 
-log "Verifying health endpoint: ${HEALTH_URL}/health"
+verify_public_probe() {
+  local path="$1"
+  local label="$2"
+  local http_code="000"
+  local attempt=0
+  local started=$SECONDS
+  local elapsed=0
 
-HEALTH_OK=false
-HTTP_CODE="000"
-HEALTH_ATTEMPT=0
-HEALTH_STARTED=$SECONDS
-HEALTH_ELAPSED=0
-while [[ $HEALTH_ELAPSED -lt $HEALTH_TIMEOUT ]]; do
-  HEALTH_ATTEMPT=$((HEALTH_ATTEMPT + 1))
-  HEALTH_REMAINING=$((HEALTH_TIMEOUT - HEALTH_ELAPSED))
-  REQUEST_TIMEOUT=$((HEALTH_REMAINING < 10 ? HEALTH_REMAINING : 10))
-  CONNECT_TIMEOUT=$((REQUEST_TIMEOUT < 5 ? REQUEST_TIMEOUT : 5))
-  HTTP_CODE=$(curl -sS \
-    --connect-timeout "$CONNECT_TIMEOUT" \
-    --max-time "$REQUEST_TIMEOUT" \
-    -o /dev/null \
-    -w "%{http_code}" \
-    "${HEALTH_URL}/health" 2>/dev/null) || HTTP_CODE="000"
-  if [[ "$HTTP_CODE" == "200" ]]; then
-    HEALTH_OK=true
-    break
-  fi
-  HEALTH_ELAPSED=$((SECONDS - HEALTH_STARTED))
-  warn "  Health check attempt ${HEALTH_ATTEMPT}: HTTP ${HTTP_CODE} (${HEALTH_ELAPSED}s elapsed)"
-  HEALTH_REMAINING=$((HEALTH_TIMEOUT - HEALTH_ELAPSED))
-  if [[ $HEALTH_REMAINING -gt 0 ]]; then
-    sleep "$((HEALTH_REMAINING < HEALTH_INTERVAL ? HEALTH_REMAINING : HEALTH_INTERVAL))"
-  fi
-  HEALTH_ELAPSED=$((SECONDS - HEALTH_STARTED))
-done
+  log "Verifying ${label} endpoint: ${HEALTH_URL}${path}"
+  while [[ $elapsed -lt $HEALTH_TIMEOUT ]]; do
+    attempt=$((attempt + 1))
+    local remaining=$((HEALTH_TIMEOUT - elapsed))
+    local request_timeout=$((remaining < 10 ? remaining : 10))
+    local connect_timeout=$((request_timeout < 5 ? request_timeout : 5))
+    http_code=$(curl -sS \
+      --connect-timeout "$connect_timeout" \
+      --max-time "$request_timeout" \
+      -o /dev/null \
+      -w "%{http_code}" \
+      "${HEALTH_URL}${path}" 2>/dev/null) || http_code="000"
+    if [[ "$http_code" == "200" ]]; then
+      ok "${label} check passed"
+      return 0
+    fi
+    elapsed=$((SECONDS - started))
+    warn "  ${label} check attempt ${attempt}: HTTP ${http_code} (${elapsed}s elapsed)"
+    remaining=$((HEALTH_TIMEOUT - elapsed))
+    if [[ $remaining -gt 0 ]]; then
+      sleep "$((remaining < HEALTH_INTERVAL ? remaining : HEALTH_INTERVAL))"
+    fi
+    elapsed=$((SECONDS - started))
+  done
 
-if $HEALTH_OK; then
-  ok "Health check passed"
-else
-  fail "Health check failed after ${HEALTH_ATTEMPT} attempts / ${HEALTH_TIMEOUT}s (last HTTP: ${HTTP_CODE})"
+  fail "${label} check failed after ${attempt} attempts / ${HEALTH_TIMEOUT}s (last HTTP: ${http_code})"
   fail "Collecting Railway logs for deployment ${DEPLOY_ID} before failing."
   dump_failure
-  exit 1
-fi
+  return 1
+}
+
+verify_public_probe "/health" "Health" || exit 1
+# Liveness alone is insufficient: /ready verifies the migrated ledger, RLS
+# deployment role, Redis/auth stores, and other durable dependencies before a
+# Railway deployment is accepted.
+verify_public_probe "/ready" "Readiness" || exit 1
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/validate-public-origin.mjs
+++ b/scripts/validate-public-origin.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import { isIP } from "node:net";
+
+function ipv4Octets(address) {
+  const parts = address.split(".").map(Number);
+  return parts.length === 4 &&
+    parts.every((part) => Number.isInteger(part) && part >= 0 && part <= 255)
+    ? parts
+    : null;
+}
+
+export function isPublicIp(address) {
+  const normalized = address
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .split("%")[0];
+  const version = isIP(normalized);
+  if (version === 4) {
+    const octets = ipv4Octets(normalized);
+    if (!octets) return false;
+    const [a, b, c] = octets;
+    return !(
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && ((b === 0 && (c === 0 || c === 2)) || b === 168)) ||
+      (a === 198 && (b === 18 || b === 19 || (b === 51 && c === 100))) ||
+      (a === 203 && b === 0 && c === 113) ||
+      a >= 224
+    );
+  }
+  if (version !== 6) return false;
+  const mapped = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  if (mapped) return isPublicIp(mapped[1]);
+  // Globally routable IPv6 unicast is 2000::/3. This rejects ULA, link-local,
+  // site-local, multicast, documentation, unspecified, and loopback space.
+  return /^[23][0-9a-f]{3}:/i.test(normalized) && !/^2001:(?:0?db8):/i.test(normalized);
+}
+
+export function parsePublicHttpsOrigin(input) {
+  let parsed;
+  try {
+    parsed = new URL(input);
+  } catch {
+    throw new Error("health authority must be a valid URL");
+  }
+  if (parsed.protocol !== "https:") throw new Error("health authority must use HTTPS");
+  if (parsed.username || parsed.password)
+    throw new Error("health authority must not contain userinfo");
+  if (parsed.search || parsed.hash)
+    throw new Error("health authority must not contain query or fragment");
+  if (parsed.pathname !== "/") throw new Error("health authority must be a root origin");
+  const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (hostname === "localhost" || hostname.endsWith(".localhost") || hostname.endsWith(".local")) {
+    throw new Error("health authority must be public");
+  }
+  if (isIP(hostname) && !isPublicIp(hostname)) {
+    throw new Error("health authority must be public");
+  }
+  return parsed.origin;
+}
+
+const [modeOrOrigin, value] = process.argv.slice(2);
+try {
+  if (modeOrOrigin === "--ip") {
+    if (!value || !isPublicIp(value)) throw new Error("probe peer must be a public address");
+    process.stdout.write(value);
+  } else {
+    if (!modeOrOrigin) throw new Error("health authority is required");
+    process.stdout.write(parsePublicHttpsOrigin(modeOrOrigin));
+  }
+} catch (error) {
+  process.stderr.write(
+    `[railway] ${error instanceof Error ? error.message : "invalid health authority"}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/scripts/validate-public-origin.mjs
+++ b/scripts/validate-public-origin.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
+import { lookup as dnsLookup } from "node:dns/promises";
 import { isIP } from "node:net";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 function ipv4Octets(address) {
   const parts = address.split(".").map(Number);
@@ -8,6 +11,25 @@ function ipv4Octets(address) {
     parts.every((part) => Number.isInteger(part) && part >= 0 && part <= 255)
     ? parts
     : null;
+}
+
+function ipv6Value(address) {
+  const halves = address.split("::");
+  if (halves.length > 2) return null;
+  const left = halves[0] ? halves[0].split(":") : [];
+  const right = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+  const missing = 8 - left.length - right.length;
+  if ((halves.length === 1 && missing !== 0) || missing < 0) return null;
+  const groups = halves.length === 2 ? [...left, ...Array(missing).fill("0"), ...right] : left;
+  if (groups.length !== 8 || groups.some((group) => !/^[0-9a-f]{1,4}$/i.test(group))) {
+    return null;
+  }
+  return groups.reduce((value, group) => (value << 16n) | BigInt(`0x${group}`), 0n);
+}
+
+function inIpv6Prefix(value, prefix, bits) {
+  const shift = BigInt(128 - bits);
+  return value >> shift === prefix >> shift;
 }
 
 export function isPublicIp(address) {
@@ -28,6 +50,7 @@ export function isPublicIp(address) {
       (a === 169 && b === 254) ||
       (a === 172 && b >= 16 && b <= 31) ||
       (a === 192 && ((b === 0 && (c === 0 || c === 2)) || b === 168)) ||
+      (a === 192 && b === 88 && c === 99) ||
       (a === 198 && (b === 18 || b === 19 || (b === 51 && c === 100))) ||
       (a === 203 && b === 0 && c === 113) ||
       a >= 224
@@ -36,9 +59,20 @@ export function isPublicIp(address) {
   if (version !== 6) return false;
   const mapped = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
   if (mapped) return isPublicIp(mapped[1]);
-  // Globally routable IPv6 unicast is 2000::/3. This rejects ULA, link-local,
-  // site-local, multicast, documentation, unspecified, and loopback space.
-  return /^[23][0-9a-f]{3}:/i.test(normalized) && !/^2001:(?:0?db8):/i.test(normalized);
+  const value = ipv6Value(normalized);
+  if (value === null) return false;
+  const prefix = (address) => ipv6Value(address);
+  const globalUnicast = prefix("2000::");
+  if (!inIpv6Prefix(value, globalUnicast, 3)) return false;
+  // Conservative denylist for IANA special-purpose ranges inside 2000::/3:
+  // protocol assignments/benchmarking, documentation, deprecated 6to4, and
+  // the documentation block formerly carved from the global-unicast pool.
+  return !(
+    inIpv6Prefix(value, prefix("2001::"), 23) ||
+    inIpv6Prefix(value, prefix("2001:db8::"), 32) ||
+    inIpv6Prefix(value, prefix("2002::"), 16) ||
+    inIpv6Prefix(value, prefix("3fff::"), 20)
+  );
 }
 
 export function parsePublicHttpsOrigin(input) {
@@ -64,18 +98,37 @@ export function parsePublicHttpsOrigin(input) {
   return parsed.origin;
 }
 
-const [modeOrOrigin, value] = process.argv.slice(2);
-try {
-  if (modeOrOrigin === "--ip") {
-    if (!value || !isPublicIp(value)) throw new Error("probe peer must be a public address");
-    process.stdout.write(value);
-  } else {
-    if (!modeOrOrigin) throw new Error("health authority is required");
-    process.stdout.write(parsePublicHttpsOrigin(modeOrOrigin));
+export async function resolvePublicHttpsOrigin(input, lookup = dnsLookup) {
+  const origin = parsePublicHttpsOrigin(input);
+  const hostname = new URL(origin).hostname.replace(/^\[|\]$/g, "");
+  if (isIP(hostname)) return origin;
+  const answers = await lookup(hostname, { all: true, verbatim: true });
+  if (!Array.isArray(answers) || answers.length === 0) {
+    throw new Error("health authority did not resolve");
   }
-} catch (error) {
-  process.stderr.write(
-    `[railway] ${error instanceof Error ? error.message : "invalid health authority"}\n`,
-  );
-  process.exitCode = 1;
+  if (answers.some((answer) => !isPublicIp(answer.address))) {
+    throw new Error("health authority resolved to a non-public address");
+  }
+  return origin;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [modeOrOrigin, value] = process.argv.slice(2);
+  try {
+    if (modeOrOrigin === "--ip") {
+      if (!value || !isPublicIp(value)) throw new Error("probe peer must be a public address");
+      process.stdout.write(value);
+    } else if (modeOrOrigin === "--resolve-origin") {
+      if (!value) throw new Error("health authority is required");
+      process.stdout.write(await resolvePublicHttpsOrigin(value));
+    } else {
+      if (!modeOrOrigin) throw new Error("health authority is required");
+      process.stdout.write(parsePublicHttpsOrigin(modeOrOrigin));
+    }
+  } catch (error) {
+    process.stderr.write(
+      `[railway] ${error instanceof Error ? error.message : "invalid health authority"}\n`,
+    );
+    process.exitCode = 1;
+  }
 }


### PR DESCRIPTION
Closes #788.

## Outcome

- gates Bun and Worker startup on the exact core migration tip and every enabled plugin migration ledger before RLS, composition, or serving
- shares one in-flight Worker initialization attempt while clearing only the rejected attempt so repaired infrastructure can retry
- validates the deployment hostname and every resolved address as public before the first Railway mutation
- rejects conservative IANA special-use IPv4/IPv6 space and revalidates the actual connected peer after each bounded health/readiness request
- preserves bounded Railway polling and actionable redacted boot diagnostics

## Exact candidate

- base: `201c1869d40ffca8a207a32a24eecc7eb6f24cd6`
- head: `2c71ca48250f26dcb338364f11465a69d4b821f2`
- tree: `87c32e4ba66b06d1a699666a5d9758f61e0bf6fb`

## Exact local evidence

- real PostgreSQL startup/readiness: 2/2, 60 assertions, natural cleanup and no scratch catalog residue
- Railway deployment/hostile DNS suite: 25/25, 148 assertions
- focused migration/startup/release suite: 23/23, 88 assertions
- Worker missing/stale/exact enabled-plugin ledger regression: pass
- affected API TypeScript no-emit check: pass
- Biome (7 files), `bash -n`, and `git diff --check`: pass
- independent exact-head source audit: ACCEPT; all three prior blockers closed

## Pending gates

- exact hosted PostgreSQL/full protected matrix on this SHA
- required independent GitHub review
- staging operator correction of the external database target and live public health/readiness receipts

This PR is intentionally draft. Do not ready or merge until the exact hosted checks, review, and external staging acceptance are complete.
