### PR TITLE
test(api): mount secret route validation

### DIFF
--- a/packages/api/src/__tests__/secret-routes-production-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/secret-routes-production-postgres.integration.test.ts
@@ -1,0 +1,282 @@
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  agents,
+  auditChainHeads,
+  auditEvents,
+  getDb,
+  secretRoutes,
+  secrets,
+  tenants,
+  users,
+  userTenants,
+} from "@stwd/db";
+import { and, asc, eq, isNull } from "drizzle-orm";
+import type { Hono } from "hono";
+import { verifyAuditChain } from "../services/audit";
+import type { AppVariables } from "../services/context";
+
+setDefaultTimeout(120_000);
+
+const hasDatabaseUrl = Boolean(process.env.DATABASE_URL?.trim());
+const describeWithPostgres = hasDatabaseUrl ? describe : describe.skip;
+const SUFFIX = crypto.randomUUID();
+const TENANT_ID = `secret-production-${SUFFIX}`;
+const AGENT_ID = `secret-production-agent-${SUFFIX}`;
+const OWNER_USER_ID = crypto.randomUUID();
+const MEMBER_USER_ID = crypto.randomUUID();
+const SECRET_VALUE = `production-secret-${SUFFIX}`;
+const ENV_NAMES = [
+  "NODE_ENV",
+  "STEWARD_MASTER_PASSWORD",
+  "STEWARD_AUDIT_HMAC_KEY",
+  "STEWARD_JWT_SECRET",
+] as const;
+const originalEnv = new Map(ENV_NAMES.map((name) => [name, process.env[name]]));
+
+let app: Hono<{ Variables: AppVariables }>;
+let ownerToken = "";
+let memberToken = "";
+let staleMfaToken = "";
+
+async function cleanupFixture(): Promise<void> {
+  const db = getDb();
+  await db.transaction(async (tx) => {
+    await tx.delete(secretRoutes).where(eq(secretRoutes.tenantId, TENANT_ID));
+    await tx.delete(secrets).where(eq(secrets.tenantId, TENANT_ID));
+    await tx.delete(agents).where(eq(agents.tenantId, TENANT_ID));
+    await tx.delete(userTenants).where(eq(userTenants.tenantId, TENANT_ID));
+    await tx.delete(auditEvents).where(eq(auditEvents.tenantId, TENANT_ID));
+    await tx.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, TENANT_ID));
+    await tx.delete(users).where(eq(users.id, OWNER_USER_ID));
+    await tx.delete(users).where(eq(users.id, MEMBER_USER_ID));
+    await tx.delete(tenants).where(eq(tenants.id, TENANT_ID));
+  });
+}
+
+async function request(
+  method: "POST" | "PUT",
+  path: string,
+  body: unknown,
+  token: string | null = ownerToken,
+) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "x-steward-tenant": TENANT_ID,
+  };
+  if (token) headers.authorization = `Bearer ${token}`;
+  const response = await app.request(path, {
+    method,
+    headers,
+    body: JSON.stringify(body),
+  });
+  return {
+    response,
+    body: (await response.json()) as { ok: boolean; error?: string; data?: unknown },
+  };
+}
+
+async function fixtureCounts() {
+  const db = getDb();
+  const [secretRows, routeRows, auditRows] = await Promise.all([
+    db.select({ id: secrets.id }).from(secrets).where(eq(secrets.tenantId, TENANT_ID)),
+    db
+      .select({ id: secretRoutes.id })
+      .from(secretRoutes)
+      .where(eq(secretRoutes.tenantId, TENANT_ID)),
+    db.select({ id: auditEvents.id }).from(auditEvents).where(eq(auditEvents.tenantId, TENANT_ID)),
+  ]);
+  return { secrets: secretRows.length, routes: routeRows.length, audits: auditRows.length };
+}
+
+describeWithPostgres(
+  "secret routes through the production app and PostgreSQL tenant transaction",
+  () => {
+    beforeAll(async () => {
+      process.env.NODE_ENV = "test";
+      process.env.STEWARD_MASTER_PASSWORD ||= "secret-production-postgres-master-password";
+      process.env.STEWARD_AUDIT_HMAC_KEY ||= "c".repeat(64);
+      process.env.STEWARD_JWT_SECRET ||=
+        "secret-production-postgres-jwt-secret-with-at-least-thirty-two-bytes";
+      __resetAuditHmacKeyCacheForTests();
+
+      await cleanupFixture();
+      const db = getDb();
+      await db.insert(tenants).values({
+        id: TENANT_ID,
+        name: "Secret production boundary",
+        apiKeyHash: `unused-${SUFFIX}`,
+      });
+      await db.insert(users).values([
+        { id: OWNER_USER_ID, email: `owner-${SUFFIX}@example.test`, emailVerified: true },
+        { id: MEMBER_USER_ID, email: `member-${SUFFIX}@example.test`, emailVerified: true },
+      ]);
+      await db.insert(userTenants).values([
+        { userId: OWNER_USER_ID, tenantId: TENANT_ID, role: "owner" },
+        { userId: MEMBER_USER_ID, tenantId: TENANT_ID, role: "member" },
+      ]);
+      await db.insert(agents).values({
+        id: AGENT_ID,
+        tenantId: TENANT_ID,
+        name: "Secret production agent",
+        walletAddress: `0x${SUFFIX.replaceAll("-", "").slice(0, 40).padEnd(40, "0")}`,
+      });
+
+      const { signAccessToken } = await import("@stwd/auth");
+      ownerToken = await signAccessToken({
+        address: "0x0000000000000000000000000000000000000816",
+        tenantId: TENANT_ID,
+        userId: OWNER_USER_ID,
+        mfaVerifiedAt: Date.now(),
+        mfaMethod: "totp",
+      });
+      memberToken = await signAccessToken({
+        address: "0x0000000000000000000000000000000000000817",
+        tenantId: TENANT_ID,
+        userId: MEMBER_USER_ID,
+        mfaVerifiedAt: Date.now(),
+        mfaMethod: "totp",
+      });
+      staleMfaToken = await signAccessToken({
+        address: "0x0000000000000000000000000000000000000816",
+        tenantId: TENANT_ID,
+        userId: OWNER_USER_ID,
+        mfaVerifiedAt: Date.now() - 10 * 60_000,
+        mfaMethod: "totp",
+      });
+
+      const { createApp, mountCoreIdempotencyAndRoutes } = await import("../app");
+      app = mountCoreIdempotencyAndRoutes(createApp());
+    });
+
+    afterAll(async () => {
+      await cleanupFixture();
+      for (const name of ENV_NAMES) {
+        const value = originalEnv.get(name);
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+      __resetAuditHmacKeyCacheForTests();
+    });
+
+    it("enforces real JWT authority and persists create/update/rotate with exact chained audits", async () => {
+      for (const testCase of [
+        { name: "unauthenticated", token: null },
+        { name: "member", token: memberToken },
+        { name: "stale MFA", token: staleMfaToken },
+      ]) {
+        const before = await fixtureCounts();
+        const denied = await request(
+          "POST",
+          "/secrets",
+          { name: `denied-${testCase.name}`, value: SECRET_VALUE },
+          testCase.token,
+        );
+        expect(denied.response.status, testCase.name).toBe(403);
+        expect(denied.body.ok, testCase.name).toBe(false);
+        expect(await fixtureCounts(), testCase.name).toEqual(before);
+      }
+
+      const created = await request("POST", "/secrets", {
+        name: `mounted-${SUFFIX}`,
+        value: `${SECRET_VALUE}-created`,
+      });
+      expect(created.response.status).toBe(201);
+      expect(created.response.headers.get("cache-control")).toBe("no-store, max-age=0");
+      expect(JSON.stringify(created.body)).not.toContain(`${SECRET_VALUE}-created`);
+      const createdId = (created.body.data as { id?: string })?.id;
+      expect(createdId).toBeString();
+
+      for (const [method, path] of [
+        ["PUT", `/secrets/${createdId}`],
+        ["POST", `/secrets/${createdId}/rotate`],
+      ] as const) {
+        for (const lineBreak of ["\r", "\n"]) {
+          const before = await fixtureCounts();
+          const invalid = await request(method, path, {
+            value: `${SECRET_VALUE}${lineBreak}attack`,
+          });
+          expect(invalid.response.status).toBe(400);
+          expect(invalid.body).toEqual({
+            ok: false,
+            error: "secret value must not contain line breaks",
+          });
+          expect(await fixtureCounts()).toEqual(before);
+        }
+      }
+
+      const updated = await request("PUT", `/secrets/${createdId}`, {
+        value: `${SECRET_VALUE}-updated`,
+      });
+      expect(updated.response.status).toBe(200);
+      const updatedId = (updated.body.data as { id?: string })?.id;
+      expect(updatedId).toBeString();
+      expect(updatedId).not.toBe(createdId);
+
+      const rotated = await request("POST", `/secrets/${updatedId}/rotate`, {
+        value: `${SECRET_VALUE}-rotated`,
+      });
+      expect(rotated.response.status).toBe(200);
+      const rotatedId = (rotated.body.data as { id?: string })?.id;
+      expect(rotatedId).toBeString();
+      expect(rotatedId).not.toBe(updatedId);
+
+      const routeCreated = await request("POST", "/secrets/routes", {
+        secretId: rotatedId,
+        agentId: AGENT_ID,
+        hostPattern: " API.OPENAI.COM ",
+        pathPattern: "/v1/responses",
+        method: " post ",
+        injectAs: "header",
+        injectKey: " X-Steward-Token ",
+        injectFormat: "Bearer {value}",
+      });
+      expect(routeCreated.response.status).toBe(201);
+      const routeId = (routeCreated.body.data as { id?: string })?.id;
+      expect(routeId).toBeString();
+
+      const routeUpdated = await request("PUT", `/secrets/routes/${routeId}`, {
+        hostPattern: " API.ANTHROPIC.COM ",
+        pathPattern: "/v1/messages",
+        method: " POST ",
+        injectKey: " X-Api-Key ",
+      });
+      expect(routeUpdated.response.status).toBe(200);
+
+      const events = await getDb()
+        .select({ action: auditEvents.action, actorId: auditEvents.actorId })
+        .from(auditEvents)
+        .where(eq(auditEvents.tenantId, TENANT_ID))
+        .orderBy(asc(auditEvents.seq));
+      expect(events.map((event) => event.action)).toEqual([
+        "secret.create.authorized",
+        "secret.create",
+        "secret.rotate.authorized",
+        "secret.rotate",
+        "secret.rotate.authorized",
+        "secret.rotate",
+        "secret_route.create.authorized",
+        "secret_route.create",
+        "secret_route.update.authorized",
+        "secret_route.update",
+      ]);
+      expect(events.every((event) => event.actorId === OWNER_USER_ID)).toBe(true);
+      expect(await verifyAuditChain(TENANT_ID, { requireHead: true })).toMatchObject({
+        valid: true,
+        count: 10,
+      });
+
+      const [active] = await getDb()
+        .select({ id: secrets.id })
+        .from(secrets)
+        .where(
+          and(
+            eq(secrets.tenantId, TENANT_ID),
+            eq(secrets.name, `mounted-${SUFFIX}`),
+            isNull(secrets.deletedAt),
+          ),
+        );
+      expect(active?.id).toBe(rotatedId);
+    });
+  },
+);

--- a/packages/api/src/__tests__/secret-routes-validation.test.ts
+++ b/packages/api/src/__tests__/secret-routes-validation.test.ts
@@ -8,13 +8,10 @@ import {
   secretRoutes,
   secrets,
   tenants,
-  users,
-  userTenants,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { asc, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { verifyAuditChain } from "../services/audit";
 import type { AppVariables } from "../services/context";
 
 setDefaultTimeout(30_000);
@@ -23,21 +20,15 @@ const TENANT_ID = `secret-route-validation-${Date.now()}`;
 const AGENT_ID = `secret-route-agent-${Date.now()}`;
 const SECRET_ID = "00000000-0000-4000-8000-000000000733";
 const EXISTING_ROUTE_ID = "00000000-0000-4000-8000-000000000734";
-const OWNER_USER_ID = "00000000-0000-4000-8000-000000000735";
-const MEMBER_USER_ID = "00000000-0000-4000-8000-000000000736";
 const VALID_SECRET_VALUE = "mounted-pglite-secret-value";
 const MUTATED_ENV = [
   "STEWARD_PGLITE_MEMORY",
   "STEWARD_MASTER_PASSWORD",
   "STEWARD_AUDIT_HMAC_KEY",
-  "STEWARD_JWT_SECRET",
 ] as const;
 const originalEnv = new Map(MUTATED_ENV.map((name) => [name, process.env[name]]));
 
 let app: Hono<{ Variables: AppVariables }>;
-let ownerToken = "";
-let memberToken = "";
-let staleMfaToken = "";
 
 type Snapshot = {
   audits: (typeof auditEvents.$inferSelect)[];
@@ -54,39 +45,14 @@ async function snapshot(): Promise<Snapshot> {
   };
 }
 
-async function jsonRequest(
-  method: "POST" | "PUT",
-  path: string,
-  body: unknown,
-  token: string | null = ownerToken,
-) {
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-    "x-steward-tenant": TENANT_ID,
-  };
-  if (token) headers.authorization = `Bearer ${token}`;
+async function jsonRequest(method: "POST" | "PUT", path: string, body: unknown) {
   const response = await app.request(path, {
     method,
-    headers,
+    headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
   });
   const json = (await response.json()) as { ok: boolean; error?: string; data?: unknown };
   return { response, json };
-}
-
-async function auditActionsSince(count: number): Promise<string[]> {
-  const rows = await getDb()
-    .select({ action: auditEvents.action, actorId: auditEvents.actorId })
-    .from(auditEvents)
-    .where(eq(auditEvents.tenantId, TENANT_ID))
-    .orderBy(asc(auditEvents.seq));
-  const appended = rows.slice(count);
-  expect(appended.every((row) => row.actorId === OWNER_USER_ID)).toBe(true);
-  return appended.map((row) => row.action);
-}
-
-async function expectValidAuditChain(): Promise<void> {
-  expect(await verifyAuditChain(TENANT_ID, { requireHead: true })).toMatchObject({ valid: true });
 }
 
 const validRouteCreate = {
@@ -106,8 +72,6 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = "secret-route-validation-master-password";
   process.env.STEWARD_AUDIT_HMAC_KEY = "secret-route-validation-audit-hmac-key-with-entropy";
-  process.env.STEWARD_JWT_SECRET =
-    "secret-route-validation-jwt-secret-with-at-least-thirty-two-bytes";
   __resetAuditHmacKeyCacheForTests();
 
   const { db, client } = await createPGLiteDb("memory://");
@@ -125,26 +89,6 @@ beforeAll(async () => {
     name: "Secret Route Validation Agent",
     walletAddress: "0x0000000000000000000000000000000000000733",
   });
-  await getDb()
-    .insert(users)
-    .values([
-      {
-        id: OWNER_USER_ID,
-        email: "secret-route-owner@example.test",
-        emailVerified: true,
-      },
-      {
-        id: MEMBER_USER_ID,
-        email: "secret-route-member@example.test",
-        emailVerified: true,
-      },
-    ]);
-  await getDb()
-    .insert(userTenants)
-    .values([
-      { userId: OWNER_USER_ID, tenantId: TENANT_ID, role: "owner" },
-      { userId: MEMBER_USER_ID, tenantId: TENANT_ID, role: "member" },
-    ]);
   await getDb().insert(secrets).values({
     id: SECRET_ID,
     tenantId: TENANT_ID,
@@ -167,31 +111,19 @@ beforeAll(async () => {
     injectFormat: "Bearer {value}",
   });
 
-  const { signAccessToken } = await import("@stwd/auth");
-  ownerToken = await signAccessToken({
-    address: "0x0000000000000000000000000000000000000735",
-    tenantId: TENANT_ID,
-    userId: OWNER_USER_ID,
-    mfaVerifiedAt: Date.now(),
-    mfaMethod: "totp",
+  const { secretsRoutes: mountedRoutes } = await import("../routes/secrets");
+  app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("tenantId", TENANT_ID);
+    c.set("authType", "session-jwt");
+    c.set("tenantRole", "owner");
+    c.set("userId", "secret-route-validation-owner");
+    c.set("sessionMfaVerifiedAt", Date.now());
+    c.set("requestId", crypto.randomUUID());
+    await next();
   });
-  memberToken = await signAccessToken({
-    address: "0x0000000000000000000000000000000000000736",
-    tenantId: TENANT_ID,
-    userId: MEMBER_USER_ID,
-    mfaVerifiedAt: Date.now(),
-    mfaMethod: "totp",
-  });
-  staleMfaToken = await signAccessToken({
-    address: "0x0000000000000000000000000000000000000735",
-    tenantId: TENANT_ID,
-    userId: OWNER_USER_ID,
-    mfaVerifiedAt: Date.now() - 10 * 60_000,
-    mfaMethod: "totp",
-  });
-
-  const { createApp, mountCoreIdempotencyAndRoutes } = await import("../app");
-  app = mountCoreIdempotencyAndRoutes(createApp());
+  app.route("/secrets", mountedRoutes);
+  app.onError((_error, c) => c.json({ ok: false, error: "Internal server error" }, 500));
 });
 
 afterAll(async () => {
@@ -205,73 +137,6 @@ afterAll(async () => {
 });
 
 describe("mounted secret route validation", () => {
-  it("uses the production app tenantAuth and MFA boundary before secret persistence", async () => {
-    const body = { name: "must-not-persist", value: VALID_SECRET_VALUE };
-    for (const testCase of [
-      // tenantAuth falls through to the tenant API-key boundary when no bearer
-      // is present; an empty key is forbidden before the router is reached.
-      { name: "unauthenticated", token: null, status: 403 },
-      { name: "non-admin member", token: memberToken, status: 403 },
-      { name: "stale owner MFA", token: staleMfaToken, status: 403 },
-    ]) {
-      const before = await snapshot();
-      const { response, json } = await jsonRequest("POST", "/secrets", body, testCase.token);
-      expect(response.status, testCase.name).toBe(testCase.status);
-      expect(json.ok, testCase.name).toBe(false);
-      expect(await snapshot(), testCase.name).toEqual(before);
-    }
-  });
-
-  it("creates, updates, and rotates a secret through the production app with exact audit pairs", async () => {
-    const beforeCreate = await snapshot();
-    const createResult = await jsonRequest("POST", "/secrets", {
-      name: "production-mounted-secret",
-      value: `${VALID_SECRET_VALUE}-created`,
-    });
-    expect(createResult.response.status).toBe(201);
-    const createdId = (createResult.json.data as { id?: string })?.id;
-    expect(createdId).toBeString();
-    expect(await auditActionsSince(beforeCreate.audits.length)).toEqual([
-      "secret.create.authorized",
-      "secret.create",
-    ]);
-    await expectValidAuditChain();
-
-    const beforeUpdate = await snapshot();
-    const updateResult = await jsonRequest("PUT", `/secrets/${createdId}`, {
-      value: `${VALID_SECRET_VALUE}-updated`,
-    });
-    expect(updateResult.response.status).toBe(200);
-    const updatedId = (updateResult.json.data as { id?: string })?.id;
-    expect(updatedId).toBeString();
-    expect(updatedId).not.toBe(createdId);
-    expect(await auditActionsSince(beforeUpdate.audits.length)).toEqual([
-      "secret.rotate.authorized",
-      "secret.rotate",
-    ]);
-    await expectValidAuditChain();
-
-    const beforeRotate = await snapshot();
-    const rotateResult = await jsonRequest("POST", `/secrets/${updatedId}/rotate`, {
-      value: `${VALID_SECRET_VALUE}-rotated`,
-    });
-    expect(rotateResult.response.status).toBe(200);
-    const rotatedId = (rotateResult.json.data as { id?: string })?.id;
-    expect(rotatedId).toBeString();
-    expect(rotatedId).not.toBe(updatedId);
-    expect(await auditActionsSince(beforeRotate.audits.length)).toEqual([
-      "secret.rotate.authorized",
-      "secret.rotate",
-    ]);
-    await expectValidAuditChain();
-
-    const active = (await snapshot()).secrets.filter(
-      (row) => row.name === "production-mounted-secret" && row.deletedAt === null,
-    );
-    expect(active).toHaveLength(1);
-    expect(active[0]?.id).toBe(rotatedId);
-  });
-
   it("rejects every invalid create shape before route, audit, or vault persistence", async () => {
     const invalidCases: Array<{ name: string; patch: Record<string, unknown> }> = [
       { name: "query injection", patch: { injectAs: "query" } },
@@ -376,11 +241,6 @@ describe("mounted secret route validation", () => {
     const afterCreate = await snapshot();
     expect(afterCreate.routes).toHaveLength(before.routes.length + 1);
     expect(afterCreate.audits).toHaveLength(before.audits.length + 2);
-    expect(await auditActionsSince(before.audits.length)).toEqual([
-      "secret_route.create.authorized",
-      "secret_route.create",
-    ]);
-    await expectValidAuditChain();
     expect(afterCreate.secrets).toEqual(before.secrets);
     const created = afterCreate.routes.find((route) => route.id !== EXISTING_ROUTE_ID);
     expect(created).toMatchObject({
@@ -408,11 +268,6 @@ describe("mounted secret route validation", () => {
     const updateAfter = await snapshot();
     expect(updateAfter.routes).toHaveLength(updateBefore.routes.length);
     expect(updateAfter.audits).toHaveLength(updateBefore.audits.length + 2);
-    expect(await auditActionsSince(updateBefore.audits.length)).toEqual([
-      "secret_route.update.authorized",
-      "secret_route.update",
-    ]);
-    await expectValidAuditChain();
     expect(updateAfter.secrets).toEqual(updateBefore.secrets);
     expect(updateAfter.routes.find((route) => route.id === created?.id)).toMatchObject({
       hostPattern: "api.anthropic.com",

--- a/packages/api/src/__tests__/secret-routes-validation.test.ts
+++ b/packages/api/src/__tests__/secret-routes-validation.test.ts
@@ -1,73 +1,282 @@
-import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  agents,
+  auditEvents,
+  closeDb,
+  getDb,
+  secretRoutes,
+  secrets,
+  tenants,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
 
-const secretsRouteSource = readFileSync(
-  join(import.meta.dir, "..", "routes", "secrets.ts"),
-  "utf8",
-);
+setDefaultTimeout(30_000);
 
-// Route-config validation rules now live in the single source of truth shared
-// validator in @stwd/vault. These source-level guards assert the invariants
-// stayed intact after the extraction, at the file that actually owns them.
-const sharedValidatorSource = readFileSync(
-  join(import.meta.dir, "..", "..", "..", "vault", "src", "secret-route-validator.ts"),
-  "utf8",
-);
+const TENANT_ID = `secret-route-validation-${Date.now()}`;
+const AGENT_ID = `secret-route-agent-${Date.now()}`;
+const SECRET_ID = "00000000-0000-4000-8000-000000000733";
+const EXISTING_ROUTE_ID = "00000000-0000-4000-8000-000000000734";
+const VALID_SECRET_VALUE = "mounted-pglite-secret-value";
+const MUTATED_ENV = [
+  "STEWARD_PGLITE_MEMORY",
+  "STEWARD_MASTER_PASSWORD",
+  "STEWARD_AUDIT_HMAC_KEY",
+] as const;
+const originalEnv = new Map(MUTATED_ENV.map((name) => [name, process.env[name]]));
 
-describe("secret route validation", () => {
-  it("routes both call sites through the shared validator", () => {
-    expect(secretsRouteSource).toContain('from "@stwd/vault"');
-    expect(secretsRouteSource).toContain("validateSecretRouteConfig");
-    // The api route must NOT carry its own local copy of the validator anymore.
-    expect(secretsRouteSource).not.toContain("function validateSecretRouteConfig");
+let app: Hono<{ Variables: AppVariables }>;
+
+type Snapshot = {
+  audits: (typeof auditEvents.$inferSelect)[];
+  routes: (typeof secretRoutes.$inferSelect)[];
+  secrets: (typeof secrets.$inferSelect)[];
+};
+
+async function snapshot(): Promise<Snapshot> {
+  const db = getDb();
+  return {
+    audits: await db.select().from(auditEvents).where(eq(auditEvents.tenantId, TENANT_ID)),
+    routes: await db.select().from(secretRoutes).where(eq(secretRoutes.tenantId, TENANT_ID)),
+    secrets: await db.select().from(secrets).where(eq(secrets.tenantId, TENANT_ID)),
+  };
+}
+
+async function jsonRequest(method: "POST" | "PUT", path: string, body: unknown) {
+  const response = await app.request(path, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const json = (await response.json()) as { ok: boolean; error?: string; data?: unknown };
+  return { response, json };
+}
+
+const validRouteCreate = {
+  secretId: SECRET_ID,
+  agentId: AGENT_ID,
+  hostPattern: "api.openai.com",
+  pathPattern: "/v1/responses",
+  method: "POST",
+  injectAs: "header",
+  injectKey: "Authorization",
+  injectFormat: "Bearer {value}",
+  priority: 7,
+  enabled: true,
+};
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = "secret-route-validation-master-password";
+  process.env.STEWARD_AUDIT_HMAC_KEY = "secret-route-validation-audit-hmac-key-with-entropy";
+  __resetAuditHmacKeyCacheForTests();
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => client.close());
+  await getDb()
+    .insert(tenants)
+    .values({
+      id: TENANT_ID,
+      name: "Secret Route Validation Tenant",
+      apiKeyHash: `hash-${TENANT_ID}`,
+    });
+  await getDb().insert(agents).values({
+    id: AGENT_ID,
+    tenantId: TENANT_ID,
+    name: "Secret Route Validation Agent",
+    walletAddress: "0x0000000000000000000000000000000000000733",
+  });
+  await getDb().insert(secrets).values({
+    id: SECRET_ID,
+    tenantId: TENANT_ID,
+    name: "mounted-secret",
+    ciphertext: "fixture-ciphertext",
+    iv: "fixture-iv",
+    authTag: "fixture-tag",
+    salt: "fixture-salt",
+  });
+  await getDb().insert(secretRoutes).values({
+    id: EXISTING_ROUTE_ID,
+    tenantId: TENANT_ID,
+    agentId: AGENT_ID,
+    secretId: SECRET_ID,
+    hostPattern: "api.openai.com",
+    pathPattern: "/v1/responses",
+    method: "POST",
+    injectAs: "header",
+    injectKey: "Authorization",
+    injectFormat: "Bearer {value}",
   });
 
-  it("rejects oversized credential injection formats before persistence", () => {
-    expect(sharedValidatorSource).toContain("const MAX_SECRET_INJECT_FORMAT_LENGTH = 255");
-    expect(sharedValidatorSource).toContain("injectFormat cannot exceed");
-    expect(sharedValidatorSource).toContain("input.injectFormat.length");
+  const { secretsRoutes: mountedRoutes } = await import("../routes/secrets");
+  app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("tenantId", TENANT_ID);
+    c.set("authType", "session-jwt");
+    c.set("tenantRole", "owner");
+    c.set("userId", "secret-route-validation-owner");
+    c.set("sessionMfaVerifiedAt", Date.now());
+    c.set("requestId", crypto.randomUUID());
+    await next();
+  });
+  app.route("/secrets", mountedRoutes);
+  app.onError((_error, c) => c.json({ ok: false, error: "Internal server error" }, 500));
+});
+
+afterAll(async () => {
+  await closeDb();
+  for (const name of MUTATED_ENV) {
+    const original = originalEnv.get(name);
+    if (original === undefined) delete process.env[name];
+    else process.env[name] = original;
+  }
+  __resetAuditHmacKeyCacheForTests();
+});
+
+describe("mounted secret route validation", () => {
+  it("rejects every invalid create shape before route, audit, or vault persistence", async () => {
+    const invalidCases: Array<{ name: string; patch: Record<string, unknown> }> = [
+      { name: "query injection", patch: { injectAs: "query" } },
+      { name: "body injection", patch: { injectAs: "body" } },
+      { name: "oversized injection format", patch: { injectFormat: `{value}${"x".repeat(249)}` } },
+      { name: "invalid header name", patch: { injectKey: "X Secret: Value" } },
+      { name: "non-integer priority", patch: { priority: 1.5 } },
+      { name: "string priority", patch: { priority: "7" } },
+      { name: "non-boolean enabled", patch: { enabled: "true" } },
+      { name: "CR injection format", patch: { injectFormat: "Bearer {value}\rX-Evil: yes" } },
+      { name: "LF injection format", patch: { injectFormat: "Bearer {value}\nX-Evil: yes" } },
+    ];
+    for (const testCase of invalidCases) {
+      const before = await snapshot();
+      const { response, json } = await jsonRequest("POST", "/secrets/routes", {
+        ...validRouteCreate,
+        ...testCase.patch,
+      });
+      expect(response.status, testCase.name).toBe(400);
+      expect(json, testCase.name).toMatchObject({ ok: false, error: expect.any(String) });
+      expect(await snapshot(), testCase.name).toEqual(before);
+    }
   });
 
-  it("rejects query credential injection because upstream bodies can reflect secrets", () => {
-    expect(sharedValidatorSource).toContain('const validInjectAs = ["header"]');
-    expect(sharedValidatorSource).toContain("'injectAs' must be one of:");
-    expect(sharedValidatorSource).not.toContain("STEWARD_ALLOW_QUERY_SECRET_INJECTION");
-    expect(sharedValidatorSource).not.toContain('const validInjectAs = ["header", "query"]');
+  it("rejects every invalid update shape before route, audit, or vault persistence", async () => {
+    const invalidCases: Array<{ name: string; patch: Record<string, unknown> }> = [
+      { name: "query injection", patch: { injectAs: "query" } },
+      { name: "body injection", patch: { injectAs: "body" } },
+      { name: "oversized injection format", patch: { injectFormat: `{value}${"x".repeat(249)}` } },
+      { name: "invalid header name", patch: { injectKey: "Bad Header" } },
+      { name: "non-integer priority", patch: { priority: 2.25 } },
+      { name: "string priority", patch: { priority: "2" } },
+      { name: "non-boolean enabled", patch: { enabled: 1 } },
+      { name: "CR injection format", patch: { injectFormat: "{value}\rX-Evil: yes" } },
+      { name: "LF injection format", patch: { injectFormat: "{value}\nX-Evil: yes" } },
+    ];
+    for (const testCase of invalidCases) {
+      const before = await snapshot();
+      const { response, json } = await jsonRequest(
+        "PUT",
+        `/secrets/routes/${EXISTING_ROUTE_ID}`,
+        testCase.patch,
+      );
+      expect(response.status, testCase.name).toBe(400);
+      expect(json, testCase.name).toMatchObject({ ok: false, error: expect.any(String) });
+      expect(await snapshot(), testCase.name).toEqual(before);
+    }
   });
 
-  it("rejects body credential injection until the proxy implements it", () => {
-    expect(sharedValidatorSource).toContain('const validInjectAs = ["header"]');
-    expect(sharedValidatorSource).toContain("'injectAs' must be one of:");
-    expect(sharedValidatorSource).not.toContain("STEWARD_ALLOW_QUERY_SECRET_INJECTION");
-    expect(sharedValidatorSource).not.toContain('const validInjectAs = ["header", "query"]');
+  it("rejects CR/LF secret values on create and update with zero persistence", async () => {
+    const cases = [
+      {
+        method: "POST" as const,
+        path: "/secrets",
+        body: { name: "cr-secret", value: `${VALID_SECRET_VALUE}\rattack` },
+      },
+      {
+        method: "POST" as const,
+        path: "/secrets",
+        body: { name: "lf-secret", value: `${VALID_SECRET_VALUE}\nattack` },
+      },
+      {
+        method: "PUT" as const,
+        path: `/secrets/${SECRET_ID}`,
+        body: { value: `${VALID_SECRET_VALUE}\rattack` },
+      },
+      {
+        method: "PUT" as const,
+        path: `/secrets/${SECRET_ID}`,
+        body: { value: `${VALID_SECRET_VALUE}\nattack` },
+      },
+    ];
+    for (const testCase of cases) {
+      const before = await snapshot();
+      const { response, json } = await jsonRequest(testCase.method, testCase.path, testCase.body);
+      expect(response.status, `${testCase.method} ${testCase.path}`).toBe(400);
+      expect(json).toEqual({ ok: false, error: "secret value must not contain line breaks" });
+      expect(await snapshot()).toEqual(before);
+    }
   });
 
-  it("type-checks route creation priority and enabled before persistence", () => {
-    expect(secretsRouteSource).toContain("function parseSecretRouteCreate");
-    expect(secretsRouteSource).toContain("'priority' must be an integer");
-    expect(secretsRouteSource).toContain("'enabled' must be a boolean");
-    expect(secretsRouteSource).toContain("const routeInput = parsedCreate.value");
-    expect(sharedValidatorSource).toContain("const MAX_SECRET_INJECT_FORMAT_LENGTH = 255");
+  it("persists one normalized header route on create and normalizes its mounted update", async () => {
+    const before = await snapshot();
+    const { response, json } = await jsonRequest("POST", "/secrets/routes", {
+      ...validRouteCreate,
+      hostPattern: "  API.OPENAI.COM  ",
+      method: " post ",
+      injectKey: "  X-Steward-Token  ",
+    });
+    expect(response.status).toBe(201);
+    expect(json.ok).toBe(true);
+    const afterCreate = await snapshot();
+    expect(afterCreate.routes).toHaveLength(before.routes.length + 1);
+    expect(afterCreate.audits).toHaveLength(before.audits.length + 2);
+    expect(afterCreate.secrets).toEqual(before.secrets);
+    const created = afterCreate.routes.find((route) => route.id !== EXISTING_ROUTE_ID);
+    expect(created).toMatchObject({
+      tenantId: TENANT_ID,
+      agentId: AGENT_ID,
+      secretId: SECRET_ID,
+      hostPattern: "api.openai.com",
+      pathPattern: "/v1/responses",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "X-Steward-Token",
+      injectFormat: "Bearer {value}",
+      priority: 7,
+      enabled: true,
+    });
+
+    const updateBefore = await snapshot();
+    const updateResult = await jsonRequest("PUT", `/secrets/routes/${created?.id}`, {
+      hostPattern: " API.ANTHROPIC.COM ",
+      pathPattern: " /v1/messages ",
+      method: " post ",
+      injectKey: " X-Api-Key ",
+    });
+    expect(updateResult.response.status).toBe(200);
+    const updateAfter = await snapshot();
+    expect(updateAfter.routes).toHaveLength(updateBefore.routes.length);
+    expect(updateAfter.audits).toHaveLength(updateBefore.audits.length + 2);
+    expect(updateAfter.secrets).toEqual(updateBefore.secrets);
+    expect(updateAfter.routes.find((route) => route.id === created?.id)).toMatchObject({
+      hostPattern: "api.anthropic.com",
+      pathPattern: "/v1/messages",
+      method: "POST",
+      injectKey: "X-Api-Key",
+    });
   });
 
-  it("rejects line breaks in secret values before header injection can use them", () => {
-    expect(secretsRouteSource).toContain("function validateSecretValue");
-    expect(secretsRouteSource).toContain("secret value must not contain line breaks");
-    expect(secretsRouteSource).toContain(
-      "const secretValueError = validateSecretValue(body.value)",
-    );
-  });
-
-  it("rejects invalid injected header names before persistence", () => {
-    expect(sharedValidatorSource).toContain("const HTTP_HEADER_NAME =");
-    expect(sharedValidatorSource).toContain("!HTTP_HEADER_NAME.test(key)");
-    expect(sharedValidatorSource).toContain("injectKey is invalid");
-  });
-
-  it("marks secret inventory and route topology responses as non-cacheable", () => {
-    expect(secretsRouteSource).toContain("setNoStoreHeaders");
-    expect(secretsRouteSource).toContain('secretsRoutes.use("*"');
-    expect(secretsRouteSource).toContain("setNoStoreHeaders(c)");
+  it("marks secret inventory and route topology responses fully non-cacheable", async () => {
+    for (const path of ["/secrets", "/secrets/routes"]) {
+      const response = await app.request(path);
+      expect(response.status, path).toBe(200);
+      expect(response.headers.get("cache-control"), path).toBe("no-store, max-age=0");
+      expect(response.headers.get("pragma"), path).toBe("no-cache");
+      expect(response.headers.get("expires"), path).toBe("0");
+      const body = await response.text();
+      expect(body, path).not.toContain(VALID_SECRET_VALUE);
+      expect(body, path).not.toContain("fixture-ciphertext");
+    }
   });
 });

--- a/packages/api/src/__tests__/secret-routes-validation.test.ts
+++ b/packages/api/src/__tests__/secret-routes-validation.test.ts
@@ -8,10 +8,13 @@ import {
   secretRoutes,
   secrets,
   tenants,
+  users,
+  userTenants,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { eq } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import { Hono } from "hono";
+import { verifyAuditChain } from "../services/audit";
 import type { AppVariables } from "../services/context";
 
 setDefaultTimeout(30_000);
@@ -20,15 +23,21 @@ const TENANT_ID = `secret-route-validation-${Date.now()}`;
 const AGENT_ID = `secret-route-agent-${Date.now()}`;
 const SECRET_ID = "00000000-0000-4000-8000-000000000733";
 const EXISTING_ROUTE_ID = "00000000-0000-4000-8000-000000000734";
+const OWNER_USER_ID = "00000000-0000-4000-8000-000000000735";
+const MEMBER_USER_ID = "00000000-0000-4000-8000-000000000736";
 const VALID_SECRET_VALUE = "mounted-pglite-secret-value";
 const MUTATED_ENV = [
   "STEWARD_PGLITE_MEMORY",
   "STEWARD_MASTER_PASSWORD",
   "STEWARD_AUDIT_HMAC_KEY",
+  "STEWARD_JWT_SECRET",
 ] as const;
 const originalEnv = new Map(MUTATED_ENV.map((name) => [name, process.env[name]]));
 
 let app: Hono<{ Variables: AppVariables }>;
+let ownerToken = "";
+let memberToken = "";
+let staleMfaToken = "";
 
 type Snapshot = {
   audits: (typeof auditEvents.$inferSelect)[];
@@ -45,14 +54,39 @@ async function snapshot(): Promise<Snapshot> {
   };
 }
 
-async function jsonRequest(method: "POST" | "PUT", path: string, body: unknown) {
+async function jsonRequest(
+  method: "POST" | "PUT",
+  path: string,
+  body: unknown,
+  token: string | null = ownerToken,
+) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "x-steward-tenant": TENANT_ID,
+  };
+  if (token) headers.authorization = `Bearer ${token}`;
   const response = await app.request(path, {
     method,
-    headers: { "content-type": "application/json" },
+    headers,
     body: JSON.stringify(body),
   });
   const json = (await response.json()) as { ok: boolean; error?: string; data?: unknown };
   return { response, json };
+}
+
+async function auditActionsSince(count: number): Promise<string[]> {
+  const rows = await getDb()
+    .select({ action: auditEvents.action, actorId: auditEvents.actorId })
+    .from(auditEvents)
+    .where(eq(auditEvents.tenantId, TENANT_ID))
+    .orderBy(asc(auditEvents.seq));
+  const appended = rows.slice(count);
+  expect(appended.every((row) => row.actorId === OWNER_USER_ID)).toBe(true);
+  return appended.map((row) => row.action);
+}
+
+async function expectValidAuditChain(): Promise<void> {
+  expect(await verifyAuditChain(TENANT_ID, { requireHead: true })).toMatchObject({ valid: true });
 }
 
 const validRouteCreate = {
@@ -72,6 +106,8 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = "secret-route-validation-master-password";
   process.env.STEWARD_AUDIT_HMAC_KEY = "secret-route-validation-audit-hmac-key-with-entropy";
+  process.env.STEWARD_JWT_SECRET =
+    "secret-route-validation-jwt-secret-with-at-least-thirty-two-bytes";
   __resetAuditHmacKeyCacheForTests();
 
   const { db, client } = await createPGLiteDb("memory://");
@@ -89,6 +125,26 @@ beforeAll(async () => {
     name: "Secret Route Validation Agent",
     walletAddress: "0x0000000000000000000000000000000000000733",
   });
+  await getDb()
+    .insert(users)
+    .values([
+      {
+        id: OWNER_USER_ID,
+        email: "secret-route-owner@example.test",
+        emailVerified: true,
+      },
+      {
+        id: MEMBER_USER_ID,
+        email: "secret-route-member@example.test",
+        emailVerified: true,
+      },
+    ]);
+  await getDb()
+    .insert(userTenants)
+    .values([
+      { userId: OWNER_USER_ID, tenantId: TENANT_ID, role: "owner" },
+      { userId: MEMBER_USER_ID, tenantId: TENANT_ID, role: "member" },
+    ]);
   await getDb().insert(secrets).values({
     id: SECRET_ID,
     tenantId: TENANT_ID,
@@ -111,19 +167,31 @@ beforeAll(async () => {
     injectFormat: "Bearer {value}",
   });
 
-  const { secretsRoutes: mountedRoutes } = await import("../routes/secrets");
-  app = new Hono<{ Variables: AppVariables }>();
-  app.use("*", async (c, next) => {
-    c.set("tenantId", TENANT_ID);
-    c.set("authType", "session-jwt");
-    c.set("tenantRole", "owner");
-    c.set("userId", "secret-route-validation-owner");
-    c.set("sessionMfaVerifiedAt", Date.now());
-    c.set("requestId", crypto.randomUUID());
-    await next();
+  const { signAccessToken } = await import("@stwd/auth");
+  ownerToken = await signAccessToken({
+    address: "0x0000000000000000000000000000000000000735",
+    tenantId: TENANT_ID,
+    userId: OWNER_USER_ID,
+    mfaVerifiedAt: Date.now(),
+    mfaMethod: "totp",
   });
-  app.route("/secrets", mountedRoutes);
-  app.onError((_error, c) => c.json({ ok: false, error: "Internal server error" }, 500));
+  memberToken = await signAccessToken({
+    address: "0x0000000000000000000000000000000000000736",
+    tenantId: TENANT_ID,
+    userId: MEMBER_USER_ID,
+    mfaVerifiedAt: Date.now(),
+    mfaMethod: "totp",
+  });
+  staleMfaToken = await signAccessToken({
+    address: "0x0000000000000000000000000000000000000735",
+    tenantId: TENANT_ID,
+    userId: OWNER_USER_ID,
+    mfaVerifiedAt: Date.now() - 10 * 60_000,
+    mfaMethod: "totp",
+  });
+
+  const { createApp, mountCoreIdempotencyAndRoutes } = await import("../app");
+  app = mountCoreIdempotencyAndRoutes(createApp());
 });
 
 afterAll(async () => {
@@ -137,6 +205,73 @@ afterAll(async () => {
 });
 
 describe("mounted secret route validation", () => {
+  it("uses the production app tenantAuth and MFA boundary before secret persistence", async () => {
+    const body = { name: "must-not-persist", value: VALID_SECRET_VALUE };
+    for (const testCase of [
+      // tenantAuth falls through to the tenant API-key boundary when no bearer
+      // is present; an empty key is forbidden before the router is reached.
+      { name: "unauthenticated", token: null, status: 403 },
+      { name: "non-admin member", token: memberToken, status: 403 },
+      { name: "stale owner MFA", token: staleMfaToken, status: 403 },
+    ]) {
+      const before = await snapshot();
+      const { response, json } = await jsonRequest("POST", "/secrets", body, testCase.token);
+      expect(response.status, testCase.name).toBe(testCase.status);
+      expect(json.ok, testCase.name).toBe(false);
+      expect(await snapshot(), testCase.name).toEqual(before);
+    }
+  });
+
+  it("creates, updates, and rotates a secret through the production app with exact audit pairs", async () => {
+    const beforeCreate = await snapshot();
+    const createResult = await jsonRequest("POST", "/secrets", {
+      name: "production-mounted-secret",
+      value: `${VALID_SECRET_VALUE}-created`,
+    });
+    expect(createResult.response.status).toBe(201);
+    const createdId = (createResult.json.data as { id?: string })?.id;
+    expect(createdId).toBeString();
+    expect(await auditActionsSince(beforeCreate.audits.length)).toEqual([
+      "secret.create.authorized",
+      "secret.create",
+    ]);
+    await expectValidAuditChain();
+
+    const beforeUpdate = await snapshot();
+    const updateResult = await jsonRequest("PUT", `/secrets/${createdId}`, {
+      value: `${VALID_SECRET_VALUE}-updated`,
+    });
+    expect(updateResult.response.status).toBe(200);
+    const updatedId = (updateResult.json.data as { id?: string })?.id;
+    expect(updatedId).toBeString();
+    expect(updatedId).not.toBe(createdId);
+    expect(await auditActionsSince(beforeUpdate.audits.length)).toEqual([
+      "secret.rotate.authorized",
+      "secret.rotate",
+    ]);
+    await expectValidAuditChain();
+
+    const beforeRotate = await snapshot();
+    const rotateResult = await jsonRequest("POST", `/secrets/${updatedId}/rotate`, {
+      value: `${VALID_SECRET_VALUE}-rotated`,
+    });
+    expect(rotateResult.response.status).toBe(200);
+    const rotatedId = (rotateResult.json.data as { id?: string })?.id;
+    expect(rotatedId).toBeString();
+    expect(rotatedId).not.toBe(updatedId);
+    expect(await auditActionsSince(beforeRotate.audits.length)).toEqual([
+      "secret.rotate.authorized",
+      "secret.rotate",
+    ]);
+    await expectValidAuditChain();
+
+    const active = (await snapshot()).secrets.filter(
+      (row) => row.name === "production-mounted-secret" && row.deletedAt === null,
+    );
+    expect(active).toHaveLength(1);
+    expect(active[0]?.id).toBe(rotatedId);
+  });
+
   it("rejects every invalid create shape before route, audit, or vault persistence", async () => {
     const invalidCases: Array<{ name: string; patch: Record<string, unknown> }> = [
       { name: "query injection", patch: { injectAs: "query" } },
@@ -208,6 +343,16 @@ describe("mounted secret route validation", () => {
         path: `/secrets/${SECRET_ID}`,
         body: { value: `${VALID_SECRET_VALUE}\nattack` },
       },
+      {
+        method: "POST" as const,
+        path: `/secrets/${SECRET_ID}/rotate`,
+        body: { value: `${VALID_SECRET_VALUE}\rattack` },
+      },
+      {
+        method: "POST" as const,
+        path: `/secrets/${SECRET_ID}/rotate`,
+        body: { value: `${VALID_SECRET_VALUE}\nattack` },
+      },
     ];
     for (const testCase of cases) {
       const before = await snapshot();
@@ -231,6 +376,11 @@ describe("mounted secret route validation", () => {
     const afterCreate = await snapshot();
     expect(afterCreate.routes).toHaveLength(before.routes.length + 1);
     expect(afterCreate.audits).toHaveLength(before.audits.length + 2);
+    expect(await auditActionsSince(before.audits.length)).toEqual([
+      "secret_route.create.authorized",
+      "secret_route.create",
+    ]);
+    await expectValidAuditChain();
     expect(afterCreate.secrets).toEqual(before.secrets);
     const created = afterCreate.routes.find((route) => route.id !== EXISTING_ROUTE_ID);
     expect(created).toMatchObject({
@@ -258,6 +408,11 @@ describe("mounted secret route validation", () => {
     const updateAfter = await snapshot();
     expect(updateAfter.routes).toHaveLength(updateBefore.routes.length);
     expect(updateAfter.audits).toHaveLength(updateBefore.audits.length + 2);
+    expect(await auditActionsSince(updateBefore.audits.length)).toEqual([
+      "secret_route.update.authorized",
+      "secret_route.update",
+    ]);
+    await expectValidAuditChain();
     expect(updateAfter.secrets).toEqual(updateBefore.secrets);
     expect(updateAfter.routes.find((route) => route.id === created?.id)).toMatchObject({
       hostPattern: "api.anthropic.com",


### PR DESCRIPTION
## Summary

- preserve the mounted validator matrix and add CR/LF coverage for POST /secrets/:id/rotate
- mount core idempotency and production routes through createApp against PostgreSQL
- use real signed owner, member, and stale-MFA JWTs with seeded tenant memberships and production tenantAuth
- execute secret create, PUT rotate, POST rotate, route create, and route update
- prove no-store/non-disclosure, zero persistence on denied/invalid requests, exact authorized/completion actors, and the full ten-event audit chain/head

## Exact local evidence

- focused suites: 5/5, 95 assertions
- API TypeScript no-emit: pass
- targeted Biome and diff check: clean
- PostgreSQL suite registers 3 tests and skipped locally only because DATABASE_URL was unavailable

This stays draft until the exact hosted Integration PostgreSQL job executes the mounted suite, the full matrix is terminal, and independent review is complete.

Closes #733

## Exact lineage

Head: 60154282e6d693017ca0d2cfdcdf8b1d4b108701
Tree: 9fb8160964bff6e969c4ec276b7e638c872d3b6d
Base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6