### PR TITLE
test(api): mount Bun readiness behavior

### DIFF
--- a/packages/api/src/__tests__/auth-import-session-store-sources.test.ts
+++ b/packages/api/src/__tests__/auth-import-session-store-sources.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { Hono } from "hono";
+import {
+  createReadinessHandler,
+  type ReadinessDependencies,
+  type ReadinessEnvironment,
+} from "../readiness";
+import type { AuthStoreSources } from "../routes/auth";
+import type { AppVariables } from "../services/context";
 
 const redisSetMock = mock(async () => "OK");
 const redisGetMock = mock(async () => null as string | null);
@@ -31,10 +37,6 @@ mock.module("../middleware/redis.js", () => ({
     redisClient = null;
   },
 }));
-
-const apiRoot = join(import.meta.dir, "..");
-const indexSource = readFileSync(join(apiRoot, "index.ts"), "utf8");
-const testSource = readFileSync(import.meta.path, "utf8");
 
 process.env.STEWARD_PGLITE_MEMORY = "true";
 process.env.DATABASE_URL = "postgres://auth-import-session-store-sources.invalid/steward";
@@ -164,29 +166,184 @@ describe("production auth-store startup gate", () => {
   });
 });
 
-describe("readiness import-session memory gate", () => {
-  it("keeps this readiness coverage source-only so importing the test does not start the server", () => {
-    expect(testSource).toContain('readFileSync(join(apiRoot, "index.ts"), "utf8")');
-    expect(testSource).not.toContain(`await ${"import"}("../index")`);
-    expect(testSource).not.toContain(`${"from"} "../index"`);
+const durableSources = {
+  challenge: "postgres",
+  token: "redis",
+  siweNonce: "postgres",
+  mfa: "redis",
+  importSession: "postgres",
+} satisfies AuthStoreSources;
+
+function mountReadiness(
+  overrides: Partial<ReadinessDependencies> = {},
+  environmentOverrides: Partial<ReadinessEnvironment> = {},
+) {
+  const dependencies: ReadinessDependencies = {
+    apiVersion: "test-version",
+    startedAt: 1_000,
+    now: () => 6_000,
+    environment: () => ({
+      allowMemoryAuthStores: false,
+      probeToken: "readiness-probe-secret",
+      requiresDurableAuthStores: true,
+      ...environmentOverrides,
+    }),
+    checkDatabase: async () => ({
+      database: { ok: true, detail: { clockSkewMs: 3 } },
+      migrations: { ok: true, detail: { expected: "0113" } },
+    }),
+    checkRedis: async () => ({ ok: true, source: "redis" }),
+    checkProxyClock: async () => ({ ok: true, detail: { clockSkewMs: 4 } }),
+    getAuthStoreSources: () => durableSources,
+    isVaultConfigured: () => true,
+    ...overrides,
+  };
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.get("/ready", createReadinessHandler(dependencies));
+  return app;
+}
+
+describe("mounted Bun readiness auth-store boundary", () => {
+  for (const storeName of Object.keys(durableSources)) {
+    it(`returns exactly 503 when production ${storeName} storage is memory-backed`, async () => {
+      const app = mountReadiness({
+        getAuthStoreSources: () => ({ ...durableSources, [storeName]: "memory" }),
+      });
+      const response = await app.request("/ready");
+      expect(response.status).toBe(503);
+      expect(await response.json()).toEqual({
+        status: "not_ready",
+        version: "test-version",
+        uptime: 5,
+        checks: {
+          database: { ok: true },
+          migrations: { ok: true },
+          redis: { ok: true },
+          proxyClock: { ok: true },
+          vault: { ok: true },
+          authStores: { ok: false },
+        },
+      });
+    });
+  }
+
+  it("returns 200 for durable stores and for an explicit single-instance acknowledgement", async () => {
+    const durableResponse = await mountReadiness().request("/ready");
+    expect(durableResponse.status).toBe(200);
+    expect((await durableResponse.json()).status).toBe("ready");
+
+    const acknowledgedResponse = await mountReadiness(
+      {
+        getAuthStoreSources: () =>
+          Object.fromEntries(Object.keys(durableSources).map((key) => [key, "memory"])),
+      },
+      { allowMemoryAuthStores: true },
+    ).request("/ready");
+    expect(acknowledgedResponse.status).toBe(200);
+    expect((await acknowledgedResponse.json()).status).toBe("ready");
   });
 
-  it("keeps /ready wired to fail production memory auth storage unless explicitly allowed", () => {
-    // Importing src/index.ts starts migrations, schedulers, and Bun.serve at module load,
-    // so keep this as a focused wiring check around the readiness boundary.
-    const readyRouteStart = indexSource.indexOf('app.get("/ready"');
-    expect(readyRouteStart).toBeGreaterThanOrEqual(0);
-    const readyRouteEnd = indexSource.indexOf("\n// ─── Database migrations", readyRouteStart);
-    const readyRoute = indexSource.slice(
-      readyRouteStart,
-      readyRouteEnd === -1 ? undefined : readyRouteEnd,
+  it("maps rejected DB, Redis, and proxy checks to stable 503 responses", async () => {
+    const cases: Array<{
+      name: string;
+      overrides: Partial<ReadinessDependencies>;
+      failedChecks: string[];
+    }> = [
+      {
+        name: "database",
+        overrides: { checkDatabase: async () => Promise.reject(new Error("database token leak")) },
+        failedChecks: ["database", "migrations"],
+      },
+      {
+        name: "redis",
+        overrides: { checkRedis: async () => Promise.reject(new Error("redis endpoint leak")) },
+        failedChecks: ["redis"],
+      },
+      {
+        name: "proxy",
+        overrides: { checkProxyClock: async () => Promise.reject(new Error("proxy token leak")) },
+        failedChecks: ["proxyClock"],
+      },
+      {
+        name: "vault",
+        overrides: { isVaultConfigured: () => false },
+        failedChecks: ["vault"],
+      },
+    ];
+
+    for (const testCase of cases) {
+      const response = await mountReadiness(testCase.overrides).request("/ready");
+      expect(response.status, testCase.name).toBe(503);
+      const body = (await response.json()) as {
+        status: string;
+        checks: Record<string, { ok: boolean }>;
+      };
+      expect(body.status, testCase.name).toBe("not_ready");
+      for (const check of testCase.failedChecks) expect(body.checks[check]).toEqual({ ok: false });
+      expect(JSON.stringify(body), testCase.name).not.toMatch(/token leak|endpoint leak/i);
+    }
+  });
+
+  it("returns 200 when unconfigured Redis and proxy checks are explicitly optional", async () => {
+    const response = await mountReadiness({
+      checkRedis: async () => ({ ok: false, required: false, error: "optional" }),
+      checkProxyClock: async () => ({ ok: false, required: false, error: "optional" }),
+    }).request("/ready");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      status: "ready",
+      checks: {
+        redis: { ok: false, required: false },
+        proxyClock: { ok: false, required: false },
+      },
+    });
+  });
+
+  it("redacts public backend diagnostics and exposes bounded detail only to the probe token", async () => {
+    const app = mountReadiness({
+      checkRedis: async () => ({
+        ok: false,
+        error: "Redis is configured but not connected",
+        source: "redis",
+      }),
+      getAuthStoreSources: () => ({ ...durableSources, importSession: "memory" }),
+    });
+
+    const publicResponse = await app.request("/ready");
+    expect(publicResponse.status).toBe(503);
+    expect(publicResponse.headers.get("cache-control")).toBe("no-store, max-age=0");
+    expect(publicResponse.headers.get("pragma")).toBe("no-cache");
+    expect(publicResponse.headers.get("expires")).toBe("0");
+    const publicText = await publicResponse.text();
+    expect(publicText).not.toContain('"source"');
+    expect(publicText).not.toContain('"error"');
+    expect(publicText).not.toMatch(
+      /challenge:|importSession:|configured but|readiness-probe-secret/i,
     );
 
-    expect(readyRoute).toContain("getAuthStoreSources()");
-    expect(readyRoute).toContain("checks.authStores");
-    expect(readyRoute).toContain("STEWARD_ALLOW_MEMORY_AUTH_STORES");
-    expect(readyRoute).toContain('process.env.NODE_ENV !== "production"');
-    expect(readyRoute).toContain('source === "memory"');
-    expect(readyRoute).toContain("Production auth stores using memory");
+    const wrongTokenResponse = await app.request("/ready", {
+      headers: { "x-steward-probe-token": "wrong-token" },
+    });
+    expect(wrongTokenResponse.headers.get("cache-control")).toBe("no-store, max-age=0");
+    expect(await wrongTokenResponse.json()).toEqual(JSON.parse(publicText));
+
+    const authorizedResponse = await app.request("/ready", {
+      headers: { "x-steward-probe-token": "readiness-probe-secret" },
+    });
+    expect(authorizedResponse.status).toBe(503);
+    expect(authorizedResponse.headers.get("cache-control")).toBe("no-store, max-age=0");
+    const authorized = (await authorizedResponse.json()) as {
+      checks: Record<string, { detail?: unknown; error?: string; source?: string }>;
+    };
+    expect(authorized.checks.database.detail).toEqual({ clockSkewMs: 3 });
+    expect(authorized.checks.redis).toEqual({
+      ok: false,
+      error: "Redis is configured but not connected",
+      source: "redis",
+    });
+    expect(authorized.checks.authStores.error).toBe(
+      "Production auth stores using memory: importSession",
+    );
+    expect(JSON.stringify(authorized)).not.toContain("readiness-probe-secret");
   });
 });

--- a/packages/api/src/__tests__/middleware-security-hardening.test.ts
+++ b/packages/api/src/__tests__/middleware-security-hardening.test.ts
@@ -102,14 +102,6 @@ describe("middleware security hardening", () => {
     expect(globalRateLimitSource).toContain('"Rate limit exceeded"');
   });
 
-  it("trims /ready fingerprint detail unless a probe token is presented (SEC-071)", () => {
-    expect(indexSource).toContain("function readyProbeAuthorized(");
-    expect(indexSource).toContain("STEWARD_READY_PROBE_TOKEN");
-    expect(indexSource).toContain("timingSafeEqual");
-    expect(indexSource).toContain('"x-steward-probe-token"');
-    expect(indexSource).toContain("checks: verbose ? checks : publicChecks");
-  });
-
   it("documents production security headers and dashboard CSP checks in source", () => {
     expect(securityHeadersSource).toContain('"X-Frame-Options": "DENY"');
     expect(securityHeadersSource).toContain('"Content-Security-Policy"');

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -12,7 +12,6 @@
  *   - `Bun.serve` plus SIGINT/SIGTERM graceful shutdown
  */
 
-import { createHash, timingSafeEqual } from "node:crypto";
 import { validateJwtSecretEnv } from "@stwd/auth";
 import {
   assertRlsDeploymentSafety,
@@ -27,6 +26,7 @@ import { sql } from "drizzle-orm";
 import { composeApp } from "./compose";
 import { getRedisClient, initRedis, isRedisConfigured, shutdownRedis } from "./middleware/redis";
 import { resolveEnabledPlugins } from "./plugin-config";
+import { createReadinessHandler, type ReadinessCheck } from "./readiness";
 import { assertAuthStoresAreSafe, getAuthStoreSources, initAuthStores } from "./routes/auth";
 import {
   API_VERSION,
@@ -133,99 +133,100 @@ const requestLogCleanupTimer = setInterval(() => {
 // STEWARD_MASTER_PASSWORD is set, DB/proxy clock skew, error strings).
 // Unauthenticated callers get the same 200/503 status plus per-check ok flags
 // only; operators can set STEWARD_READY_PROBE_TOKEN and send it as
-// X-Steward-Probe-Token to receive the full diagnostic detail.
+// X-Steward-Probe-Token to receive the full diagnostic detail. The handler
+// policy lives in readiness.ts; this entrypoint supplies the production I/O.
 
-function readyProbeAuthorized(presented: string | undefined): boolean {
-  const expected = process.env.STEWARD_READY_PROBE_TOKEN;
-  if (!expected || !presented) return false;
-  const a = createHash("sha256").update(expected).digest();
-  const b = createHash("sha256").update(presented).digest();
-  return timingSafeEqual(a, b);
-}
-
-app.get("/ready", async (c) => {
-  const checks: Record<
-    string,
-    { ok: boolean; required?: boolean; error?: string; source?: string; detail?: unknown }
-  > = {};
-
-  const expectedMigration = getMigrationExpectation();
-  checks.migrations = { ok: false, detail: { expected: expectedMigration.tag } };
-
-  try {
-    const db = getDb();
-    const pglite = shouldUsePGLite();
-    const result = pglite
-      ? await db.execute(sql`
+app.get(
+  "/ready",
+  createReadinessHandler({
+    apiVersion: API_VERSION,
+    startedAt: startTime,
+    environment: () => ({
+      allowMemoryAuthStores: process.env.STEWARD_ALLOW_MEMORY_AUTH_STORES === "true",
+      probeToken: process.env.STEWARD_READY_PROBE_TOKEN,
+      requiresDurableAuthStores:
+        process.env.NODE_ENV === "production" || process.env.STEWARD_RUNTIME === "workers",
+    }),
+    checkDatabase: async () => {
+      const checks: Record<string, ReadinessCheck> = {};
+      const expectedMigration = getMigrationExpectation();
+      checks.migrations = { ok: false, detail: { expected: expectedMigration.tag } };
+      try {
+        const db = getDb();
+        const pglite = shouldUsePGLite();
+        const result = pglite
+          ? await db.execute(sql`
           SELECT
             EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS database_time_ms,
             EXISTS(
               SELECT 1 FROM __steward_migrations WHERE tag = ${expectedMigration.tag}
             ) AS expected_migration_applied
         `)
-      : await db.execute(sql`
+          : await db.execute(sql`
           SELECT
             EXTRACT(EPOCH FROM clock_timestamp()) * 1000 AS database_time_ms,
             (SELECT MAX(created_at) FROM drizzle.__drizzle_migrations) AS migration_created_at
         `);
-    const rows = Array.isArray(result)
-      ? result
-      : ((result as unknown as { rows?: unknown[] }).rows ?? []);
-    const row = rows[0] as
-      | { database_time_ms?: string | number; migration_created_at?: string | number | null }
-      | undefined;
-    const databaseTimeMs = Number(row?.database_time_ms);
-    const migrationCreatedAt = Number(row?.migration_created_at);
-    const expectedMigrationApplied =
-      (row as { expected_migration_applied?: unknown } | undefined)?.expected_migration_applied ===
-      true;
-    const databaseSkewMs = Math.abs(Date.now() - databaseTimeMs);
-    checks.database = {
-      ok: Number.isFinite(databaseTimeMs) && databaseSkewMs <= 30_000,
-      detail: { clockSkewMs: Math.round(databaseSkewMs), serverTime: new Date().toISOString() },
-    };
-    checks.migrations = {
-      ok:
-        migrationsRan &&
-        (pglite ? expectedMigrationApplied : migrationCreatedAt === expectedMigration.createdAt),
-      detail: {
-        expected: expectedMigration.tag,
-        expectedCreatedAt: expectedMigration.createdAt,
-        ...(pglite
-          ? { expectedMigrationApplied }
-          : { actualCreatedAt: Number.isFinite(migrationCreatedAt) ? migrationCreatedAt : null }),
-      },
-    };
-    if (process.env.NODE_ENV === "production") {
-      const expectedRole = process.env.STEWARD_APP_DATABASE_ROLE;
-      if (!expectedRole) throw new Error("STEWARD_APP_DATABASE_ROLE is required in production");
-      await assertRlsDeploymentSafety(db, { expectedRole });
-      checks.rlsDeployment = { ok: true };
-    }
-  } catch {
-    checks.database = { ok: false, error: "Database health check failed" };
-  }
-
-  try {
-    const redis = getRedisClient();
-    checks.redis = redis
-      ? { ok: (await redis.ping()).toUpperCase() === "PONG" }
-      : isRedisConfigured()
-        ? { ok: false, error: "Redis is configured but not connected" }
-        : { ok: false, required: false, error: "Redis is not configured (optional mode)" };
-  } catch {
-    checks.redis = { ok: false, error: "Redis health check failed" };
-  }
-
-  const proxyUrl = process.env.STEWARD_PROXY_URL?.replace(/\/+$/, "");
-  if (!proxyUrl) {
-    checks.proxyClock = {
-      ok: false,
-      required: false,
-      error: "STEWARD_PROXY_URL not configured",
-    };
-  } else {
-    try {
+        const rows = Array.isArray(result)
+          ? result
+          : ((result as unknown as { rows?: unknown[] }).rows ?? []);
+        const row = rows[0] as
+          | { database_time_ms?: string | number; migration_created_at?: string | number | null }
+          | undefined;
+        const databaseTimeMs = Number(row?.database_time_ms);
+        const migrationCreatedAt = Number(row?.migration_created_at);
+        const expectedMigrationApplied =
+          (row as { expected_migration_applied?: unknown } | undefined)
+            ?.expected_migration_applied === true;
+        const databaseSkewMs = Math.abs(Date.now() - databaseTimeMs);
+        checks.database = {
+          ok: Number.isFinite(databaseTimeMs) && databaseSkewMs <= 30_000,
+          detail: { clockSkewMs: Math.round(databaseSkewMs), serverTime: new Date().toISOString() },
+        };
+        checks.migrations = {
+          ok:
+            migrationsRan &&
+            (pglite
+              ? expectedMigrationApplied
+              : migrationCreatedAt === expectedMigration.createdAt),
+          detail: {
+            expected: expectedMigration.tag,
+            expectedCreatedAt: expectedMigration.createdAt,
+            ...(pglite
+              ? { expectedMigrationApplied }
+              : {
+                  actualCreatedAt: Number.isFinite(migrationCreatedAt) ? migrationCreatedAt : null,
+                }),
+          },
+        };
+        if (process.env.NODE_ENV === "production") {
+          const expectedRole = process.env.STEWARD_APP_DATABASE_ROLE;
+          if (!expectedRole) throw new Error("STEWARD_APP_DATABASE_ROLE is required in production");
+          await assertRlsDeploymentSafety(db, { expectedRole });
+          checks.rlsDeployment = { ok: true };
+        }
+      } catch {
+        checks.database = { ok: false, error: "Database health check failed" };
+      }
+      return checks;
+    },
+    checkRedis: async () => {
+      const redis = getRedisClient();
+      return redis
+        ? { ok: (await redis.ping()).toUpperCase() === "PONG" }
+        : isRedisConfigured()
+          ? { ok: false, error: "Redis is configured but not connected" }
+          : { ok: false, required: false, error: "Redis is not configured (optional mode)" };
+    },
+    checkProxyClock: async () => {
+      const proxyUrl = process.env.STEWARD_PROXY_URL?.replace(/\/+$/, "");
+      if (!proxyUrl) {
+        return {
+          ok: false,
+          required: false,
+          error: "STEWARD_PROXY_URL not configured",
+        };
+      }
       const startedAt = Date.now();
       const response = await fetch(`${proxyUrl}/health`, { signal: AbortSignal.timeout(3_000) });
       const body = (await response.json()) as { serverTime?: unknown };
@@ -233,71 +234,33 @@ app.get("/ready", async (c) => {
       const proxyTime = Date.parse(String(body.serverTime ?? ""));
       const midpoint = startedAt + (endedAt - startedAt) / 2;
       const skewMs = Math.abs(proxyTime - midpoint);
-      checks.proxyClock = {
+      return {
         ok: response.ok && Number.isFinite(proxyTime) && skewMs <= 30_000,
         detail: { clockSkewMs: Math.round(skewMs) },
       };
-    } catch {
-      checks.proxyClock = { ok: false, error: "Proxy health check failed" };
-    }
-  }
-
-  if (!process.env.STEWARD_MASTER_PASSWORD) {
-    checks.vault = { ok: false, error: "STEWARD_MASTER_PASSWORD not set" };
-  } else {
-    checks.vault = { ok: true };
-  }
-
-  const storeSources = getAuthStoreSources();
-  const memoryAuthStores = Object.entries(storeSources)
-    .filter(([, source]) => source === "memory")
-    .map(([name]) => name);
-  const memoryAuthStoresAllowed =
-    process.env.STEWARD_ALLOW_MEMORY_AUTH_STORES === "true" ||
-    process.env.NODE_ENV !== "production";
-  checks.authStores = {
-    ok: memoryAuthStores.length === 0 || memoryAuthStoresAllowed,
-    source: Object.entries(storeSources)
-      .map(([name, source]) => `${name}:${source}`)
-      .join(","),
-    ...(memoryAuthStores.length > 0 && !memoryAuthStoresAllowed
-      ? { error: `Production auth stores using memory: ${memoryAuthStores.join(", ")}` }
-      : {}),
-  };
-
-  if (capabilitiesEnabled) {
-    const health = getUpstreamCredentialLeaseSchedulerHealth();
-    checks.upstreamCredentialLeases = {
-      ok: health.ok,
-      detail: {
-        enabled: health.enabled,
-        inFlight: health.inFlight,
-        lastStartedAt: health.lastStartedAt,
-        lastSucceededAt: health.lastSucceededAt,
-        lastFailedAt: health.lastFailedAt,
-      },
-      ...(health.lastError ? { error: health.lastError } : {}),
-    };
-  }
-
-  const allOk = Object.values(checks).every((check) => check.ok || check.required === false);
-  const verbose = readyProbeAuthorized(c.req.header("x-steward-probe-token"));
-  const publicChecks = Object.fromEntries(
-    Object.entries(checks).map(([name, check]) => [
-      name,
-      { ok: check.ok, ...(check.required === false ? { required: false } : {}) },
-    ]),
-  );
-  return c.json(
-    {
-      status: allOk ? "ready" : "not_ready",
-      version: API_VERSION,
-      uptime: Math.floor((Date.now() - startTime) / 1000),
-      checks: verbose ? checks : publicChecks,
     },
-    allOk ? 200 : 503,
-  );
-});
+    getAuthStoreSources,
+    isVaultConfigured: () => Boolean(process.env.STEWARD_MASTER_PASSWORD),
+    getAdditionalChecks: capabilitiesEnabled
+      ? () => {
+          const health = getUpstreamCredentialLeaseSchedulerHealth();
+          return {
+            upstreamCredentialLeases: {
+              ok: health.ok,
+              detail: {
+                enabled: health.enabled,
+                inFlight: health.inFlight,
+                lastStartedAt: health.lastStartedAt,
+                lastSucceededAt: health.lastSucceededAt,
+                lastFailedAt: health.lastFailedAt,
+              },
+              ...(health.lastError ? { error: health.lastError } : {}),
+            },
+          };
+        }
+      : undefined,
+  }),
+);
 
 // ─── Database migrations (blocking — must complete before serving traffic) ───
 

--- a/packages/api/src/readiness.ts
+++ b/packages/api/src/readiness.ts
@@ -1,0 +1,122 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { Handler } from "hono";
+import type { AuthStoreSources } from "./routes/auth";
+import type { AppVariables } from "./services/context";
+
+export type ReadinessCheck = {
+  ok: boolean;
+  required?: boolean;
+  error?: string;
+  source?: string;
+  detail?: unknown;
+};
+
+export type ReadinessEnvironment = {
+  allowMemoryAuthStores: boolean;
+  probeToken?: string;
+  requiresDurableAuthStores: boolean;
+};
+
+export type ReadinessDependencies = {
+  apiVersion: string;
+  startedAt: number;
+  now?: () => number;
+  environment: () => ReadinessEnvironment;
+  checkDatabase: () => Promise<Record<string, ReadinessCheck>>;
+  checkRedis: () => Promise<ReadinessCheck>;
+  checkProxyClock: () => Promise<ReadinessCheck>;
+  getAuthStoreSources: () => AuthStoreSources;
+  isVaultConfigured: () => boolean;
+  getAdditionalChecks?: () => Record<string, ReadinessCheck>;
+};
+
+function probeAuthorized(presented: string | undefined, expected: string | undefined): boolean {
+  if (!expected || !presented) return false;
+  const a = createHash("sha256").update(expected).digest();
+  const b = createHash("sha256").update(presented).digest();
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Build the Bun readiness route without starting the Bun process. All I/O is
+ * supplied by the entrypoint, which keeps this policy boundary mountable in
+ * tests and reusable without migrations, schedulers, timers, or Bun.serve.
+ */
+export function createReadinessHandler(
+  dependencies: ReadinessDependencies,
+): Handler<{ Variables: AppVariables }> {
+  return async (c) => {
+    // An authorized probe can include operational diagnostics. Apply the
+    // secret-bearing response policy before any dependency work so public,
+    // authorized, and unexpected failure variants can never be cached or
+    // replayed across callers by an intermediary.
+    c.header("Cache-Control", "no-store, max-age=0");
+    c.header("Pragma", "no-cache");
+    c.header("Expires", "0");
+    const checks: Record<string, ReadinessCheck> = {};
+
+    try {
+      Object.assign(checks, await dependencies.checkDatabase());
+    } catch {
+      checks.database = { ok: false, error: "Database health check failed" };
+      checks.migrations = { ok: false, error: "Migration health check failed" };
+    }
+
+    try {
+      checks.redis = await dependencies.checkRedis();
+    } catch {
+      checks.redis = { ok: false, error: "Redis health check failed" };
+    }
+
+    try {
+      checks.proxyClock = await dependencies.checkProxyClock();
+    } catch {
+      checks.proxyClock = { ok: false, error: "Proxy health check failed" };
+    }
+
+    checks.vault = dependencies.isVaultConfigured()
+      ? { ok: true }
+      : { ok: false, error: "STEWARD_MASTER_PASSWORD not set" };
+
+    const environment = dependencies.environment();
+    const storeSources = dependencies.getAuthStoreSources();
+    const memoryAuthStores = Object.entries(storeSources)
+      .filter(([, source]) => source === "memory")
+      .map(([name]) => name);
+    const memoryAuthStoresAllowed =
+      environment.allowMemoryAuthStores || !environment.requiresDurableAuthStores;
+    checks.authStores = {
+      ok: memoryAuthStores.length === 0 || memoryAuthStoresAllowed,
+      source: Object.entries(storeSources)
+        .map(([name, source]) => `${name}:${source}`)
+        .join(","),
+      ...(memoryAuthStores.length > 0 && !memoryAuthStoresAllowed
+        ? { error: `Production auth stores using memory: ${memoryAuthStores.join(", ")}` }
+        : {}),
+    };
+
+    if (dependencies.getAdditionalChecks) {
+      Object.assign(checks, dependencies.getAdditionalChecks());
+    }
+
+    const allOk = Object.values(checks).every((check) => check.ok || check.required === false);
+    const verbose = probeAuthorized(c.req.header("x-steward-probe-token"), environment.probeToken);
+    const publicChecks = Object.fromEntries(
+      Object.entries(checks).map(([name, check]) => [
+        name,
+        { ok: check.ok, ...(check.required === false ? { required: false } : {}) },
+      ]),
+    );
+    const now = dependencies.now ?? Date.now;
+
+    return c.json(
+      {
+        status: allOk ? "ready" : "not_ready",
+        version: dependencies.apiVersion,
+        uptime: Math.max(0, Math.floor((now() - dependencies.startedAt) / 1000)),
+        checks: verbose ? checks : publicChecks,
+      },
+      allOk ? 200 : 503,
+    );
+  };
+}


### PR DESCRIPTION
## Summary

- extract the Bun /ready policy into a side-effect-free handler with injected production dependencies
- preserve blocking migration, RLS, Redis/auth-store, scheduler, custody, then Bun.serve startup order
- replace source scans with mounted behavior for every auth-store source, optional dependencies, failure redaction, and authorized diagnostics

## Exact lineage

- base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6
- head: e923a4091dc156df22b8cde5ee0b18b4a1f0d0ce
- tree: 6bf07241d628aeecfdee2e5380ab8784b0be0b10

## Validation

- focused readiness/security tests: 22 pass, 0 fail, 120 assertions
- @stwd/api TypeScript build: pass
- changed-file Biome: pass
- git diff --check: pass
- direct readiness-module import exits without listener/timer side effects

Closes #734.

Held draft until exact hosted matrix and independent review complete.