### PR TITLE
test(api): mount retired control-plane boundaries

### DIFF
--- a/packages/api/src/__tests__/policy-template-id-validation.test.ts
+++ b/packages/api/src/__tests__/policy-template-id-validation.test.ts
@@ -1,30 +1,107 @@
 import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { auditEvents, getDb, policyTemplates } from "@stwd/db";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
 
-const routeSource = readFileSync(
-  join(import.meta.dir, "..", "routes", "policies-standalone.ts"),
-  "utf8",
-);
+const TENANT_ID = "policy-template-id-boundary";
+const VALID_MISSING_ID = "11111111-1111-4111-8111-111111111111";
 
-describe("policy template id validation", () => {
-  it("rejects malformed UUID path params before raw SQL uuid casts", () => {
-    expect(routeSource).toContain("const UUID_RE =");
-    expect(routeSource).toContain("function isValidTemplateId");
-    expect(routeSource).toContain("Invalid policy template id format");
+async function makeApp(options: { mfa?: boolean; role?: "admin" | "member" } = {}) {
+  const { policiesStandaloneRoutes } = await import("../routes/policies-standalone");
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("tenantId", TENANT_ID);
+    c.set("authType", "session-jwt");
+    c.set("tenantRole", options.role ?? "admin");
+    c.set("userId", "22222222-2222-4222-8222-222222222222");
+    if (options.mfa !== false) c.set("sessionMfaVerifiedAt", Date.now());
+    await next();
+  });
+  app.route("/policies", policiesStandaloneRoutes);
+  return app;
+}
 
-    for (const marker of [
-      'policiesStandaloneRoutes.get("/:id"',
-      'policiesStandaloneRoutes.put("/:id"',
-      'policiesStandaloneRoutes.delete("/:id"',
-      'policiesStandaloneRoutes.post("/:id/assign"',
-    ]) {
-      const routeStart = routeSource.indexOf(marker);
-      expect(routeStart).toBeGreaterThanOrEqual(0);
-      const validation = routeSource.indexOf("isValidTemplateId(id)", routeStart);
-      const firstTemplateRead = routeSource.indexOf("getTemplate(tenantId, id)", routeStart);
-      expect(validation).toBeGreaterThan(routeStart);
-      expect(firstTemplateRead === -1 || validation < firstTemplateRead).toBe(true);
+const malformedIds = [
+  "not-a-uuid",
+  "00000000-0000-0000-0000-000000000000",
+  `11111111-1111-4111-8111-111111111111${"x".repeat(256)}`,
+  "11111111-1111-4111-8111-111111111111\u0000suffix",
+  "11111111-1111-4111-8111-111111111111\nsuffix",
+];
+
+const routes = [
+  { method: "GET", suffix: "", body: undefined },
+  { method: "PUT", suffix: "", body: { name: "must-not-update" } },
+  { method: "DELETE", suffix: "", body: undefined },
+  { method: "POST", suffix: "/assign", body: { agentIds: ["must-not-assign"] } },
+] as const;
+
+describe("mounted policy-template id boundary", () => {
+  it("uniformly rejects malformed IDs before lookup, mutation, or audit", async () => {
+    const app = await makeApp();
+    const beforeTemplates = await getDb()
+      .select({ id: policyTemplates.id })
+      .from(policyTemplates)
+      .where(eq(policyTemplates.tenantId, TENANT_ID));
+    const beforeAudits = await getDb()
+      .select({ id: auditEvents.id })
+      .from(auditEvents)
+      .where(eq(auditEvents.tenantId, TENANT_ID));
+
+    for (const id of malformedIds) {
+      for (const route of routes) {
+        const response = await app.request(`/policies/${encodeURIComponent(id)}${route.suffix}`, {
+          method: route.method,
+          headers: { "content-type": "application/json" },
+          body: route.body === undefined ? undefined : JSON.stringify(route.body),
+        });
+        expect(response.status, `${route.method} ${JSON.stringify(id)}`).toBe(400);
+        await expect(response.json()).resolves.toEqual({
+          ok: false,
+          error: "Invalid policy template id format",
+        });
+      }
     }
+
+    expect(
+      await getDb()
+        .select({ id: policyTemplates.id })
+        .from(policyTemplates)
+        .where(eq(policyTemplates.tenantId, TENANT_ID)),
+    ).toEqual(beforeTemplates);
+    expect(
+      await getDb()
+        .select({ id: auditEvents.id })
+        .from(auditEvents)
+        .where(eq(auditEvents.tenantId, TENANT_ID)),
+    ).toEqual(beforeAudits);
+  });
+
+  it("distinguishes a valid missing UUID from malformed input", async () => {
+    const app = await makeApp();
+    for (const route of routes) {
+      const response = await app.request(`/policies/${VALID_MISSING_ID}${route.suffix}`, {
+        method: route.method,
+        headers: { "content-type": "application/json" },
+        body: route.body === undefined ? undefined : JSON.stringify(route.body),
+      });
+      expect(response.status, route.method).toBe(404);
+      await expect(response.json()).resolves.toMatchObject({
+        ok: false,
+        error: expect.stringMatching(/not found/i),
+      });
+    }
+  });
+
+  it("preserves adjacent admin and recent-MFA boundaries", async () => {
+    const noMfa = await makeApp({ mfa: false });
+    const member = await makeApp({ role: "member" });
+    const noMfaResponse = await noMfa.request(`/policies/${VALID_MISSING_ID}`);
+    const memberResponse = await member.request(`/policies/${VALID_MISSING_ID}`, {
+      method: "DELETE",
+    });
+    expect(noMfaResponse.status).toBe(403);
+    expect(memberResponse.status).toBe(403);
   });
 });

--- a/packages/api/src/__tests__/tenant-webhook-deprecation.test.ts
+++ b/packages/api/src/__tests__/tenant-webhook-deprecation.test.ts
@@ -1,21 +1,130 @@
-import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { auditEvents, getDb, tenants, users, userTenants } from "@stwd/db";
+import { and, eq, inArray } from "drizzle-orm";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
 
-const source = readFileSync(join(import.meta.dir, "..", "routes", "tenants.ts"), "utf8");
+const PLATFORM_KEY = "legacy-webhook-platform-key-with-enough-entropy";
+const TENANT_ID = "legacy-webhook-existing";
+const CREATE_TENANT_ID = "legacy-webhook-create";
+const LEGACY_URL = "https://attacker.example.test/unsigned";
+const EXPECTED_ERROR =
+  "webhookUrl is retired because it cannot provision a receiver-verifiable signing secret; create a webhook with POST /webhooks instead (the secret is returned once)";
 
-describe("legacy tenant webhook deprecation", () => {
-  it("rejects new legacy values and never creates an undisclosed signing secret", () => {
-    expect(source).toContain("LEGACY_WEBHOOK_DEPRECATION_ERROR");
-    expect(source).toContain("POST /webhooks instead (the secret is returned once)");
-    expect(source.match(/LEGACY_WEBHOOK_DEPRECATION_ERROR }, 410/g)).toHaveLength(2);
-    expect(source).not.toContain("upsertLegacyTenantWebhook");
-    expect(source).not.toContain("generateWebhookSecret");
-    expect(source).not.toContain('description: "legacy:tenant-webhook"');
+let app: Hono<{ Variables: AppVariables }>;
+let tenantConfigs: typeof import("../services/context")["tenantConfigs"];
+let sessionToken: string;
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+
+beforeAll(async () => {
+  process.env.STEWARD_PLATFORM_KEYS = PLATFORM_KEY;
+  process.env.STEWARD_PLATFORM_KEY_SCOPES = JSON.stringify({
+    [PLATFORM_KEY]: ["platform:write", "platform:tenant:create"],
   });
 
-  it("does not present or preserve a historical inert URL as active", () => {
-    expect(source).toContain("const { webhookUrl: _webhookUrl");
-    expect(source).toContain("webhookUrl: undefined");
+  const context = await import("../services/context");
+  const { tenantRoutes } = await import("../routes/tenants");
+  tenantConfigs = context.tenantConfigs;
+  await getDb()
+    .insert(tenants)
+    .values({
+      id: TENANT_ID,
+      name: "Historical webhook tenant",
+      apiKeyHash: `hash-${TENANT_ID}`,
+    });
+  await getDb()
+    .insert(users)
+    .values({ id: USER_ID, email: `${USER_ID}@example.test` });
+  await getDb().insert(userTenants).values({ userId: USER_ID, tenantId: TENANT_ID, role: "owner" });
+  const { createSessionToken } = await import("../routes/auth");
+  sessionToken = await createSessionToken("0x0000000000000000000000000000000000000000", TENANT_ID, {
+    userId: USER_ID,
+    email: `${USER_ID}@example.test`,
+    mfaVerifiedAt: Date.now(),
+    mfaMethod: "totp",
+  });
+  tenantConfigs.set(TENANT_ID, {
+    id: TENANT_ID,
+    name: "Historical webhook tenant",
+    webhookUrl: LEGACY_URL,
+  });
+
+  app = new Hono<{ Variables: AppVariables }>();
+  app.route("/tenants", tenantRoutes);
+});
+
+afterAll(async () => {
+  tenantConfigs?.delete(TENANT_ID);
+  await getDb().delete(userTenants).where(eq(userTenants.tenantId, TENANT_ID));
+  await getDb().delete(users).where(eq(users.id, USER_ID));
+  await getDb().delete(tenants).where(eq(tenants.id, TENANT_ID));
+  delete process.env.STEWARD_PLATFORM_KEYS;
+  delete process.env.STEWARD_PLATFORM_KEY_SCOPES;
+});
+
+async function legacyAuditRows() {
+  return getDb()
+    .select({ action: auditEvents.action })
+    .from(auditEvents)
+    .where(
+      and(
+        inArray(auditEvents.tenantId, [TENANT_ID, CREATE_TENANT_ID]),
+        inArray(auditEvents.action, [
+          "tenant.create.authorized",
+          "tenant.create",
+          "tenant.update.authorized",
+          "tenant.update",
+        ]),
+      ),
+    );
+}
+
+describe("legacy tenant webhook deprecation", () => {
+  it("rejects both mounted legacy write shapes identically before mutation or audit", async () => {
+    const before = await legacyAuditRows();
+    const create = await app.request("/tenants", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-steward-platform-key": PLATFORM_KEY,
+      },
+      body: JSON.stringify({
+        id: CREATE_TENANT_ID,
+        name: "Legacy webhook create",
+        apiKeyHash: "raw-api-key",
+        webhookUrl: LEGACY_URL,
+      }),
+    });
+    const update = await app.request(`/tenants/${TENANT_ID}/webhook`, {
+      method: "PUT",
+      headers: {
+        authorization: `Bearer ${sessionToken}`,
+        "content-type": "application/json",
+        "x-steward-tenant": TENANT_ID,
+      },
+      body: JSON.stringify({ webhookUrl: LEGACY_URL }),
+    });
+
+    for (const response of [create, update]) {
+      expect(response.status).toBe(410);
+      await expect(response.json()).resolves.toEqual({ ok: false, error: EXPECTED_ERROR });
+    }
+    expect(update.headers.get("cache-control")).toContain("no-store");
+    expect(tenantConfigs.get(TENANT_ID)?.webhookUrl).toBe(LEGACY_URL);
+    expect(await legacyAuditRows()).toEqual(before);
+  });
+
+  it("keeps historical values inert and absent from mounted reads", async () => {
+    const response = await app.request(`/tenants/${TENANT_ID}`, {
+      headers: {
+        authorization: `Bearer ${sessionToken}`,
+        "x-steward-tenant": TENANT_ID,
+      },
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { data: Record<string, unknown> };
+    expect(body.data.webhookUrl).toBeUndefined();
+    expect(JSON.stringify(body)).not.toContain(LEGACY_URL);
+    expect(response.headers.get("cache-control")).toContain("no-store");
   });
 });


### PR DESCRIPTION
Closes #708
Closes #709

Exact head: 85aaad3e62b1c9c70c1b24ac195bfde88bb49c8a
Base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6

Replaces source-text assertions with mounted behavior for the retired tenant webhook write shapes and policy-template path IDs.

The webhook proof exercises both hostile legacy mutations, requires identical 410 guidance, proves no config or audit mutation, keeps historical URLs inert and absent from reads, and preserves the signed POST /webhooks replacement contract. The policy proof exercises GET, PUT, DELETE, and assign across malformed, null/control, oversized, and valid-missing UUIDs, proving malformed values return uniform 400 before lookup/mutation/audit while valid missing IDs return 404 and adjacent MFA/admin fences remain enforced.

Local exact evidence:
- package-preloaded migrated PGLite combined run: 5/5, 63 assertions
- API dependency graph build: 24/24
- targeted Biome and diff-check clean
- public-package metadata clean

Draft only. Hosted exact-head PostgreSQL checks and independent approval remain required before readiness or merge.