### PR TITLE
docs: align API port and JWT deployment contracts

### DIFF
--- a/docs/guides/cloud-deployment.mdx
+++ b/docs/guides/cloud-deployment.mdx
@@ -86,7 +86,7 @@ Steward binds to `0.0.0.0:3200` so Docker containers can reach it via the bridge
 ```bash
 # On each node
 STEWARD_BIND_HOST=0.0.0.0
-STEWARD_PORT=3200
+PORT=3200
 ```
 
 <Note>

--- a/docs/guides/docker.mdx
+++ b/docs/guides/docker.mdx
@@ -39,7 +39,7 @@ services:
       DATABASE_URL: postgres://steward:${DB_PASSWORD:-changeme}@postgres:5432/steward
       STEWARD_MASTER_PASSWORD: ${STEWARD_MASTER_PASSWORD}
       STEWARD_JWT_SECRET: ${STEWARD_JWT_SECRET}
-      STEWARD_PORT: "3200"
+      PORT: "3200"
       STEWARD_BIND_HOST: "0.0.0.0"
       RPC_URL: ${RPC_URL:-https://mainnet.base.org}
       CHAIN_ID: ${CHAIN_ID:-8453}

--- a/docs/guides/self-hosting.mdx
+++ b/docs/guides/self-hosting.mdx
@@ -72,13 +72,26 @@ DATABASE_URL=postgres://user:pass@localhost:5432/steward
 
 ### API Server
 
+Generate a dedicated JWT signing secret and store the output in your secret
+manager or `.env` file:
+
 ```bash
-STEWARD_PORT=3200                           # API port (default: 3200)
-STEWARD_BIND_HOST=0.0.0.0                   # Bind address
-STEWARD_JWT_SECRET=separate-jwt-signing-key  # Defaults to master password if not set
-STEWARD_PLATFORM_KEY=your-platform-admin-key # For platform-level management
-STEWARD_EMBEDDED=false                       # Set true for PGLite mode
+openssl rand -hex 32
 ```
+
+```bash
+PORT=3200                                              # API port (default: 3200)
+STEWARD_BIND_HOST=0.0.0.0                              # Bind address
+STEWARD_JWT_SECRET=<paste-64-character-hex-output-here> # Required outside embedded/local mode
+STEWARD_PLATFORM_KEY=your-platform-admin-key           # For platform-level management
+STEWARD_EMBEDDED=false                                  # Set true for PGLite mode
+```
+
+For non-embedded production, `STEWARD_JWT_SECRET` is required and must contain
+at least 32 high-entropy characters. Keep it separate from
+`STEWARD_MASTER_PASSWORD`. Derivation from the master password is available
+only in embedded/local development mode; production fails closed when the
+dedicated JWT secret is absent or too short.
 
 ### Blockchain
 
@@ -203,7 +216,7 @@ server {
 ## Production Checklist
 
 - [ ] Set a unique `STEWARD_MASTER_PASSWORD` (32+ chars, random)
-- [ ] Set a separate `STEWARD_JWT_SECRET`
+- [ ] Set a separate, high-entropy `STEWARD_JWT_SECRET` (32+ characters)
 - [ ] Use TLS for all connections (API + database)
 - [ ] Restrict database access to the Steward server only
 - [ ] Set `STEWARD_PLATFORM_KEY` for admin operations

--- a/docs/guides/self-hosting.mdx
+++ b/docs/guides/self-hosting.mdx
@@ -82,16 +82,19 @@ openssl rand -hex 32
 ```bash
 PORT=3200                                              # API port (default: 3200)
 STEWARD_BIND_HOST=0.0.0.0                              # Bind address
-STEWARD_JWT_SECRET=<paste-64-character-hex-output-here> # Required outside embedded/local mode
+STEWARD_JWT_SECRET=<paste-64-character-hex-output-here> # Canonical for new non-embedded production deployments
 STEWARD_PLATFORM_KEY=your-platform-admin-key           # For platform-level management
 STEWARD_EMBEDDED=false                                  # Set true for PGLite mode
 ```
 
-For non-embedded production, `STEWARD_JWT_SECRET` is required and must contain
-at least 32 high-entropy characters. Keep it separate from
-`STEWARD_MASTER_PASSWORD`. Derivation from the master password is available
-only in embedded/local development mode; production fails closed when the
-dedicated JWT secret is absent or too short.
+For new non-embedded production deployments, configure the canonical
+`STEWARD_JWT_SECRET` with at least 32 high-entropy characters and keep it
+separate from `STEWARD_MASTER_PASSWORD`. During migration, the runtime
+temporarily accepts a 32+ character `STEWARD_SESSION_SECRET` when the canonical
+variable is absent, but that name is deprecated and should be replaced with
+`STEWARD_JWT_SECRET`. Without either sufficiently long signing secret,
+non-embedded production fails closed. Derivation from the master password is
+available only in embedded/local mode.
 
 ### Blockchain
 

--- a/packages/auth/src/__tests__/jwt.test.ts
+++ b/packages/auth/src/__tests__/jwt.test.ts
@@ -148,3 +148,50 @@ describe("JWT secret strength policy (SEC-053, SEC-054)", () => {
     }
   });
 });
+
+describe("#778 non-embedded production JWT migration contract", () => {
+  it("rejects a master-password fallback outside embedded mode", async () => {
+    const { getJwtSecret } = await import(`../jwt?docs778-master=${Date.now()}`);
+    expect(() =>
+      getJwtSecret({
+        warn: null,
+        environment: {
+          NODE_ENV: "production",
+          STEWARD_MASTER_PASSWORD: "master-password-is-not-a-server-jwt-secret",
+        },
+      }),
+    ).toThrow("STEWARD_JWT_SECRET is required in production");
+  });
+
+  it("temporarily accepts and deprecates a sufficiently long legacy session secret", async () => {
+    const { getJwtSecret } = await import(`../jwt?docs778-session=${Date.now()}`);
+    const warnings: string[] = [];
+    const legacySecret = "legacy-session-secret-with-at-least-32-characters";
+    expect(
+      getJwtSecret({
+        warn: (message) => warnings.push(message),
+        environment: {
+          NODE_ENV: "production",
+          STEWARD_SESSION_SECRET: legacySecret,
+        },
+      }),
+    ).toBe(legacySecret);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("STEWARD_SESSION_SECRET is deprecated");
+  });
+
+  it("derives a domain-separated embedded production secret from the master", async () => {
+    const { getJwtSecret } = await import(`../jwt?docs778-embedded=${Date.now()}`);
+    const masterPassword = "embedded-master-password-with-at-least-32-characters";
+    const derived = getJwtSecret({
+      warn: null,
+      environment: {
+        NODE_ENV: "production",
+        STEWARD_EMBEDDED: "true",
+        STEWARD_MASTER_PASSWORD: masterPassword,
+      },
+    });
+    expect(derived).not.toBe(masterPassword);
+    expect(derived).toHaveLength(64);
+  });
+});

--- a/packages/proxy/src/__tests__/deploy-artifacts.test.ts
+++ b/packages/proxy/src/__tests__/deploy-artifacts.test.ts
@@ -37,6 +37,49 @@ describe("published Docker runtime network contract", () => {
   });
 });
 
+function readRepositoryFile(...segments: string[]): string {
+  return readFileSync(join(ROOT_DIR, ...segments), "utf8");
+}
+
+describe("#778 self-hosting JWT secret boundary", () => {
+  const guide = readRepositoryFile("docs", "guides", "self-hosting.mdx");
+
+  test("non-embedded production requires a dedicated high-entropy JWT secret", () => {
+    expect(guide).toContain("For non-embedded production, `STEWARD_JWT_SECRET` is required");
+    expect(guide).toContain("at least 32 high-entropy characters");
+    expect(guide).toContain("Keep it separate from\n`STEWARD_MASTER_PASSWORD`");
+    expect(guide).toContain("only in embedded/local development mode");
+    expect(guide).toContain("production fails closed");
+    expect(guide).not.toContain("Defaults to master password if not set");
+  });
+
+  test("the example generates rather than publishing a short literal secret", () => {
+    expect(guide).toContain("openssl rand -hex 32");
+    expect(guide).toContain("STEWARD_JWT_SECRET=<paste-64-character-hex-output-here>");
+    expect(guide).not.toContain("STEWARD_JWT_SECRET=separate-jwt-signing-key");
+  });
+});
+
+describe("#783 active deployment guides use the API runtime's canonical port variable", () => {
+  const apiEntry = readRepositoryFile("packages", "api", "src", "index.ts");
+  const activeGuides = [
+    "docs/guides/self-hosting.mdx",
+    "docs/guides/docker.mdx",
+    "docs/guides/cloud-deployment.mdx",
+  ].map((path) => [path, readRepositoryFile(...path.split("/"))] as const);
+
+  test("the API runtime declares PORT=3200 as its default", () => {
+    expect(apiEntry).toContain('process.env.PORT || "3200"');
+  });
+
+  for (const [path, guide] of activeGuides) {
+    test(`${path} configures PORT=3200 and never advertises STEWARD_PORT`, () => {
+      expect(guide).toMatch(/\bPORT(?:=|:\s*["']?)3200/);
+      expect(guide).not.toContain("STEWARD_PORT");
+    });
+  }
+});
+
 /**
  * Extract the `steward-proxy:` service block from the compose file (everything
  * from the `steward-proxy:` key up to the next top-level service or section).

--- a/packages/proxy/src/__tests__/deploy-artifacts.test.ts
+++ b/packages/proxy/src/__tests__/deploy-artifacts.test.ts
@@ -44,12 +44,15 @@ function readRepositoryFile(...segments: string[]): string {
 describe("#778 self-hosting JWT secret boundary", () => {
   const guide = readRepositoryFile("docs", "guides", "self-hosting.mdx");
 
-  test("non-embedded production requires a dedicated high-entropy JWT secret", () => {
-    expect(guide).toContain("For non-embedded production, `STEWARD_JWT_SECRET` is required");
-    expect(guide).toContain("at least 32 high-entropy characters");
-    expect(guide).toContain("Keep it separate from\n`STEWARD_MASTER_PASSWORD`");
-    expect(guide).toContain("only in embedded/local development mode");
-    expect(guide).toContain("production fails closed");
+  test("documents the canonical secret and temporary migration fallback", () => {
+    expect(guide).toContain("For new non-embedded production deployments, configure the canonical");
+    expect(guide).toContain("`STEWARD_JWT_SECRET` with at least 32 high-entropy characters");
+    expect(guide).toContain("separate from `STEWARD_MASTER_PASSWORD`");
+    expect(guide).toContain("temporarily accepts a 32+ character `STEWARD_SESSION_SECRET`");
+    expect(guide).toContain("that name is deprecated");
+    expect(guide).toContain("Without either sufficiently long signing secret");
+    expect(guide).toContain("non-embedded production fails closed");
+    expect(guide).toContain("only in embedded/local mode");
     expect(guide).not.toContain("Defaults to master password if not set");
   });
 

--- a/packages/solana-signer/README.md
+++ b/packages/solana-signer/README.md
@@ -20,7 +20,7 @@ different API replicas.
 import { createStewardSolanaSigner } from "@stwd/solana-signer";
 
 const signer = await createStewardSolanaSigner({
-  baseUrl: "http://127.0.0.1:3000",
+  baseUrl: "http://127.0.0.1:3200",
   agentId: "agent-1",
   bearerToken: process.env.STEWARD_AGENT_TOKEN,
   chainId: 102, // devnet; 101 (default) is mainnet

--- a/packages/solana-signer/src/__tests__/docs-contract.test.ts
+++ b/packages/solana-signer/src/__tests__/docs-contract.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PACKAGE_DIR = join(import.meta.dir, "..", "..");
+const REPOSITORY_DIR = join(PACKAGE_DIR, "..", "..");
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+describe("Solana signer API URL documentation", () => {
+  test("active examples follow the API runtime's canonical default port", () => {
+    const apiEntry = read(join(REPOSITORY_DIR, "packages", "api", "src", "index.ts"));
+    const defaultPort = apiEntry.match(
+      /const PORT = parseInt\(process\.env\.PORT \|\| "([0-9]+)", 10\)/,
+    )?.[1];
+
+    expect(defaultPort).toBeDefined();
+    if (!defaultPort) throw new Error("API entry point no longer declares a default port");
+
+    const activeGuidance = [
+      read(join(PACKAGE_DIR, "README.md")),
+      read(join(PACKAGE_DIR, "src", "steward-signer.ts")),
+    ];
+    for (const content of activeGuidance) {
+      expect(content).toContain(`http://127.0.0.1:${defaultPort}`);
+      expect(content).not.toContain("http://127.0.0.1:3000");
+    }
+  });
+});

--- a/packages/solana-signer/src/steward-signer.ts
+++ b/packages/solana-signer/src/steward-signer.ts
@@ -139,7 +139,7 @@ export function toSignerError(err: unknown): StewardSignerError {
 export interface StewardSolanaSignerConfig {
   /** Agent whose vault key signs. */
   agentId: string;
-  /** Steward API base URL, e.g. http://127.0.0.1:3000. Ignored when `client` is given. */
+  /** Steward API base URL, e.g. http://127.0.0.1:3200. Ignored when `client` is given. */
   baseUrl?: string;
   /** Agent-scoped bearer JWT. One of bearerToken, apiKey, or client is required. */
   bearerToken?: string;


### PR DESCRIPTION
## Summary

- use the canonical Steward API port 3200 in Solana signer guidance and source comments
- use the API runtime's PORT variable in active self-hosting, Docker, and cloud deployment guides
- document STEWARD_JWT_SECRET as the canonical non-embedded production signing root
- document the bounded deprecated STEWARD_SESSION_SECRET migration fallback and embedded-only master derivation
- execute the port and JWT documentation contracts against production source behavior

## Exact head

4115bdf3f3d66c1261fc65cb020b7c14f1784ce3 on develop base 201c1869d40ffca8a207a32a24eecc7eb6f24cd6.

## Validation

- focused auth, proxy deploy-artifact, and Solana signer contract tests: 67/67
- Auth, Proxy, and Solana signer builds pass
- changed-file Biome, public-package metadata, and diff-check pass
- full hosted matrix and independent approval remain required

Closed #785 is historical and not delivery evidence for this current-base exact head.

Closes #777
Closes #778
Closes #783