### PR TITLE
test(web): execute WalletConnect and middleware security boundaries

### DIFF
--- a/web/e2e/wallets/cache-contract.ts
+++ b/web/e2e/wallets/cache-contract.ts
@@ -3,6 +3,8 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
 export const PHANTOM_CHROME_EXTENSION_ID = "bfnaelmomeimhlpmgjnjophhpkkoljpa";
+export const METAMASK_CACHE_ID = "steward-metamask-siwe-v8";
+export const PHANTOM_CACHE_ID = "steward-phantom-siws-v5";
 export const METAMASK_VERSION = "12.20.1";
 export const METAMASK_ARTIFACT_SHA256 =
   "498247c0fe6040652ec4b51ca43461cb6b2a99d389e17216ee48d1670ddc1101";

--- a/web/e2e/wallets/setup/metamask/metamask.setup.ts
+++ b/web/e2e/wallets/setup/metamask/metamask.setup.ts
@@ -10,13 +10,14 @@
  */
 
 import { defineWalletSetup } from "@synthetixio/synpress";
+import { METAMASK_CACHE_ID } from "../../cache-contract";
 
 // The collection-only command imports this module without provisioning
 // credentials. Cache and execution commands run the fail-closed preflight
 // before either value reaches a browser.
 export const SEED_PHRASE = process.env.E2E_METAMASK_SEED_PHRASE?.trim() ?? "";
 export const PASSWORD = process.env.E2E_METAMASK_PASSWORD?.trim() ?? "";
-export const METAMASK_CACHE_ID = "steward-metamask-siwe-v8";
+export { METAMASK_CACHE_ID };
 
 const metamaskSetup = defineWalletSetup(PASSWORD, async (_context, walletPage) => {
   // Synpress 4.1.2's importer targets newer MetaMask onboarding and attempts

--- a/web/e2e/wallets/setup/phantom/phantom.setup.ts
+++ b/web/e2e/wallets/setup/phantom/phantom.setup.ts
@@ -11,10 +11,11 @@
 
 import { defineWalletSetup } from "@synthetixio/synpress";
 import { Phantom } from "@synthetixio/synpress/playwright";
+import { PHANTOM_CACHE_ID } from "../../cache-contract";
 
 export const PHANTOM_SEED = process.env.E2E_PHANTOM_SEED_PHRASE?.trim() ?? "";
 export const PHANTOM_PASSWORD = process.env.E2E_PHANTOM_PASSWORD?.trim() ?? "";
-export const PHANTOM_CACHE_ID = "steward-phantom-siws-v5";
+export { PHANTOM_CACHE_ID };
 
 const phantomSetup = defineWalletSetup(PHANTOM_PASSWORD, async (context, walletPage) => {
   const phantom = new Phantom(context, walletPage, PHANTOM_PASSWORD);

--- a/web/e2e/wallets/wallet-e2e-contract.test.ts
+++ b/web/e2e/wallets/wallet-e2e-contract.test.ts
@@ -6,7 +6,11 @@ import walletConfig from "../../playwright.wallets.config";
 import { cleanupWalletE2E } from "../../scripts/cleanup-wallet-e2e";
 import { assertWalletCaches, walletCacheRequirements } from "../../scripts/run-wallet-e2e";
 import { e2eChildProcessEnvironment } from "../global-setup";
-import { assertWalletExtensionIntegrity } from "./cache-contract";
+import {
+  assertWalletExtensionIntegrity,
+  METAMASK_CACHE_ID,
+  PHANTOM_CACHE_ID,
+} from "./cache-contract";
 import {
   assertWalletE2EPasswords,
   environmentWithoutWalletCredentials,
@@ -15,8 +19,6 @@ import {
   WALLET_E2E_PASSWORD_NAMES,
   withWalletCredentialsRemoved,
 } from "./credentials";
-import { METAMASK_CACHE_ID } from "./setup/metamask/metamask.setup";
-import { PHANTOM_CACHE_ID } from "./setup/phantom/phantom.setup";
 import { withWalletBrowserProfile } from "./wallet-browser-profile";
 import {
   assertWalletCacheIdentity,

--- a/web/src/lib/__fixtures__/import-wagmi.ts
+++ b/web/src/lib/__fixtures__/import-wagmi.ts
@@ -1,0 +1,17 @@
+const warnings: string[] = [];
+console.warn = (...values: unknown[]) => {
+  warnings.push(values.map(String).join(" "));
+};
+
+const { WALLETCONNECT_PROJECT_ID } = await import("../wagmi");
+
+process.stdout.write(
+  JSON.stringify({
+    projectId: WALLETCONNECT_PROJECT_ID,
+    warnings,
+    browserGlobalsPresent:
+      "window" in globalThis || "indexedDB" in globalThis || "localStorage" in globalThis,
+  }),
+);
+
+export {};

--- a/web/src/lib/middleware-config.test.ts
+++ b/web/src/lib/middleware-config.test.ts
@@ -1,64 +1,149 @@
-// @ts-nocheck
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { unstable_doesMiddlewareMatch } from "next/experimental/testing/server";
+import { NextRequest } from "next/server";
+import { config, middleware } from "../middleware";
 
-const middlewareSource = readFileSync(join(import.meta.dir, "..", "middleware.ts"), "utf8");
-const nextConfigSource = readFileSync(join(import.meta.dir, "..", "..", "next.config.ts"), "utf8");
-const providersSource = readFileSync(
-  join(import.meta.dir, "..", "components", "providers.tsx"),
-  "utf8",
-);
+const EXPECTED_SECURITY_HEADERS = {
+  "Cross-Origin-Opener-Policy": "same-origin-allow-popups",
+  "Cross-Origin-Resource-Policy": "same-origin",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=(), browsing-topics=(), payment=()",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+} as const;
 
-/**
- * SEC-155/SEC-156: middleware matcher anchoring + cross-origin isolation
- * headers. Source-level assertions mirror the repo's existing web test style
- * (see components/providers.test.ts).
- */
-describe("middleware matcher anchoring (SEC-155)", () => {
-  const matcherMatch = middlewareSource.match(/source:\s*\n?\s*"([^"]+)"/);
-  const pattern = matcherMatch?.[1] ?? "";
+function matchesMiddleware(pathname: string): boolean {
+  return unstable_doesMiddlewareMatch({
+    config,
+    url: `https://steward.test${pathname}`,
+  });
+}
 
-  test("the api exclusion is anchored to api/ only", () => {
-    expect(pattern).toContain("(?!api/|");
-    expect(pattern).not.toContain("(?!api|");
+function configuredHeaders(allowInsecureHttp: boolean) {
+  const webRoot = join(import.meta.dir, "..", "..");
+  const { E2E_ALLOW_INSECURE_HTTP: _ignored, ...cleanEnv } = process.env;
+  const result = Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      "--eval",
+      'const { default: config } = await import("./next.config.ts"); console.log(JSON.stringify(await config.headers?.()));',
+    ],
+    cwd: webRoot,
+    env: allowInsecureHttp ? { ...cleanEnv, E2E_ALLOW_INSECURE_HTTP: "true" } : cleanEnv,
+    stderr: "pipe",
+    stdout: "pipe",
   });
 
-  test("api routes are excluded but api-prefixed pages are not", () => {
-    // The matcher source "/((?!api/|_next/static|...).*)" maps to a regex over
-    // the full pathname: leading slash, then a segment not starting with an
-    // excluded prefix.
-    const regex = new RegExp(`^${pattern}$`);
-    expect(regex.test("/api/auth/refresh")).toBe(false);
-    expect(regex.test("/api/anything")).toBe(false);
-    expect(regex.test("/api-keys")).toBe(true);
-    expect(regex.test("/dashboard")).toBe(true);
-    expect(regex.test("/login")).toBe(true);
-    expect(regex.test("/_next/static/chunk.js")).toBe(false);
+  expect(result.exitCode, result.stderr.toString()).toBe(0);
+  return JSON.parse(result.stdout.toString()) as Array<{
+    source: string;
+    headers: Array<{ key: string; value: string }>;
+  }>;
+}
+
+describe("middleware security contract", () => {
+  test("sets the response security headers and forwards one nonce-bound CSP", () => {
+    const previousApiUrl = process.env.NEXT_PUBLIC_STEWARD_API_URL;
+    process.env.NEXT_PUBLIC_STEWARD_API_URL = "https://api.steward.test";
+
+    try {
+      const response = middleware(
+        new NextRequest("https://steward.test/dashboard", {
+          headers: {
+            "x-nonce": "attacker-controlled",
+            "content-security-policy": "default-src *",
+          },
+        }),
+      );
+
+      for (const [key, value] of Object.entries(EXPECTED_SECURITY_HEADERS)) {
+        expect(response.headers.get(key)).toBe(value);
+      }
+
+      const csp = response.headers.get("Content-Security-Policy");
+      expect(csp).not.toBeNull();
+      expect(csp).toContain("default-src 'self'");
+      expect(csp).toContain("frame-ancestors 'none'");
+      expect(csp).toContain("upgrade-insecure-requests");
+
+      const nonce = csp?.match(/'nonce-([^']+)'/)?.[1];
+      expect(nonce).toMatch(/^[A-Za-z0-9+/]{22}==$/);
+      expect(nonce).not.toBe("attacker-controlled");
+      expect(response.headers.get("x-middleware-request-x-nonce")).toBe(nonce);
+      expect(response.headers.get("x-middleware-request-content-security-policy")).toBe(csp);
+      expect(response.headers.get("x-middleware-override-headers")?.split(",").sort()).toEqual([
+        "content-security-policy",
+        "x-nonce",
+      ]);
+    } finally {
+      if (previousApiUrl === undefined) delete process.env.NEXT_PUBLIC_STEWARD_API_URL;
+      else process.env.NEXT_PUBLIC_STEWARD_API_URL = previousApiUrl;
+    }
   });
 });
 
-describe("cross-origin isolation headers (SEC-156)", () => {
-  test("middleware sets COOP same-origin-allow-popups (keeps OAuth popup opener)", () => {
-    expect(middlewareSource).toContain(
-      '["Cross-Origin-Opener-Policy", "same-origin-allow-popups"]',
+describe("exported middleware matcher", () => {
+  test.each([
+    "/api/auth/refresh",
+    "/api/anything",
+    "/_next/static/chunk.js",
+    "/_next/image",
+    "/favicon.ico",
+    "/icon-192.png",
+    "/apple-touch-icon.png",
+    "/site.webmanifest",
+  ])("excludes %s", (pathname) => {
+    expect(matchesMiddleware(pathname)).toBe(false);
+  });
+
+  test.each(["/api-keys", "/dashboard", "/login"])("covers %s", (pathname) => {
+    expect(matchesMiddleware(pathname)).toBe(true);
+  });
+
+  test("skips router prefetches through the exported missing-header rules", () => {
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        url: "https://steward.test/dashboard",
+        headers: { purpose: "prefetch" },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("next.config static security headers", () => {
+  test("matches the middleware header posture by default", () => {
+    const entries = configuredHeaders(false);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.source).toBe("/:path*");
+
+    const actualHeaders = Object.fromEntries(
+      (entries[0]?.headers ?? []).map(({ key, value }) => [key, value]),
     );
-    // Must NOT be plain same-origin — that severs window.opener for the OAuth
-    // popup flow once the popup navigates cross-origin.
-    expect(middlewareSource).not.toContain('["Cross-Origin-Opener-Policy", "same-origin"]');
+    expect(actualHeaders).toEqual(EXPECTED_SECURITY_HEADERS);
   });
 
-  test("middleware sets CORP same-origin", () => {
-    expect(middlewareSource).toContain('"Cross-Origin-Resource-Policy"');
-    expect(middlewareSource).toContain('"same-origin"');
-  });
+  test("only omits HSTS under the explicit e2e insecure-HTTP opt-out", () => {
+    const entries = configuredHeaders(true);
+    const actualHeaders = Object.fromEntries(
+      (entries[0]?.headers ?? []).map(({ key, value }) => [key, value]),
+    );
+    const { "Strict-Transport-Security": _hsts, ...expectedWithoutHsts } =
+      EXPECTED_SECURITY_HEADERS;
 
-  test("static-asset headers in next.config.ts mirror COOP/CORP", () => {
-    expect(nextConfigSource).toContain('"Cross-Origin-Opener-Policy"');
-    expect(nextConfigSource).toContain('"Cross-Origin-Resource-Policy"');
+    expect(actualHeaders).toEqual(expectedWithoutHsts);
   });
+});
 
-  test("no stale web/vercel.json CSP references remain", () => {
+describe("security configuration inventory", () => {
+  test("the provider does not retain the retired vercel.json CSP reference", () => {
+    const providersSource = readFileSync(
+      join(import.meta.dir, "..", "components", "providers.tsx"),
+      "utf8",
+    );
     expect(providersSource).not.toContain("vercel.json");
   });
 });

--- a/web/src/lib/middleware-config.test.ts
+++ b/web/src/lib/middleware-config.test.ts
@@ -70,6 +70,7 @@ describe("middleware security contract", () => {
       expect(csp).toContain("upgrade-insecure-requests");
 
       const nonce = csp?.match(/'nonce-([^']+)'/)?.[1];
+      if (!nonce) throw new Error("middleware CSP did not contain a nonce");
       expect(nonce).toMatch(/^[A-Za-z0-9+/]{22}==$/);
       expect(nonce).not.toBe("attacker-controlled");
       expect(response.headers.get("x-middleware-request-x-nonce")).toBe(nonce);

--- a/web/src/lib/wagmi.test.ts
+++ b/web/src/lib/wagmi.test.ts
@@ -1,27 +1,76 @@
-// @ts-nocheck
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-const wagmiSource = readFileSync(join(import.meta.dir, "wagmi.ts"), "utf8");
-const guardSource = readFileSync(
-  join(import.meta.dir, "..", "..", "scripts", "assert-production-deploy-env.mjs"),
-  "utf8",
-);
+const fixturePath = join(import.meta.dir, "__fixtures__", "import-wagmi.ts");
+const guardPath = join(import.meta.dir, "..", "..", "scripts", "assert-production-deploy-env.mjs");
+const SHARED_FALLBACK_PROJECT_ID = "2c7ddf841a48e522748c5e2782d73443";
 
-/**
- * SEC-157: the hardcoded shared WalletConnect projectId must not silently
- * serve production builds — the deploy pipeline requires the env var and
- * production builds warn at runtime when the shared fallback is in use.
- */
+function childEnv(values: Record<string, string | undefined>): Record<string, string> {
+  const env = { ...process.env } as Record<string, string>;
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined) delete env[key];
+    else env[key] = value;
+  }
+  return env;
+}
+
+function runWagmiImport(environment: "production" | "development", projectId?: string) {
+  const child = Bun.spawnSync({
+    cmd: [process.execPath, fixturePath],
+    env: childEnv({
+      NODE_ENV: environment,
+      NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: projectId,
+    }),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(child.exitCode, child.stderr.toString()).toBe(0);
+  return JSON.parse(child.stdout.toString()) as {
+    projectId: string;
+    warnings: string[];
+    browserGlobalsPresent: boolean;
+  };
+}
+
+function runDeployGuard(projectId?: string) {
+  return Bun.spawnSync({
+    cmd: [process.execPath, guardPath],
+    env: childEnv({
+      E2E_ALLOW_INSECURE_HTTP: undefined,
+      NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: projectId,
+    }),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
 describe("WalletConnect projectId fallback is dev-only (SEC-157)", () => {
-  test("production builds warn when the shared fallback is in use", () => {
-    expect(wagmiSource).toContain('process.env.NODE_ENV === "production"');
-    expect(wagmiSource).toContain("SHARED_FALLBACK_PROJECT_ID");
-    expect(wagmiSource).toContain("NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID is unset");
+  test("production import warns and resolves the shared fallback when configuration is absent", () => {
+    const result = runWagmiImport("production");
+    expect(result.projectId).toBe(SHARED_FALLBACK_PROJECT_ID);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID is unset");
+    expect(result.browserGlobalsPresent).toBe(false);
   });
 
-  test("the production deploy guard requires NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID", () => {
-    expect(guardSource).toContain("!process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID");
+  test("configured production and unconfigured development imports resolve without warnings", () => {
+    const configured = runWagmiImport("production", "dedicated-walletconnect-project");
+    expect(configured.projectId).toBe("dedicated-walletconnect-project");
+    expect(configured.warnings).toEqual([]);
+    expect(configured.browserGlobalsPresent).toBe(false);
+
+    const development = runWagmiImport("development");
+    expect(development.projectId).toBe(SHARED_FALLBACK_PROJECT_ID);
+    expect(development.warnings).toEqual([]);
+    expect(development.browserGlobalsPresent).toBe(false);
+  });
+
+  test("the checked-in production deploy guard fails closed without a dedicated project id", () => {
+    const missing = runDeployGuard();
+    expect(missing.exitCode).not.toBe(0);
+    expect(missing.stderr.toString()).toContain("NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID is unset");
+
+    const configured = runDeployGuard("dedicated-walletconnect-project");
+    expect(configured.exitCode, configured.stderr.toString()).toBe(0);
   });
 });

--- a/web/src/lib/wagmi.ts
+++ b/web/src/lib/wagmi.ts
@@ -25,9 +25,13 @@ import { arbitrum, base, bsc, gnosis, mainnet, optimism, polygon } from "wagmi/c
  * loudly at runtime if the fallback is somehow still in use.
  */
 const SHARED_FALLBACK_PROJECT_ID = "2c7ddf841a48e522748c5e2782d73443";
-const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || SHARED_FALLBACK_PROJECT_ID;
+export const WALLETCONNECT_PROJECT_ID =
+  process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || SHARED_FALLBACK_PROJECT_ID;
 
-if (process.env.NODE_ENV === "production" && projectId === SHARED_FALLBACK_PROJECT_ID) {
+if (
+  process.env.NODE_ENV === "production" &&
+  WALLETCONNECT_PROJECT_ID === SHARED_FALLBACK_PROJECT_ID
+) {
   console.warn(
     "[steward] NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID is unset: this build shares the default WalletConnect projectId quota/identity. Configure a dedicated projectId for production.",
   );
@@ -65,7 +69,7 @@ export function getWagmiConfig(): Config {
         ],
       },
     ],
-    { appName: "Steward", projectId },
+    { appName: "Steward", projectId: WALLETCONNECT_PROJECT_ID },
   );
   cachedConfig = createConfig({
     connectors,


### PR DESCRIPTION
## Summary

- execute WalletConnect production/development imports in isolated subprocesses and assert resolved project ID, warnings, and absence of browser globals
- execute the checked-in production deploy guard with missing and configured WalletConnect authority
- invoke the real middleware and assert nonce-bound CSP plus exact security headers
- behaviorally evaluate the exported matcher across API, static, image, icon, prefetch, API-prefixed page, dashboard, and login paths
- invoke Next headers configuration in isolated postures and assert default/HSTS opt-out parity

## Exact head

71834ac1362a1614d73fe4233f1cc601e8c1e8ec on develop base 201c1869d40ffca8a207a32a24eecc7eb6f24cd6.

## Validation

- focused web behavior suites: 19/19n- hosted-failure corrective: web TypeScript + middleware/WalletConnect/wallet-contract suites 36/36
- web dependency graph and production Next build: 8/8
- changed-file Biome and diff-check pass
- full hosted matrix and independent approval remain required

Issue #758 remains out of scope and still requires live production-server/browser HTTP coverage.

Closes #726
Closes #727