### PR TITLE
fix(api): make condition-set mutations audit-atomic

### DIFF
--- a/packages/api/src/__tests__/audit-policy-hardening.test.ts
+++ b/packages/api/src/__tests__/audit-policy-hardening.test.ts
@@ -117,25 +117,28 @@ describe("audit and policy route hardening", () => {
       conditionSetsSource.indexOf('conditionSetRoutes.patch("/:id"'),
     );
     expect(updateRoute.indexOf('action: "condition_set.update.authorized"')).toBeLessThan(
-      updateRoute.indexOf(".update(conditionSets)"),
+      updateRoute.indexOf("withTenantAuditedTransaction"),
     );
-    expect(updateRoute.indexOf(".returning()")).toBeLessThan(
-      updateRoute.indexOf("if (!row) return c.json<ApiResponse>"),
-    );
-    expect(updateRoute.indexOf("if (!row) return c.json<ApiResponse>")).toBeLessThan(
+    expect(updateRoute).toContain("readLockedConditionSet");
+    expect(updateRoute.indexOf(".update(conditionSets)")).toBeLessThan(
       updateRoute.indexOf('action: "condition_set.update"'),
+    );
+    expect(updateRoute.indexOf('action: "condition_set.update"')).toBeLessThan(
+      updateRoute.indexOf("return updated"),
     );
 
     const replaceRoute = conditionSetsSource.slice(
       conditionSetsSource.indexOf('conditionSetRoutes.put("/:id/items"'),
     );
     expect(replaceRoute.indexOf('action: "condition_set.items.replace.authorized"')).toBeLessThan(
-      replaceRoute.indexOf("await db.transaction"),
+      replaceRoute.indexOf("withTenantAuditedTransaction"),
     );
-    expect(replaceRoute).toContain("const [currentSet] = await tx");
-    expect(replaceRoute).toContain("if (!currentSet) return null");
-    expect(replaceRoute.indexOf("if (!rows) return c.json<ApiResponse>")).toBeLessThan(
+    expect(replaceRoute).toContain("readLockedConditionSet");
+    expect(replaceRoute.indexOf(".delete(conditionSetItems)")).toBeLessThan(
       replaceRoute.indexOf('action: "condition_set.items.replace"'),
+    );
+    expect(replaceRoute.indexOf('action: "condition_set.items.replace"')).toBeLessThan(
+      replaceRoute.indexOf("return replaced"),
     );
   });
 

--- a/packages/api/src/__tests__/condition-set-audit-rollback.test.ts
+++ b/packages/api/src/__tests__/condition-set-audit-rollback.test.ts
@@ -7,15 +7,11 @@ const routeSource = readFileSync(
   "utf8",
 );
 
-describe("condition set audit rollback hardening", () => {
-  it("restores condition sets and items when final audit writes fail", () => {
-    expect(routeSource).toContain("type ConditionSetRow = typeof conditionSets.$inferSelect");
-    expect(routeSource).toContain(
-      "type ConditionSetItemRow = typeof conditionSetItems.$inferSelect",
-    );
-    expect(routeSource).toContain("async function snapshotConditionSetItems");
-    expect(routeSource).toContain("async function restoreConditionSet");
-    expect(routeSource).toContain("async function restoreConditionSetItems");
+describe("condition set audit atomicity", () => {
+  it("uses audited transactions without snapshot restoration for every mutation", () => {
+    expect(routeSource).not.toContain("snapshotConditionSetItems");
+    expect(routeSource).not.toContain("restoreConditionSet");
+    expect(routeSource).not.toContain("restoreConditionSetItems");
 
     const createStart = routeSource.indexOf('conditionSetRoutes.post("/",');
     const createEnd = routeSource.indexOf("conditionSetRoutes.", createStart + 1);
@@ -23,15 +19,13 @@ describe("condition set audit rollback hardening", () => {
     expect(createRoute).toContain("withTenantAuditedTransaction");
     expect(createRoute).toContain("appendRequiredAudit");
 
-    for (const [marker, rollback] of [
-      ['conditionSetRoutes.patch("/:id",', "restoreConditionSet(tenantId, current"],
-      ['conditionSetRoutes.delete("/:id",', "restoreConditionSet(tenantId, current, currentItems)"],
-      ['conditionSetRoutes.post("/:id/items",', "restoreConditionSetItems(tenantId, set.id"],
-      ['conditionSetRoutes.put("/:id/items",', "restoreConditionSetItems(tenantId, set.id"],
-      [
-        'conditionSetRoutes.delete("/:id/items/:itemId",',
-        "restoreConditionSetItems(tenantId, set.id",
-      ],
+    for (const marker of [
+      'conditionSetRoutes.patch("/:id",',
+      'conditionSetRoutes.delete("/:id",',
+      'conditionSetRoutes.post("/:id/items",',
+      'conditionSetRoutes.put("/:id/items",',
+      'conditionSetRoutes.patch("/:id/items/:itemId",',
+      'conditionSetRoutes.delete("/:id/items/:itemId",',
     ] as const) {
       const start = routeSource.indexOf(marker);
       expect(start).toBeGreaterThanOrEqual(0);
@@ -39,8 +33,9 @@ describe("condition set audit rollback hardening", () => {
       // is captured regardless of nested `});` blocks inside the handler.
       const next = routeSource.indexOf("conditionSetRoutes.", start + marker.length);
       const route = routeSource.slice(start, next === -1 ? undefined : next);
-      expect(route).toContain("try {");
-      expect(route).toContain(rollback);
+      expect(route).toContain("withTenantAuditedTransaction");
+      expect(route).toContain("appendRequiredAudit");
+      expect(route).toContain("readLockedConditionSet");
     }
   });
 });

--- a/packages/api/src/__tests__/condition-set-auth-boundary.test.ts
+++ b/packages/api/src/__tests__/condition-set-auth-boundary.test.ts
@@ -65,6 +65,27 @@ describe("condition set executable auth boundary", () => {
       });
       expect(response.status).toBe(403);
     }
+
+    const setId = "10000000-0000-4000-8000-000000000001";
+    const itemId = "10000000-0000-4000-8000-000000000002";
+    for (const [path, method, body] of [
+      [`/condition-sets/${setId}`, "PATCH", { name: "blocked" }],
+      [`/condition-sets/${setId}`, "DELETE", undefined],
+      [`/condition-sets/${setId}/items`, "POST", { value: "blocked" }],
+      [`/condition-sets/${setId}/items`, "PUT", { items: [] }],
+      [`/condition-sets/${setId}/items/${itemId}`, "PATCH", { label: "blocked" }],
+      [`/condition-sets/${setId}/items/${itemId}`, "DELETE", undefined],
+    ] as const) {
+      const response = await app.request(path, {
+        method,
+        headers: {
+          ...(body ? { "Content-Type": "application/json" } : {}),
+          "x-test-auth-mode": "admin-no-mfa",
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      expect(response.status).toBe(403);
+    }
   });
 
   it("allows owner/admin sessions with recent MFA to manage condition sets", async () => {

--- a/packages/api/src/__tests__/condition-set-postgres-concurrency.integration.test.ts
+++ b/packages/api/src/__tests__/condition-set-postgres-concurrency.integration.test.ts
@@ -20,7 +20,7 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
   let admin: ReturnType<typeof createDb>;
   let app: Hono<{ Variables: AppVariables }>;
   const tenantIds: string[] = [];
-  const childProcesses = new Set<ReturnType<typeof spawnRoute>>();
+  const childProcesses = new Set<ReturnType<typeof Bun.spawn>>();
 
   beforeAll(async () => {
     admin = createDb(databaseUrl!);
@@ -51,9 +51,9 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
 
   afterEach(async () => {
     await Promise.all(
-      [...childProcesses].map(async (process) => {
-        process.kill("SIGTERM");
-        await process.exited;
+      [...childProcesses].map(async (childProcess) => {
+        childProcess.kill("SIGTERM");
+        await childProcess.exited;
       }),
     );
     childProcesses.clear();
@@ -81,15 +81,15 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
     body?: unknown;
     requestId?: string;
   }) {
-    const process = Bun.spawn(
+    const childProcess = Bun.spawn(
       [
-        process.execPath,
+        globalThis.process.execPath,
         new URL("./fixtures/condition-set-route-writer.ts", import.meta.url).pathname,
       ],
       {
         cwd: new URL("../../../..", import.meta.url).pathname,
         env: {
-          ...process.env,
+          ...globalThis.process.env,
           DATABASE_URL: databaseUrl!,
           STEWARD_AUDIT_HMAC_KEY: process.env.STEWARD_AUDIT_HMAC_KEY!,
           TEST_TENANT_ID: input.tenantId,
@@ -102,21 +102,63 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
         stderr: "pipe",
       },
     );
-    childProcesses.add(process);
-    return process;
+    childProcesses.add(childProcess);
+
+    let resolveBackendPid!: (pid: number) => void;
+    let rejectBackendPid!: (error: unknown) => void;
+    const backendPid = new Promise<number>((resolve, reject) => {
+      resolveBackendPid = resolve;
+      rejectBackendPid = reject;
+    });
+    const output = (async () => {
+      const reader = childProcess.stdout.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let result: { status: number; body: unknown } | undefined;
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          buffer += decoder.decode(value, { stream: !done });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+          for (const line of lines) {
+            if (!line) continue;
+            const frame = JSON.parse(line) as
+              | { type: "backend"; pid: number }
+              | { type: "result"; status: number; body: unknown };
+            if (frame.type === "backend") resolveBackendPid(frame.pid);
+            else result = { status: frame.status, body: frame.body };
+          }
+          if (done) break;
+        }
+        if (!result) throw new Error("condition-set writer emitted no result frame");
+        return result;
+      } catch (error) {
+        rejectBackendPid(error);
+        throw error;
+      }
+    })();
+    return {
+      backendPid,
+      childProcess,
+      output,
+      stderr: new Response(childProcess.stderr).text(),
+    };
   }
 
-  async function routeResult(process: ReturnType<typeof spawnRoute>) {
-    const stdout = new Response(process.stdout).text();
-    const stderr = new Response(process.stderr).text();
+  async function routeResult(routeProcess: ReturnType<typeof spawnRoute>) {
     try {
-      const [exit, output, errorOutput] = await Promise.all([process.exited, stdout, stderr]);
+      const [exit, output, errorOutput] = await Promise.all([
+        routeProcess.childProcess.exited,
+        routeProcess.output,
+        routeProcess.stderr,
+      ]);
       if (exit !== 0) {
         throw new Error(`condition-set writer failed: ${errorOutput}`);
       }
-      return JSON.parse(output) as { status: number; body: unknown };
+      return output;
     } finally {
-      childProcesses.delete(process);
+      childProcesses.delete(routeProcess.childProcess);
     }
   }
 
@@ -128,7 +170,7 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
     return row.key;
   }
 
-  async function waitForAdvisoryWaiter(lockKey: string, excludedPid?: number) {
+  async function waitForAdvisoryWaiter(lockKey: string, expectedPid?: number) {
     for (let attempt = 0; attempt < 200; attempt++) {
       const rows = await admin.client<{ pid: number }[]>`
         with expected as (select ${lockKey}::bigint as key)
@@ -140,7 +182,7 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
           and locks.objsubid = 1
           and locks.classid = ((expected.key >> 32) & 4294967295)::oid
           and locks.objid = (expected.key & 4294967295)::oid
-          and (${excludedPid ?? null}::integer is null or locks.pid <> ${excludedPid ?? null})
+          and (${expectedPid ?? null}::integer is null or locks.pid = ${expectedPid ?? null})
       `;
       if (rows.length === 1) return rows[0].pid;
       if (rows.length > 1) {
@@ -291,10 +333,12 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
         requestId: winnerRequestId,
         body: { label: "winner-label" },
       });
+      const expectedWinnerPid = await winner.backendPid;
       const winnerPid = await waitForAdvisoryWaiter(
         await advisoryKey(`steward_audit_${tenantId}`),
-        failedPid,
+        expectedWinnerPid,
       );
+      expect(winnerPid).toBe(expectedWinnerPid);
       expect(winnerPid).not.toBe(failedPid);
       await gate.release();
       const [failedResponse, winnerResponse] = await Promise.all([failed, routeResult(winner)]);
@@ -353,10 +397,12 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
         requestId: upsertRequestId,
         body: { value: "concurrent-upsert" },
       });
+      const expectedUpsertPid = await upsert.backendPid;
       const upsertPid = await waitForAdvisoryWaiter(
         await advisoryKey(`steward_audit_${tenantId}`),
-        replacePid,
+        expectedUpsertPid,
       );
+      expect(upsertPid).toBe(expectedUpsertPid);
       expect(upsertPid).not.toBe(replacePid);
       await gate.release();
       const [replaceResponse, upsertResponse] = await Promise.all([replace, routeResult(upsert)]);

--- a/packages/api/src/__tests__/condition-set-postgres-concurrency.integration.test.ts
+++ b/packages/api/src/__tests__/condition-set-postgres-concurrency.integration.test.ts
@@ -379,6 +379,224 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
     }
   }, 120_000);
 
+  it("rolls back an audit-failed set patch before a concurrent delete commits", async () => {
+    const { suffix, tenantId } = await createTenant("patch-delete");
+    const [set] = await admin.db
+      .insert(conditionSets)
+      .values({
+        tenantId,
+        name: "patch delete",
+        description: "original",
+        ownerId: "postgres-race",
+      })
+      .returning({ id: conditionSets.id });
+    const failedRequestId = `failed-patch-${suffix}`;
+    const winnerRequestId = `winner-delete-${suffix}`;
+    const gate = await installAuditGate({
+      suffix,
+      tenantId,
+      requestId: failedRequestId,
+      action: "condition_set.update",
+      fail: true,
+    });
+    try {
+      const failedPatch = request(tenantId, `/condition-sets/${set.id}`, {
+        method: "PATCH",
+        headers: { "x-request-id": failedRequestId },
+        body: JSON.stringify({ description: "must roll back" }),
+      });
+      const failedPid = await waitForAdvisoryWaiter(String(gate.gateKey));
+      const winningDelete = spawnRoute({
+        tenantId,
+        path: `/condition-sets/${set.id}`,
+        method: "DELETE",
+        requestId: winnerRequestId,
+      });
+      const expectedWinnerPid = await winningDelete.backendPid;
+      const winnerPid = await waitForAdvisoryWaiter(
+        await advisoryKey(`steward_audit_${tenantId}`),
+        expectedWinnerPid,
+      );
+      expect(winnerPid).toBe(expectedWinnerPid);
+      expect(winnerPid).not.toBe(failedPid);
+
+      await gate.release();
+      const [failedResponse, winnerResponse] = await Promise.all([
+        failedPatch,
+        routeResult(winningDelete),
+      ]);
+      expect(failedResponse.status).toBe(500);
+      expect(winnerResponse.status).toBe(200);
+      expect(
+        await admin.db
+          .select({ id: conditionSets.id })
+          .from(conditionSets)
+          .where(eq(conditionSets.id, set.id)),
+      ).toEqual([]);
+      expect(
+        await admin.db
+          .select({ action: auditEvents.action, requestId: auditEvents.requestId })
+          .from(auditEvents)
+          .where(
+            and(
+              eq(auditEvents.tenantId, tenantId),
+              inArray(auditEvents.action, ["condition_set.update", "condition_set.delete"]),
+            ),
+          ),
+      ).toEqual([{ action: "condition_set.delete", requestId: winnerRequestId }]);
+    } finally {
+      await gate.cleanup();
+    }
+  }, 120_000);
+
+  it("rolls back an audit-failed item delete before a concurrent replacement commits", async () => {
+    const { suffix, tenantId } = await createTenant("delete-replace");
+    const [set] = await admin.db
+      .insert(conditionSets)
+      .values({ tenantId, name: "delete replace", ownerId: "postgres-race" })
+      .returning({ id: conditionSets.id });
+    const [item] = await admin.db
+      .insert(conditionSetItems)
+      .values({ tenantId, conditionSetId: set.id, value: "original", label: "original" })
+      .returning({ id: conditionSetItems.id });
+    const failedRequestId = `failed-delete-${suffix}`;
+    const winnerRequestId = `winner-replace-${suffix}`;
+    const gate = await installAuditGate({
+      suffix,
+      tenantId,
+      requestId: failedRequestId,
+      action: "condition_set.item.delete",
+      fail: true,
+    });
+    try {
+      const failedDelete = request(tenantId, `/condition-sets/${set.id}/items/${item.id}`, {
+        method: "DELETE",
+        headers: { "x-request-id": failedRequestId },
+      });
+      const failedPid = await waitForAdvisoryWaiter(String(gate.gateKey));
+      const winningReplace = spawnRoute({
+        tenantId,
+        path: `/condition-sets/${set.id}/items`,
+        method: "PUT",
+        requestId: winnerRequestId,
+        body: { items: [{ value: "replacement", label: "winner" }] },
+      });
+      const expectedWinnerPid = await winningReplace.backendPid;
+      const winnerPid = await waitForAdvisoryWaiter(
+        await advisoryKey(`steward_audit_${tenantId}`),
+        expectedWinnerPid,
+      );
+      expect(winnerPid).toBe(expectedWinnerPid);
+      expect(winnerPid).not.toBe(failedPid);
+
+      await gate.release();
+      const [failedResponse, winnerResponse] = await Promise.all([
+        failedDelete,
+        routeResult(winningReplace),
+      ]);
+      expect(failedResponse.status).toBe(500);
+      expect(winnerResponse.status).toBe(200);
+      expect(
+        await admin.db
+          .select({ value: conditionSetItems.value, label: conditionSetItems.label })
+          .from(conditionSetItems)
+          .where(eq(conditionSetItems.conditionSetId, set.id)),
+      ).toEqual([{ value: "replacement", label: "winner" }]);
+      expect(
+        await admin.db
+          .select({ action: auditEvents.action, requestId: auditEvents.requestId })
+          .from(auditEvents)
+          .where(
+            and(
+              eq(auditEvents.tenantId, tenantId),
+              inArray(auditEvents.action, [
+                "condition_set.item.delete",
+                "condition_set.items.replace",
+              ]),
+            ),
+          ),
+      ).toEqual([{ action: "condition_set.items.replace", requestId: winnerRequestId }]);
+    } finally {
+      await gate.cleanup();
+    }
+  }, 120_000);
+
+  it("rolls back an audit-failed item delete before a concurrent upsert commits", async () => {
+    const { suffix, tenantId } = await createTenant("delete-upsert");
+    const [set] = await admin.db
+      .insert(conditionSets)
+      .values({ tenantId, name: "delete upsert", ownerId: "postgres-race" })
+      .returning({ id: conditionSets.id });
+    const [item] = await admin.db
+      .insert(conditionSetItems)
+      .values({ tenantId, conditionSetId: set.id, value: "target", label: "original" })
+      .returning({ id: conditionSetItems.id });
+    const failedRequestId = `failed-delete-${suffix}`;
+    const winnerRequestId = `winner-upsert-${suffix}`;
+    const gate = await installAuditGate({
+      suffix,
+      tenantId,
+      requestId: failedRequestId,
+      action: "condition_set.item.delete",
+      fail: true,
+    });
+    try {
+      const failedDelete = request(tenantId, `/condition-sets/${set.id}/items/${item.id}`, {
+        method: "DELETE",
+        headers: { "x-request-id": failedRequestId },
+      });
+      const failedPid = await waitForAdvisoryWaiter(String(gate.gateKey));
+      const winningUpsert = spawnRoute({
+        tenantId,
+        path: `/condition-sets/${set.id}/items`,
+        method: "POST",
+        requestId: winnerRequestId,
+        body: { value: "target", label: "winner" },
+      });
+      const expectedWinnerPid = await winningUpsert.backendPid;
+      const winnerPid = await waitForAdvisoryWaiter(
+        await advisoryKey(`steward_audit_${tenantId}`),
+        expectedWinnerPid,
+      );
+      expect(winnerPid).toBe(expectedWinnerPid);
+      expect(winnerPid).not.toBe(failedPid);
+
+      await gate.release();
+      const [failedResponse, winnerResponse] = await Promise.all([
+        failedDelete,
+        routeResult(winningUpsert),
+      ]);
+      expect(failedResponse.status).toBe(500);
+      expect(winnerResponse.status).toBe(201);
+      expect(
+        await admin.db
+          .select({
+            id: conditionSetItems.id,
+            value: conditionSetItems.value,
+            label: conditionSetItems.label,
+          })
+          .from(conditionSetItems)
+          .where(eq(conditionSetItems.conditionSetId, set.id)),
+      ).toEqual([{ id: item.id, value: "target", label: "winner" }]);
+      expect(
+        await admin.db
+          .select({ action: auditEvents.action, requestId: auditEvents.requestId })
+          .from(auditEvents)
+          .where(
+            and(
+              eq(auditEvents.tenantId, tenantId),
+              inArray(auditEvents.action, [
+                "condition_set.item.delete",
+                "condition_set.item.upsert",
+              ]),
+            ),
+          ),
+      ).toEqual([{ action: "condition_set.item.upsert", requestId: winnerRequestId }]);
+    } finally {
+      await gate.cleanup();
+    }
+  }, 120_000);
+
   it("serializes replace before an upsert queued on the same condition set", async () => {
     const { suffix, tenantId } = await createTenant("replace-upsert");
     const [set] = await admin.db
@@ -438,7 +656,8 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
               "condition_set.item.upsert",
             ]),
           ),
-        );
+        )
+        .orderBy(auditEvents.seq);
       expect(events).toEqual([
         { action: "condition_set.items.replace", requestId: replaceRequestId },
         { action: "condition_set.item.upsert", requestId: upsertRequestId },

--- a/packages/api/src/__tests__/condition-set-postgres-concurrency.integration.test.ts
+++ b/packages/api/src/__tests__/condition-set-postgres-concurrency.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import {
   __resetAuditHmacKeyCacheForTests,
   auditChainHeads,
@@ -20,6 +20,7 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
   let admin: ReturnType<typeof createDb>;
   let app: Hono<{ Variables: AppVariables }>;
   const tenantIds: string[] = [];
+  const childProcesses = new Set<ReturnType<typeof spawnRoute>>();
 
   beforeAll(async () => {
     admin = createDb(databaseUrl!);
@@ -48,6 +49,16 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
     await admin.client.end();
   });
 
+  afterEach(async () => {
+    await Promise.all(
+      [...childProcesses].map(async (process) => {
+        process.kill("SIGTERM");
+        await process.exited;
+      }),
+    );
+    childProcesses.clear();
+  });
+
   async function createTenant(label: string) {
     const suffix = crypto.randomUUID().replaceAll("-", "");
     const tenantId = `condition-set-${label}-${suffix}`.slice(0, 64);
@@ -70,7 +81,7 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
     body?: unknown;
     requestId?: string;
   }) {
-    return Bun.spawn(
+    const process = Bun.spawn(
       [
         process.execPath,
         new URL("./fixtures/condition-set-route-writer.ts", import.meta.url).pathname,
@@ -91,28 +102,54 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
         stderr: "pipe",
       },
     );
+    childProcesses.add(process);
+    return process;
   }
 
   async function routeResult(process: ReturnType<typeof spawnRoute>) {
-    const exit = await process.exited;
-    const stdout = await new Response(process.stdout).text();
-    if (exit !== 0) {
-      throw new Error(`condition-set writer failed: ${await new Response(process.stderr).text()}`);
+    const stdout = new Response(process.stdout).text();
+    const stderr = new Response(process.stderr).text();
+    try {
+      const [exit, output, errorOutput] = await Promise.all([process.exited, stdout, stderr]);
+      if (exit !== 0) {
+        throw new Error(`condition-set writer failed: ${errorOutput}`);
+      }
+      return JSON.parse(output) as { status: number; body: unknown };
+    } finally {
+      childProcesses.delete(process);
     }
-    return JSON.parse(stdout) as { status: number; body: unknown };
   }
 
-  async function waitForAdvisoryWaiter(pattern: string) {
+  async function advisoryKey(value: string): Promise<string> {
+    const [row] = await admin.client<{ key: string }[]>`
+      select hashtextextended(${value}, 0)::text as key
+    `;
+    if (!row) throw new Error(`failed to derive advisory key for ${value}`);
+    return row.key;
+  }
+
+  async function waitForAdvisoryWaiter(lockKey: string, excludedPid?: number) {
     for (let attempt = 0; attempt < 200; attempt++) {
-      const [row] = await admin.client<{ total: string }[]>`
-        select count(*)::text as total
-        from pg_stat_activity
-        where wait_event = 'advisory' and query ilike ${pattern}
+      const rows = await admin.client<{ pid: number }[]>`
+        with expected as (select ${lockKey}::bigint as key)
+        select locks.pid
+        from pg_locks locks
+        cross join expected
+        where locks.locktype = 'advisory'
+          and not locks.granted
+          and locks.objsubid = 1
+          and locks.classid = ((expected.key >> 32) & 4294967295)::oid
+          and locks.objid = (expected.key & 4294967295)::oid
+          and (${excludedPid ?? null}::integer is null or locks.pid <> ${excludedPid ?? null})
       `;
-      if (Number(row?.total ?? "0") > 0) return;
-      if (attempt === 199) throw new Error(`missing advisory waiter matching ${pattern}`);
+      if (rows.length === 1) return rows[0].pid;
+      if (rows.length > 1) {
+        throw new Error(`ambiguous advisory waiters for key ${lockKey}: ${rows.length}`);
+      }
+      if (attempt === 199) throw new Error(`missing advisory waiter for key ${lockKey}`);
       await Bun.sleep(10);
     }
+    throw new Error(`missing advisory waiter for key ${lockKey}`);
   }
 
   async function installAuditGate(input: {
@@ -147,6 +184,7 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
     await locker`select pg_advisory_lock(${gateKey})`;
     let locked = true;
     return {
+      gateKey,
       release: async () => {
         if (!locked) return;
         await locker`select pg_advisory_unlock(${gateKey})`;
@@ -245,7 +283,7 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
         headers: { "x-request-id": failedRequestId },
         body: JSON.stringify({ label: "failed-label" }),
       });
-      await waitForAdvisoryWaiter("%INSERT INTO audit_events%");
+      const failedPid = await waitForAdvisoryWaiter(String(gate.gateKey));
       const winner = spawnRoute({
         tenantId,
         path: `/condition-sets/${set.id}/items/${item.id}`,
@@ -253,7 +291,11 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
         requestId: winnerRequestId,
         body: { label: "winner-label" },
       });
-      await waitForAdvisoryWaiter("%pg_advisory_xact_lock%");
+      const winnerPid = await waitForAdvisoryWaiter(
+        await advisoryKey(`steward_audit_${tenantId}`),
+        failedPid,
+      );
+      expect(winnerPid).not.toBe(failedPid);
       await gate.release();
       const [failedResponse, winnerResponse] = await Promise.all([failed, routeResult(winner)]);
       expect(failedResponse.status).toBe(500);
@@ -303,7 +345,7 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
         headers: { "x-request-id": replaceRequestId },
         body: JSON.stringify({ items: [{ value: "replacement" }] }),
       });
-      await waitForAdvisoryWaiter("%INSERT INTO audit_events%");
+      const replacePid = await waitForAdvisoryWaiter(String(gate.gateKey));
       const upsert = spawnRoute({
         tenantId,
         path: `/condition-sets/${set.id}/items`,
@@ -311,7 +353,11 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
         requestId: upsertRequestId,
         body: { value: "concurrent-upsert" },
       });
-      await waitForAdvisoryWaiter("%pg_advisory_xact_lock%");
+      const upsertPid = await waitForAdvisoryWaiter(
+        await advisoryKey(`steward_audit_${tenantId}`),
+        replacePid,
+      );
+      expect(upsertPid).not.toBe(replacePid);
       await gate.release();
       const [replaceResponse, upsertResponse] = await Promise.all([replace, routeResult(upsert)]);
       expect(replaceResponse.status).toBe(200);

--- a/packages/api/src/__tests__/condition-set-postgres-concurrency.integration.test.ts
+++ b/packages/api/src/__tests__/condition-set-postgres-concurrency.integration.test.ts
@@ -1,0 +1,344 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  auditChainHeads,
+  auditEvents,
+  conditionSetItems,
+  conditionSets,
+  createDb,
+  tenants,
+} from "@stwd/db";
+import { and, count, eq, inArray } from "drizzle-orm";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeRealPostgres =
+  databaseUrl && !process.env.STEWARD_PGLITE_MEMORY ? describe : describe.skip;
+
+describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
+  let admin: ReturnType<typeof createDb>;
+  let app: Hono<{ Variables: AppVariables }>;
+  const tenantIds: string[] = [];
+
+  beforeAll(async () => {
+    admin = createDb(databaseUrl!);
+    process.env.STEWARD_AUDIT_HMAC_KEY = "condition-set-postgres-audit-key-with-enough-entropy";
+    __resetAuditHmacKeyCacheForTests();
+    const { conditionSetRoutes } = await import("../routes/condition-sets");
+    app = new Hono<{ Variables: AppVariables }>();
+    app.use("*", async (c, next) => {
+      c.set("tenantId", c.req.header("x-test-tenant")!);
+      c.set("authType", "session-jwt");
+      c.set("tenantRole", "admin");
+      c.set("userId", "condition-set-postgres-admin");
+      c.set("sessionMfaVerifiedAt", Date.now());
+      c.set("requestId", c.req.header("x-request-id"));
+      await next();
+    });
+    app.route("/condition-sets", conditionSetRoutes);
+  });
+
+  afterAll(async () => {
+    if (tenantIds.length > 0) {
+      await admin.db.delete(auditEvents).where(inArray(auditEvents.tenantId, tenantIds));
+      await admin.db.delete(auditChainHeads).where(inArray(auditChainHeads.tenantId, tenantIds));
+      await admin.db.delete(tenants).where(inArray(tenants.id, tenantIds));
+    }
+    await admin.client.end();
+  });
+
+  async function createTenant(label: string) {
+    const suffix = crypto.randomUUID().replaceAll("-", "");
+    const tenantId = `condition-set-${label}-${suffix}`.slice(0, 64);
+    tenantIds.push(tenantId);
+    await admin.db.insert(tenants).values({ id: tenantId, name: tenantId, apiKeyHash: suffix });
+    return { suffix, tenantId };
+  }
+
+  function request(tenantId: string, path: string, init: RequestInit = {}) {
+    const headers = new Headers(init.headers);
+    headers.set("x-test-tenant", tenantId);
+    if (init.body) headers.set("Content-Type", "application/json");
+    return app.request(path, { ...init, headers });
+  }
+
+  function spawnRoute(input: {
+    tenantId: string;
+    path: string;
+    method: string;
+    body?: unknown;
+    requestId?: string;
+  }) {
+    return Bun.spawn(
+      [
+        process.execPath,
+        new URL("./fixtures/condition-set-route-writer.ts", import.meta.url).pathname,
+      ],
+      {
+        cwd: new URL("../../../..", import.meta.url).pathname,
+        env: {
+          ...process.env,
+          DATABASE_URL: databaseUrl!,
+          STEWARD_AUDIT_HMAC_KEY: process.env.STEWARD_AUDIT_HMAC_KEY!,
+          TEST_TENANT_ID: input.tenantId,
+          TEST_PATH: input.path,
+          TEST_METHOD: input.method,
+          ...(input.body === undefined ? {} : { TEST_BODY: JSON.stringify(input.body) }),
+          ...(input.requestId ? { TEST_REQUEST_ID: input.requestId } : {}),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+  }
+
+  async function routeResult(process: ReturnType<typeof spawnRoute>) {
+    const exit = await process.exited;
+    const stdout = await new Response(process.stdout).text();
+    if (exit !== 0) {
+      throw new Error(`condition-set writer failed: ${await new Response(process.stderr).text()}`);
+    }
+    return JSON.parse(stdout) as { status: number; body: unknown };
+  }
+
+  async function waitForAdvisoryWaiter(pattern: string) {
+    for (let attempt = 0; attempt < 200; attempt++) {
+      const [row] = await admin.client<{ total: string }[]>`
+        select count(*)::text as total
+        from pg_stat_activity
+        where wait_event = 'advisory' and query ilike ${pattern}
+      `;
+      if (Number(row?.total ?? "0") > 0) return;
+      if (attempt === 199) throw new Error(`missing advisory waiter matching ${pattern}`);
+      await Bun.sleep(10);
+    }
+  }
+
+  async function installAuditGate(input: {
+    suffix: string;
+    tenantId: string;
+    requestId: string;
+    action: string;
+    fail: boolean;
+  }) {
+    const functionName = `condition_set_gate_${input.suffix}`;
+    const triggerName = `condition_set_gate_${input.suffix}`;
+    const gateKey = Number.parseInt(input.suffix.slice(0, 12), 16);
+    const locker = await admin.client.reserve();
+    await admin.client.unsafe(`
+      create function "${functionName}"() returns trigger language plpgsql as $$
+      begin
+        if new.tenant_id = '${input.tenantId}'
+           and new.request_id = '${input.requestId}'
+           and new.action = '${input.action}' then
+          perform pg_advisory_xact_lock(${gateKey});
+          ${input.fail ? "raise exception 'forced condition set completion audit failure';" : "return new;"}
+        end if;
+        return new;
+      end
+      $$
+    `);
+    await admin.client.unsafe(`
+      create trigger "${triggerName}"
+      before insert on audit_events
+      for each row execute function "${functionName}"()
+    `);
+    await locker`select pg_advisory_lock(${gateKey})`;
+    let locked = true;
+    return {
+      release: async () => {
+        if (!locked) return;
+        await locker`select pg_advisory_unlock(${gateKey})`;
+        locked = false;
+      },
+      cleanup: async () => {
+        if (locked) await locker`select pg_advisory_unlock(${gateKey})`;
+        locker.release();
+        await admin.client.unsafe(`drop trigger if exists "${triggerName}" on audit_events`);
+        await admin.client.unsafe(`drop function if exists "${functionName}"()`);
+      },
+    };
+  }
+
+  it("admits exactly one concurrent 100th set and 1,000th item", async () => {
+    const { tenantId } = await createTenant("quota");
+    await admin.db.insert(conditionSets).values(
+      Array.from({ length: 99 }, (_, index) => ({
+        tenantId,
+        name: `seed-set-${index}`,
+        ownerId: "postgres-quota",
+      })),
+    );
+    const setResponses = await Promise.all(
+      ["candidate-a", "candidate-b"].map((name) =>
+        routeResult(
+          spawnRoute({
+            tenantId,
+            path: "/condition-sets",
+            method: "POST",
+            body: { name, ownerId: "postgres-quota" },
+          }),
+        ),
+      ),
+    );
+    expect(setResponses.map((response) => response.status).sort()).toEqual([201, 400]);
+    const [{ total: setTotal }] = await admin.db
+      .select({ total: count() })
+      .from(conditionSets)
+      .where(eq(conditionSets.tenantId, tenantId));
+    expect(Number(setTotal)).toBe(100);
+
+    const [itemSet] = await admin.db
+      .insert(conditionSets)
+      .values({ tenantId, name: "item-quota", ownerId: "postgres-quota" })
+      .returning({ id: conditionSets.id });
+    await admin.db.insert(conditionSetItems).values(
+      Array.from({ length: 999 }, (_, index) => ({
+        tenantId,
+        conditionSetId: itemSet.id,
+        value: `seed-item-${index}`,
+      })),
+    );
+    const itemResponses = await Promise.all(
+      ["candidate-item-a", "candidate-item-b"].map((value) =>
+        routeResult(
+          spawnRoute({
+            tenantId,
+            path: `/condition-sets/${itemSet.id}/items`,
+            method: "POST",
+            body: { value },
+          }),
+        ),
+      ),
+    );
+    expect(itemResponses.map((response) => response.status).sort()).toEqual([201, 400]);
+    const [{ total: itemTotal }] = await admin.db
+      .select({ total: count() })
+      .from(conditionSetItems)
+      .where(eq(conditionSetItems.conditionSetId, itemSet.id));
+    expect(Number(itemTotal)).toBe(1_000);
+  }, 120_000);
+
+  it("rolls back an audit-failed item update before a concurrent winner commits", async () => {
+    const { suffix, tenantId } = await createTenant("audit-race");
+    const [set] = await admin.db
+      .insert(conditionSets)
+      .values({ tenantId, name: "audit race", ownerId: "postgres-race" })
+      .returning({ id: conditionSets.id });
+    const [item] = await admin.db
+      .insert(conditionSetItems)
+      .values({ tenantId, conditionSetId: set.id, value: "target", label: "original" })
+      .returning({ id: conditionSetItems.id });
+    const failedRequestId = `failed-${suffix}`;
+    const winnerRequestId = `winner-${suffix}`;
+    const gate = await installAuditGate({
+      suffix,
+      tenantId,
+      requestId: failedRequestId,
+      action: "condition_set.item.update",
+      fail: true,
+    });
+    try {
+      const failed = request(tenantId, `/condition-sets/${set.id}/items/${item.id}`, {
+        method: "PATCH",
+        headers: { "x-request-id": failedRequestId },
+        body: JSON.stringify({ label: "failed-label" }),
+      });
+      await waitForAdvisoryWaiter("%INSERT INTO audit_events%");
+      const winner = spawnRoute({
+        tenantId,
+        path: `/condition-sets/${set.id}/items/${item.id}`,
+        method: "PATCH",
+        requestId: winnerRequestId,
+        body: { label: "winner-label" },
+      });
+      await waitForAdvisoryWaiter("%pg_advisory_xact_lock%");
+      await gate.release();
+      const [failedResponse, winnerResponse] = await Promise.all([failed, routeResult(winner)]);
+      expect(failedResponse.status).toBe(500);
+      expect(winnerResponse.status).toBe(200);
+      expect(
+        await admin.db
+          .select({ label: conditionSetItems.label })
+          .from(conditionSetItems)
+          .where(eq(conditionSetItems.id, item.id)),
+      ).toEqual([{ label: "winner-label" }]);
+      const events = await admin.db
+        .select({ requestId: auditEvents.requestId })
+        .from(auditEvents)
+        .where(
+          and(
+            eq(auditEvents.tenantId, tenantId),
+            eq(auditEvents.action, "condition_set.item.update"),
+          ),
+        );
+      expect(events).toEqual([{ requestId: winnerRequestId }]);
+    } finally {
+      await gate.cleanup();
+    }
+  }, 120_000);
+
+  it("serializes replace before an upsert queued on the same condition set", async () => {
+    const { suffix, tenantId } = await createTenant("replace-upsert");
+    const [set] = await admin.db
+      .insert(conditionSets)
+      .values({ tenantId, name: "replace upsert", ownerId: "postgres-race" })
+      .returning({ id: conditionSets.id });
+    await admin.db
+      .insert(conditionSetItems)
+      .values({ tenantId, conditionSetId: set.id, value: "original" });
+    const replaceRequestId = `replace-${suffix}`;
+    const upsertRequestId = `upsert-${suffix}`;
+    const gate = await installAuditGate({
+      suffix,
+      tenantId,
+      requestId: replaceRequestId,
+      action: "condition_set.items.replace",
+      fail: false,
+    });
+    try {
+      const replace = request(tenantId, `/condition-sets/${set.id}/items`, {
+        method: "PUT",
+        headers: { "x-request-id": replaceRequestId },
+        body: JSON.stringify({ items: [{ value: "replacement" }] }),
+      });
+      await waitForAdvisoryWaiter("%INSERT INTO audit_events%");
+      const upsert = spawnRoute({
+        tenantId,
+        path: `/condition-sets/${set.id}/items`,
+        method: "POST",
+        requestId: upsertRequestId,
+        body: { value: "concurrent-upsert" },
+      });
+      await waitForAdvisoryWaiter("%pg_advisory_xact_lock%");
+      await gate.release();
+      const [replaceResponse, upsertResponse] = await Promise.all([replace, routeResult(upsert)]);
+      expect(replaceResponse.status).toBe(200);
+      expect(upsertResponse.status).toBe(201);
+      const values = await admin.db
+        .select({ value: conditionSetItems.value })
+        .from(conditionSetItems)
+        .where(eq(conditionSetItems.conditionSetId, set.id));
+      expect(values.map((row) => row.value).sort()).toEqual(["concurrent-upsert", "replacement"]);
+      const events = await admin.db
+        .select({ action: auditEvents.action, requestId: auditEvents.requestId })
+        .from(auditEvents)
+        .where(
+          and(
+            eq(auditEvents.tenantId, tenantId),
+            inArray(auditEvents.action, [
+              "condition_set.items.replace",
+              "condition_set.item.upsert",
+            ]),
+          ),
+        );
+      expect(events).toEqual([
+        { action: "condition_set.items.replace", requestId: replaceRequestId },
+        { action: "condition_set.item.upsert", requestId: upsertRequestId },
+      ]);
+    } finally {
+      await gate.cleanup();
+    }
+  }, 120_000);
+});

--- a/packages/api/src/__tests__/condition-set-postgres-concurrency.integration.test.ts
+++ b/packages/api/src/__tests__/condition-set-postgres-concurrency.integration.test.ts
@@ -53,7 +53,14 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
     await Promise.all(
       [...childProcesses].map(async (childProcess) => {
         childProcess.kill("SIGTERM");
-        await childProcess.exited;
+        const exited = await Promise.race([
+          childProcess.exited.then(() => true),
+          Bun.sleep(1_000).then(() => false),
+        ]);
+        if (!exited) {
+          childProcess.kill("SIGKILL");
+          await childProcess.exited;
+        }
       }),
     );
     childProcesses.clear();
@@ -182,11 +189,18 @@ describeRealPostgres("condition set real-PostgreSQL atomicity", () => {
           and locks.objsubid = 1
           and locks.classid = ((expected.key >> 32) & 4294967295)::oid
           and locks.objid = (expected.key & 4294967295)::oid
-          and (${expectedPid ?? null}::integer is null or locks.pid = ${expectedPid ?? null})
       `;
-      if (rows.length === 1) return rows[0].pid;
       if (rows.length > 1) {
         throw new Error(`ambiguous advisory waiters for key ${lockKey}: ${rows.length}`);
+      }
+      if (rows.length === 1) {
+        const waiterPid = rows[0].pid;
+        if (expectedPid !== undefined && waiterPid !== expectedPid) {
+          throw new Error(
+            `advisory waiter for key ${lockKey} was backend ${waiterPid}, expected ${expectedPid}`,
+          );
+        }
+        return waiterPid;
       }
       if (attempt === 199) throw new Error(`missing advisory waiter for key ${lockKey}`);
       await Bun.sleep(10);

--- a/packages/api/src/__tests__/condition-set-quota.test.ts
+++ b/packages/api/src/__tests__/condition-set-quota.test.ts
@@ -1,22 +1,109 @@
-import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { auditEvents, closeDb, conditionSetItems, conditionSets, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { count, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
 
-const routeSource = readFileSync(
-  join(import.meta.dir, "..", "routes", "condition-sets.ts"),
-  "utf8",
-);
+const TENANT_ID = `condition-set-quota-${Date.now()}`;
 
-describe("condition set quota enforcement", () => {
-  it("enforces item count and value-size limits on append as well as replace", () => {
-    expect(routeSource).toContain("MAX_CONDITION_SETS = 100");
-    expect(routeSource).toContain("tenant cannot contain more than");
-    expect(routeSource).toContain("MAX_CONDITION_SET_DESCRIPTION_LENGTH = 2_000");
-    expect(routeSource).toContain("MAX_CONDITION_SET_ITEM_LABEL_LENGTH = 255");
-    expect(routeSource).toContain("MAX_CONDITION_SET_ITEMS = 1_000");
-    expect(routeSource).toContain("MAX_CONDITION_SET_ITEM_VALUE_LENGTH");
-    expect(routeSource).toContain("condition set cannot contain more than");
-    expect(routeSource).toContain("pg_advisory_xact_lock");
-    expect(routeSource).toContain("shouldUsePostgresAdvisoryLocks()");
+describe("condition set mounted quota enforcement", () => {
+  let app: Hono<{ Variables: AppVariables }>;
+
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_MASTER_PASSWORD = "condition-set-quota-master-password";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "condition-set-quota-audit-key-with-enough-entropy";
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+    await getDb().insert(tenants).values({ id: TENANT_ID, name: TENANT_ID, apiKeyHash: "hash" });
+    const { conditionSetRoutes } = await import("../routes/condition-sets");
+    app = new Hono<{ Variables: AppVariables }>();
+    app.use("*", async (c, next) => {
+      c.set("tenantId", TENANT_ID);
+      c.set("authType", "session-jwt");
+      c.set("tenantRole", "admin");
+      c.set("userId", "condition-set-quota-admin");
+      c.set("sessionMfaVerifiedAt", Date.now());
+      await next();
+    });
+    app.route("/condition-sets", conditionSetRoutes);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
+  });
+
+  it("admits exactly one concurrent 100th condition set", async () => {
+    await getDb()
+      .insert(conditionSets)
+      .values(
+        Array.from({ length: 99 }, (_, index) => ({
+          tenantId: TENANT_ID,
+          name: `seed-set-${index}`,
+          ownerId: "quota-test",
+        })),
+      );
+
+    const responses = await Promise.all(
+      ["candidate-a", "candidate-b"].map((name) =>
+        app.request("/condition-sets", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, ownerId: "quota-test" }),
+        }),
+      ),
+    );
+    expect(responses.map((response) => response.status).sort()).toEqual([201, 400]);
+    const [{ total }] = await getDb()
+      .select({ total: count() })
+      .from(conditionSets)
+      .where(eq(conditionSets.tenantId, TENANT_ID));
+    expect(Number(total)).toBe(100);
+    const completed = await getDb()
+      .select({ id: auditEvents.id })
+      .from(auditEvents)
+      .where(eq(auditEvents.action, "condition_set.create"));
+    expect(completed).toHaveLength(1);
+  });
+
+  it("admits exactly one concurrent 1,000th item", async () => {
+    const [set] = await getDb()
+      .insert(conditionSets)
+      .values({ tenantId: TENANT_ID, name: "item-quota", ownerId: "quota-test" })
+      .returning({ id: conditionSets.id });
+    await getDb()
+      .insert(conditionSetItems)
+      .values(
+        Array.from({ length: 999 }, (_, index) => ({
+          tenantId: TENANT_ID,
+          conditionSetId: set.id,
+          value: `seed-item-${index}`,
+        })),
+      );
+
+    const responses = await Promise.all(
+      ["candidate-item-a", "candidate-item-b"].map((value) =>
+        app.request(`/condition-sets/${set.id}/items`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ value }),
+        }),
+      ),
+    );
+    expect(responses.map((response) => response.status).sort()).toEqual([201, 400]);
+    const [{ total }] = await getDb()
+      .select({ total: count() })
+      .from(conditionSetItems)
+      .where(eq(conditionSetItems.conditionSetId, set.id));
+    expect(Number(total)).toBe(1_000);
+    const completed = await getDb()
+      .select({ id: auditEvents.id })
+      .from(auditEvents)
+      .where(eq(auditEvents.action, "condition_set.item.upsert"));
+    expect(completed).toHaveLength(1);
   });
 });

--- a/packages/api/src/__tests__/condition-sets.test.ts
+++ b/packages/api/src/__tests__/condition-sets.test.ts
@@ -1,7 +1,15 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { agents, closeDb, conditionSets, getDb, tenants } from "@stwd/db";
+import {
+  agents,
+  auditEvents,
+  closeDb,
+  conditionSetItems,
+  conditionSets,
+  getDb,
+  tenants,
+} from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { and, eq, sql } from "drizzle-orm";
+import { and, count, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
 
@@ -283,6 +291,156 @@ describeConditionSets("condition sets", () => {
         sql.raw("DROP FUNCTION IF EXISTS fail_condition_set_completion_audit()"),
       );
     }
+  });
+
+  it("rolls back every set and item mutation when its required completion audit fails", async () => {
+    const [set] = await getDb()
+      .insert(conditionSets)
+      .values({
+        tenantId: TENANT_ID,
+        name: "atomic mutation set",
+        description: "original description",
+        ownerId: "atomic-owner",
+      })
+      .returning();
+    const [item] = await getDb()
+      .insert(conditionSetItems)
+      .values({
+        tenantId: TENANT_ID,
+        conditionSetId: set.id,
+        value: "original-value",
+        label: "original-label",
+      })
+      .returning();
+
+    async function withFailingCompletionAudit(action: string, request: () => Promise<Response>) {
+      const [{ total: beforeTotal }] = await getDb()
+        .select({ total: count() })
+        .from(auditEvents)
+        .where(and(eq(auditEvents.tenantId, TENANT_ID), eq(auditEvents.action, action)));
+      await getDb().execute(
+        sql.raw(`
+          CREATE OR REPLACE FUNCTION fail_condition_set_mutation_audit()
+          RETURNS trigger AS $$
+          BEGIN
+            IF NEW.tenant_id = '${TENANT_ID}' AND NEW.action = '${action}' THEN
+              RAISE EXCEPTION 'forced condition set mutation audit failure';
+            END IF;
+            RETURN NEW;
+          END;
+          $$ LANGUAGE plpgsql
+        `),
+      );
+      await getDb().execute(
+        sql.raw(`
+          CREATE TRIGGER condition_set_mutation_audit_failure
+          BEFORE INSERT ON audit_events
+          FOR EACH ROW EXECUTE FUNCTION fail_condition_set_mutation_audit()
+        `),
+      );
+      try {
+        const response = await request();
+        expect(response.status).toBe(500);
+        await expect(response.json()).resolves.toEqual({
+          ok: false,
+          error: "Internal server error",
+        });
+        const [{ total: afterTotal }] = await getDb()
+          .select({ total: count() })
+          .from(auditEvents)
+          .where(and(eq(auditEvents.tenantId, TENANT_ID), eq(auditEvents.action, action)));
+        expect(Number(afterTotal)).toBe(Number(beforeTotal));
+      } finally {
+        await getDb().execute(
+          sql.raw("DROP TRIGGER IF EXISTS condition_set_mutation_audit_failure ON audit_events"),
+        );
+        await getDb().execute(
+          sql.raw("DROP FUNCTION IF EXISTS fail_condition_set_mutation_audit()"),
+        );
+      }
+    }
+
+    await withFailingCompletionAudit("condition_set.update", () =>
+      app.request(`/condition-sets/${set.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description: "must roll back" }),
+      }),
+    );
+    expect(
+      await getDb()
+        .select({ description: conditionSets.description })
+        .from(conditionSets)
+        .where(eq(conditionSets.id, set.id)),
+    ).toEqual([{ description: "original description" }]);
+
+    await withFailingCompletionAudit("condition_set.item.upsert", () =>
+      app.request(`/condition-sets/${set.id}/items`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "must-not-commit" }),
+      }),
+    );
+    expect(
+      await getDb()
+        .select({ value: conditionSetItems.value })
+        .from(conditionSetItems)
+        .where(eq(conditionSetItems.conditionSetId, set.id)),
+    ).toEqual([{ value: "original-value" }]);
+
+    await withFailingCompletionAudit("condition_set.items.replace", () =>
+      app.request(`/condition-sets/${set.id}/items`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ items: [{ value: "replacement" }] }),
+      }),
+    );
+    expect(
+      await getDb()
+        .select({ value: conditionSetItems.value })
+        .from(conditionSetItems)
+        .where(eq(conditionSetItems.conditionSetId, set.id)),
+    ).toEqual([{ value: "original-value" }]);
+
+    await withFailingCompletionAudit("condition_set.item.update", () =>
+      app.request(`/condition-sets/${set.id}/items/${item.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label: "must roll back" }),
+      }),
+    );
+    expect(
+      await getDb()
+        .select({ label: conditionSetItems.label })
+        .from(conditionSetItems)
+        .where(eq(conditionSetItems.id, item.id)),
+    ).toEqual([{ label: "original-label" }]);
+
+    await withFailingCompletionAudit("condition_set.item.delete", () =>
+      app.request(`/condition-sets/${set.id}/items/${item.id}`, { method: "DELETE" }),
+    );
+    expect(
+      await getDb()
+        .select({ id: conditionSetItems.id })
+        .from(conditionSetItems)
+        .where(eq(conditionSetItems.id, item.id)),
+    ).toEqual([{ id: item.id }]);
+
+    await withFailingCompletionAudit("condition_set.delete", () =>
+      app.request(`/condition-sets/${set.id}`, { method: "DELETE" }),
+    );
+    expect(
+      await getDb()
+        .select({ id: conditionSets.id })
+        .from(conditionSets)
+        .where(eq(conditionSets.id, set.id)),
+    ).toEqual([{ id: set.id }]);
+    expect(
+      await getDb()
+        .select({ id: conditionSetItems.id })
+        .from(conditionSetItems)
+        .where(eq(conditionSetItems.id, item.id)),
+    ).toEqual([{ id: item.id }]);
   });
 
   it("rejects policy templates that reference missing condition sets", async () => {

--- a/packages/api/src/__tests__/fixtures/condition-set-route-writer.ts
+++ b/packages/api/src/__tests__/fixtures/condition-set-route-writer.ts
@@ -27,4 +27,10 @@ const response = await app.request(path, {
 });
 const body = await response.json();
 await closeDb();
-process.stdout.write(JSON.stringify({ body, status: response.status }));
+await new Promise<void>((resolve, reject) => {
+  process.stdout.write(`${JSON.stringify({ body, status: response.status })}\n`, (error) => {
+    if (error) reject(error);
+    else resolve();
+  });
+});
+process.exit(0);

--- a/packages/api/src/__tests__/fixtures/condition-set-route-writer.ts
+++ b/packages/api/src/__tests__/fixtures/condition-set-route-writer.ts
@@ -1,4 +1,4 @@
-import { closeDb } from "@stwd/db";
+import { createDb, sql, withTenantTransactionDatabase } from "@stwd/db";
 import { Hono } from "hono";
 import { conditionSetRoutes } from "../../routes/condition-sets";
 import type { AppVariables } from "../../services/context";
@@ -20,17 +20,46 @@ app.use("*", async (c, next) => {
 });
 app.route("/condition-sets", conditionSetRoutes);
 
-const response = await app.request(path, {
-  method,
-  headers: process.env.TEST_BODY ? { "Content-Type": "application/json" } : undefined,
-  body: process.env.TEST_BODY,
-});
-const body = await response.json();
-await closeDb();
+async function writeFrame(frame: unknown) {
+  await new Promise<void>((resolve, reject) => {
+    globalThis.process.stdout.write(`${JSON.stringify(frame)}\n`, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+const database = createDb();
+let result: { body: unknown; status: number } | undefined;
+try {
+  await database.db.transaction(async (tx) => {
+    const rows = (await tx.execute(sql`select pg_backend_pid()::integer as pid`)) as unknown as {
+      pid: number;
+    }[];
+    const backend = rows[0];
+    if (!backend) throw new Error("condition-set writer could not resolve its backend PID");
+    await writeFrame({ type: "backend", pid: backend.pid });
+
+    const response = await withTenantTransactionDatabase(tx as never, { tenantId }, () =>
+      app.request(path, {
+        method,
+        headers: globalThis.process.env.TEST_BODY
+          ? { "Content-Type": "application/json" }
+          : undefined,
+        body: globalThis.process.env.TEST_BODY,
+      }),
+    );
+    result = { body: await response.json(), status: response.status };
+  });
+} finally {
+  await database.client.end();
+}
+if (!result) throw new Error("condition-set writer produced no route result");
+await writeFrame({ type: "result", ...result });
 await new Promise<void>((resolve, reject) => {
-  process.stdout.write(`${JSON.stringify({ body, status: response.status })}\n`, (error) => {
+  globalThis.process.stdout.write("", (error) => {
     if (error) reject(error);
     else resolve();
   });
 });
-process.exit(0);
+globalThis.process.exit(0);

--- a/packages/api/src/__tests__/fixtures/condition-set-route-writer.ts
+++ b/packages/api/src/__tests__/fixtures/condition-set-route-writer.ts
@@ -1,0 +1,30 @@
+import { closeDb } from "@stwd/db";
+import { Hono } from "hono";
+import { conditionSetRoutes } from "../../routes/condition-sets";
+import type { AppVariables } from "../../services/context";
+
+const tenantId = process.env.TEST_TENANT_ID;
+const path = process.env.TEST_PATH;
+const method = process.env.TEST_METHOD;
+if (!tenantId || !path || !method) throw new Error("condition-set writer input is incomplete");
+
+const app = new Hono<{ Variables: AppVariables }>();
+app.use("*", async (c, next) => {
+  c.set("tenantId", tenantId);
+  c.set("authType", "session-jwt");
+  c.set("tenantRole", "admin");
+  c.set("userId", "condition-set-postgres-writer");
+  c.set("sessionMfaVerifiedAt", Date.now());
+  c.set("requestId", process.env.TEST_REQUEST_ID);
+  await next();
+});
+app.route("/condition-sets", conditionSetRoutes);
+
+const response = await app.request(path, {
+  method,
+  headers: process.env.TEST_BODY ? { "Content-Type": "application/json" } : undefined,
+  body: process.env.TEST_BODY,
+});
+const body = await response.json();
+await closeDb();
+process.stdout.write(JSON.stringify({ body, status: response.status }));

--- a/packages/api/src/routes/condition-sets.ts
+++ b/packages/api/src/routes/condition-sets.ts
@@ -69,7 +69,6 @@ type ReplaceItemsBody = {
   items: UpsertItemBody[];
 };
 
-type ConditionSetRow = typeof conditionSets.$inferSelect;
 type ConditionSetItemRow = typeof conditionSetItems.$inferSelect;
 
 class ConditionSetValidationError extends Error {}
@@ -197,62 +196,6 @@ async function ensureConditionSet(tenantId: string, id: string) {
   return set ?? null;
 }
 
-async function snapshotConditionSetItems(
-  tenantId: string,
-  conditionSetId: string,
-): Promise<ConditionSetItemRow[]> {
-  return db
-    .select()
-    .from(conditionSetItems)
-    .where(
-      and(
-        eq(conditionSetItems.tenantId, tenantId),
-        eq(conditionSetItems.conditionSetId, conditionSetId),
-      ),
-    );
-}
-
-async function restoreConditionSet(
-  tenantId: string,
-  set: ConditionSetRow,
-  items: ConditionSetItemRow[],
-): Promise<void> {
-  await db.transaction(async (tx) => {
-    await tx
-      .delete(conditionSetItems)
-      .where(
-        and(eq(conditionSetItems.tenantId, tenantId), eq(conditionSetItems.conditionSetId, set.id)),
-      );
-    await tx
-      .delete(conditionSets)
-      .where(and(eq(conditionSets.id, set.id), eq(conditionSets.tenantId, tenantId)));
-    await tx.insert(conditionSets).values(set);
-    if (items.length > 0) {
-      await tx.insert(conditionSetItems).values(items);
-    }
-  });
-}
-
-async function restoreConditionSetItems(
-  tenantId: string,
-  conditionSetId: string,
-  items: ConditionSetItemRow[],
-): Promise<void> {
-  await db.transaction(async (tx) => {
-    await tx
-      .delete(conditionSetItems)
-      .where(
-        and(
-          eq(conditionSetItems.tenantId, tenantId),
-          eq(conditionSetItems.conditionSetId, conditionSetId),
-        ),
-      );
-    if (items.length > 0) {
-      await tx.insert(conditionSetItems).values(items);
-    }
-  });
-}
-
 export const conditionSetRoutes = new Hono<{ Variables: AppVariables }>();
 
 const MAX_CONDITION_SETS = 100;
@@ -266,6 +209,24 @@ const MAX_ITEM_METADATA_BYTES = 4_096;
 
 function shouldUsePostgresAdvisoryLocks(): boolean {
   return process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true";
+}
+
+async function lockConditionSet(tx: typeof db, tenantId: string, conditionSetId: string) {
+  if (shouldUsePostgresAdvisoryLocks()) {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${`condition_set:${tenantId}:${conditionSetId}`}, 0))`,
+    );
+  }
+}
+
+async function readLockedConditionSet(tx: typeof db, tenantId: string, conditionSetId: string) {
+  await lockConditionSet(tx, tenantId, conditionSetId);
+  const query = tx
+    .select()
+    .from(conditionSets)
+    .where(and(eq(conditionSets.id, conditionSetId), eq(conditionSets.tenantId, tenantId)));
+  const [set] = shouldUsePostgresAdvisoryLocks() ? await query.for("update") : await query;
+  return set ?? null;
 }
 
 function parsePaginationParam(
@@ -377,7 +338,7 @@ conditionSetRoutes.post("/", async (c) => {
       const tx = txRaw as typeof db;
       if (shouldUsePostgresAdvisoryLocks()) {
         await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtext(${`condition_sets:${tenantId}`}))`,
+          sql`select pg_advisory_xact_lock(hashtextextended(${`condition_sets:${tenantId}`}, 0))`,
         );
       }
 
@@ -456,24 +417,24 @@ conditionSetRoutes.patch("/:id", async (c) => {
   try {
     const current = await ensureConditionSet(tenantId, c.req.param("id"));
     if (!current) return c.json<ApiResponse>({ ok: false, error: "Condition set not found" }, 404);
-    const name =
+    const namePatch =
       body.name !== undefined
         ? normalizeRequiredText(body.name, "name", MAX_CONDITION_SET_NAME_LENGTH)
-        : current.name;
-    const description =
+        : undefined;
+    const descriptionPatch =
       body.description !== undefined
         ? normalizeOptionalText(
             body.description,
             "description",
             MAX_CONDITION_SET_DESCRIPTION_LENGTH,
           )
-        : current.description;
-    const ownerId =
+        : undefined;
+    const ownerIdPatch =
       body.ownerId !== undefined
         ? normalizeRequiredText(body.ownerId, "ownerId", MAX_CONDITION_SET_OWNER_ID_LENGTH)
-        : current.ownerId;
-    const metadata =
-      body.metadata !== undefined ? normalizeMetadata(body.metadata) : current.metadata;
+        : undefined;
+    const metadataPatch =
+      body.metadata !== undefined ? normalizeMetadata(body.metadata) : undefined;
 
     await writeAuditEvent({
       tenantId,
@@ -488,38 +449,38 @@ conditionSetRoutes.patch("/:id", async (c) => {
       requestId: c.get("requestId") ?? null,
     });
 
-    const [row] = await db
-      .update(conditionSets)
-      .set({
-        name,
-        description,
-        ownerId,
-        metadata,
-        updatedAt: new Date(),
-      })
-      .where(and(eq(conditionSets.id, current.id), eq(conditionSets.tenantId, tenantId)))
-      .returning();
-
-    if (!row) return c.json<ApiResponse>({ ok: false, error: "Condition set not found" }, 404);
-
-    try {
-      await writeAuditEvent({
+    const row = await withTenantAuditedTransaction(tenantId, async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof db;
+      const locked = await readLockedConditionSet(tx, tenantId, current.id);
+      if (!locked) return null;
+      const [updated] = await tx
+        .update(conditionSets)
+        .set({
+          name: namePatch ?? locked.name,
+          description: descriptionPatch === undefined ? locked.description : descriptionPatch,
+          ownerId: ownerIdPatch ?? locked.ownerId,
+          metadata: metadataPatch ?? locked.metadata,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(conditionSets.id, locked.id), eq(conditionSets.tenantId, tenantId)))
+        .returning();
+      if (!updated) return null;
+      await appendRequiredAudit({
         tenantId,
         actorType: "user",
         actorId: c.get("userId") ?? tenantId,
         action: "condition_set.update",
         resourceType: "condition_set",
-        resourceId: current.id,
+        resourceId: updated.id,
         metadata: {},
         ipAddress: c.req.header("x-forwarded-for") ?? null,
         userAgent: c.req.header("user-agent") ?? null,
         requestId: c.get("requestId") ?? null,
       });
-    } catch (error) {
-      const currentItems = await snapshotConditionSetItems(tenantId, current.id);
-      await restoreConditionSet(tenantId, current, currentItems);
-      throw error;
-    }
+      return updated;
+    });
+
+    if (!row) return c.json<ApiResponse>({ ok: false, error: "Condition set not found" }, 404);
 
     return c.json<ApiResponse<ConditionSetResponse>>({ ok: true, data: setToResponse(row) });
   } catch (err) {
@@ -540,7 +501,6 @@ conditionSetRoutes.delete("/:id", async (c) => {
 
   const current = await ensureConditionSet(tenantId, c.req.param("id"));
   if (!current) return c.json<ApiResponse>({ ok: false, error: "Condition set not found" }, 404);
-  const currentItems = await snapshotConditionSetItems(tenantId, current.id);
 
   await writeAuditEvent({
     tenantId,
@@ -555,32 +515,40 @@ conditionSetRoutes.delete("/:id", async (c) => {
     requestId: c.get("requestId") ?? null,
   });
 
-  const [deleted] = await db
-    .delete(conditionSets)
-    .where(and(eq(conditionSets.id, current.id), eq(conditionSets.tenantId, tenantId)))
-    .returning({ id: conditionSets.id });
-
-  if (!deleted) return c.json<ApiResponse>({ ok: false, error: "Condition set not found" }, 404);
-
   try {
-    await writeAuditEvent({
+    const deleted = await withTenantAuditedTransaction(
       tenantId,
-      actorType: "user",
-      actorId: c.get("userId") ?? tenantId,
-      action: "condition_set.delete",
-      resourceType: "condition_set",
-      resourceId: deleted.id,
-      metadata: {},
-      ipAddress: c.req.header("x-forwarded-for") ?? null,
-      userAgent: c.req.header("user-agent") ?? null,
-      requestId: c.get("requestId") ?? null,
-    });
-  } catch (error) {
-    await restoreConditionSet(tenantId, current, currentItems);
-    throw error;
-  }
+      async (txRaw, appendRequiredAudit) => {
+        const tx = txRaw as typeof db;
+        const locked = await readLockedConditionSet(tx, tenantId, current.id);
+        if (!locked) return null;
+        const [row] = await tx
+          .delete(conditionSets)
+          .where(and(eq(conditionSets.id, locked.id), eq(conditionSets.tenantId, tenantId)))
+          .returning({ id: conditionSets.id });
+        if (!row) return null;
+        await appendRequiredAudit({
+          tenantId,
+          actorType: "user",
+          actorId: c.get("userId") ?? tenantId,
+          action: "condition_set.delete",
+          resourceType: "condition_set",
+          resourceId: row.id,
+          metadata: {},
+          ipAddress: c.req.header("x-forwarded-for") ?? null,
+          userAgent: c.req.header("user-agent") ?? null,
+          requestId: c.get("requestId") ?? null,
+        });
+        return row;
+      },
+    );
 
-  return c.json<ApiResponse>({ ok: true });
+    if (!deleted) return c.json<ApiResponse>({ ok: false, error: "Condition set not found" }, 404);
+
+    return c.json<ApiResponse>({ ok: true });
+  } catch (err) {
+    return conditionSetMutationError(c, err);
+  }
 });
 
 conditionSetRoutes.get("/:id/items", async (c) => {
@@ -644,7 +612,6 @@ conditionSetRoutes.post("/:id/items", async (c) => {
 
   try {
     const item = normalizeItem(body);
-    const previousItems = await snapshotConditionSetItems(tenantId, set.id);
     await writeAuditEvent({
       tenantId,
       actorType: "user",
@@ -658,10 +625,10 @@ conditionSetRoutes.post("/:id/items", async (c) => {
       requestId: c.get("requestId") ?? null,
     });
 
-    const [row] = await db.transaction(async (tx) => {
-      if (shouldUsePostgresAdvisoryLocks()) {
-        await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${set.id}))`);
-      }
+    const row = await withTenantAuditedTransaction(tenantId, async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof db;
+      const lockedSet = await readLockedConditionSet(tx, tenantId, set.id);
+      if (!lockedSet) return null;
 
       const [existing] = await tx
         .select({ id: conditionSetItems.id })
@@ -669,7 +636,7 @@ conditionSetRoutes.post("/:id/items", async (c) => {
         .where(
           and(
             eq(conditionSetItems.tenantId, tenantId),
-            eq(conditionSetItems.conditionSetId, set.id),
+            eq(conditionSetItems.conditionSetId, lockedSet.id),
             eq(conditionSetItems.value, item.value),
           ),
         );
@@ -681,7 +648,7 @@ conditionSetRoutes.post("/:id/items", async (c) => {
           .where(
             and(
               eq(conditionSetItems.tenantId, tenantId),
-              eq(conditionSetItems.conditionSetId, set.id),
+              eq(conditionSetItems.conditionSetId, lockedSet.id),
             ),
           );
         if (Number(total) >= MAX_CONDITION_SET_ITEMS) {
@@ -691,10 +658,10 @@ conditionSetRoutes.post("/:id/items", async (c) => {
         }
       }
 
-      return tx
+      const [upserted] = await tx
         .insert(conditionSetItems)
         .values({
-          conditionSetId: set.id,
+          conditionSetId: lockedSet.id,
           tenantId,
           value: item.value,
           label: item.label,
@@ -709,25 +676,21 @@ conditionSetRoutes.post("/:id/items", async (c) => {
           },
         })
         .returning();
-    });
-
-    try {
-      await writeAuditEvent({
+      await appendRequiredAudit({
         tenantId,
         actorType: "user",
         actorId: c.get("userId") ?? tenantId,
         action: "condition_set.item.upsert",
         resourceType: "condition_set_item",
-        resourceId: row.id,
-        metadata: { conditionSetId: set.id, value: row.value },
+        resourceId: upserted.id,
+        metadata: { conditionSetId: lockedSet.id, value: upserted.value },
         ipAddress: c.req.header("x-forwarded-for") ?? null,
         userAgent: c.req.header("user-agent") ?? null,
         requestId: c.get("requestId") ?? null,
       });
-    } catch (error) {
-      await restoreConditionSetItems(tenantId, set.id, previousItems);
-      throw error;
-    }
+      return upserted;
+    });
+    if (!row) return c.json<ApiResponse>({ ok: false, error: "Condition set not found" }, 404);
 
     return c.json<ApiResponse<ConditionSetItemResponse>>(
       { ok: true, data: itemToResponse(row) },
@@ -766,7 +729,6 @@ conditionSetRoutes.put("/:id/items", async (c) => {
 
   try {
     const items = body.items.map(normalizeItem);
-    const previousItems = await snapshotConditionSetItems(tenantId, set.id);
     await writeAuditEvent({
       tenantId,
       actorType: "user",
@@ -780,57 +742,60 @@ conditionSetRoutes.put("/:id/items", async (c) => {
       requestId: c.get("requestId") ?? null,
     });
 
-    const rows = await db.transaction(async (tx) => {
-      const [currentSet] = await tx
-        .select({ id: conditionSets.id })
-        .from(conditionSets)
-        .where(and(eq(conditionSets.id, set.id), eq(conditionSets.tenantId, tenantId)));
-      if (!currentSet) return null;
+    const rows = await withTenantAuditedTransaction(
+      tenantId,
+      async (txRaw, appendRequiredAudit) => {
+        const tx = txRaw as typeof db;
+        const lockedSet = await readLockedConditionSet(tx, tenantId, set.id);
+        if (!lockedSet) return null;
+        if (items.length > MAX_CONDITION_SET_ITEMS) {
+          throw new ConditionSetValidationError(
+            `items cannot contain more than ${MAX_CONDITION_SET_ITEMS} entries`,
+          );
+        }
 
-      await tx
-        .delete(conditionSetItems)
-        .where(
-          and(
-            eq(conditionSetItems.tenantId, tenantId),
-            eq(conditionSetItems.conditionSetId, set.id),
-          ),
-        );
+        await tx
+          .delete(conditionSetItems)
+          .where(
+            and(
+              eq(conditionSetItems.tenantId, tenantId),
+              eq(conditionSetItems.conditionSetId, lockedSet.id),
+            ),
+          );
 
-      if (items.length === 0) return [];
+        const replaced =
+          items.length === 0
+            ? []
+            : await tx
+                .insert(conditionSetItems)
+                .values(
+                  items.map((item) => ({
+                    conditionSetId: lockedSet.id,
+                    tenantId,
+                    value: item.value,
+                    label: item.label,
+                    metadata: item.metadata,
+                  })),
+                )
+                .returning();
 
-      return tx
-        .insert(conditionSetItems)
-        .values(
-          items.map((item) => ({
-            conditionSetId: set.id,
-            tenantId,
-            value: item.value,
-            label: item.label,
-            metadata: item.metadata,
-          })),
-        )
-        .returning();
-    });
+        await appendRequiredAudit({
+          tenantId,
+          actorType: "user",
+          actorId: c.get("userId") ?? tenantId,
+          action: "condition_set.items.replace",
+          resourceType: "condition_set",
+          resourceId: lockedSet.id,
+          metadata: { itemCount: replaced.length },
+          ipAddress: c.req.header("x-forwarded-for") ?? null,
+          userAgent: c.req.header("user-agent") ?? null,
+          requestId: c.get("requestId") ?? null,
+        });
+        return replaced;
+      },
+    );
 
     if (!rows) return c.json<ApiResponse>({ ok: false, error: "Condition set not found" }, 404);
-
-    try {
-      await writeAuditEvent({
-        tenantId,
-        actorType: "user",
-        actorId: c.get("userId") ?? tenantId,
-        action: "condition_set.items.replace",
-        resourceType: "condition_set",
-        resourceId: set.id,
-        metadata: { itemCount: rows.length },
-        ipAddress: c.req.header("x-forwarded-for") ?? null,
-        userAgent: c.req.header("user-agent") ?? null,
-        requestId: c.get("requestId") ?? null,
-      });
-    } catch (error) {
-      await restoreConditionSetItems(tenantId, set.id, previousItems);
-      throw error;
-    }
 
     return c.json<ApiResponse<ConditionSetItemResponse[]>>({
       ok: true,
@@ -901,8 +866,7 @@ conditionSetRoutes.patch("/:id/items/:itemId", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Condition set item not found" }, 404);
 
   try {
-    const item = normalizeItemUpdate(current, body);
-    const previousItems = await snapshotConditionSetItems(tenantId, set.id);
+    const authorizedItem = normalizeItemUpdate(current, body);
     await writeAuditEvent({
       tenantId,
       actorType: "user",
@@ -910,50 +874,74 @@ conditionSetRoutes.patch("/:id/items/:itemId", async (c) => {
       action: "condition_set.item.update.authorized",
       resourceType: "condition_set_item",
       resourceId: current.id,
-      metadata: { conditionSetId: set.id, value: item.value },
+      metadata: { conditionSetId: set.id, value: authorizedItem.value },
       ipAddress: c.req.header("x-forwarded-for") ?? null,
       userAgent: c.req.header("user-agent") ?? null,
       requestId: c.get("requestId") ?? null,
     });
 
-    const [row] = await db
-      .update(conditionSetItems)
-      .set({
-        value: item.value,
-        label: item.label,
-        metadata: item.metadata,
-        updatedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(conditionSetItems.id, current.id),
-          eq(conditionSetItems.tenantId, tenantId),
-          eq(conditionSetItems.conditionSetId, set.id),
-        ),
-      )
-      .returning();
-
-    if (!row) return c.json<ApiResponse>({ ok: false, error: "Condition set item not found" }, 404);
-
-    try {
-      await writeAuditEvent({
+    const row = await withTenantAuditedTransaction(tenantId, async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof db;
+      const lockedSet = await readLockedConditionSet(tx, tenantId, set.id);
+      if (!lockedSet) return { kind: "set_not_found" as const };
+      const query = tx
+        .select()
+        .from(conditionSetItems)
+        .where(
+          and(
+            eq(conditionSetItems.id, current.id),
+            eq(conditionSetItems.tenantId, tenantId),
+            eq(conditionSetItems.conditionSetId, lockedSet.id),
+          ),
+        );
+      const [lockedItem] = shouldUsePostgresAdvisoryLocks()
+        ? await query.for("update")
+        : await query;
+      if (!lockedItem) return { kind: "item_not_found" as const };
+      const item = normalizeItemUpdate(lockedItem, body);
+      const [updated] = await tx
+        .update(conditionSetItems)
+        .set({
+          value: item.value,
+          label: item.label,
+          metadata: item.metadata,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(conditionSetItems.id, lockedItem.id),
+            eq(conditionSetItems.tenantId, tenantId),
+            eq(conditionSetItems.conditionSetId, lockedSet.id),
+          ),
+        )
+        .returning();
+      if (!updated) return { kind: "item_not_found" as const };
+      await appendRequiredAudit({
         tenantId,
         actorType: "user",
         actorId: c.get("userId") ?? tenantId,
         action: "condition_set.item.update",
         resourceType: "condition_set_item",
-        resourceId: row.id,
-        metadata: { conditionSetId: set.id, value: row.value },
+        resourceId: updated.id,
+        metadata: { conditionSetId: lockedSet.id, value: updated.value },
         ipAddress: c.req.header("x-forwarded-for") ?? null,
         userAgent: c.req.header("user-agent") ?? null,
         requestId: c.get("requestId") ?? null,
       });
-    } catch (error) {
-      await restoreConditionSetItems(tenantId, set.id, previousItems);
-      throw error;
+      return { kind: "updated" as const, row: updated };
+    });
+
+    if (row.kind === "set_not_found") {
+      return c.json<ApiResponse>({ ok: false, error: "Condition set not found" }, 404);
+    }
+    if (row.kind === "item_not_found") {
+      return c.json<ApiResponse>({ ok: false, error: "Condition set item not found" }, 404);
     }
 
-    return c.json<ApiResponse<ConditionSetItemResponse>>({ ok: true, data: itemToResponse(row) });
+    return c.json<ApiResponse<ConditionSetItemResponse>>({
+      ok: true,
+      data: itemToResponse(row.row),
+    });
   } catch (err) {
     return conditionSetMutationError(c, err);
   }
@@ -986,7 +974,6 @@ conditionSetRoutes.delete("/:id/items/:itemId", async (c) => {
 
   if (!current)
     return c.json<ApiResponse>({ ok: false, error: "Condition set item not found" }, 404);
-  const previousItems = await snapshotConditionSetItems(tenantId, set.id);
 
   await writeAuditEvent({
     tenantId,
@@ -1001,37 +988,49 @@ conditionSetRoutes.delete("/:id/items/:itemId", async (c) => {
     requestId: c.get("requestId") ?? null,
   });
 
-  const [deleted] = await db
-    .delete(conditionSetItems)
-    .where(
-      and(
-        eq(conditionSetItems.id, c.req.param("itemId")),
-        eq(conditionSetItems.tenantId, tenantId),
-        eq(conditionSetItems.conditionSetId, set.id),
-      ),
-    )
-    .returning({ id: conditionSetItems.id, value: conditionSetItems.value });
-
-  if (!deleted)
-    return c.json<ApiResponse>({ ok: false, error: "Condition set item not found" }, 404);
-
   try {
-    await writeAuditEvent({
+    const deleted = await withTenantAuditedTransaction(
       tenantId,
-      actorType: "user",
-      actorId: c.get("userId") ?? tenantId,
-      action: "condition_set.item.delete",
-      resourceType: "condition_set_item",
-      resourceId: deleted.id,
-      metadata: { conditionSetId: set.id, value: deleted.value },
-      ipAddress: c.req.header("x-forwarded-for") ?? null,
-      userAgent: c.req.header("user-agent") ?? null,
-      requestId: c.get("requestId") ?? null,
-    });
-  } catch (error) {
-    await restoreConditionSetItems(tenantId, set.id, previousItems);
-    throw error;
-  }
+      async (txRaw, appendRequiredAudit) => {
+        const tx = txRaw as typeof db;
+        const lockedSet = await readLockedConditionSet(tx, tenantId, set.id);
+        if (!lockedSet) return { kind: "set_not_found" as const };
+        const [row] = await tx
+          .delete(conditionSetItems)
+          .where(
+            and(
+              eq(conditionSetItems.id, c.req.param("itemId")),
+              eq(conditionSetItems.tenantId, tenantId),
+              eq(conditionSetItems.conditionSetId, lockedSet.id),
+            ),
+          )
+          .returning({ id: conditionSetItems.id, value: conditionSetItems.value });
+        if (!row) return { kind: "item_not_found" as const };
+        await appendRequiredAudit({
+          tenantId,
+          actorType: "user",
+          actorId: c.get("userId") ?? tenantId,
+          action: "condition_set.item.delete",
+          resourceType: "condition_set_item",
+          resourceId: row.id,
+          metadata: { conditionSetId: lockedSet.id, value: row.value },
+          ipAddress: c.req.header("x-forwarded-for") ?? null,
+          userAgent: c.req.header("user-agent") ?? null,
+          requestId: c.get("requestId") ?? null,
+        });
+        return { kind: "deleted" as const };
+      },
+    );
 
-  return c.json<ApiResponse>({ ok: true });
+    if (deleted.kind === "set_not_found") {
+      return c.json<ApiResponse>({ ok: false, error: "Condition set not found" }, 404);
+    }
+    if (deleted.kind === "item_not_found") {
+      return c.json<ApiResponse>({ ok: false, error: "Condition set item not found" }, 404);
+    }
+
+    return c.json<ApiResponse>({ ok: true });
+  } catch (err) {
+    return conditionSetMutationError(c, err);
+  }
 });


### PR DESCRIPTION
Closes #703

Exact head: 9bce76b541f9ef1ca7b3049ea3b62e9839af5b49
Base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6

Runs condition-set creation, patch, deletion, item upsert/deletion, and full replacement with their required completion audits inside one condition-set-locked database transaction. Quota and existence checks are re-read under that lock, snapshot compensation is removed, and the duplicate MFA branch is eliminated.

Mounted quota tests prove exactly one concurrent 100th set and 1,000th item. Deterministic real-PostgreSQL cases cover audit-failed update/delete against concurrent winners and replace-versus-upsert ordering.

Local exact evidence:
- focused mounted suites: 5 pass, 20 service-only skips, 50 assertions
- PGLite quota races and auth/audit contracts green
- API build green
- targeted Biome, diff-check, and metadata green

Draft only. Hosted exact-head PostgreSQL races, the full matrix, and independent approval remain required before readiness or merge.