### PR TITLE
fix(api): prove sponsored transfer accounting

### DIFF
--- a/packages/api/src/__tests__/gas-sponsorship-config.test.ts
+++ b/packages/api/src/__tests__/gas-sponsorship-config.test.ts
@@ -1,6 +1,4 @@
 import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import {
   normalizeGasSpendQuery,
   normalizeGasSponsorshipConfig,
@@ -135,99 +133,5 @@ describe("gas sponsorship config", () => {
         endTimestamp: 1_764_195_200 + 31 * 86400,
       }),
     ).toBe("gas spend queries cannot exceed 30 days");
-  });
-
-  it("keeps sponsored transfer reservations atomic and before signing", () => {
-    const serviceSource = readFileSync(
-      join(import.meta.dir, "../services/gas-sponsorship.ts"),
-      "utf8",
-    );
-    expect(serviceSource).toContain("export async function reserveSponsoredGasEvent");
-    expect(serviceSource).toContain("pg_advisory_xact_lock");
-    expect(serviceSource).toContain("sponsored_gas:");
-    expect(serviceSource).toContain("getSponsorshipCapError");
-
-    const vaultSource = readFileSync(join(import.meta.dir, "../routes/vault.ts"), "utf8");
-    const transferRoute = vaultSource.slice(
-      vaultSource.indexOf('vaultRoutes.post("/:agentId/actions/transfer"'),
-    );
-    const reserveCall = transferRoute.indexOf('status: "reserved"');
-    const signCall = transferRoute.indexOf("vault.signTransaction(signRequest");
-    expect(reserveCall).toBeGreaterThan(-1);
-    expect(signCall).toBeGreaterThan(-1);
-    expect(reserveCall).toBeLessThan(signCall);
-    expect(vaultSource).toContain('reservedUsd: input.status === "failed" ? 0 : estimatedUsd');
-  });
-
-  it("reserves and finalizes sponsorship for manual transfer approvals", () => {
-    const vaultSource = readFileSync(join(import.meta.dir, "../routes/vault.ts"), "utf8");
-    const transferRoute = vaultSource.slice(
-      vaultSource.indexOf('vaultRoutes.post("/:agentId/actions/transfer"'),
-      vaultSource.indexOf('vaultRoutes.post("/:agentId/approve/:txId"'),
-    );
-    const pendingDecision = transferRoute.indexOf(
-      'const status = evaluation.requiresManualApproval ? "pending" : "rejected"',
-    );
-    const pendingInsert = transferRoute.indexOf("db.insert(transactions).values", pendingDecision);
-    const pendingReservation = transferRoute.indexOf('status: "reserved"', pendingInsert);
-    const queuedAudit = transferRoute.indexOf(
-      "wallet_action.transfer.queued_for_approval",
-      pendingInsert,
-    );
-    expect(pendingDecision).toBeGreaterThanOrEqual(0);
-    expect(pendingInsert).toBeGreaterThanOrEqual(0);
-    expect(pendingInsert).toBeGreaterThan(pendingDecision);
-    expect(pendingReservation).toBeGreaterThan(pendingInsert);
-    expect(queuedAudit).toBeGreaterThan(pendingInsert);
-    expect(queuedAudit).toBeGreaterThan(pendingReservation);
-    expect(transferRoute).toContain("db.delete(transactions).where(eq(transactions.id, actionId))");
-    expect(transferRoute).toContain('status: "failed"');
-
-    const approvalRoute = vaultSource.slice(
-      vaultSource.indexOf('vaultRoutes.post("/:agentId/approve/:txId"'),
-      vaultSource.indexOf('vaultRoutes.post("/:agentId/reject/:txId"'),
-    );
-    const signCall = approvalRoute.indexOf("vault.signTransaction(approvalSignRequest");
-    const approvalReservation = approvalRoute.indexOf('status: "reserved"');
-    const finalSponsorship = approvalRoute.indexOf(
-      "sponsorship: transferPayload.sponsorship",
-      signCall,
-    );
-    const finalAudit = approvalRoute.indexOf("wallet_action.transfer.succeeded", signCall);
-    expect(approvalReservation).toBeGreaterThanOrEqual(0);
-    expect(signCall).toBeGreaterThanOrEqual(0);
-    expect(approvalReservation).toBeLessThan(signCall);
-    expect(finalSponsorship).toBeGreaterThan(signCall);
-    expect(finalSponsorship).toBeLessThan(finalAudit);
-    expect(approvalRoute).toContain('status: shouldBroadcast ? "submitted" : "signed"');
-  });
-
-  it("rejects sponsored signed-only transfer paths before gas reservation", () => {
-    const vaultSource = readFileSync(join(import.meta.dir, "../routes/vault.ts"), "utf8");
-    const transferRoute = vaultSource.slice(
-      vaultSource.indexOf('vaultRoutes.post("/:agentId/actions/transfer"'),
-      vaultSource.indexOf('vaultRoutes.post("/:agentId/approve/:txId"'),
-    );
-    const signedOnlyGuard = transferRoute.indexOf(
-      "transfer.sponsor === true && transfer.broadcast === false",
-    );
-    const sponsorshipResolve = transferRoute.indexOf("resolveGasSponsorshipRequest");
-    const reservation = transferRoute.indexOf('status: "reserved"');
-    expect(signedOnlyGuard).toBeGreaterThanOrEqual(0);
-    expect(sponsorshipResolve).toBeGreaterThan(signedOnlyGuard);
-    expect(reservation).toBeGreaterThan(signedOnlyGuard);
-    expect(transferRoute).toContain("signed-only actions do not spend sponsored gas");
-
-    const approvalRoute = vaultSource.slice(
-      vaultSource.indexOf('vaultRoutes.post("/:agentId/approve/:txId"'),
-      vaultSource.indexOf('vaultRoutes.post("/:agentId/reject/:txId"'),
-    );
-    const approvalGuard = approvalRoute.indexOf(
-      "transferPayload?.sponsorship?.sponsored === true && !shouldBroadcast",
-    );
-    const approvalReservation = approvalRoute.indexOf('status: "reserved"', approvalGuard);
-    expect(approvalGuard).toBeGreaterThanOrEqual(0);
-    expect(approvalReservation).toBeGreaterThan(approvalGuard);
-    expect(approvalRoute).toContain("resolvedAt: null");
   });
 });

--- a/packages/api/src/__tests__/gas-sponsorship-postgres-concurrency.integration.test.ts
+++ b/packages/api/src/__tests__/gas-sponsorship-postgres-concurrency.integration.test.ts
@@ -1,0 +1,96 @@
+/**
+ * PGLite is single-connection, so the mounted route suite proves state and
+ * failure behavior there while this gated test proves the production advisory
+ * lock with genuinely concurrent PostgreSQL transactions.
+ */
+import { expect, it } from "bun:test";
+import { agents, getDb, sponsoredGasEvents, tenantConfigs, tenants, transactions } from "@stwd/db";
+import { eq, inArray } from "drizzle-orm";
+import { reserveSponsoredGasEvent } from "../services/gas-sponsorship";
+
+const realPostgresIt =
+  process.env.DATABASE_URL && process.env.STEWARD_PGLITE_MEMORY !== "true" ? it : it.skip;
+
+realPostgresIt(
+  "serializes concurrent wallet and tenant cap reservations to one bounded winner",
+  async () => {
+    const suffix = crypto.randomUUID().replaceAll("-", "").slice(0, 12);
+    const tenantId = `sponsor-race-${suffix}`;
+    const agentId = `sponsor-agent-${suffix}`;
+    const txIds = [`sponsor-tx-a-${suffix}`, `sponsor-tx-b-${suffix}`];
+    const db = getDb();
+    try {
+      await db.insert(tenants).values({
+        id: tenantId,
+        name: tenantId,
+        apiKeyHash: `hash-${tenantId}`,
+      });
+      await db.insert(tenantConfigs).values({
+        tenantId,
+        gasSponsorshipConfig: {
+          enabled: true,
+          provider: "mock",
+          mode: "erc4337",
+          allowClientSponsorship: true,
+          maxPerTxUsd: 0.6,
+          maxPerWalletDayUsd: 1,
+          maxTenantDayUsd: 1,
+        },
+      });
+      await db.insert(agents).values({
+        id: agentId,
+        tenantId,
+        name: agentId,
+        walletAddress: "0x7350000000000000000000000000000000000000",
+      });
+      await db.insert(transactions).values(
+        txIds.map((id) => ({
+          id,
+          agentId,
+          status: "pending" as const,
+          toAddress: "0x1234567890123456789012345678901234567890",
+          value: "1",
+          chainId: 8453,
+          actionType: "transfer",
+          actionPayload: { type: "transfer", token: "native", broadcast: true },
+        })),
+      );
+
+      const results = await Promise.all(
+        txIds.map((txId) =>
+          reserveSponsoredGasEvent({
+            tenantId,
+            agentId,
+            txId,
+            chainId: 8453,
+            caip2: "eip155:8453",
+            provider: "mock",
+            mode: "erc4337",
+            reservedUsd: 0.6,
+            metadata: { actionType: "transfer" },
+          }),
+        ),
+      );
+
+      expect(results.filter((result) => result === undefined)).toHaveLength(1);
+      expect(results.filter((result) => typeof result === "string")).toHaveLength(1);
+      const rows = await db
+        .select()
+        .from(sponsoredGasEvents)
+        .where(eq(sponsoredGasEvents.tenantId, tenantId));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        agentId,
+        status: "reserved",
+        reservedUsd: "0.600000",
+      });
+    } finally {
+      await db.delete(sponsoredGasEvents).where(eq(sponsoredGasEvents.tenantId, tenantId));
+      await db.delete(transactions).where(inArray(transactions.id, txIds));
+      await db.delete(agents).where(eq(agents.id, agentId));
+      await db.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, tenantId));
+      await db.delete(tenants).where(eq(tenants.id, tenantId));
+    }
+  },
+  120_000,
+);

--- a/packages/api/src/__tests__/gas-sponsorship-route-behavior.test.ts
+++ b/packages/api/src/__tests__/gas-sponsorship-route-behavior.test.ts
@@ -1,0 +1,430 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import {
+  agents,
+  approvalQueue,
+  auditEvents,
+  closeDb,
+  getDb,
+  policies,
+  sponsoredGasEvents,
+  tenantConfigs,
+  tenants,
+  transactions,
+  users,
+  userTenants,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { and, eq, sql } from "drizzle-orm";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
+
+const RUN = crypto.randomUUID().slice(0, 8);
+const TENANT_ID = `sponsorship-route-${RUN}`;
+const REQUESTER_ID = "00000000-0000-4000-8000-000000007351";
+const APPROVER_ID = "00000000-0000-4000-8000-000000007352";
+const AUTO_AGENT = `sponsor-auto-${RUN}`;
+const MANUAL_AGENT = `sponsor-manual-${RUN}`;
+const AUDIT_AGENT = `sponsor-audit-${RUN}`;
+const RECIPIENT = "0x1234567890123456789012345678901234567890";
+const TOKEN = "0x4200000000000000000000000000000000000006";
+
+const originalRedisUrl = process.env.REDIS_URL;
+const originalRedisRequired = process.env.REDIS_REQUIRED;
+const originalAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+const originalMasterPassword = process.env.STEWARD_MASTER_PASSWORD;
+
+async function makeApp(userId: string) {
+  const { vaultRoutes } = await import("../routes/vault");
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("tenantId", TENANT_ID);
+    c.set("authType", "session-jwt");
+    c.set("tenantRole", "owner");
+    c.set("userId", userId);
+    c.set("sessionMfaVerifiedAt", Date.now());
+    await next();
+  });
+  app.route("/vault", vaultRoutes);
+  app.onError((error, c) => c.json({ ok: false, error: error.message }, 500));
+  return app;
+}
+
+async function seedTransferAgent(agentId: string, manual: boolean) {
+  await getDb()
+    .insert(agents)
+    .values({
+      id: agentId,
+      tenantId: TENANT_ID,
+      name: agentId,
+      walletAddress:
+        `0x${agentId === AUTO_AGENT ? "1" : agentId === MANUAL_AGENT ? "2" : "3"}`.padEnd(42, "0"),
+    });
+  await getDb()
+    .insert(policies)
+    .values([
+      {
+        id: `${agentId}-addresses`,
+        agentId,
+        type: "approved-addresses",
+        enabled: true,
+        config: { addresses: [RECIPIENT, TOKEN], mode: "whitelist" },
+      },
+      {
+        id: `${agentId}-selector`,
+        agentId,
+        type: "contract-allowlist",
+        enabled: true,
+        config: {
+          contracts: [
+            {
+              address: TOKEN,
+              selectors: ["0xa9059cbb"],
+              constraints: {
+                "0xa9059cbb": { recipientAllowlist: [RECIPIENT], maxAmount: "1000000" },
+              },
+            },
+          ],
+        },
+      },
+      ...(manual
+        ? [
+            {
+              id: `${agentId}-manual`,
+              agentId,
+              type: "auto-approve-threshold",
+              enabled: true,
+              config: {},
+            },
+          ]
+        : []),
+    ]);
+}
+
+function transfer(
+  app: Awaited<ReturnType<typeof makeApp>>,
+  agentId: string,
+  key: string,
+  extra = {},
+) {
+  return app.request(`/vault/${agentId}/actions/transfer`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "Idempotency-Key": key },
+    body: JSON.stringify({
+      to: RECIPIENT,
+      token: TOKEN,
+      value: "10",
+      chainId: 8453,
+      broadcast: true,
+      sponsor: true,
+      referenceId: key,
+      ...extra,
+    }),
+  });
+}
+
+describe("gas sponsorship mounted accounting", () => {
+  let requesterApp: Awaited<ReturnType<typeof makeApp>>;
+  let approverApp: Awaited<ReturnType<typeof makeApp>>;
+
+  beforeAll(async () => {
+    delete process.env.REDIS_URL;
+    delete process.env.REDIS_REQUIRED;
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_MASTER_PASSWORD = "sponsorship-route-test-master-password";
+    process.env.STEWARD_AUDIT_HMAC_KEY =
+      "sponsorship-route-test-audit-key-0123456789abcdef0123456789";
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+
+    await getDb()
+      .insert(tenants)
+      .values({
+        id: TENANT_ID,
+        name: TENANT_ID,
+        apiKeyHash: `hash-${TENANT_ID}`,
+      });
+    await getDb()
+      .insert(tenantConfigs)
+      .values({
+        tenantId: TENANT_ID,
+        gasSponsorshipConfig: {
+          enabled: true,
+          provider: "mock",
+          mode: "erc4337",
+          allowClientSponsorship: true,
+          allowedChainIds: [8453],
+          maxPerTxUsd: 0.5,
+          maxPerWalletDayUsd: 0.5,
+          maxTenantDayUsd: 0.5,
+        },
+      });
+    await getDb()
+      .insert(users)
+      .values([
+        { id: REQUESTER_ID, email: `sponsor-requester-${RUN}@example.test` },
+        { id: APPROVER_ID, email: `sponsor-approver-${RUN}@example.test` },
+      ]);
+    await getDb()
+      .insert(userTenants)
+      .values([
+        { userId: REQUESTER_ID, tenantId: TENANT_ID, role: "owner" },
+        { userId: APPROVER_ID, tenantId: TENANT_ID, role: "owner" },
+      ]);
+    await seedTransferAgent(AUTO_AGENT, false);
+    await seedTransferAgent(MANUAL_AGENT, true);
+    await seedTransferAgent(AUDIT_AGENT, false);
+    requesterApp = await makeApp(REQUESTER_ID);
+    approverApp = await makeApp(APPROVER_ID);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    if (originalRedisUrl === undefined) delete process.env.REDIS_URL;
+    else process.env.REDIS_URL = originalRedisUrl;
+    if (originalRedisRequired === undefined) delete process.env.REDIS_REQUIRED;
+    else process.env.REDIS_REQUIRED = originalRedisRequired;
+    if (originalAuditKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    else process.env.STEWARD_AUDIT_HMAC_KEY = originalAuditKey;
+    if (originalMasterPassword === undefined) delete process.env.STEWARD_MASTER_PASSWORD;
+    else process.env.STEWARD_MASTER_PASSWORD = originalMasterPassword;
+  });
+
+  it("rejects signed-only sponsorship, including replay, before reservation or signing", async () => {
+    const context = await import("../services/context");
+    const originalSign = context.vault.signTransaction.bind(context.vault);
+    let signCalls = 0;
+    context.vault.signTransaction = async () => {
+      signCalls += 1;
+      throw new Error("signed-only sponsorship reached signing");
+    };
+    try {
+      for (let replay = 0; replay < 2; replay += 1) {
+        const response = await requesterApp.request(`/vault/${AUTO_AGENT}/actions/transfer`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            to: RECIPIENT,
+            token: TOKEN,
+            value: "10",
+            chainId: 8453,
+            broadcast: false,
+            sponsor: true,
+            referenceId: "signed-only-replay",
+          }),
+        });
+        expect(response.status).toBe(400);
+        expect(await response.json()).toMatchObject({
+          ok: false,
+          error: expect.stringContaining("signed-only actions"),
+        });
+      }
+      expect(signCalls).toBe(0);
+      expect(await getDb().select().from(sponsoredGasEvents)).toHaveLength(0);
+      expect(await getDb().select().from(transactions)).toHaveLength(0);
+    } finally {
+      context.vault.signTransaction = originalSign;
+    }
+  });
+
+  it("does not sign and records a zero-value failure when the required audit fails", async () => {
+    const context = await import("../services/context");
+    const originalSign = context.vault.signTransaction.bind(context.vault);
+    let signCalls = 0;
+    context.vault.signTransaction = async () => {
+      signCalls += 1;
+      return "0xunexpected";
+    };
+    await getDb().execute(
+      sql.raw(`
+      create function fail_sponsor_authorized_${RUN}() returns trigger language plpgsql as $$
+      begin
+        if new.action = 'wallet_action.transfer.authorized' then
+          raise exception 'forced sponsorship authorization audit failure';
+        end if;
+        return new;
+      end $$
+    `),
+    );
+    await getDb().execute(
+      sql.raw(`
+      create trigger fail_sponsor_authorized_${RUN}
+      before insert on audit_events for each row
+      execute function fail_sponsor_authorized_${RUN}()
+    `),
+    );
+    try {
+      const response = await transfer(requesterApp, AUDIT_AGENT, "audit-failure");
+      expect([500, 502]).toContain(response.status);
+      const body = (await response.json()) as { data: { actionId: string } };
+      expect(signCalls).toBe(0);
+      const [event] = await getDb()
+        .select()
+        .from(sponsoredGasEvents)
+        .where(eq(sponsoredGasEvents.txId, body.data.actionId));
+      expect(event).toMatchObject({
+        status: "failed",
+        reservedUsd: "0.000000",
+        actualUsd: "0.000000",
+      });
+      const [tx] = await getDb()
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, body.data.actionId));
+      expect(tx.status).toBe("failed");
+      expect(
+        await getDb()
+          .select()
+          .from(auditEvents)
+          .where(
+            and(
+              eq(auditEvents.tenantId, TENANT_ID),
+              eq(auditEvents.action, "wallet_action.transfer.authorized"),
+            ),
+          ),
+      ).toHaveLength(0);
+    } finally {
+      await getDb().execute(sql.raw(`drop trigger fail_sponsor_authorized_${RUN} on audit_events`));
+      await getDb().execute(sql.raw(`drop function fail_sponsor_authorized_${RUN}()`));
+      context.vault.signTransaction = originalSign;
+    }
+  });
+
+  it("turns a reservation into a zero-value failure when signing fails", async () => {
+    const context = await import("../services/context");
+    const originalSign = context.vault.signTransaction.bind(context.vault);
+    let signCalls = 0;
+    context.vault.signTransaction = async () => {
+      signCalls += 1;
+      throw new Error("fault-injected signer failure");
+    };
+    try {
+      const response = await transfer(requesterApp, AUTO_AGENT, "signer-failure");
+      expect(response.status, await response.clone().text()).toBe(500);
+      const body = (await response.json()) as { data: { actionId: string } };
+      expect(signCalls).toBe(1);
+      const [event] = await getDb()
+        .select()
+        .from(sponsoredGasEvents)
+        .where(eq(sponsoredGasEvents.txId, body.data.actionId));
+      expect(event).toMatchObject({
+        status: "failed",
+        reservedUsd: "0.000000",
+        actualUsd: "0.000000",
+      });
+      const [tx] = await getDb()
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, body.data.actionId));
+      expect(tx.status).toBe("failed");
+      const actions = (
+        await getDb()
+          .select({ action: auditEvents.action })
+          .from(auditEvents)
+          .where(eq(auditEvents.resourceId, body.data.actionId))
+      ).map((row) => row.action);
+      expect(actions).toEqual([
+        "wallet_action.transfer.authorized",
+        "wallet_action.transfer.failed",
+      ]);
+    } finally {
+      context.vault.signTransaction = originalSign;
+    }
+  });
+
+  it("queues, approves, and broadcasts with one reservation row and one finalization", async () => {
+    const context = await import("../services/context");
+    const originalSign = context.vault.signTransaction.bind(context.vault);
+    let signCalls = 0;
+    context.vault.signTransaction = async () => {
+      signCalls += 1;
+      return "0xmanual-sponsored-broadcast";
+    };
+    try {
+      const queued = await transfer(requesterApp, MANUAL_AGENT, "manual-sponsored");
+      expect(queued.status, await queued.clone().text()).toBe(202);
+      const queuedBody = (await queued.json()) as { data: { id: string; status: string } };
+      expect(queuedBody.data.status).toBe("pending_approval");
+      expect(signCalls).toBe(0);
+
+      let rows = await getDb()
+        .select()
+        .from(sponsoredGasEvents)
+        .where(eq(sponsoredGasEvents.txId, queuedBody.data.id));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ status: "reserved", reservedUsd: "0.500000" });
+
+      const approved = await approverApp.request(
+        `/vault/${MANUAL_AGENT}/approve/${queuedBody.data.id}`,
+        { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+      );
+      expect(approved.status, await approved.clone().text()).toBe(200);
+      expect(signCalls).toBe(1);
+      rows = await getDb()
+        .select()
+        .from(sponsoredGasEvents)
+        .where(eq(sponsoredGasEvents.txId, queuedBody.data.id));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        status: "submitted",
+        reservedUsd: "0.500000",
+        txHash: "0xmanual-sponsored-broadcast",
+      });
+      const [tx] = await getDb()
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, queuedBody.data.id));
+      expect(tx).toMatchObject({ status: "broadcast", txHash: "0xmanual-sponsored-broadcast" });
+      const [approval] = await getDb()
+        .select()
+        .from(approvalQueue)
+        .where(eq(approvalQueue.txId, queuedBody.data.id));
+      expect(approval.status).toBe("approved");
+    } finally {
+      context.vault.signTransaction = originalSign;
+    }
+  });
+
+  it("admits one bounded winner when concurrent mounted requests race the remaining cap", async () => {
+    await getDb()
+      .update(tenantConfigs)
+      .set({
+        gasSponsorshipConfig: {
+          enabled: true,
+          provider: "mock",
+          mode: "erc4337",
+          allowClientSponsorship: true,
+          allowedChainIds: [8453],
+          maxPerTxUsd: 0.5,
+          maxPerWalletDayUsd: 1,
+          maxTenantDayUsd: 1,
+        },
+      })
+      .where(eq(tenantConfigs.tenantId, TENANT_ID));
+    const context = await import("../services/context");
+    const originalSign = context.vault.signTransaction.bind(context.vault);
+    let signCalls = 0;
+    context.vault.signTransaction = async () => {
+      signCalls += 1;
+      return `0xcap-race-${signCalls}`;
+    };
+    try {
+      const responses = await Promise.all([
+        transfer(requesterApp, AUTO_AGENT, "cap-race-a"),
+        transfer(requesterApp, AUTO_AGENT, "cap-race-b"),
+      ]);
+      expect(responses.map((response) => response.status).sort()).toEqual([200, 403]);
+      expect(signCalls).toBe(1);
+      const submitted = (
+        await getDb()
+          .select()
+          .from(sponsoredGasEvents)
+          .where(eq(sponsoredGasEvents.agentId, AUTO_AGENT))
+      ).filter((row) => row.status === "submitted");
+      expect(submitted).toHaveLength(1);
+      expect(submitted[0]?.reservedUsd).toBe("0.500000");
+    } finally {
+      context.vault.signTransaction = originalSign;
+    }
+  });
+});

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -3546,6 +3546,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
 
     let completedResult: string | null = null;
     let completedStatus: "broadcast" | "signed" | null = null;
+    let sponsoredTransferStaged = false;
     try {
       await writeVaultAudit(c, {
         tenantId,
@@ -3564,6 +3565,21 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           policyResults: evaluation.results,
         },
       });
+      if (sponsorshipPayload?.sponsored === true && !solanaRecoveryBinding) {
+        await db.insert(transactions).values({
+          id: actionId,
+          agentId,
+          status: "pending",
+          toAddress: signRequest.to,
+          value: signRequest.value,
+          data: signRequest.data,
+          chainId: signRequest.chainId,
+          actionType: "transfer",
+          actionPayload: storedTransferActionPayload,
+          policyResults: evaluation.results,
+        });
+        sponsoredTransferStaged = true;
+      }
       const reservationError = await recordSponsoredActionIfNeeded({
         sponsorship: sponsorshipPayload,
         tenantId,
@@ -3575,6 +3591,10 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
         status: "reserved",
       });
       if (typeof reservationError === "string") {
+        if (sponsoredTransferStaged) {
+          await db.delete(transactions).where(eq(transactions.id, actionId));
+          sponsoredTransferStaged = false;
+        }
         return c.json<ApiResponse>({ ok: false, error: reservationError }, 403);
       }
       let result: string;
@@ -3841,6 +3861,11 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
         if (!(await markSolanaRecoveryAnchorFailed(actionId, agentId, solanaExecutionToken))) {
           return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
         }
+      } else if (sponsoredTransferStaged) {
+        await db
+          .update(transactions)
+          .set({ status: "failed", policyResults: evaluation.results })
+          .where(and(eq(transactions.id, actionId), eq(transactions.agentId, agentId)));
       } else {
         await db.insert(transactions).values({
           id: actionId,

--- a/packages/api/src/services/gas-sponsorship.ts
+++ b/packages/api/src/services/gas-sponsorship.ts
@@ -11,6 +11,29 @@ import { validateWebhookUrl } from "./webhook-url";
 
 type SponsoredGasChainFamily = "evm" | "solana";
 
+const pgliteReservationTails = new Map<string, Promise<void>>();
+
+function isPGLiteRuntime(): boolean {
+  return process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true";
+}
+
+async function withPGLiteReservationLock<T>(tenantId: string, operation: () => Promise<T>) {
+  if (!isPGLiteRuntime()) return operation();
+  const prior = pgliteReservationTails.get(tenantId) ?? Promise.resolve();
+  let release!: () => void;
+  const tail = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  pgliteReservationTails.set(tenantId, tail);
+  await prior.catch(() => undefined);
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (pgliteReservationTails.get(tenantId) === tail) pgliteReservationTails.delete(tenantId);
+  }
+}
+
 const PROVIDERS = new Set<GasSponsorshipProvider>([
   "custom_evm_paymaster",
   "custom_bundler",
@@ -318,6 +341,7 @@ async function getSponsorshipCapError(input: {
   estimatedUsd: number;
   config: TenantGasSponsorshipConfig;
   db?: Pick<ReturnType<typeof getDb>, "select">;
+  existingReservationUsd?: number;
 }): Promise<string | null> {
   const now = Date.now();
   const dayStart = new Date(now - 24 * 60 * 60 * 1000);
@@ -326,6 +350,7 @@ async function getSponsorshipCapError(input: {
   // `>` so spend exactly at the cap is allowed, matching the platform's spend-cap semantics
   // (policy-engine trade-order/evaluators) shared with the atomic reserve path.
   const estimatedCents = usdToCents(input.estimatedUsd);
+  const existingReservationCents = usdToCents(input.existingReservationUsd ?? 0);
   if (input.config.maxPerWalletDayUsd !== undefined) {
     // Fail closed: the per-wallet cap cannot be enforced without an agent identifier.
     if (!input.agentId) {
@@ -337,7 +362,10 @@ async function getSponsorshipCapError(input: {
       since: dayStart,
       db: input.db,
     });
-    if (usdToCents(walletDaySpend) + estimatedCents > usdToCents(input.config.maxPerWalletDayUsd)) {
+    if (
+      usdToCents(walletDaySpend) - existingReservationCents + estimatedCents >
+      usdToCents(input.config.maxPerWalletDayUsd)
+    ) {
       return "Gas sponsorship wallet daily cap exceeded";
     }
   }
@@ -347,7 +375,10 @@ async function getSponsorshipCapError(input: {
       since: dayStart,
       db: input.db,
     });
-    if (usdToCents(tenantDaySpend) + estimatedCents > usdToCents(input.config.maxTenantDayUsd)) {
+    if (
+      usdToCents(tenantDaySpend) - existingReservationCents + estimatedCents >
+      usdToCents(input.config.maxTenantDayUsd)
+    ) {
       return "Gas sponsorship tenant daily cap exceeded";
     }
   }
@@ -358,7 +389,7 @@ async function getSponsorshipCapError(input: {
       db: input.db,
     });
     if (
-      usdToCents(tenantMonthSpend) + estimatedCents >
+      usdToCents(tenantMonthSpend) - existingReservationCents + estimatedCents >
       usdToCents(input.config.maxTenantMonthUsd)
     ) {
       return "Gas sponsorship tenant monthly cap exceeded";
@@ -436,56 +467,75 @@ export async function reserveSponsoredGasEvent(input: {
   reservedUsd: number;
   metadata?: Record<string, unknown>;
 }): Promise<void | string> {
-  return getDb().transaction(async (tx) => {
-    await tx.execute(
-      sql`select pg_advisory_xact_lock(hashtextextended(${`sponsored_gas:${input.tenantId}`}, 0))`,
-    );
-    const [configRow] = await tx
-      .select({ gasSponsorshipConfig: tenantConfigsTable.gasSponsorshipConfig })
-      .from(tenantConfigsTable)
-      .where(eq(tenantConfigsTable.tenantId, input.tenantId));
-    const config =
-      (configRow?.gasSponsorshipConfig as TenantGasSponsorshipConfig | undefined) ?? {};
-    const capError = await getSponsorshipCapError({
-      tenantId: input.tenantId,
-      agentId: input.agentId,
-      estimatedUsd: input.reservedUsd,
-      config,
-      db: tx,
-    });
-    if (capError) return capError;
-
-    await tx
-      .insert(sponsoredGasEvents)
-      .values({
+  return withPGLiteReservationLock(input.tenantId, () =>
+    getDb().transaction(async (tx) => {
+      if (!isPGLiteRuntime()) {
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${`sponsored_gas:${input.tenantId}`}, 0))`,
+        );
+      }
+      const [configRow] = await tx
+        .select({ gasSponsorshipConfig: tenantConfigsTable.gasSponsorshipConfig })
+        .from(tenantConfigsTable)
+        .where(eq(tenantConfigsTable.tenantId, input.tenantId));
+      const config =
+        (configRow?.gasSponsorshipConfig as TenantGasSponsorshipConfig | undefined) ?? {};
+      const [existingReservation] = await tx
+        .select({
+          actualUsd: sponsoredGasEvents.actualUsd,
+          reservedUsd: sponsoredGasEvents.reservedUsd,
+        })
+        .from(sponsoredGasEvents)
+        .where(
+          and(
+            eq(sponsoredGasEvents.tenantId, input.tenantId),
+            eq(sponsoredGasEvents.txId, input.txId),
+          ),
+        );
+      const capError = await getSponsorshipCapError({
         tenantId: input.tenantId,
         agentId: input.agentId,
-        txId: input.txId,
-        chainFamily: input.chainFamily ?? "evm",
-        chainId: input.chainId ?? null,
-        caip2: input.caip2 ?? null,
-        provider: input.provider,
-        mode: input.mode,
-        status: "reserved",
-        reservedUsd: String(input.reservedUsd),
-        actualUsd: null,
-        metadata: input.metadata ?? {},
-      })
-      .onConflictDoUpdate({
-        target: [sponsoredGasEvents.tenantId, sponsoredGasEvents.txId],
-        targetWhere: sql`${sponsoredGasEvents.txId} is not null`,
-        set: {
+        estimatedUsd: input.reservedUsd,
+        config,
+        db: tx,
+        existingReservationUsd: Number(
+          existingReservation?.actualUsd ?? existingReservation?.reservedUsd ?? 0,
+        ),
+      });
+      if (capError) return capError;
+
+      await tx
+        .insert(sponsoredGasEvents)
+        .values({
+          tenantId: input.tenantId,
+          agentId: input.agentId,
+          txId: input.txId,
+          chainFamily: input.chainFamily ?? "evm",
+          chainId: input.chainId ?? null,
+          caip2: input.caip2 ?? null,
+          provider: input.provider,
+          mode: input.mode,
           status: "reserved",
           reservedUsd: String(input.reservedUsd),
           actualUsd: null,
-          txHash: null,
-          userOperationHash: null,
-          signature: null,
           metadata: input.metadata ?? {},
-          updatedAt: new Date(),
-        },
-      });
-  });
+        })
+        .onConflictDoUpdate({
+          target: [sponsoredGasEvents.tenantId, sponsoredGasEvents.txId],
+          targetWhere: sql`${sponsoredGasEvents.txId} is not null`,
+          set: {
+            status: "reserved",
+            reservedUsd: String(input.reservedUsd),
+            actualUsd: null,
+            txHash: null,
+            userOperationHash: null,
+            signature: null,
+            metadata: input.metadata ?? {},
+            updatedAt: new Date(),
+          },
+        });
+    }),
+  );
 }
 
 export function normalizeGasSpendQuery(input: {


### PR DESCRIPTION
## Summary

- replace gas-sponsorship source-order claims with mounted transfer, approval, signing-fault, audit-fault, replay, and cap-race behavior
- stage sponsored transaction authority before signing and keep reservation/failure state consistent
- serialize PGLite reservations per tenant while production PostgreSQL uses the advisory transaction lock
- make reservation upserts cap-neutral for the same existing sponsorship record

## Local validation

- gas sponsorship suites: 10 pass, 1 explicit real-Postgres skip, 51 assertions
- API typecheck, targeted Biome, public-package metadata, and git diff check: pass

The local environment did not provide PostgreSQL, so the two-connection advisory-lock race remains an exact-head hosted gate. This PR stays draft until that proof and independent review complete.

Closes #735

## Exact lineage

Head: 670dd887875d9cde7d5878671057fda32bcbd059
Base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6