### PR TITLE
test(api): execute external agent JWT trust boundaries

### DIFF
--- a/packages/api/src/__tests__/agent-jwt-hardening.test.ts
+++ b/packages/api/src/__tests__/agent-jwt-hardening.test.ts
@@ -32,6 +32,7 @@ let rotatedJwksBody = "";
 let privateKey1: KeyLike;
 let privateKey2: KeyLike;
 let downstreamCalls = 0;
+let jwksFetches = 0;
 
 type TokenOptions = {
   agentId?: string;
@@ -126,6 +127,7 @@ beforeAll(async () => {
   });
   jwksBody = firstJwksBody;
   jwksServer = createServer((_request, response) => {
+    jwksFetches += 1;
     response.writeHead(200, { "content-type": "application/json" });
     response.end(jwksBody);
   });
@@ -205,6 +207,10 @@ describe("external agent JWT trust and scope boundaries", () => {
     );
   });
 
+  test("accepts an omitted platform claim only through server-side agent registration", async () => {
+    expect((await probe(await signToken({ platformId: null }))).status).toBe(200);
+  });
+
   test("rejects missing trade scope and never upgrades api:proxy on metadata/admin routes", async () => {
     const calls = downstreamCalls;
     for (const path of ["/trade", "/metadata", "/admin"]) {
@@ -220,8 +226,9 @@ describe("external agent JWT trust and scope boundaries", () => {
   test("rejects cap scopes before tenant/agent resolution, including mixed broad scopes", async () => {
     const calls = downstreamCalls;
     const agentsBefore = await getDb().select().from(agents);
+    const tenantsBefore = await getDb().select().from(tenants);
     for (const scopes of [["cap:github:write"], ["trade:order", "api:proxy", "cap:github:write"]]) {
-      const response = await capabilityApp.request("/capability", {
+      const response = await app.request("/trade", {
         headers: {
           authorization: `Bearer ${await signToken({ scopes })}`,
           "X-Steward-Tenant": "does-not-exist",
@@ -231,6 +238,7 @@ describe("external agent JWT trust and scope boundaries", () => {
     }
     expect(downstreamCalls).toBe(calls);
     expect(await getDb().select().from(agents)).toEqual(agentsBefore);
+    expect(await getDb().select().from(tenants)).toEqual(tenantsBefore);
   });
 
   test("accepts a non-capability extra scope without weakening the explicit trade gate", async () => {
@@ -262,10 +270,20 @@ describe("external agent JWT trust and scope boundaries", () => {
   });
 
   test("refreshes cached JWKS once when a rotated kid appears", async () => {
+    const fetchesBefore = jwksFetches;
     expect((await probe(await signToken())).status).toBe(200);
     jwksBody = rotatedJwksBody;
     const rotated = await signToken({ kid: KID_2, key: privateKey2 });
     expect((await probe(rotated)).status).toBe(200);
+    expect(jwksFetches - fetchesBefore).toBe(2);
+  });
+
+  test("does not retain keys when the configured JWKS trust anchor changes", async () => {
+    expect((await probe(await signToken())).status).toBe(200);
+    jwksBody = JSON.stringify({ keys: JSON.parse(rotatedJwksBody).keys.slice(1) });
+    process.env.ELIZA_CLOUD_JWKS_URL = `${jwksUrl}?anchor=rotated`;
+    await denial(await probe(await signToken()), 401, "unknown kid");
+    expect((await probe(await signToken({ kid: KID_2, key: privateKey2 }))).status).toBe(200);
   });
 
   test("production and unconfigured development both fail closed", async () => {

--- a/packages/api/src/__tests__/agent-jwt-hardening.test.ts
+++ b/packages/api/src/__tests__/agent-jwt-hardening.test.ts
@@ -33,6 +33,7 @@ let privateKey1: KeyLike;
 let privateKey2: KeyLike;
 let downstreamCalls = 0;
 let jwksFetches = 0;
+let jwksResponseBarrier: { observed: () => void; release: Promise<void> } | null = null;
 
 type TokenOptions = {
   agentId?: string;
@@ -126,8 +127,13 @@ beforeAll(async () => {
     ],
   });
   jwksBody = firstJwksBody;
-  jwksServer = createServer((_request, response) => {
+  jwksServer = createServer(async (_request, response) => {
     jwksFetches += 1;
+    const barrier = jwksResponseBarrier;
+    if (barrier) {
+      barrier.observed();
+      await barrier.release;
+    }
     response.writeHead(200, { "content-type": "application/json" });
     response.end(jwksBody);
   });
@@ -169,6 +175,7 @@ afterEach(async () => {
   process.env.ELIZA_CLOUD_JWKS_URL = jwksUrl;
   delete process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS;
   jwksBody = firstJwksBody;
+  jwksResponseBarrier = null;
   const { clearAgentJwksCacheForTests } = await import("../middleware/agent-jwt");
   clearAgentJwksCacheForTests();
 });
@@ -276,6 +283,40 @@ describe("external agent JWT trust and scope boundaries", () => {
     const rotated = await signToken({ kid: KID_2, key: privateKey2 });
     expect((await probe(rotated)).status).toBe(200);
     expect(jwksFetches - fetchesBefore).toBe(2);
+  });
+
+  test("shares one forced JWKS refresh across concurrent rotated-token requests", async () => {
+    expect((await probe(await signToken())).status).toBe(200);
+    jwksBody = rotatedJwksBody;
+    let releaseResponse = () => {};
+    let observeRequest = () => {};
+    const requestObserved = new Promise<void>((resolve) => {
+      observeRequest = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releaseResponse = resolve;
+    });
+    jwksResponseBarrier = { observed: observeRequest, release };
+    const fetchesBefore = jwksFetches;
+    const rotated = await signToken({ kid: KID_2, key: privateKey2 });
+    const requests = Array.from({ length: 8 }, () => probe(rotated));
+    await requestObserved;
+    releaseResponse();
+    const responses = await Promise.all(requests);
+    jwksResponseBarrier = null;
+    expect(responses.every((response) => response.status === 200)).toBe(true);
+    expect(jwksFetches - fetchesBefore).toBe(1);
+  });
+
+  test("isolates JWKS miss-refresh throttles between configured trust anchors", async () => {
+    expect((await probe(await signToken())).status).toBe(200);
+    const rotated = await signToken({ kid: KID_2, key: privateKey2 });
+    await denial(await probe(rotated), 401, "unknown kid");
+
+    process.env.ELIZA_CLOUD_JWKS_URL = `${jwksUrl}?anchor=second`;
+    expect((await probe(await signToken())).status).toBe(200);
+    jwksBody = rotatedJwksBody;
+    expect((await probe(rotated)).status).toBe(200);
   });
 
   test("does not retain keys when the configured JWKS trust anchor changes", async () => {

--- a/packages/api/src/__tests__/agent-jwt-hardening.test.ts
+++ b/packages/api/src/__tests__/agent-jwt-hardening.test.ts
@@ -1,71 +1,299 @@
-import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { createServer, type Server } from "node:http";
+import { agents, closeDb, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Hono } from "hono";
+import { exportJWK, generateKeyPair, type KeyLike, SignJWT } from "jose";
+import type { AppVariables } from "../services/context";
 
-const source = readFileSync(join(import.meta.dir, "..", "middleware", "agent-jwt.ts"), "utf8");
-const contextSource = readFileSync(join(import.meta.dir, "..", "services", "context.ts"), "utf8");
+setDefaultTimeout(30_000);
 
-describe("external agent JWT hardening", () => {
-  it("binds external agent JWTs to tenant and platform claims", () => {
-    expect(source).toContain('stringClaim(payload, "tenant_id", "tenantId")');
-    // A PRESENT tenant claim must still match the requested tenant.
-    expect(source).toContain("tokenTenantId && tokenTenantId !== tenantId");
-    expect(source).toContain('reason: "invalid tenant claims"');
-    expect(source).toContain('stringClaim(payload, "platform_id", "platformId")');
-    // A PRESENT platform claim must match the agent's registered platform.
-    expect(source).toContain(
-      "agent.platformId && tokenPlatformId && tokenPlatformId !== agent.platformId",
-    );
-    expect(source).toContain('reason: "invalid platform claims"');
+const TENANT = `agent-jwt-tenant-${Date.now()}`;
+const OTHER_TENANT = `agent-jwt-other-${Date.now()}`;
+const AGENT = `agent-jwt-agent-${Date.now()}`;
+const KID_1 = "agent-jwt-hardening-key-1";
+const KID_2 = "agent-jwt-hardening-key-2";
+
+let app: Hono<{ Variables: AppVariables }>;
+let capabilityApp: Hono<{ Variables: AppVariables }>;
+let jwksServer: Server;
+let jwksUrl = "";
+let jwksBody = "";
+let firstJwksBody = "";
+let rotatedJwksBody = "";
+let privateKey1: KeyLike;
+let privateKey2: KeyLike;
+let downstreamCalls = 0;
+
+type TokenOptions = {
+  agentId?: string;
+  alg?: "RS256" | "HS256";
+  audience?: string;
+  expiresAt?: number;
+  issuedAt?: number;
+  issuer?: string;
+  kid?: string;
+  notBefore?: number;
+  scopes?: string[];
+  tenantId?: string | null;
+  platformId?: string | null;
+  key?: KeyLike | Uint8Array;
+};
+
+async function signToken(options: TokenOptions = {}): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const agentId = options.agentId ?? AGENT;
+  const alg = options.alg ?? "RS256";
+  const claims: Record<string, unknown> = {
+    agent_id: agentId,
+    scopes: options.scopes ?? ["trade:order"],
+  };
+  if (options.tenantId !== null) claims.tenant_id = options.tenantId ?? TENANT;
+  if (options.platformId !== null) claims.platform_id = options.platformId ?? "platform-a";
+
+  const token = new SignJWT(claims)
+    .setProtectedHeader({ alg, kid: options.kid ?? KID_1 })
+    .setIssuer(options.issuer ?? "eliza-cloud")
+    .setAudience(options.audience ?? "steward")
+    .setSubject(`agent:${agentId}`)
+    .setIssuedAt(options.issuedAt ?? now)
+    .setExpirationTime(options.expiresAt ?? now + 600);
+  if (options.notBefore !== undefined) token.setNotBefore(options.notBefore);
+  return token.sign(options.key ?? privateKey1);
+}
+
+async function probe(token: string, tenantId = TENANT, path = "/trade"): Promise<Response> {
+  return app.request(path, {
+    headers: { authorization: `Bearer ${token}`, "X-Steward-Tenant": tenantId },
+  });
+}
+
+async function denial(response: Response, status: number, reason: string) {
+  expect(response.status).toBe(status);
+  const body = (await response.json()) as { code?: string; reason?: string; error?: string };
+  if (status === 401) {
+    expect(body.code).toBe("invalid-jwt");
+    expect(body.reason).toBe(reason);
+  } else {
+    expect(body.error).toBe(reason);
+  }
+}
+
+beforeAll(async () => {
+  process.env.NODE_ENV = "test";
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_AUDIT_HMAC_KEY ||= "1".repeat(64);
+  process.env.STEWARD_MASTER_PASSWORD ||= "agent-jwt-hardening-test-password";
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => client.close());
+
+  await getDb()
+    .insert(tenants)
+    .values([
+      { id: TENANT, name: "Agent JWT Tenant", apiKeyHash: `hash-${TENANT}` },
+      { id: OTHER_TENANT, name: "Other Agent JWT Tenant", apiKeyHash: `hash-${OTHER_TENANT}` },
+    ]);
+  await getDb().insert(agents).values({
+    id: AGENT,
+    tenantId: TENANT,
+    platformId: "platform-a",
+    name: AGENT,
+    walletAddress: "0x00000000000000000000000000000000000000a1",
   });
 
-  it("falls back to agent->tenant registration when the trusted issuer omits the tenant claim", () => {
-    // The eliza-cloud single-tenant minter does not embed tenant_id. We must NOT
-    // reject on a missing claim (that bricked legitimate order auth); the binding
-    // is enforced by ensureAgentForTenant, which 403s a mismatched agent.
-    expect(source).not.toContain("!tokenTenantId || tokenTenantId !== tenantId");
-    expect(source).toContain("const agent = await ensureAgentForTenant(tenantId, agentId)");
-    expect(source).toContain("agent is not registered for tenant");
+  const keyPair1 = await generateKeyPair("RS256");
+  const keyPair2 = await generateKeyPair("RS256");
+  privateKey1 = keyPair1.privateKey;
+  privateKey2 = keyPair2.privateKey;
+  const publicJwk1 = await exportJWK(keyPair1.publicKey);
+  const publicJwk2 = await exportJWK(keyPair2.publicKey);
+  firstJwksBody = JSON.stringify({
+    keys: [{ ...publicJwk1, kid: KID_1, alg: "RS256", use: "sig" }],
+  });
+  rotatedJwksBody = JSON.stringify({
+    keys: [
+      { ...publicJwk1, kid: KID_1, alg: "RS256", use: "sig" },
+      { ...publicJwk2, kid: KID_2, alg: "RS256", use: "sig" },
+    ],
+  });
+  jwksBody = firstJwksBody;
+  jwksServer = createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(jwksBody);
+  });
+  await new Promise<void>((resolve) => jwksServer.listen(0, "127.0.0.1", resolve));
+  const address = jwksServer.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  jwksUrl = `http://127.0.0.1:${port}/jwks`;
+  process.env.ELIZA_CLOUD_JWKS_URL = jwksUrl;
+
+  const { clearAgentJwksCacheForTests, requireAgentJwt, requireCapabilityAgentJwt } = await import(
+    "../middleware/agent-jwt"
+  );
+  clearAgentJwksCacheForTests();
+  app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", requireAgentJwt);
+  app.get("/trade", (context) => {
+    downstreamCalls += 1;
+    return context.json({ agentId: context.get("agentScope"), scopes: context.get("agentScopes") });
+  });
+  app.get("/metadata", () => {
+    downstreamCalls += 1;
+    return new Response("unexpected");
+  });
+  app.get("/admin", () => {
+    downstreamCalls += 1;
+    return new Response("unexpected");
   });
 
-  it("requires explicit trade scope and configured JWKS for external agent order JWTs", () => {
-    expect(source).toContain('const TRADE_ORDER_SCOPE = "trade:order"');
-    expect(source).toContain('stringArrayClaim(payload, "scopes", "scope")');
-    expect(source).toContain("auth.scopes.includes(TRADE_ORDER_SCOPE)");
-    expect(source).toContain("Token missing required ${TRADE_ORDER_SCOPE} scope");
-    // SEC-069: no implicit hardcoded trust anchor — production requires
-    // ELIZA_CLOUD_JWKS_URL, and the dev anchor requires an explicit opt-in.
-    expect(source).toContain("function resolveJwksUrl()");
-    expect(source).toContain('process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS === "true"');
-    expect(source).toContain('throw new Error("jwks-url-required")');
+  capabilityApp = new Hono<{ Variables: AppVariables }>();
+  capabilityApp.use("*", requireCapabilityAgentJwt);
+  capabilityApp.get("/capability", () => {
+    downstreamCalls += 1;
+    return new Response("unexpected");
+  });
+});
+
+afterEach(async () => {
+  process.env.NODE_ENV = "test";
+  process.env.ELIZA_CLOUD_JWKS_URL = jwksUrl;
+  delete process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS;
+  jwksBody = firstJwksBody;
+  const { clearAgentJwksCacheForTests } = await import("../middleware/agent-jwt");
+  clearAgentJwksCacheForTests();
+});
+
+afterAll(async () => {
+  await closeDb();
+  await new Promise<void>((resolve) => jwksServer.close(() => resolve()));
+  delete process.env.ELIZA_CLOUD_JWKS_URL;
+  delete process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS;
+});
+
+describe("external agent JWT trust and scope boundaries", () => {
+  test("binds signed tenant/platform claims and admits an explicitly scoped trade token", async () => {
+    const response = await probe(await signToken());
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ agentId: AGENT, scopes: ["agent", "trade:order"] });
+
+    await denial(
+      await probe(await signToken({ tenantId: OTHER_TENANT })),
+      401,
+      "invalid tenant claims",
+    );
+    await denial(
+      await probe(await signToken({ platformId: "platform-b" })),
+      401,
+      "invalid platform claims",
+    );
   });
 
-  it("does not treat api:proxy as implicit broad agent metadata scope", () => {
-    expect(contextSource).not.toContain("new Set([AGENT_SCOPE])");
-    expect(contextSource).toContain("if (!scopes || scopes.length === 0) return [AGENT_SCOPE]");
-    expect(contextSource).toContain('c.set("agentScopes", agentTokenScopes)');
-    expect(contextSource).toContain(
-      'agentScope === c.req.param("agentId") && hasAgentTokenScope(c.get("agentScopes"))',
+  test("accepts an omitted tenant claim only through server-side agent registration", async () => {
+    expect((await probe(await signToken({ tenantId: null }))).status).toBe(200);
+    await denial(
+      await probe(await signToken({ tenantId: null }), OTHER_TENANT),
+      403,
+      "Forbidden: agent is not registered for tenant",
     );
   });
 
-  it("refuses capability-scoped (cap:) tokens on the general tenant surface", () => {
-    // SEC-033: a token-mode capability token authorizes EXACTLY one capability.
-    // The tenant gate must reject any agent token carrying a `cap:` scope —
-    // even one that also stamps the broad `agent` scope — so it can never act
-    // as a general agent credential.
-    expect(contextSource).toContain('CAPABILITY_TOKEN_SCOPE_PREFIX = "cap:"');
-    expect(contextSource).toContain(
-      "agentTokenScopes.some((scope) => scope.startsWith(CAPABILITY_TOKEN_SCOPE_PREFIX))",
+  test("rejects missing trade scope and never upgrades api:proxy on metadata/admin routes", async () => {
+    const calls = downstreamCalls;
+    for (const path of ["/trade", "/metadata", "/admin"]) {
+      await denial(
+        await probe(await signToken({ scopes: ["api:proxy"] }), TENANT, path),
+        403,
+        "Token missing required trade:order scope",
+      );
+    }
+    expect(downstreamCalls).toBe(calls);
+  });
+
+  test("rejects cap scopes before tenant/agent resolution, including mixed broad scopes", async () => {
+    const calls = downstreamCalls;
+    const agentsBefore = await getDb().select().from(agents);
+    for (const scopes of [["cap:github:write"], ["trade:order", "api:proxy", "cap:github:write"]]) {
+      const response = await capabilityApp.request("/capability", {
+        headers: {
+          authorization: `Bearer ${await signToken({ scopes })}`,
+          "X-Steward-Tenant": "does-not-exist",
+        },
+      });
+      await denial(response, 401, "unsupported capability scope");
+    }
+    expect(downstreamCalls).toBe(calls);
+    expect(await getDb().select().from(agents)).toEqual(agentsBefore);
+  });
+
+  test("accepts a non-capability extra scope without weakening the explicit trade gate", async () => {
+    expect((await probe(await signToken({ scopes: ["trade:order", "api:proxy"] }))).status).toBe(
+      200,
     );
-    // The refusal happens BEFORE any agent lookup/context install (fail fast).
-    const refusal = contextSource.indexOf(
-      "agentTokenScopes.some((scope) => scope.startsWith(CAPABILITY_TOKEN_SCOPE_PREFIX))",
+  });
+
+  test("returns stable denials for unknown kid and unsupported algorithm", async () => {
+    await denial(await probe(await signToken({ kid: "unknown-kid" })), 401, "unknown kid");
+    await denial(
+      await probe(await signToken({ alg: "HS256", key: new TextEncoder().encode("x".repeat(32)) })),
+      401,
+      "unsupported alg",
     );
-    const agentLookup = contextSource.indexOf(
-      "const agentSubject = await findAgentBootstrapSubject(",
+  });
+
+  test("returns stable denials for issuer, audience, expiry, and future timestamps", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await denial(await probe(await signToken({ issuer: "attacker" })), 401, "invalid issuer");
+    await denial(await probe(await signToken({ audience: "attacker" })), 401, "invalid audience");
+    await denial(await probe(await signToken({ expiresAt: now - 1 })), 401, "token expired");
+    await denial(await probe(await signToken({ notBefore: now + 300 })), 401, "token not active");
+    await denial(
+      await probe(await signToken({ issuedAt: now + 300 })),
+      401,
+      "token issued in the future",
     );
-    expect(refusal).toBeGreaterThanOrEqual(0);
-    expect(agentLookup).toBeGreaterThan(refusal);
+  });
+
+  test("refreshes cached JWKS once when a rotated kid appears", async () => {
+    expect((await probe(await signToken())).status).toBe(200);
+    jwksBody = rotatedJwksBody;
+    const rotated = await signToken({ kid: KID_2, key: privateKey2 });
+    expect((await probe(rotated)).status).toBe(200);
+  });
+
+  test("production and unconfigured development both fail closed", async () => {
+    delete process.env.ELIZA_CLOUD_JWKS_URL;
+    process.env.NODE_ENV = "production";
+    await denial(await probe(await signToken()), 401, "jwks-url-required");
+
+    process.env.NODE_ENV = "test";
+    await denial(await probe(await signToken()), 401, "jwks-url-required");
+  });
+
+  test("the default development anchor requires explicit opt-in", async () => {
+    delete process.env.ELIZA_CLOUD_JWKS_URL;
+    process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS = "true";
+    const originalFetch = globalThis.fetch;
+    let requestedUrl = "";
+    globalThis.fetch = (async (input) => {
+      requestedUrl = String(input);
+      return new Response(firstJwksBody, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    try {
+      expect((await probe(await signToken())).status).toBe(200);
+      expect(requestedUrl).toBe("https://milady.shad0w.xyz/.well-known/jwks.json");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/packages/api/src/__tests__/capability-agent-jwt.test.ts
+++ b/packages/api/src/__tests__/capability-agent-jwt.test.ts
@@ -9,7 +9,9 @@
  * (default-deny) in the invoke path.
  *
  * Behavioral proof over a real RS256 agent JWT (local JWKS fixture + PGLite):
- *   - a token WITHOUT `trade:order` passes requireCapabilityAgentJwt
+ *   - a scope-less token passes requireCapabilityAgentJwt
+ *   - legacy `cap:` scope claims fail closed before capability authorization;
+ *     capability authority comes only from grants + policy
  *   - the same token is still rejected by requireAgentJwt (control: the
  *     trading gate itself is untouched)
  *   - an unverifiable token is still a 401 (authentication is unchanged)
@@ -93,12 +95,11 @@ async function probe(path: string, token: string): Promise<Response> {
 }
 
 describe("requireCapabilityAgentJwt (SEC-092)", () => {
-  test("admits a capability-only agent JWT with no trade:order scope", async () => {
+  test("rejects legacy cap scope claims before capability authorization", async () => {
     const res = await probe("/cap/probe", await signToken(["cap:github:app:org"]));
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { ok: boolean; agentId: string };
-    expect(body.ok).toBe(true);
-    expect(body.agentId).toBe(AGENT);
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { code: string; reason: string };
+    expect(body).toEqual({ code: "invalid-jwt", reason: "unsupported capability scope" });
   });
 
   test("admits a scope-less agent JWT (authz is the grant + policy, not the scope)", async () => {
@@ -107,7 +108,7 @@ describe("requireCapabilityAgentJwt (SEC-092)", () => {
   });
 
   test("control: requireAgentJwt still hard-requires trade:order", async () => {
-    const res = await probe("/trade/probe", await signToken(["cap:github:app:org"]));
+    const res = await probe("/trade/probe", await signToken([]));
     expect(res.status).toBe(403);
     const scoped = await probe("/trade/probe", await signToken(["trade:order"]));
     expect(scoped.status).toBe(200);

--- a/packages/api/src/__tests__/capability-agent-jwt.test.ts
+++ b/packages/api/src/__tests__/capability-agent-jwt.test.ts
@@ -9,9 +9,7 @@
  * (default-deny) in the invoke path.
  *
  * Behavioral proof over a real RS256 agent JWT (local JWKS fixture + PGLite):
- *   - a scope-less token passes requireCapabilityAgentJwt
- *   - legacy `cap:` scope claims fail closed before capability authorization;
- *     capability authority comes only from grants + policy
+ *   - a token WITHOUT `trade:order` passes requireCapabilityAgentJwt
  *   - the same token is still rejected by requireAgentJwt (control: the
  *     trading gate itself is untouched)
  *   - an unverifiable token is still a 401 (authentication is unchanged)
@@ -95,11 +93,12 @@ async function probe(path: string, token: string): Promise<Response> {
 }
 
 describe("requireCapabilityAgentJwt (SEC-092)", () => {
-  test("rejects legacy cap scope claims before capability authorization", async () => {
+  test("admits a capability-only agent JWT with no trade:order scope", async () => {
     const res = await probe("/cap/probe", await signToken(["cap:github:app:org"]));
-    expect(res.status).toBe(401);
-    const body = (await res.json()) as { code: string; reason: string };
-    expect(body).toEqual({ code: "invalid-jwt", reason: "unsupported capability scope" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; agentId: string };
+    expect(body.ok).toBe(true);
+    expect(body.agentId).toBe(AGENT);
   });
 
   test("admits a scope-less agent JWT (authz is the grant + policy, not the scope)", async () => {
@@ -108,8 +107,8 @@ describe("requireCapabilityAgentJwt (SEC-092)", () => {
   });
 
   test("control: requireAgentJwt still hard-requires trade:order", async () => {
-    const res = await probe("/trade/probe", await signToken([]));
-    expect(res.status).toBe(403);
+    const res = await probe("/trade/probe", await signToken(["cap:github:app:org"]));
+    expect(res.status).toBe(401);
     const scoped = await probe("/trade/probe", await signToken(["trade:order"]));
     expect(scoped.status).toBe(200);
   });

--- a/packages/api/src/middleware/agent-jwt.ts
+++ b/packages/api/src/middleware/agent-jwt.ts
@@ -34,7 +34,11 @@ const DEFAULT_ELIZA_CLOUD_JWKS_URL = "https://milady.shad0w.xyz/.well-known/jwks
 const TRADE_ORDER_SCOPE = "trade:order";
 
 let jwksCache: CacheEntry | null = null;
-let lastJwksMissRefreshAt = 0;
+const lastJwksMissRefreshAt = new Map<string, number>();
+const jwksMissRefreshInFlight = new Map<
+  string,
+  Promise<Map<string, Awaited<ReturnType<typeof importJWK>>>>
+>();
 
 function invalid(c: Context, reason: string, status: 401 = 401) {
   return c.json({ code: "invalid-jwt", reason }, status);
@@ -83,6 +87,27 @@ async function loadJwks(
 
   jwksCache = { url: jwksUrl, keys, expiresAt: now + JWKS_CACHE_MS };
   return keys;
+}
+
+function refreshJwksAfterMiss(
+  jwksUrl: string,
+): Promise<Map<string, Awaited<ReturnType<typeof importJWK>>>> | null {
+  const inFlight = jwksMissRefreshInFlight.get(jwksUrl);
+  if (inFlight) return inFlight;
+
+  const now = Date.now();
+  if (now - (lastJwksMissRefreshAt.get(jwksUrl) ?? 0) < JWKS_MISS_REFRESH_MIN_INTERVAL_MS) {
+    return null;
+  }
+  lastJwksMissRefreshAt.set(jwksUrl, now);
+  let refresh: Promise<Map<string, Awaited<ReturnType<typeof importJWK>>>>;
+  refresh = loadJwks(true, jwksUrl).finally(() => {
+    if (jwksMissRefreshInFlight.get(jwksUrl) === refresh) {
+      jwksMissRefreshInFlight.delete(jwksUrl);
+    }
+  });
+  jwksMissRefreshInFlight.set(jwksUrl, refresh);
+  return refresh;
 }
 
 function getBearer(c: Context): string | null {
@@ -292,11 +317,12 @@ export async function authenticateAgentJwt(
     // Issuers can publish a rotated kid before this process's cache expires.
     // Refresh exactly once on a miss so rotation is prompt while an actually
     // unknown kid remains fail-closed.
-    const now = Date.now();
-    if (!key && hadFreshCache && now - lastJwksMissRefreshAt >= JWKS_MISS_REFRESH_MIN_INTERVAL_MS) {
-      lastJwksMissRefreshAt = now;
-      keys = await loadJwks(true, jwksUrl);
-      key = keys.get(header.kid);
+    if (!key && hadFreshCache) {
+      const refresh = refreshJwksAfterMiss(jwksUrl);
+      if (refresh) {
+        keys = await refresh;
+        key = keys.get(header.kid);
+      }
     }
     if (!key) return { kind: "invalid-token", reason: "unknown kid" };
 
@@ -502,5 +528,6 @@ export async function requireProviderAgentJwt(c: Context<{ Variables: AppVariabl
 
 export function clearAgentJwksCacheForTests() {
   jwksCache = null;
-  lastJwksMissRefreshAt = 0;
+  lastJwksMissRefreshAt.clear();
+  jwksMissRefreshInFlight.clear();
 }

--- a/packages/api/src/middleware/agent-jwt.ts
+++ b/packages/api/src/middleware/agent-jwt.ts
@@ -16,6 +16,7 @@ type JwksKey = JsonWebKey & { kid?: string; alg?: string; use?: string };
 type Jwks = { keys?: JwksKey[] };
 
 type CacheEntry = {
+  url: string;
   keys: Map<string, Awaited<ReturnType<typeof importJWK>>>;
   expiresAt: number;
 };
@@ -58,10 +59,12 @@ function resolveJwksUrl(): string {
 
 async function loadJwks(
   forceRefresh = false,
+  jwksUrl = resolveJwksUrl(),
 ): Promise<Map<string, Awaited<ReturnType<typeof importJWK>>>> {
-  const jwksUrl = resolveJwksUrl();
   const now = Date.now();
-  if (!forceRefresh && jwksCache && jwksCache.expiresAt > now) return jwksCache.keys;
+  if (!forceRefresh && jwksCache?.url === jwksUrl && jwksCache.expiresAt > now) {
+    return jwksCache.keys;
+  }
 
   const response = await fetch(jwksUrl, {
     headers: { accept: "application/json" },
@@ -78,7 +81,7 @@ async function loadJwks(
     keys.set(jwk.kid, await importJWK(jwk, jwk.alg ?? "RS256"));
   }
 
-  jwksCache = { keys, expiresAt: now + JWKS_CACHE_MS };
+  jwksCache = { url: jwksUrl, keys, expiresAt: now + JWKS_CACHE_MS };
   return keys;
 }
 
@@ -272,6 +275,7 @@ export function isAgentJwtFailure(
  */
 export async function authenticateAgentJwt(
   c: Context<{ Variables: AppVariables }>,
+  options: { rejectCapabilityScopes?: boolean } = {},
 ): Promise<AgentJwtAuthenticationResult | AgentJwtAuthenticationFailure> {
   const token = getBearer(c);
   if (!token) return { kind: "invalid-token", reason: "missing bearer token" };
@@ -281,8 +285,9 @@ export async function authenticateAgentJwt(
   if (header.alg !== "RS256") return { kind: "invalid-token", reason: "unsupported alg" };
 
   try {
-    const hadFreshCache = Boolean(jwksCache && jwksCache.expiresAt > Date.now());
-    let keys = await loadJwks();
+    const jwksUrl = resolveJwksUrl();
+    const hadFreshCache = Boolean(jwksCache?.url === jwksUrl && jwksCache.expiresAt > Date.now());
+    let keys = await loadJwks(false, jwksUrl);
     let key = keys.get(header.kid);
     // Issuers can publish a rotated kid before this process's cache expires.
     // Refresh exactly once on a miss so rotation is prompt while an actually
@@ -290,7 +295,7 @@ export async function authenticateAgentJwt(
     const now = Date.now();
     if (!key && hadFreshCache && now - lastJwksMissRefreshAt >= JWKS_MISS_REFRESH_MIN_INTERVAL_MS) {
       lastJwksMissRefreshAt = now;
-      keys = await loadJwks(true);
+      keys = await loadJwks(true, jwksUrl);
       key = keys.get(header.kid);
     }
     if (!key) return { kind: "invalid-token", reason: "unknown kid" };
@@ -303,7 +308,7 @@ export async function authenticateAgentJwt(
     const agentId = agentIdFromPayload(payload);
     if (!agentId) return { kind: "invalid-token", reason: "invalid agent claims" };
     const scopes = stringArrayClaim(payload, "scopes", "scope");
-    if (scopes.some((scope) => scope.startsWith("cap:"))) {
+    if (options.rejectCapabilityScopes && scopes.some((scope) => scope.startsWith("cap:"))) {
       return { kind: "invalid-token", reason: "unsupported capability scope" };
     }
     const nowSeconds = Math.floor(Date.now() / 1000);
@@ -410,7 +415,7 @@ export async function installAgentJwtContext(
  * trading endpoints depend on.
  */
 export async function requireAgentJwt(c: Context<{ Variables: AppVariables }>, next: Next) {
-  const auth = await authenticateAgentJwt(c);
+  const auth = await authenticateAgentJwt(c, { rejectCapabilityScopes: true });
   if (isAgentJwtFailure(auth)) {
     // Preserve the EXACT legacy wire behavior per failure kind.
     if (auth.kind === "tenant-not-found") {
@@ -475,7 +480,7 @@ export async function requireCapabilityAgentJwt(
  * bindings/grants, never by token scope. ONLY provider-action routes use this.
  */
 export async function requireProviderAgentJwt(c: Context<{ Variables: AppVariables }>, next: Next) {
-  const auth = await authenticateAgentJwt(c);
+  const auth = await authenticateAgentJwt(c, { rejectCapabilityScopes: true });
   if (isAgentJwtFailure(auth)) {
     // Map onto the spec §8 deny table for provider-action routes.
     if (auth.kind === "token-expired") {

--- a/packages/api/src/middleware/agent-jwt.ts
+++ b/packages/api/src/middleware/agent-jwt.ts
@@ -21,7 +21,9 @@ type CacheEntry = {
 };
 
 const JWKS_CACHE_MS = 5 * 60 * 1000;
+const JWKS_MISS_REFRESH_MIN_INTERVAL_MS = 10 * 1000;
 const AGENT_TOKEN_EXPIRING_THRESHOLD_SECONDS = 5 * 60;
+const MAX_IAT_CLOCK_SKEW_SECONDS = 60;
 // Dev convenience trust anchor. SEC-069: only honored behind an explicit
 // opt-in (STEWARD_ALLOW_DEFAULT_ELIZA_JWKS=true) outside production — domain
 // takeover/compromise of this host would otherwise silently become a minting
@@ -31,6 +33,7 @@ const DEFAULT_ELIZA_CLOUD_JWKS_URL = "https://milady.shad0w.xyz/.well-known/jwks
 const TRADE_ORDER_SCOPE = "trade:order";
 
 let jwksCache: CacheEntry | null = null;
+let lastJwksMissRefreshAt = 0;
 
 function invalid(c: Context, reason: string, status: 401 = 401) {
   return c.json({ code: "invalid-jwt", reason }, status);
@@ -53,10 +56,12 @@ function resolveJwksUrl(): string {
   throw new Error("jwks-url-required");
 }
 
-async function loadJwks(): Promise<Map<string, Awaited<ReturnType<typeof importJWK>>>> {
+async function loadJwks(
+  forceRefresh = false,
+): Promise<Map<string, Awaited<ReturnType<typeof importJWK>>>> {
   const jwksUrl = resolveJwksUrl();
   const now = Date.now();
-  if (jwksCache && jwksCache.expiresAt > now) return jwksCache.keys;
+  if (!forceRefresh && jwksCache && jwksCache.expiresAt > now) return jwksCache.keys;
 
   const response = await fetch(jwksUrl, {
     headers: { accept: "application/json" },
@@ -276,8 +281,22 @@ export async function authenticateAgentJwt(
   if (header.alg !== "RS256") return { kind: "invalid-token", reason: "unsupported alg" };
 
   try {
-    const keys = await loadJwks();
-    const key = keys.get(header.kid);
+    const hadFreshCache = Boolean(jwksCache && jwksCache.expiresAt > Date.now());
+    let keys = await loadJwks();
+    let key = keys.get(header.kid);
+    // Issuers can publish a rotated kid before this process's cache expires.
+    // Refresh exactly once on a miss so rotation is prompt while an actually
+    // unknown kid remains fail-closed.
+    const now = Date.now();
+    if (
+      !key &&
+      hadFreshCache &&
+      now - lastJwksMissRefreshAt >= JWKS_MISS_REFRESH_MIN_INTERVAL_MS
+    ) {
+      lastJwksMissRefreshAt = now;
+      keys = await loadJwks(true);
+      key = keys.get(header.kid);
+    }
     if (!key) return { kind: "invalid-token", reason: "unknown kid" };
 
     const { payload } = await jwtVerify(token, key, {
@@ -288,6 +307,13 @@ export async function authenticateAgentJwt(
     const agentId = agentIdFromPayload(payload);
     if (!agentId) return { kind: "invalid-token", reason: "invalid agent claims" };
     const scopes = stringArrayClaim(payload, "scopes", "scope");
+    if (scopes.some((scope) => scope.startsWith("cap:"))) {
+      return { kind: "invalid-token", reason: "unsupported capability scope" };
+    }
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    if (typeof payload.iat === "number" && payload.iat > nowSeconds + MAX_IAT_CLOCK_SKEW_SECONDS) {
+      return { kind: "invalid-token", reason: "token issued in the future" };
+    }
 
     const tenantId = c.req.header("X-Steward-Tenant") || DEFAULT_TENANT_ID;
     // Tenant binding: when the token DOES carry a tenant claim it MUST match the
@@ -335,6 +361,12 @@ export async function authenticateAgentJwt(
     if (error instanceof errors.JWTExpired) {
       observeExpiredAgentToken(c, token);
       return { kind: "token-expired", reason: "token expired" };
+    }
+    if (error instanceof errors.JWTClaimValidationFailed) {
+      if (error.claim === "iss") return { kind: "invalid-token", reason: "invalid issuer" };
+      if (error.claim === "aud") return { kind: "invalid-token", reason: "invalid audience" };
+      if (error.claim === "nbf") return { kind: "invalid-token", reason: "token not active" };
+      return { kind: "invalid-token", reason: "invalid token claims" };
     }
     const reason = error instanceof Error ? error.message : "verification failed";
     return { kind: "invalid-token", reason };
@@ -469,4 +501,5 @@ export async function requireProviderAgentJwt(c: Context<{ Variables: AppVariabl
 
 export function clearAgentJwksCacheForTests() {
   jwksCache = null;
+  lastJwksMissRefreshAt = 0;
 }

--- a/packages/api/src/middleware/agent-jwt.ts
+++ b/packages/api/src/middleware/agent-jwt.ts
@@ -288,11 +288,7 @@ export async function authenticateAgentJwt(
     // Refresh exactly once on a miss so rotation is prompt while an actually
     // unknown kid remains fail-closed.
     const now = Date.now();
-    if (
-      !key &&
-      hadFreshCache &&
-      now - lastJwksMissRefreshAt >= JWKS_MISS_REFRESH_MIN_INTERVAL_MS
-    ) {
+    if (!key && hadFreshCache && now - lastJwksMissRefreshAt >= JWKS_MISS_REFRESH_MIN_INTERVAL_MS) {
       lastJwksMissRefreshAt = now;
       keys = await loadJwks(true);
       key = keys.get(header.kid);


### PR DESCRIPTION
## Summary

- replace external-agent JWT source scans with signed tokens against a local immutable JWKS fixture and mounted middleware
- prove tenant/platform binding, scope isolation, capability refusal, stable claim denials, production fail-closed behavior, and explicit development trust opt-in
- make JWKS rotation refresh prompt, serialized across concurrent requests, throttled per trust anchor, and isolated when configuration changes
- reject materially future issued-at timestamps before tenant or agent authority is installed

## Local validation

- mounted JWT and capability boundary tests: 18/18, 82 assertions
- API typecheck, targeted Biome, public-package metadata, and git diff check: pass

This PR stays draft until the exact-head hosted matrix and independent review complete.

Closes #741

## Exact lineage

Head: 2558e2bd1116542fa03d25f1310dbc2c40568dbe
Base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6