### PR TITLE
fix(agent-trader): fail closed without trading credentials

### DIFF
--- a/packages/agent-trader/src/__tests__/config.test.ts
+++ b/packages/agent-trader/src/__tests__/config.test.ts
@@ -52,7 +52,7 @@ describe("loadConfig (SEC-188)", () => {
 
     const config = loadConfig();
     expect(config.agents).toEqual([]);
-    expect(config.steward.apiUrl).toBe("http://localhost:3000");
+    expect(config.steward.apiUrl).toBe("http://localhost:3200");
   });
 
   it("loads a valid config file", () => {
@@ -64,4 +64,85 @@ describe("loadConfig (SEC-188)", () => {
     expect(config.webhookSecret).toBe("s");
     expect(config.dryRun).toBe(true);
   });
+
+  it("permits a blank API key in webhook-only mode", () => {
+    const path = join(dir, "agent-trader.config.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        webhookSecret: "s",
+        steward: { apiKey: "   " },
+        agents: [validAgent({ enabled: false })],
+      }),
+    );
+    process.env.CONFIG_PATH = path;
+
+    expect(loadConfig().steward.apiKey).toBe("   ");
+  });
+
+  it.each([
+    undefined,
+    "",
+    "   ",
+  ])("fails fast when an enabled agent has a missing or blank API key (%p)", (apiKey) => {
+    const path = join(dir, "agent-trader.config.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        webhookSecret: "s",
+        steward: apiKey === undefined ? {} : { apiKey },
+        agents: [validAgent()],
+      }),
+    );
+    process.env.CONFIG_PATH = path;
+
+    expect(() => loadConfig()).toThrow(
+      "Config error: steward.apiKey is required when any agent is enabled",
+    );
+  });
+
+  it("accepts an enabled agent with a nonblank API key", () => {
+    const path = join(dir, "agent-trader.config.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        webhookSecret: "s",
+        steward: { apiKey: "test-key" },
+        agents: [validAgent()],
+      }),
+    );
+    process.env.CONFIG_PATH = path;
+
+    expect(loadConfig().steward.apiKey).toBe("test-key");
+  });
+
+  it("rejects a blank environment override for an enabled agent", () => {
+    const path = join(dir, "agent-trader.config.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        webhookSecret: "s",
+        steward: { apiKey: "file-key" },
+        agents: [validAgent()],
+      }),
+    );
+    process.env.CONFIG_PATH = path;
+    process.env.STEWARD_API_KEY = "   ";
+
+    expect(() => loadConfig()).toThrow(
+      "Config error: steward.apiKey is required when any agent is enabled",
+    );
+  });
 });
+
+function validAgent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    agentId: "agent-1",
+    tokenAddress: "0x0000000000000000000000000000000000000001",
+    strategy: "manual",
+    intervalSeconds: 60,
+    enabled: true,
+    params: {},
+    ...overrides,
+  };
+}

--- a/packages/agent-trader/src/__tests__/startup-config.test.ts
+++ b/packages/agent-trader/src/__tests__/startup-config.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "agent-trader-startup-test-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("agent-trader startup configuration", () => {
+  it("exits before starting services when an enabled agent has no API key", () => {
+    const configPath = join(dir, "agent-trader.config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        webhookSecret: "test-secret",
+        agents: [
+          {
+            agentId: "agent-1",
+            tokenAddress: "0x0000000000000000000000000000000000000001",
+            strategy: "manual",
+            intervalSeconds: 60,
+            enabled: true,
+            params: {},
+          },
+        ],
+      }),
+    );
+
+    const result = Bun.spawnSync({
+      cmd: [process.execPath, "src/index.ts"],
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        CONFIG_PATH: configPath,
+        STEWARD_API_KEY: "",
+        NODE_ENV: "test",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(result.exitCode).toBe(1);
+    const stderr = result.stderr.toString();
+    expect(stderr).toContain("Failed to load configuration");
+    expect(result.stdout.toString()).not.toContain("Configuration loaded");
+  });
+});

--- a/packages/agent-trader/src/config.ts
+++ b/packages/agent-trader/src/config.ts
@@ -118,7 +118,7 @@ export function loadConfig(): TraderConfig {
 
   // Merge: file takes precedence, env vars override the connection block
   const steward: StewardConnection = {
-    apiUrl: process.env.STEWARD_API_URL ?? file.steward?.apiUrl ?? "http://localhost:3000",
+    apiUrl: process.env.STEWARD_API_URL ?? file.steward?.apiUrl ?? "http://localhost:3200",
     tenantId: process.env.STEWARD_TENANT_ID ?? file.steward?.tenantId ?? "default",
     apiKey: process.env.STEWARD_API_KEY ?? file.steward?.apiKey ?? "",
   };
@@ -149,6 +149,12 @@ function validate(config: TraderConfig): void {
   }
   if (!config.steward.tenantId) {
     throw new Error("Config error: steward.tenantId is required");
+  }
+  if (
+    config.agents.some((agent) => agent.enabled) &&
+    (typeof config.steward.apiKey !== "string" || config.steward.apiKey.trim().length === 0)
+  ) {
+    throw new Error("Config error: steward.apiKey is required when any agent is enabled");
   }
   if (!config.webhookSecret && !allowUnsignedWebhooks()) {
     throw new Error(


### PR DESCRIPTION
## Summary

- fail startup before services launch when any enabled trading agent lacks a nonblank Steward API key
- keep webhook-only operation available when every trading agent is disabled
- use the canonical local Steward API port 3200 instead of the retired 3000 default
- cover file, environment-override, blank, enabled, disabled, and spawned-startup behavior

## Exact head

f715e4c9a21e06d34c2f68b32e2e84fc6d2bfb52 on develop base 201c1869d40ffca8a207a32a24eecc7eb6f24cd6.

## Validation

- agent-trader package tests: 62/62
- agent-trader dependency graph build: 8/8
- changed-file Biome and diff-check pass
- full hosted matrix and independent approval remain required

Closed #780 is historical and not delivery evidence for this rebased exact head.

Closes #774