### PR TITLE
test(auth): execute tenant SAML and SSO-domain contracts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
       "version": "0.4.4",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.700.0",
+        "@node-saml/node-saml": "5.1.0",
         "@scure/btc-signer": "^2.2.0",
         "@stwd/adapters": "workspace:*",
         "@stwd/attestation": "workspace:*",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-kms": "^3.700.0",
+    "@node-saml/node-saml": "5.1.0",
     "@scure/btc-signer": "^2.2.0",
     "@stwd/adapters": "workspace:*",
     "@stwd/attestation": "workspace:*",

--- a/packages/api/src/__tests__/fixtures/saml-idp.ts
+++ b/packages/api/src/__tests__/fixtures/saml-idp.ts
@@ -1,0 +1,106 @@
+import { signXml } from "@node-saml/node-saml/lib/xml";
+
+export const TEST_IDP_CERT = `-----BEGIN CERTIFICATE-----
+MIIDITCCAgmgAwIBAgIUKybcclhsj+h8d+H36sVUjlfVXkgwDQYJKoZIhvcNAQEL
+BQAwIDEeMBwGA1UEAwwVU3Rld2FyZCBTQU1MIFRlc3QgSWRQMB4XDTI2MDUyOTAz
+MjYyMloXDTM2MDUyNjAzMjYyMlowIDEeMBwGA1UEAwwVU3Rld2FyZCBTQU1MIFRl
+c3QgSWRQMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAj/bmD2BOnJYE
+69J2S8w56ACMNBY9YADrpISPKCSF8dbcb3MtpKdK9Rd32VQbktLbDIJ5Hx0KVCGk
+uVKQ3AljypPmc9QggFeIeGhSGIv4qj91mR1r5T7FtT/Uu09QhOj93rCJXmigxS+H
+nW9m+NAyspZnrI2c/k0nAzYdoCRurHq4eApQANC3MsSAGLLyVbFsGpHyeJZEoURv
+Os0B06OBRnPlmOeQnWJPVOcPETePy72IlIkxjUa/mSzgjPvzyKYw+GtabcHkEfgM
+EK2MAsEa0hELtylolHZ1Z4dMF2uY+XETX7TI+jM0gHUbsVbIBjVJeBl0Y1l16FSR
+E16dSaTY0wIDAQABo1MwUTAdBgNVHQ4EFgQUjS1h9KMehQHPwvAgPvKnUtXOn4ow
+HwYDVR0jBBgwFoAUjS1h9KMehQHPwvAgPvKnUtXOn4owDwYDVR0TAQH/BAUwAwEB
+/zANBgkqhkiG9w0BAQsFAAOCAQEAIrIixamp28P8EnXSnN+qD2wjkaMjx+CMVfYn
+K0ybv7U1cV7vafdY7D2P9r+vfYB9TFVsi96Hn44okWRcS+AAd0Fst+yg1p173bDU
+WWCIzrnf31jsP/OVtQi1k2vTBmtXFtY394yr29/pwHIysJ6+9+98s745MHQUdF40
+qlVtzbU3DtjURtzqi3OQDpxTmADAHdU6UoeVTOuMDNQryJV9IMf7szko15oBzQJv
+xQpVMiAAIZ00Y/Q/hFsXPOLgIFtc3/O0euRQ2zkvk8eqBewjduyaP5dkHfySVfoa
+fDIFQJSzQbapRCV/a6SwPOKV5oD3ElPqkQHIt/U+ezTY0KuCcA==
+-----END CERTIFICATE-----`;
+
+const TEST_IDP_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCP9uYPYE6clgTr
+0nZLzDnoAIw0Fj1gAOukhI8oJIXx1txvcy2kp0r1F3fZVBuS0tsMgnkfHQpUIaS5
+UpDcCWPKk+Zz1CCAV4h4aFIYi/iqP3WZHWvlPsW1P9S7T1CE6P3esIleaKDFL4ed
+b2b40DKylmesjZz+TScDNh2gJG6serh4ClAA0LcyxIAYsvJVsWwakfJ4lkShRG86
+zQHTo4FGc+WY55CdYk9U5w8RN4/LvYiUiTGNRr+ZLOCM+/PIpjD4a1ptweQR+AwQ
+rYwCwRrSEQu3KWiUdnVnh0wXa5j5cRNftMj6MzSAdRuxVsgGNUl4GXRjWXXoVJET
+Xp1JpNjTAgMBAAECggEAEqR/o5DDx/Xf/+8VGo5Wa/tbgd3kvMCMberXOZ+L04a7
+V5isBHJq0So6KY6BXkCn1QrgRxh/nz1sE1jkdq9QmN8Q11b/jnRyBlrxUUnEPbz8
+rC3p1u82CFk9DF8iUikfFu34G/L4lBBU7hzgUhVukJR21cV7ha2AASPKL6ldcOrm
+/GHGRqXy7yuRprSN4S5pIsjVhLrOM2QL56VekVibyvCcVyP2mTSVFkTgc7keMBe/
+biaR2L1uqrpWDRz5PGKD4HQzbc5huwcP/R9PtEvx8qJTF7K7z5/pdVwE+G/STqvd
+e6SbsFyplazilNW73Nx6V+B1IBbZtH9PyEHq7TkLgQKBgQDGG4Gf3SnDrryfj9no
+JLoCZbMVIzdRBBrupyiCyCFNVzOl0CFGHMcjUg9gK9twZnCzlBdS4NSytFRuGEZ5
+s70vD6WXi3LJLE1ySxZ2r/JKSlHpiSzIVc73ke8G0m1bfQl3abRvpLJ3QhPAcBIx
+eJu9Lv270icCmllVjfjONFavkQKBgQC6CO8Wm2FSrr/RgQ8eNWwPsszWP3D2UqWu
+t+HtATy1ao2dJG07WCtpdiygRyrqjOYLUmSY6a6ZauiXjihGMnq3aazUE+0QE19g
++cbMqGgQuVRgvbfTDUXDvQ5oIF578+nBnyTEptt0+nRpuPP3XV2k7gGMOnGAWwWu
+Zvr4F+FYIwKBgQCbc8YZjdBR7vGwO48ALKGRdAA8m++yMQh5MM4HIceQCtdKS7Fw
+dPCGdMP/8So2Xwwcvh43OJluyTZfVckngrT3Es4bxp8B4TO8ddNgutvjE8KHAM8V
+PNA1UFxB/Ck32zvsahPeb1xjXIRnQwnjrAJ5R0Bve46E6l0jV05fcI59IQKBgQCQ
+cA1JjRwT+Q9/Fufo+WtMCPOWyKzo4qQ2shgcTmCXLgKDZlvUvpD+Eb12N6svbnPR
+iIgIXS6teN7bhIjqb5jtvINuKYZee9wKzAM4tOwPSAUmE0ac+2oWHjwIRlF1hZwR
+M4F1mWM8QJSP3QS2Iuxo+E2FVX74PDN+BACJDOlt5wKBgDpJ5fKbawRZjuF70IjT
+nCZBXYblR/x/lN9gvgNvPTcB4a3blk2bzbHXnrBND+Jzvq3O/DU1dkWr/Y/8FzqA
+csqQ2vt05YmH3WaBuXw3obBjwSmSRJ5/fn6KeACxi0yGg2rPdMKC8/mZQ04B59RJ
+Q6KFw30AGA+dh9xnxw4ZPxy0
+-----END PRIVATE KEY-----`;
+
+export interface SignedSamlResponseOptions {
+  requestId: string;
+  assertionId: string;
+  responseId?: string;
+  issuer: string;
+  audience: string;
+  acsUrl: string;
+  email: string;
+  destination?: string;
+  recipient?: string;
+}
+
+function signElement(xml: string, elementName: "Assertion" | "Response"): string {
+  return signXml(
+    xml,
+    `//*[local-name(.)='${elementName}']`,
+    {
+      reference: `//*[local-name(.)='${elementName}']/*[local-name(.)='Issuer']`,
+      action: "after",
+    },
+    {
+      privateKey: TEST_IDP_PRIVATE_KEY,
+      publicCert: TEST_IDP_CERT,
+      signatureAlgorithm: "sha256",
+      digestAlgorithm: "sha256",
+    },
+  );
+}
+
+export function signedSamlResponse(options: SignedSamlResponseOptions): string {
+  const issueInstant = new Date().toISOString();
+  const notBefore = new Date(Date.now() - 60_000).toISOString();
+  const notOnOrAfter = new Date(Date.now() + 240_000).toISOString();
+  const destination = options.destination ?? options.acsUrl;
+  const recipient = options.recipient ?? options.acsUrl;
+  const assertion = [
+    `<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="${options.assertionId}" Version="2.0" IssueInstant="${issueInstant}">`,
+    `<saml:Issuer>${options.issuer}</saml:Issuer>`,
+    `<saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">${options.email}</saml:NameID>`,
+    `<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="${notOnOrAfter}" Recipient="${recipient}"/></saml:SubjectConfirmation></saml:Subject>`,
+    `<saml:Conditions NotBefore="${notBefore}" NotOnOrAfter="${notOnOrAfter}"><saml:AudienceRestriction><saml:Audience>${options.audience}</saml:Audience></saml:AudienceRestriction></saml:Conditions>`,
+    `<saml:AuthnStatement AuthnInstant="${issueInstant}" SessionIndex="_session-${options.assertionId}"><saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement>`,
+    `<saml:AttributeStatement><saml:Attribute Name="ID"><saml:AttributeValue>${options.assertionId}</saml:AttributeValue></saml:Attribute><saml:Attribute Name="email"><saml:AttributeValue>${options.email}</saml:AttributeValue></saml:Attribute><saml:Attribute Name="groups"><saml:AttributeValue>Engineering</saml:AttributeValue></saml:Attribute></saml:AttributeStatement>`,
+    `</saml:Assertion>`,
+  ].join("");
+  const signedAssertion = signElement(assertion, "Assertion");
+  const response = [
+    `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="${options.responseId ?? `_response-${options.assertionId}`}" Version="2.0" IssueInstant="${issueInstant}" Destination="${destination}" InResponseTo="${options.requestId}">`,
+    `<saml:Issuer>${options.issuer}</saml:Issuer>`,
+    `<samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>`,
+    signedAssertion,
+    `</samlp:Response>`,
+  ].join("");
+  return Buffer.from(signElement(response, "Response"), "utf8").toString("base64");
+}

--- a/packages/api/src/__tests__/tenant-saml-sso.test.ts
+++ b/packages/api/src/__tests__/tenant-saml-sso.test.ts
@@ -20,10 +20,6 @@ AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 AQIDAQAB
 -----END CERTIFICATE-----`;
 
-function read(path: string): string {
-  return readFileSync(join(ROOT, path), "utf-8");
-}
-
 // Assert the composed SAML DDL contract across
 // the full set of migration files rather than hard-coded filenames.
 function allMigrations(): string {
@@ -93,28 +89,8 @@ describe("tenant SAML SSO config foundation", () => {
     ).toBe("groupRoleMappings role must be admin, developer, billing, viewer, or member");
   });
 
-  it("adds MFA-gated tenant routes, atomic audit, metadata, login, and ACS guardrails", () => {
-    const tenantConfigSource = read("packages/api/src/routes/tenant-config.ts");
-    const authSource = read("packages/api/src/routes/auth.ts");
+  it("retains the immutable SAML schema constraints across composed migrations", () => {
     const migration = allMigrations();
-
-    expect(tenantConfigSource).toContain('tenantConfigRoutes.get("/:id/saml-sso"');
-    expect(tenantConfigSource).toContain('tenantConfigRoutes.put("/:id/saml-sso"');
-    expect(tenantConfigSource).toContain('tenantConfigRoutes.delete("/:id/saml-sso"');
-    expect(tenantConfigSource).toContain('requireRecentTenantAdminMfa(c, "SAML SSO config');
-    expect(tenantConfigSource).toContain("tenant.saml_sso.update.authorized");
-    expect(tenantConfigSource).toContain("withTenantAuditedTransaction");
-    expect(tenantConfigSource).not.toContain("restoreTenantSamlSsoConfig");
-
-    expect(authSource).toContain('auth.get("/saml/:tenantId/metadata"');
-    expect(authSource).toContain('auth.get("/saml/:tenantId/login"');
-    expect(authSource).toContain('auth.post("/saml/:tenantId/acs"');
-    expect(authSource).toContain("application/samlmetadata+xml");
-    expect(authSource).toContain('WantAssertionsSigned="true"');
-    expect(authSource).toContain("verifySamlAcsResponse");
-    expect(authSource).toContain("isVerifiedSsoEmailDomainForTenant");
-    expect(authSource).toContain("recordSamlAssertionReplay");
-    expect(authSource).toContain("resolveSamlMappedRole(config, groups)");
 
     expect(migration).toContain("\"jit_default_role\" varchar(32) NOT NULL DEFAULT 'viewer'");
     expect(migration).toContain('"tenant_saml_sso_configs_viewer_jit_role_check"');

--- a/packages/api/src/__tests__/tenant-sso-domain-race-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/tenant-sso-domain-race-postgres.integration.test.ts
@@ -1,0 +1,138 @@
+import { expect, it } from "bun:test";
+import { generateApiKey } from "@stwd/auth";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  auditChainHeads,
+  auditEvents,
+  createDb,
+  tenantSsoDomains,
+  tenants,
+  users,
+  userTenants,
+} from "@stwd/db";
+import { and, eq, inArray } from "drizzle-orm";
+import { Hono } from "hono";
+
+const databaseUrl = process.env.DATABASE_URL;
+const realPostgresIt = databaseUrl && !process.env.STEWARD_PGLITE_MEMORY ? it : it.skip;
+
+realPostgresIt(
+  "allows exactly one tenant to verify the same DNS-proven domain under a deterministic race",
+  async () => {
+    const suffix = crypto.randomUUID().replaceAll("-", "").slice(0, 16);
+    const tenantIds = [`sso-race-a-${suffix}`, `sso-race-b-${suffix}`];
+    const userIds = [crypto.randomUUID(), crypto.randomUUID()];
+    const domain = `race-${suffix}.example.test`;
+    const previousAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+    const previousJwtSecret = process.env.STEWARD_JWT_SECRET;
+    const previousMasterPassword = process.env.STEWARD_MASTER_PASSWORD;
+    process.env.STEWARD_AUDIT_HMAC_KEY = `sso-race-audit-${suffix}-at-least-32-bytes`;
+    process.env.STEWARD_JWT_SECRET = `sso-race-jwt-${suffix}-at-least-32-bytes`;
+    process.env.STEWARD_MASTER_PASSWORD = `sso-race-master-${suffix}-at-least-32-bytes`;
+    __resetAuditHmacKeyCacheForTests();
+
+    const admin = createDb(databaseUrl!);
+    let resetTxtResolver: (() => void) | undefined;
+    try {
+      for (let index = 0; index < tenantIds.length; index++) {
+        const pair = generateApiKey();
+        await admin.db.insert(tenants).values({
+          id: tenantIds[index],
+          name: `SSO race ${index}`,
+          apiKeyHash: pair.hash,
+        });
+        await admin.db.insert(users).values({
+          id: userIds[index],
+          email: `sso-race-${index}-${suffix}@example.test`,
+        });
+        await admin.db.insert(userTenants).values({
+          userId: userIds[index],
+          tenantId: tenantIds[index],
+          role: "owner",
+        });
+        await admin.db.insert(tenantSsoDomains).values({
+          tenantId: tenantIds[index],
+          domain,
+          verificationToken: `steward-sso-race-${suffix}`,
+          status: "pending",
+          ssoRequired: true,
+        });
+      }
+
+      const authModule = await import("../routes/auth");
+      const tenantModule = await import("../routes/tenant-config");
+      resetTxtResolver = () => tenantModule.__setSsoDomainTxtResolverForTests();
+      const tokens = await Promise.all(
+        tenantIds.map((tenantId, index) =>
+          authModule.createSessionToken("0x0000000000000000000000000000000000000000", tenantId, {
+            userId: userIds[index],
+            tenantId,
+            mfaVerifiedAt: Date.now(),
+            mfaMethod: "totp",
+          }),
+        ),
+      );
+      const app = new Hono().route("/tenants", tenantModule.tenantConfigRoutes);
+      app.onError((error, c) => c.json({ ok: false, error: error.message }, 500));
+
+      let arrivals = 0;
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      tenantModule.__setSsoDomainTxtResolverForTests(async () => {
+        arrivals++;
+        if (arrivals === 2) release();
+        await gate;
+        return [[`steward-sso-race-${suffix}`]];
+      });
+      const requests = tenantIds.map((tenantId, index) =>
+        app.request(`/tenants/${tenantId}/sso-domains/${domain}/verify`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${tokens[index]}` },
+        }),
+      );
+
+      const responses = await Promise.all(requests);
+      expect(responses.map((response) => response.status).sort()).toEqual([200, 409]);
+
+      const rows = await admin.db
+        .select({ tenantId: tenantSsoDomains.tenantId, status: tenantSsoDomains.status })
+        .from(tenantSsoDomains)
+        .where(eq(tenantSsoDomains.domain, domain));
+      expect(rows.filter((row) => row.status === "verified")).toHaveLength(1);
+      expect(rows.filter((row) => row.status === "pending")).toHaveLength(1);
+
+      const completions = await admin.db
+        .select({ tenantId: auditEvents.tenantId })
+        .from(auditEvents)
+        .where(
+          and(
+            inArray(auditEvents.tenantId, tenantIds),
+            eq(auditEvents.action, "tenant.sso_domain.verify"),
+          ),
+        );
+      expect(completions).toHaveLength(1);
+      expect(completions[0]?.tenantId).toBe(
+        rows.find((row) => row.status === "verified")?.tenantId,
+      );
+    } finally {
+      resetTxtResolver?.();
+      await admin.db.delete(auditEvents).where(inArray(auditEvents.tenantId, tenantIds));
+      await admin.db.delete(auditChainHeads).where(inArray(auditChainHeads.tenantId, tenantIds));
+      await admin.db.delete(tenantSsoDomains).where(inArray(tenantSsoDomains.tenantId, tenantIds));
+      await admin.db.delete(userTenants).where(inArray(userTenants.tenantId, tenantIds));
+      await admin.db.delete(tenants).where(inArray(tenants.id, tenantIds));
+      await admin.db.delete(users).where(inArray(users.id, userIds));
+      await admin.client.end();
+      if (previousAuditKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+      else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditKey;
+      if (previousJwtSecret === undefined) delete process.env.STEWARD_JWT_SECRET;
+      else process.env.STEWARD_JWT_SECRET = previousJwtSecret;
+      if (previousMasterPassword === undefined) delete process.env.STEWARD_MASTER_PASSWORD;
+      else process.env.STEWARD_MASTER_PASSWORD = previousMasterPassword;
+      __resetAuditHmacKeyCacheForTests();
+    }
+  },
+  120_000,
+);

--- a/packages/api/src/__tests__/tenant-sso-domains.test.ts
+++ b/packages/api/src/__tests__/tenant-sso-domains.test.ts
@@ -1,113 +1,469 @@
-import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { generateApiKey } from "@stwd/auth";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  auditEvents,
+  closeDb,
+  getDb,
+  tenantConfigs,
+  tenantSamlSsoConfigs,
+  tenantSsoDomains,
+  tenants,
+  users,
+  userTenants,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { and, eq, sql } from "drizzle-orm";
+import { Hono } from "hono";
 
-const ROOT = join(import.meta.dir, "../../../..");
+const TENANT_ID = "tenant-sso-mounted";
+const DOMAIN = "company.example.test";
+const CERT = `-----BEGIN CERTIFICATE-----
+${"c2lnbmVkLXRlc3QtY2VydGlmaWNhdGU=".repeat(5)}
+-----END CERTIFICATE-----`;
 
-function read(path: string): string {
-  return readFileSync(join(ROOT, path), "utf-8");
-}
+describe("mounted tenant SAML and SSO-domain control plane", () => {
+  let app: Hono;
+  let ownerToken = "";
+  let memberToken = "";
+  let staleToken = "";
+  let apiKey = "";
+  let setTxtResolver: (resolver?: (hostname: string) => Promise<string[][]>) => void;
 
-describe("tenant SSO domain hardening", () => {
-  it("requires DNS TXT proof before a tenant SSO domain can become discoverable", () => {
-    const source = read("packages/api/src/routes/tenant-config.ts");
-    const verifyStart = source.indexOf('tenantConfigRoutes.post("/:id/sso-domains/:domain/verify"');
-    expect(verifyStart).toBeGreaterThanOrEqual(0);
-    const verifyEnd = source.indexOf("\ntenantConfigRoutes.", verifyStart + 1);
-    const verifyRoute = source.slice(verifyStart, verifyEnd === -1 ? undefined : verifyEnd);
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_MASTER_PASSWORD = "tenant-sso-mounted-master-password";
+    process.env.STEWARD_JWT_SECRET = "tenant-sso-mounted-jwt-secret";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "tenant-sso-mounted-audit-key-at-least-32-bytes";
+    process.env.APP_URL = "https://api.example.test/";
+    process.env.GOOGLE_CLIENT_ID = "tenant-sso-google-client";
+    process.env.GOOGLE_CLIENT_SECRET = "tenant-sso-google-secret";
+    process.env.STEWARD_ALLOW_UNBOUND_OAUTH_PROVIDER_CODE_EXCHANGE = "true";
+    __resetAuditHmacKeyCacheForTests();
 
-    expect(source).toContain('import { resolveTxt } from "node:dns/promises"');
-    expect(source).toContain("async function hasSsoDomainVerificationTxt");
-    expect(source).toContain("resolveTxt(`_steward-sso.${domain}`)");
-    expect(verifyRoute).toContain("previousDomain.verificationToken");
-    expect(verifyRoute).toContain(
-      "hasSsoDomainVerificationTxt(domain, previousDomain.verificationToken)",
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+
+    const keyPair = generateApiKey();
+    apiKey = keyPair.key;
+    await getDb().insert(tenants).values({
+      id: TENANT_ID,
+      name: "Mounted SSO Tenant",
+      apiKeyHash: keyPair.hash,
+    });
+    await getDb()
+      .insert(tenantConfigs)
+      .values({
+        tenantId: TENANT_ID,
+        joinMode: "open",
+        allowedOrigins: ["https://app.example.test"],
+        allowedRedirectUrls: ["https://app.example.test/callback"],
+      });
+    const [owner, member] = await getDb()
+      .insert(users)
+      .values([
+        { email: "owner@company.example.test", emailVerified: true },
+        { email: "member@company.example.test", emailVerified: true },
+      ])
+      .returning({ id: users.id });
+    await getDb()
+      .insert(userTenants)
+      .values([
+        { userId: owner.id, tenantId: TENANT_ID, role: "owner" },
+        { userId: member.id, tenantId: TENANT_ID, role: "member" },
+      ]);
+
+    const authModule = await import("../routes/auth");
+    const tenantModule = await import("../routes/tenant-config");
+    setTxtResolver = tenantModule.__setSsoDomainTxtResolverForTests;
+    ownerToken = await authModule.createSessionToken(
+      "0x0000000000000000000000000000000000000000",
+      TENANT_ID,
+      { userId: owner.id, tenantId: TENANT_ID, mfaVerifiedAt: Date.now(), mfaMethod: "totp" },
     );
-    expect(verifyRoute).toContain('action: "tenant.sso_domain.verify.authorized"');
-    expect(verifyRoute.indexOf('action: "tenant.sso_domain.verify.authorized"')).toBeLessThan(
-      verifyRoute.indexOf(".update(tenantSsoDomains)"),
+    memberToken = await authModule.createSessionToken(
+      "0x0000000000000000000000000000000000000000",
+      TENANT_ID,
+      { userId: member.id, tenantId: TENANT_ID, mfaVerifiedAt: Date.now(), mfaMethod: "totp" },
     );
+    staleToken = await authModule.createSessionToken(
+      "0x0000000000000000000000000000000000000000",
+      TENANT_ID,
+      {
+        userId: owner.id,
+        tenantId: TENANT_ID,
+        mfaVerifiedAt: Date.now() - 20 * 60_000,
+        mfaMethod: "totp",
+      },
+    );
+
+    app = new Hono();
+    app.route("/tenants", tenantModule.tenantConfigRoutes);
+    app.route("/auth", authModule.authRoutes);
+    app.onError((error, c) => c.json({ ok: false, error: error.message }, 500));
+  }, 120_000);
+
+  afterAll(async () => {
+    setTxtResolver?.();
+    await closeDb();
+    for (const name of [
+      "STEWARD_PGLITE_MEMORY",
+      "STEWARD_MASTER_PASSWORD",
+      "STEWARD_JWT_SECRET",
+      "STEWARD_AUDIT_HMAC_KEY",
+      "APP_URL",
+      "GOOGLE_CLIENT_ID",
+      "GOOGLE_CLIENT_SECRET",
+      "STEWARD_ALLOW_UNBOUND_OAUTH_PROVIDER_CODE_EXCHANGE",
+    ]) {
+      delete process.env[name];
+    }
+    __resetAuditHmacKeyCacheForTests();
   });
 
-  it("makes SSO domain control-plane mutations atomic with final audits", () => {
-    const source = read("packages/api/src/routes/tenant-config.ts");
+  const sessionHeaders = (token = ownerToken): Record<string, string> => ({
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  });
 
-    for (const [marker, authorizedAction, finalAction] of [
-      [
-        'tenantConfigRoutes.post("/:id/sso-domains"',
-        'action: "tenant.sso_domain.upsert.authorized"',
-        'action: "tenant.sso_domain.upsert"',
-      ],
-      [
-        'tenantConfigRoutes.post("/:id/sso-domains/:domain/verify"',
-        'action: "tenant.sso_domain.verify.authorized"',
-        'action: "tenant.sso_domain.verify"',
-      ],
-      [
-        'tenantConfigRoutes.delete("/:id/sso-domains/:domain"',
-        'action: "tenant.sso_domain.delete.authorized"',
-        'action: "tenant.sso_domain.delete"',
-      ],
-    ] as const) {
-      const start = source.indexOf(marker);
-      expect(start).toBeGreaterThanOrEqual(0);
-      const nextRoute = source.indexOf("\ntenantConfigRoutes.", start + marker.length);
-      const route = source.slice(start, nextRoute === -1 ? undefined : nextRoute);
-      expect(route).toContain(authorizedAction);
-      expect(route).toContain("withTenantAuditedTransaction(tenantId");
-      expect(route).toContain("appendRequiredAudit({");
-      expect(route).toContain(finalAction);
-      expect(route).not.toContain("restoreTenantSsoDomain");
+  const samlConfig = () => ({
+    enabled: true,
+    idpEntityId: "https://idp.example.test/saml",
+    idpSsoUrl: "https://idp.example.test/sso",
+    idpCertPems: [CERT],
+    emailAttribute: "email",
+    groupsAttribute: "groups",
+    groupRoleMappings: [{ group: "Engineering", role: "developer" }],
+    allowJitProvisioning: true,
+  });
+
+  it("denies API keys, non-admin members, and stale MFA before SSO config reads or writes", async () => {
+    for (const headers of [
+      { "X-Steward-Key": apiKey, "X-Steward-Tenant": TENANT_ID },
+      sessionHeaders(memberToken),
+      sessionHeaders(staleToken),
+    ]) {
+      const getResponse = await app.request(`/tenants/${TENANT_ID}/saml-sso`, { headers });
+      expect(getResponse.status).toBe(403);
+      const putResponse = await app.request(`/tenants/${TENANT_ID}/saml-sso`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify(samlConfig()),
+      });
+      expect(putResponse.status).toBe(403);
     }
   });
 
-  it("does not let two tenants verify the same SSO discovery domain", () => {
-    const source = read("packages/api/src/routes/tenant-config.ts");
-    const auth = read("packages/api/src/routes/auth.ts");
-    const verifyStart = source.indexOf('tenantConfigRoutes.post("/:id/sso-domains/:domain/verify"');
-    const verifyEnd = source.indexOf("\ntenantConfigRoutes.", verifyStart + 1);
-    const verifyRoute = source.slice(verifyStart, verifyEnd === -1 ? undefined : verifyEnd);
+  it("mounts SAML config and public metadata with APP_URL-pinned, no-store SP URLs", async () => {
+    const unsafe = await app.request(`/tenants/${TENANT_ID}/saml-sso`, {
+      method: "PUT",
+      headers: sessionHeaders(),
+      body: JSON.stringify({ ...samlConfig(), idpSsoUrl: "https://127.0.0.1/sso" }),
+    });
+    expect(unsafe.status).toBe(400);
 
-    expect(verifyRoute).toContain("existingVerifiedDomain");
-    expect(verifyRoute).toContain("existingVerifiedDomain.tenantId !== tenantId");
-    expect(verifyRoute).toContain("SSO domain is already verified by another tenant");
-    expect(auth).toContain("steward_bootstrap.auth_sso_discovery_subject");
-    expect(auth).toContain("rows.length === 1");
+    const privateKey = await app.request(`/tenants/${TENANT_ID}/saml-sso`, {
+      method: "PUT",
+      headers: sessionHeaders(),
+      body: JSON.stringify({
+        ...samlConfig(),
+        idpCertPems: [`-----BEGIN PRIVATE KEY-----\n${"a".repeat(160)}\n-----END PRIVATE KEY-----`],
+      }),
+    });
+    expect(privateKey.status).toBe(400);
+
+    const put = await app.request(`/tenants/${TENANT_ID}/saml-sso`, {
+      method: "PUT",
+      headers: sessionHeaders(),
+      body: JSON.stringify(samlConfig()),
+    });
+    expect(put.status).toBe(200);
+    const putBody = (await put.json()) as {
+      data: { config: { spEntityId: string; acsUrl: string } };
+    };
+    expect(putBody.data.config).toMatchObject({
+      spEntityId: `https://api.example.test/auth/saml/${TENANT_ID}/metadata`,
+      acsUrl: `https://api.example.test/auth/saml/${TENANT_ID}/acs`,
+    });
+    expect(put.headers.get("cache-control")).toContain("no-store");
+
+    const get = await app.request(`/tenants/${TENANT_ID}/saml-sso`, {
+      headers: sessionHeaders(),
+    });
+    expect(get.status).toBe(200);
+    expect((await get.json()) as object).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          serviceProvider: {
+            spEntityId: `https://api.example.test/auth/saml/${TENANT_ID}/metadata`,
+            acsUrl: `https://api.example.test/auth/saml/${TENANT_ID}/acs`,
+            metadataUrl: `https://api.example.test/auth/saml/${TENANT_ID}/metadata`,
+          },
+        }),
+      }),
+    );
+
+    const metadata = await app.request(`/auth/saml/${TENANT_ID}/metadata`);
+    expect(metadata.status).toBe(200);
+    expect(metadata.headers.get("content-type")).toContain("application/samlmetadata+xml");
+    const xml = await metadata.text();
+    expect(xml).toContain(`entityID="https://api.example.test/auth/saml/${TENANT_ID}/metadata"`);
+    expect(xml).toContain(`Location="https://api.example.test/auth/saml/${TENANT_ID}/acs"`);
+
+    const malformedAcs = await app.request(`/auth/saml/${TENANT_ID}/acs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ SAMLResponse: "not-a-secret" }),
+    });
+    expect(malformedAcs.status).toBe(400);
+    const malformedBody = await malformedAcs.text();
+    expect(malformedBody).not.toContain(CERT);
+    expect(malformedBody).not.toContain("PRIVATE KEY");
   });
 
-  it("enforces SSO-required domains against email and built-in OAuth login", () => {
-    const auth = read("packages/api/src/routes/auth.ts");
+  it("uses injected DNS proof for add, verify, discovery, and delete behavior", async () => {
+    const add = await app.request(`/tenants/${TENANT_ID}/sso-domains`, {
+      method: "POST",
+      headers: sessionHeaders(),
+      body: JSON.stringify({ domain: DOMAIN.toUpperCase(), ssoRequired: true }),
+    });
+    expect(add.status).toBe(201);
+    const addBody = (await add.json()) as {
+      data: { domain: { domain: string; verificationToken: string; status: string } };
+    };
+    const token = addBody.data.domain.verificationToken;
+    expect(addBody.data.domain).toMatchObject({ domain: DOMAIN, status: "pending" });
 
-    expect(auth).toContain("async function isSsoRequiredForEmailDomain");
-    expect(auth).toContain("async function requireNonSsoEmailLoginAllowed");
-    expect(auth).toContain("Email login is disabled because this email domain requires SSO");
-    expect(auth).toContain("OAuth login is disabled because this email domain requires SSO");
-    expect(auth).toContain('authMethod: "oidc"');
-  });
+    let requestedHostname = "";
+    setTxtResolver(async (hostname) => {
+      requestedHostname = hostname;
+      return [["wrong-token"]];
+    });
+    const missing = await app.request(`/tenants/${TENANT_ID}/sso-domains/${DOMAIN}/verify`, {
+      method: "POST",
+      headers: sessionHeaders(),
+    });
+    expect(missing.status).toBe(409);
+    expect(requestedHostname).toBe(`_steward-sso.${DOMAIN}`);
 
-  it("enforces SSO-required domains against passkey enrollment and login", () => {
-    const auth = read("packages/api/src/routes/auth.ts");
+    setTxtResolver(async () => [[token.slice(0, 12), token.slice(12)]]);
+    const verify = await app.request(`/tenants/${TENANT_ID}/sso-domains/${DOMAIN}/verify`, {
+      method: "POST",
+      headers: sessionHeaders(),
+    });
+    expect(verify.status).toBe(200);
 
-    for (const [routeMarker, tenantMarker] of [
-      ['auth.post("/passkey/register/options"', "session.payload.tenantId"],
-      ['auth.post("/passkey/register/verify"', "tenantId"],
-      ['auth.post("/passkey/login/options"', "optionTenantId"],
-      ['auth.post("/passkey/login/verify"', "tenantId"],
+    const discovery = await app.request("/auth/sso/discover", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: `person@${DOMAIN}` }),
+    });
+    expect(discovery.status).toBe(200);
+    expect(await discovery.json()).toEqual({
+      ok: true,
+      data: {
+        available: true,
+        domain: DOMAIN,
+        tenantId: TENANT_ID,
+        ssoRequired: true,
+      },
+    });
+
+    for (const [path, body, headers] of [
+      [
+        "/auth/email/send",
+        { email: `owner@${DOMAIN}`, tenantId: TENANT_ID },
+        { "Content-Type": "application/json" },
+      ],
+      [
+        "/auth/passkey/login/options",
+        { email: `owner@${DOMAIN}`, tenantId: TENANT_ID },
+        { "Content-Type": "application/json" },
+      ],
+      ["/auth/passkey/register/options", { email: `owner@${DOMAIN}` }, sessionHeaders()],
     ] as const) {
-      const routeStart = auth.indexOf(routeMarker);
-      expect(routeStart).toBeGreaterThanOrEqual(0);
-      const nextRoute = auth.indexOf("\nauth.", routeStart + routeMarker.length);
-      const route = auth.slice(routeStart, nextRoute === -1 ? undefined : nextRoute);
-      expect(route).toContain("requireNonSsoEmailLoginAllowed(");
-      expect(route).toContain(tenantMarker);
-      expect(route).toContain("email");
-      expect(route).toContain('"Passkey"');
-      expect(route).toContain("if (ssoRequiredResponse) return ssoRequiredResponse");
-      if (routeMarker === 'auth.post("/passkey/login/verify"') {
-        expect(route.indexOf("if (ssoRequiredResponse) return ssoRequiredResponse")).toBeLessThan(
-          route.indexOf("getChallengeStore().consume"),
+      const blocked = await app.request(path, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+      expect(blocked.status).toBe(403);
+      expect(((await blocked.json()) as { error: string }).error).toContain("requires SSO");
+    }
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://oauth2.googleapis.com/token") {
+        return new Response(
+          JSON.stringify({
+            access_token: "provider-token",
+            expires_in: 3600,
+            token_type: "Bearer",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
         );
       }
+      if (url === "https://www.googleapis.com/oauth2/v3/userinfo") {
+        return new Response(
+          JSON.stringify({
+            id: "sso-oauth-user",
+            email: `owner@${DOMAIN}`,
+            verified_email: true,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(`unexpected fetch: ${url}`, { status: 500 });
+    }) as typeof fetch;
+    try {
+      const oauth = await app.request("/auth/oauth/google/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code: "provider-code",
+          redirectUri: "https://app.example.test/callback",
+          tenantId: TENANT_ID,
+        }),
+      });
+      expect(oauth.status).toBe(403);
+      expect(((await oauth.json()) as { error: string }).error).toContain("requires SSO");
+    } finally {
+      globalThis.fetch = originalFetch;
     }
+
+    const remove = await app.request(`/tenants/${TENANT_ID}/sso-domains/${DOMAIN}`, {
+      method: "DELETE",
+      headers: sessionHeaders(),
+    });
+    expect(remove.status).toBe(200);
+    const unavailable = await app.request("/auth/sso/discover", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: `person@${DOMAIN}` }),
+    });
+    expect(await unavailable.json()).toEqual({
+      ok: true,
+      data: {
+        available: false,
+        domain: DOMAIN,
+        tenantId: null,
+        ssoRequired: false,
+      },
+    });
+  });
+
+  it("rolls back every SAML/domain mutation when its completion audit is rejected", async () => {
+    const cases = [
+      "tenant.saml_sso.update",
+      "tenant.saml_sso.delete",
+      "tenant.sso_domain.upsert",
+      "tenant.sso_domain.verify",
+      "tenant.sso_domain.delete",
+    ] as const;
+
+    for (const action of cases) {
+      const completedBefore = await getDb()
+        .select()
+        .from(auditEvents)
+        .where(and(eq(auditEvents.tenantId, TENANT_ID), eq(auditEvents.action, action)));
+      await getDb().execute(sql`DROP TRIGGER IF EXISTS reject_sso_completion ON audit_events`);
+      await getDb().execute(sql`DROP FUNCTION IF EXISTS reject_sso_completion()`);
+      await getDb().execute(
+        sql.raw(`
+        CREATE FUNCTION reject_sso_completion() RETURNS trigger AS $$
+        BEGIN
+          IF NEW.action = '${action}' THEN
+            RAISE EXCEPTION 'injected SSO completion audit failure';
+          END IF;
+          RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+      `),
+      );
+      await getDb().execute(sql`
+        CREATE TRIGGER reject_sso_completion BEFORE INSERT ON audit_events
+        FOR EACH ROW EXECUTE FUNCTION reject_sso_completion()
+      `);
+
+      if (action === "tenant.saml_sso.update") {
+        await getDb()
+          .delete(tenantSamlSsoConfigs)
+          .where(eq(tenantSamlSsoConfigs.tenantId, TENANT_ID));
+        const response = await app.request(`/tenants/${TENANT_ID}/saml-sso`, {
+          method: "PUT",
+          headers: sessionHeaders(),
+          body: JSON.stringify(samlConfig()),
+        });
+        expect(response.status).toBe(500);
+        expect(await getDb().select().from(tenantSamlSsoConfigs)).toHaveLength(0);
+      } else if (action === "tenant.saml_sso.delete") {
+        await getDb().execute(sql`DROP TRIGGER reject_sso_completion ON audit_events`);
+        await app.request(`/tenants/${TENANT_ID}/saml-sso`, {
+          method: "PUT",
+          headers: sessionHeaders(),
+          body: JSON.stringify(samlConfig()),
+        });
+        await getDb().execute(sql`
+          CREATE TRIGGER reject_sso_completion BEFORE INSERT ON audit_events
+          FOR EACH ROW EXECUTE FUNCTION reject_sso_completion()
+        `);
+        const response = await app.request(`/tenants/${TENANT_ID}/saml-sso`, {
+          method: "DELETE",
+          headers: sessionHeaders(),
+        });
+        expect(response.status).toBe(500);
+        expect(await getDb().select().from(tenantSamlSsoConfigs)).toHaveLength(1);
+      } else {
+        await getDb().delete(tenantSsoDomains).where(eq(tenantSsoDomains.tenantId, TENANT_ID));
+        if (action === "tenant.sso_domain.upsert") {
+          const response = await app.request(`/tenants/${TENANT_ID}/sso-domains`, {
+            method: "POST",
+            headers: sessionHeaders(),
+            body: JSON.stringify({ domain: DOMAIN, ssoRequired: true }),
+          });
+          expect(response.status).toBe(500);
+          expect(await getDb().select().from(tenantSsoDomains)).toHaveLength(0);
+        } else {
+          await getDb().execute(sql`DROP TRIGGER reject_sso_completion ON audit_events`);
+          await getDb()
+            .insert(tenantSsoDomains)
+            .values({
+              tenantId: TENANT_ID,
+              domain: DOMAIN,
+              verificationToken: "steward-sso-test-token",
+              status: action === "tenant.sso_domain.delete" ? "verified" : "pending",
+              ssoRequired: true,
+            });
+          await getDb().execute(sql`
+            CREATE TRIGGER reject_sso_completion BEFORE INSERT ON audit_events
+            FOR EACH ROW EXECUTE FUNCTION reject_sso_completion()
+          `);
+          setTxtResolver(async () => [["steward-sso-test-token"]]);
+          const response = await app.request(
+            `/tenants/${TENANT_ID}/sso-domains/${DOMAIN}${action.endsWith("verify") ? "/verify" : ""}`,
+            { method: action.endsWith("verify") ? "POST" : "DELETE", headers: sessionHeaders() },
+          );
+          expect(response.status).toBe(500);
+          const [stored] = await getDb()
+            .select()
+            .from(tenantSsoDomains)
+            .where(
+              and(eq(tenantSsoDomains.tenantId, TENANT_ID), eq(tenantSsoDomains.domain, DOMAIN)),
+            );
+          expect(stored?.status).toBe(action.endsWith("verify") ? "pending" : "verified");
+        }
+      }
+
+      expect(
+        await getDb()
+          .select()
+          .from(auditEvents)
+          .where(and(eq(auditEvents.tenantId, TENANT_ID), eq(auditEvents.action, action))),
+      ).toHaveLength(completedBefore.length);
+    }
+
+    await getDb().execute(sql`DROP TRIGGER IF EXISTS reject_sso_completion ON audit_events`);
+    await getDb().execute(sql`DROP FUNCTION IF EXISTS reject_sso_completion()`);
   });
 });

--- a/packages/api/src/__tests__/tenant-sso-domains.test.ts
+++ b/packages/api/src/__tests__/tenant-sso-domains.test.ts
@@ -305,11 +305,12 @@ describe("mounted tenant SAML and SSO-domain control plane", () => {
       });
 
     const initial = await startLogin();
+    const hostileMarker = "hostile-saml-verification-marker";
     for (const { label, response } of [
       {
         label: "issuer",
         response: responseFor(initial.requestId, "_wrong-issuer", {
-          issuer: "https://hostile-idp.example.test/saml",
+          issuer: `https://${hostileMarker}.example.test/saml`,
         }),
       },
       {
@@ -329,6 +330,8 @@ describe("mounted tenant SAML and SSO-domain control plane", () => {
       const denied = await postAcs(initial.relayState, response);
       expect(denied.status, label).toBe(401);
       const text = await denied.text();
+      expect(JSON.parse(text)).toEqual({ ok: false, error: "SAML verification failed" });
+      expect(text).not.toContain(hostileMarker);
       expect(text).not.toContain(CERT);
       expect(text).not.toContain("PRIVATE KEY");
     }

--- a/packages/api/src/__tests__/tenant-sso-domains.test.ts
+++ b/packages/api/src/__tests__/tenant-sso-domains.test.ts
@@ -6,6 +6,8 @@ import {
   closeDb,
   getDb,
   tenantConfigs,
+  tenantSamlAssertionReplays,
+  tenantSamlAuthnRequests,
   tenantSamlSsoConfigs,
   tenantSsoDomains,
   tenants,
@@ -15,12 +17,11 @@ import {
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { and, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
+import { signedSamlResponse, TEST_IDP_CERT } from "./fixtures/saml-idp";
 
 const TENANT_ID = "tenant-sso-mounted";
 const DOMAIN = "company.example.test";
-const CERT = `-----BEGIN CERTIFICATE-----
-${"c2lnbmVkLXRlc3QtY2VydGlmaWNhdGU=".repeat(5)}
------END CERTIFICATE-----`;
+const CERT = TEST_IDP_CERT;
 
 describe("mounted tenant SAML and SSO-domain control plane", () => {
   let app: Hono;
@@ -137,20 +138,36 @@ describe("mounted tenant SAML and SSO-domain control plane", () => {
     allowJitProvisioning: true,
   });
 
-  it("denies API keys, non-admin members, and stale MFA before SSO config reads or writes", async () => {
+  it("denies API keys, non-admin members, and stale MFA before every SSO config read or mutation", async () => {
+    const requests = [
+      { path: `/tenants/${TENANT_ID}/saml-sso`, method: "GET" },
+      { path: `/tenants/${TENANT_ID}/saml-sso`, method: "PUT", body: samlConfig() },
+      { path: `/tenants/${TENANT_ID}/saml-sso`, method: "DELETE" },
+      { path: `/tenants/${TENANT_ID}/sso-domains`, method: "GET" },
+      {
+        path: `/tenants/${TENANT_ID}/sso-domains`,
+        method: "POST",
+        body: { domain: DOMAIN, ssoRequired: true },
+      },
+      {
+        path: `/tenants/${TENANT_ID}/sso-domains/${DOMAIN}/verify`,
+        method: "POST",
+      },
+      { path: `/tenants/${TENANT_ID}/sso-domains/${DOMAIN}`, method: "DELETE" },
+    ] as const;
     for (const headers of [
       { "X-Steward-Key": apiKey, "X-Steward-Tenant": TENANT_ID },
       sessionHeaders(memberToken),
       sessionHeaders(staleToken),
     ]) {
-      const getResponse = await app.request(`/tenants/${TENANT_ID}/saml-sso`, { headers });
-      expect(getResponse.status).toBe(403);
-      const putResponse = await app.request(`/tenants/${TENANT_ID}/saml-sso`, {
-        method: "PUT",
-        headers,
-        body: JSON.stringify(samlConfig()),
-      });
-      expect(putResponse.status).toBe(403);
+      for (const request of requests) {
+        const response = await app.request(request.path, {
+          method: request.method,
+          headers,
+          body: "body" in request ? JSON.stringify(request.body) : undefined,
+        });
+        expect(response.status, `${request.method} ${request.path}`).toBe(403);
+      }
     }
   });
 
@@ -219,6 +236,122 @@ describe("mounted tenant SAML and SSO-domain control plane", () => {
     const malformedBody = await malformedAcs.text();
     expect(malformedBody).not.toContain(CERT);
     expect(malformedBody).not.toContain("PRIVATE KEY");
+  });
+
+  it("mounts signed IdP login and ACS success with issuer, audience, tenant, and replay denial", async () => {
+    const configure = await app.request(`/tenants/${TENANT_ID}/saml-sso`, {
+      method: "PUT",
+      headers: sessionHeaders(),
+      body: JSON.stringify(samlConfig()),
+    });
+    expect(configure.status).toBe(200);
+    await getDb()
+      .insert(tenantSsoDomains)
+      .values({
+        tenantId: TENANT_ID,
+        domain: DOMAIN,
+        verificationToken: "signed-saml-domain-proof",
+        status: "verified",
+        ssoRequired: true,
+      })
+      .onConflictDoUpdate({
+        target: [tenantSsoDomains.tenantId, tenantSsoDomains.domain],
+        set: { status: "verified", ssoRequired: true },
+      });
+    await getDb()
+      .delete(tenantSamlAssertionReplays)
+      .where(eq(tenantSamlAssertionReplays.tenantId, TENANT_ID));
+
+    const startLogin = async () => {
+      const login = await app.request(
+        `/auth/saml/${TENANT_ID}/login?redirect_uri=${encodeURIComponent("https://app.example.test/callback")}&state=mounted-state&response_type=code&code_challenge=${"a".repeat(43)}&code_challenge_method=S256`,
+      );
+      expect(login.status).toBe(302);
+      const idpLocation = login.headers.get("location");
+      expect(idpLocation).toStartWith("https://idp.example.test/sso?");
+      const relayState = new URL(idpLocation as string).searchParams.get("RelayState");
+      expect(relayState).toBeTruthy();
+      const [request] = await getDb()
+        .select()
+        .from(tenantSamlAuthnRequests)
+        .where(
+          and(
+            eq(tenantSamlAuthnRequests.tenantId, TENANT_ID),
+            eq(tenantSamlAuthnRequests.relayState, relayState as string),
+          ),
+        );
+      expect(request?.requestId).toBeTruthy();
+      return { relayState: relayState as string, requestId: request.requestId };
+    };
+    const postAcs = (relayState: string, response: string) =>
+      app.request(`/auth/saml/${TENANT_ID}/acs`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ RelayState: relayState, SAMLResponse: response }),
+      });
+    const responseFor = (
+      requestId: string,
+      assertionId: string,
+      overrides: Partial<Parameters<typeof signedSamlResponse>[0]> = {},
+    ) =>
+      signedSamlResponse({
+        requestId,
+        assertionId,
+        issuer: "https://idp.example.test/saml",
+        audience: `https://api.example.test/auth/saml/${TENANT_ID}/metadata`,
+        acsUrl: `https://api.example.test/auth/saml/${TENANT_ID}/acs`,
+        email: `owner@${DOMAIN}`,
+        ...overrides,
+      });
+
+    const initial = await startLogin();
+    for (const { label, response } of [
+      {
+        label: "issuer",
+        response: responseFor(initial.requestId, "_wrong-issuer", {
+          issuer: "https://hostile-idp.example.test/saml",
+        }),
+      },
+      {
+        label: "audience",
+        response: responseFor(initial.requestId, "_wrong-audience", {
+          audience: "https://hostile-sp.example.test/metadata",
+        }),
+      },
+      {
+        label: "tenant",
+        response: responseFor(initial.requestId, "_wrong-tenant", {
+          destination: "https://api.example.test/auth/saml/another-tenant/acs",
+          recipient: "https://api.example.test/auth/saml/another-tenant/acs",
+        }),
+      },
+    ]) {
+      const denied = await postAcs(initial.relayState, response);
+      expect(denied.status, label).toBe(401);
+      const text = await denied.text();
+      expect(text).not.toContain(CERT);
+      expect(text).not.toContain("PRIVATE KEY");
+    }
+
+    const assertionId = "_mounted-success-assertion";
+    const success = await postAcs(initial.relayState, responseFor(initial.requestId, assertionId));
+    expect(success.status, await success.clone().text()).toBe(302);
+    const successRedirect = new URL(success.headers.get("location") as string);
+    expect(successRedirect.origin + successRedirect.pathname).toBe(
+      "https://app.example.test/callback",
+    );
+    expect(successRedirect.hash).toContain("code=");
+    expect(successRedirect.hash).toContain("state=mounted-state");
+
+    const replay = await startLogin();
+    const replayed = await postAcs(
+      replay.relayState,
+      responseFor(replay.requestId, assertionId, { responseId: "_mounted-replay-response" }),
+    );
+    expect(replayed.status).toBe(302);
+    expect(new URL(replayed.headers.get("location") as string).searchParams.get("error")).toBe(
+      "saml_assertion_replay",
+    );
   });
 
   it("uses injected DNS proof for add, verify, discovery, and delete behavior", async () => {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -4599,11 +4599,8 @@ auth.post("/saml/:tenantId/acs", async (c) => {
     const appState = await getChallengeStore().consume(`saml-app-state:${relayState}`);
     setRedirectFragment(redirectUrl, { code: exchangeCode, state: appState ?? undefined });
     return c.redirect(redirectUrl.toString(), 302);
-  } catch (err) {
-    return c.json<ApiResponse>(
-      { ok: false, error: err instanceof Error ? err.message : "SAML verification failed" },
-      401,
-    );
+  } catch {
+    return c.json<ApiResponse>({ ok: false, error: "SAML verification failed" }, 401);
   }
 });
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -47,6 +47,7 @@
 import { createPublicKey, randomBytes, verify as verifySignature } from "node:crypto";
 import { request as httpsRequest } from "node:https";
 import { isIP } from "node:net";
+import { parseXml2JsFromString } from "@node-saml/node-saml/lib/xml";
 import {
   ACCESS_TOKEN_EXPIRY,
   ACCESS_TOKEN_EXPIRY_SECONDS,
@@ -4361,6 +4362,44 @@ async function recordSamlAssertionReplay(
   });
 }
 
+async function assertSamlAcsTenantBinding(
+  samlResponse: string,
+  expectedAcsUrl: string,
+): Promise<void> {
+  const parsed = (await parseXml2JsFromString(
+    Buffer.from(samlResponse, "base64").toString("utf8"),
+  )) as {
+    Response?: {
+      $?: { Destination?: string };
+      Assertion?: Array<{
+        Subject?: Array<{
+          SubjectConfirmation?: Array<{
+            SubjectConfirmationData?: Array<{ $?: { Recipient?: string } }>;
+          }>;
+        }>;
+      }>;
+    };
+  };
+  const response = parsed.Response;
+  if (response?.$?.Destination !== expectedAcsUrl) {
+    throw new Error("SAML response destination did not match this tenant's ACS");
+  }
+  const recipients =
+    response.Assertion?.flatMap(
+      (assertion) =>
+        assertion.Subject?.flatMap(
+          (subject) =>
+            subject.SubjectConfirmation?.flatMap(
+              (confirmation) =>
+                confirmation.SubjectConfirmationData?.map((data) => data.$?.Recipient) ?? [],
+            ) ?? [],
+        ) ?? [],
+    ) ?? [];
+  if (recipients.length === 0 || recipients.some((recipient) => recipient !== expectedAcsUrl)) {
+    throw new Error("SAML assertion recipient did not match this tenant's ACS");
+  }
+}
+
 /**
  * GET /saml/:tenantId/login
  * SP-initiated dashboard/team SSO. Stores an app-bound PKCE exchange request
@@ -4502,6 +4541,10 @@ auth.post("/saml/:tenantId/acs", async (c) => {
       emailAttribute: config.emailAttribute,
       groupsAttribute: config.groupsAttribute,
     });
+    await assertSamlAcsTenantBinding(samlResponse, config.acsUrl);
+    if (verified.issuer !== config.idpEntityId) {
+      throw new Error("SAML assertion issuer did not match the configured IdP");
+    }
     if (!(await isVerifiedSsoEmailDomainForTenant(tenantId, verified.email))) {
       redirectUrl.searchParams.set("error", "saml_email_domain_not_verified");
       return c.redirect(redirectUrl.toString(), 302);

--- a/packages/api/src/routes/tenant-config.ts
+++ b/packages/api/src/routes/tenant-config.ts
@@ -979,9 +979,28 @@ function serializeTenantSamlSsoConfig(row: TenantSamlSsoConfigRow): TenantSamlSs
   };
 }
 
+function databaseErrorCode(error: unknown): string | undefined {
+  let current = error;
+  for (let depth = 0; depth < 3 && current && typeof current === "object"; depth++) {
+    const candidate = current as { code?: unknown; cause?: unknown };
+    if (typeof candidate.code === "string") return candidate.code;
+    current = candidate.cause;
+  }
+  return undefined;
+}
+
+type SsoDomainTxtResolver = (hostname: string) => Promise<string[][]>;
+
+let ssoDomainTxtResolver: SsoDomainTxtResolver = resolveTxt;
+
+/** Replace DNS only in tests so route behavior never depends on the public network. */
+export function __setSsoDomainTxtResolverForTests(resolver?: SsoDomainTxtResolver): void {
+  ssoDomainTxtResolver = resolver ?? resolveTxt;
+}
+
 async function hasSsoDomainVerificationTxt(domain: string, token: string): Promise<boolean> {
   try {
-    const records = await resolveTxt(`_steward-sso.${domain}`);
+    const records = await ssoDomainTxtResolver(`_steward-sso.${domain}`);
     return records.some((chunks) => chunks.join("").trim() === token);
   } catch {
     return false;
@@ -1949,34 +1968,45 @@ tenantConfigRoutes.post("/:id/sso-domains/:domain/verify", requireTenantId, asyn
       409,
     );
   }
-  const row = await withTenantAuditedTransaction(tenantId, async (txRaw, appendRequiredAudit) => {
-    const tx = txRaw as typeof db;
-    const [updated] = await tx
-      .update(tenantSsoDomains)
-      .set({ status: "verified", verifiedAt: new Date(), updatedAt: new Date() })
-      .where(
-        and(
-          eq(tenantSsoDomains.tenantId, tenantId),
-          eq(tenantSsoDomains.domain, domain),
-          eq(tenantSsoDomains.verificationToken, previousDomain.verificationToken),
-        ),
-      )
-      .returning();
-    if (!updated) return null;
-    await appendRequiredAudit({
-      tenantId,
-      actorType: "user",
-      actorId: c.get("userId") ?? tenantId,
-      action: "tenant.sso_domain.verify",
-      resourceType: "tenant_sso_domain",
-      resourceId: updated.id,
-      metadata: { domain },
-      ipAddress: c.req.header("x-forwarded-for") ?? null,
-      userAgent: c.req.header("user-agent") ?? null,
-      requestId: c.get("requestId") ?? null,
+  let row: TenantSsoDomainRow | null;
+  try {
+    row = await withTenantAuditedTransaction(tenantId, async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof db;
+      const [updated] = await tx
+        .update(tenantSsoDomains)
+        .set({ status: "verified", verifiedAt: new Date(), updatedAt: new Date() })
+        .where(
+          and(
+            eq(tenantSsoDomains.tenantId, tenantId),
+            eq(tenantSsoDomains.domain, domain),
+            eq(tenantSsoDomains.verificationToken, previousDomain.verificationToken),
+          ),
+        )
+        .returning();
+      if (!updated) return null;
+      await appendRequiredAudit({
+        tenantId,
+        actorType: "user",
+        actorId: c.get("userId") ?? tenantId,
+        action: "tenant.sso_domain.verify",
+        resourceType: "tenant_sso_domain",
+        resourceId: updated.id,
+        metadata: { domain },
+        ipAddress: c.req.header("x-forwarded-for") ?? null,
+        userAgent: c.req.header("user-agent") ?? null,
+        requestId: c.get("requestId") ?? null,
+      });
+      return updated;
     });
-    return updated;
-  });
+  } catch (error) {
+    if (databaseErrorCode(error) === "23505") {
+      return c.json<ApiResponse>(
+        { ok: false, error: "SSO domain is already verified by another tenant" },
+        409,
+      );
+    }
+    throw error;
+  }
   if (!row) {
     return c.json<ApiResponse>({ ok: false, error: "SSO domain changed during verification" }, 409);
   }


### PR DESCRIPTION
## Summary

- mount signed tenant SAML login and ACS success with issuer, audience, destination, recipient, tenant, and replay enforcement
- execute SAML config, metadata, DNS domain add/verify/discovery/delete, MFA authorization, and audit rollback boundaries
- add deterministic cross-tenant domain race coverage for real Postgres
- redact SAML verification failures at the public ACS boundary

## Local validation

- mounted tenant SAML and SSO-domain tests: 8/8, 107 assertions
- focused SAML verifier tests: 6/6
- API typecheck, targeted Biome, public-package metadata, and git diff check: pass

The local environment did not provide the real-Postgres service, so the domain-race integration remains an explicit hosted gate. This PR stays draft until the exact-head matrix and independent review complete.

Closes #739

## Exact lineage

Head: b74521384d39eca610bddb55830521957b7cf9b1
Base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6