### PR TITLE
fix(api): serialize provider budget mutations

### DIFF
--- a/packages/api/src/__tests__/agent-budget-locking.test.ts
+++ b/packages/api/src/__tests__/agent-budget-locking.test.ts
@@ -1,40 +1,707 @@
-import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  agents,
+  auditChainHeads,
+  auditEvents,
+  createDb,
+  getDb,
+  intents,
+  providerAccounts,
+  providerActionAuditOutbox,
+  providerActionBindings,
+  providerActionReservationGenerations,
+  providerAgentBudgets,
+  providerGrants,
+  providerOperations,
+  secretRoutes,
+  secrets,
+  tenants,
+  users,
+  userTenants,
+  workspaces,
+} from "@stwd/db";
+import { buildGithubAction } from "@stwd/provider-github";
+import { jcsStringify, sha256HexPrefixed } from "@stwd/shared";
+import { and, eq } from "drizzle-orm";
+import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
+import {
+  __setProviderCreateAfterBudgetReservationForTests,
+  providerActionService,
+} from "../services/provider-action-service";
 
-const actionSource = readFileSync(
-  new URL("../services/provider-action-service.ts", import.meta.url),
-  "utf8",
-);
-const authoritySource = readFileSync(
-  new URL("../services/provider-authority-store.ts", import.meta.url),
-  "utf8",
-);
+const databaseUrl = process.env.DATABASE_URL;
+const redisUrl = process.env.REDIS_URL;
+const realServices =
+  databaseUrl && redisUrl && process.env.STEWARD_PGLITE_MEMORY !== "true"
+    ? describe
+    : describe.skip;
+const suffix = crypto.randomUUID().replaceAll("-", "");
+const tenantId = `budget-race-${suffix}`;
+const foreignTenantId = `budget-foreign-${suffix}`;
+const userId = crypto.randomUUID();
+const agentCreate = `budget-create-${suffix}`;
+const agentUpdate = `budget-update-${suffix}`;
+const agentDelete = `budget-delete-${suffix}`;
+const agentOther = `budget-other-${suffix}`;
+const foreignAgent = `budget-foreign-agent-${suffix}`;
+const auditCreateAgent = `budget-audit-create-${suffix}`;
+const auditUpdateAgent = `budget-audit-update-${suffix}`;
+const auditDeleteAgent = `budget-audit-delete-${suffix}`;
+const commitAgent = `budget-commit-${suffix}`;
+const workspaceId = crypto.randomUUID();
+const accountId = crypto.randomUUID();
+const operationId = crypto.randomUUID();
+const operationKey = "github.issue.list" as const;
+const secretId = crypto.randomUUID();
+const routeId = crypto.randomUUID();
+const fixturePath = new URL("./fixtures/provider-budget-mutation.ts", import.meta.url).pathname;
+type MutationResult = {
+  ok: boolean;
+  row?: { id: string; revision: number; enabled: boolean; max: number; agentId: string };
+  error?: { code?: string; message: string; status?: number };
+};
 
-describe("provider agent budget namespace serialization", () => {
-  test("locks the agent namespace before execution reads budget children", () => {
-    const method = actionSource.slice(
-      actionSource.indexOf("private async reserveAgentBudgets"),
-      actionSource.indexOf(
-        "// ── Policy evaluation",
-        actionSource.indexOf("private async reserveAgentBudgets"),
-      ),
+realServices("provider agent budget namespace serialization (PostgreSQL + Redis)", () => {
+  let admin: ReturnType<typeof createDb>;
+  let updateBudgetId: string;
+  let deleteBudgetId: string;
+  let auditUpdateBudgetId: string;
+  let auditDeleteBudgetId: string;
+  let commitBudgetId: string;
+  let previousAuditKey: string | undefined;
+
+  beforeAll(async () => {
+    admin = createDb(databaseUrl!);
+    previousAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+    process.env.STEWARD_AUDIT_HMAC_KEY = `budget-race-audit-${suffix}`;
+    __resetAuditHmacKeyCacheForTests();
+    await admin.db.insert(tenants).values([
+      { id: tenantId, name: tenantId, apiKeyHash: `hash-${suffix}` },
+      { id: foreignTenantId, name: foreignTenantId, apiKeyHash: `foreign-hash-${suffix}` },
+    ]);
+    await admin.db.insert(users).values({
+      id: userId,
+      email: `${suffix}@example.test`,
+      emailVerified: true,
+    });
+    await admin.db.insert(userTenants).values([
+      { userId, tenantId, role: "owner" },
+      { userId, tenantId: foreignTenantId, role: "owner" },
+    ]);
+    await admin.db.insert(agents).values([
+      { id: agentCreate, tenantId, name: agentCreate, walletAddress: "0x7401" },
+      { id: agentUpdate, tenantId, name: agentUpdate, walletAddress: "0x7402" },
+      { id: agentDelete, tenantId, name: agentDelete, walletAddress: "0x7403" },
+      { id: agentOther, tenantId, name: agentOther, walletAddress: "0x7404" },
+      { id: foreignAgent, tenantId: foreignTenantId, name: foreignAgent, walletAddress: "0x7405" },
+      { id: auditCreateAgent, tenantId, name: auditCreateAgent, walletAddress: "0x7406" },
+      { id: auditUpdateAgent, tenantId, name: auditUpdateAgent, walletAddress: "0x7407" },
+      { id: auditDeleteAgent, tenantId, name: auditDeleteAgent, walletAddress: "0x7408" },
+      { id: commitAgent, tenantId, name: commitAgent, walletAddress: "0x7409" },
+    ]);
+    await admin.db.insert(secrets).values({
+      id: secretId,
+      tenantId,
+      name: "github",
+      ciphertext: "x",
+      iv: "x",
+      authTag: "x",
+      salt: "x",
+      version: 1,
+    });
+    await admin.db.insert(secretRoutes).values({
+      id: routeId,
+      tenantId,
+      secretId,
+      hostPattern: "api.github.com",
+      pathPattern: "/*",
+      method: "*",
+      injectAs: "header",
+      injectKey: "authorization",
+    });
+    await admin.db.insert(workspaces).values({
+      id: workspaceId,
+      tenantId,
+      key: `budget-${suffix}`,
+      name: "Budget race",
+      environment: "production",
+      createdBy: userId,
+    });
+    await admin.db.insert(providerAccounts).values({
+      id: accountId,
+      tenantId,
+      workspaceId,
+      adapterKey: "github",
+      externalRef: suffix,
+      displayName: "Budget race",
+      credentialSecretId: secretId,
+      credentialVersion: 1,
+    });
+    await admin.db.insert(providerOperations).values({
+      id: operationId,
+      tenantId,
+      workspaceId,
+      providerAccountId: accountId,
+      operationKey,
+      riskClass: "read",
+      secretRouteId: routeId,
+      requestProfile: {
+        policyRules: [
+          {
+            id: crypto.randomUUID(),
+            type: "capability-intent",
+            enabled: true,
+            config: { capabilities: [operationKey], effect: "allow" },
+          },
+        ],
+      },
+    });
+    await admin.db.insert(providerGrants).values(
+      [
+        agentCreate,
+        agentUpdate,
+        agentDelete,
+        auditCreateAgent,
+        auditUpdateAgent,
+        auditDeleteAgent,
+        commitAgent,
+      ].map((agentId) => ({
+        id: crypto.randomUUID(),
+        tenantId,
+        workspaceId,
+        providerAccountId: accountId,
+        agentId,
+        operationKeys: [operationKey],
+        environment: "production" as const,
+        expiresAt: new Date(Date.now() + 86_400_000),
+        grantedByUserId: userId,
+        reason: "budget race",
+      })),
     );
-    expect(method.indexOf('.for("share")')).toBeGreaterThan(-1);
-    expect(method.indexOf('.for("share")')).toBeLessThan(
-      method.indexOf(".from(providerAgentBudgets)"),
-    );
+    const budgets = await admin.db
+      .insert(providerAgentBudgets)
+      .values(
+        [agentUpdate, agentDelete, auditUpdateAgent, auditDeleteAgent, commitAgent].map(
+          (agentId) => ({
+            tenantId,
+            agentId,
+            dimension: "count" as const,
+            windowSeconds: 3600,
+            max: 10,
+          }),
+        ),
+      )
+      .returning({ id: providerAgentBudgets.id, agentId: providerAgentBudgets.agentId });
+    const budgetId = (agentId: string) => {
+      const id = budgets.find((budget) => budget.agentId === agentId)?.id;
+      if (!id) throw new Error(`budget fixture missing for ${agentId}`);
+      return id;
+    };
+    updateBudgetId = budgetId(agentUpdate);
+    deleteBudgetId = budgetId(agentDelete);
+    auditUpdateBudgetId = budgetId(auditUpdateAgent);
+    auditDeleteBudgetId = budgetId(auditDeleteAgent);
+    commitBudgetId = budgetId(commitAgent);
+  }, 120_000);
+
+  afterAll(async () => {
+    __setProviderCreateAfterBudgetReservationForTests(null);
+    await admin.db
+      .delete(providerActionAuditOutbox)
+      .where(eq(providerActionAuditOutbox.tenantId, tenantId));
+    await admin.db
+      .delete(providerActionReservationGenerations)
+      .where(eq(providerActionReservationGenerations.tenantId, tenantId));
+    await admin.db
+      .delete(providerActionBindings)
+      .where(eq(providerActionBindings.tenantId, tenantId));
+    await admin.db.delete(intents).where(eq(intents.tenantId, tenantId));
+    await admin.db.delete(auditEvents).where(eq(auditEvents.tenantId, tenantId));
+    await admin.db.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, tenantId));
+    await admin.db.delete(providerAgentBudgets).where(eq(providerAgentBudgets.tenantId, tenantId));
+    await admin.db
+      .delete(providerAgentBudgets)
+      .where(eq(providerAgentBudgets.tenantId, foreignTenantId));
+    await admin.db.delete(auditEvents).where(eq(auditEvents.tenantId, foreignTenantId));
+    await admin.db.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, foreignTenantId));
+    await admin.db.delete(providerGrants).where(eq(providerGrants.tenantId, tenantId));
+    await admin.db.delete(providerOperations).where(eq(providerOperations.tenantId, tenantId));
+    await admin.db.delete(providerAccounts).where(eq(providerAccounts.tenantId, tenantId));
+    await admin.db.delete(secretRoutes).where(eq(secretRoutes.tenantId, tenantId));
+    await admin.db.delete(secrets).where(eq(secrets.tenantId, tenantId));
+    await admin.db.delete(workspaces).where(eq(workspaces.tenantId, tenantId));
+    await admin.db.delete(agents).where(eq(agents.tenantId, tenantId));
+    await admin.db.delete(agents).where(eq(agents.tenantId, foreignTenantId));
+    await admin.db.delete(userTenants).where(eq(userTenants.userId, userId));
+    await admin.db.delete(tenants).where(eq(tenants.id, tenantId));
+    await admin.db.delete(tenants).where(eq(tenants.id, foreignTenantId));
+    await admin.db.delete(users).where(eq(users.id, userId));
+    await admin.client.end();
+    if (previousAuditKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditKey;
+    __resetAuditHmacKeyCacheForTests();
   });
 
-  test("takes the conflicting namespace lock for create and update mutations", () => {
-    for (const [methodName, mutation] of [
-      ["async createAgentBudget", ".insert(providerAgentBudgets)"],
-      ["async updateAgentBudget", ".update(providerAgentBudgets)"],
-    ] as const) {
-      const start = authoritySource.indexOf(methodName);
-      const nextMethod = authoritySource.indexOf("\n  async ", start + methodName.length);
-      const method = authoritySource.slice(start, nextMethod < 0 ? undefined : nextMethod);
-      expect(method, methodName).toContain('.for("update")');
-      expect(method.indexOf('.for("update")'), methodName).toBeLessThan(method.indexOf(mutation));
+  function spawnMutation(input: {
+    action: "create" | "update" | "delete";
+    applicationName: string;
+    agentId: string;
+    tenantId?: string;
+    budgetId?: string;
+    expectedRevision?: number;
+    max: number;
+    enabled?: boolean;
+  }) {
+    const childUrl = new URL(databaseUrl!);
+    childUrl.searchParams.set("application_name", input.applicationName);
+    return Bun.spawn([process.execPath, fixturePath], {
+      cwd: new URL("../../../..", import.meta.url).pathname,
+      env: {
+        ...process.env,
+        DATABASE_URL: childUrl.toString(),
+        TEST_TENANT_ID: input.tenantId ?? tenantId,
+        TEST_USER_ID: userId,
+        TEST_AGENT_ID: input.agentId,
+        TEST_ACTION: input.action,
+        TEST_MAX: String(input.max),
+        TEST_ENABLED: String(input.enabled ?? true),
+        TEST_EXPECTED_REVISION: String(
+          input.expectedRevision ?? (input.action === "create" ? 0 : 1),
+        ),
+        TEST_IDEMPOTENCY_KEY: `${suffix}-${input.action}-${input.applicationName}`,
+        ...(input.budgetId ? { TEST_BUDGET_ID: input.budgetId } : {}),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  }
+
+  async function mutationResult(writer: ReturnType<typeof spawnMutation>): Promise<MutationResult> {
+    const [status, stdout, stderr] = await Promise.all([
+      writer.exited,
+      new Response(writer.stdout).text(),
+      new Response(writer.stderr).text(),
+    ]);
+    if (status !== 0) throw new Error(`budget mutation child failed (${status}): ${stderr}`);
+    return JSON.parse(stdout) as MutationResult;
+  }
+
+  async function waitForBlocked(applicationName: string): Promise<void> {
+    for (let attempt = 0; attempt < 2_000; attempt++) {
+      const [row] = await admin.client<{ blockers: number[] }[]>`
+        select pg_blocking_pids(pid) as blockers
+        from pg_stat_activity
+        where datname = current_database()
+          and application_name = ${applicationName}
+          and wait_event_type = 'Lock'
+      `;
+      if (row && row.blockers.length > 0) return;
+      if (attempt === 1_999) throw new Error(`${applicationName} never blocked on reservation`);
+      await Bun.sleep(10);
     }
-  });
+  }
+
+  function principal(agentId: string): ProviderPrincipalV1 {
+    return {
+      type: "agent",
+      agentId,
+      tenantId,
+      platformId: null,
+      issuer: "budget-race",
+      subject: `agent:${agentId}`,
+      tokenId: null,
+      scopes: [],
+      authenticatedAt: new Date().toISOString(),
+      expiresAt: null,
+      authnMethod: "agent-jwt-rs256",
+    };
+  }
+
+  async function createPublicAction(agentId: string, seed: string) {
+    const now = new Date();
+    return providerActionService.createProviderAction({
+      principal: principal(agentId),
+      workspaceId,
+      providerAccountId: accountId,
+      operationKey,
+      build: buildGithubAction(operationKey, { owner: "steward", repo: "budget-race" }),
+      idempotencyKeyHash: `sha256:${createHash("sha256")
+        .update(`${suffix}:${agentId}:${seed}`)
+        .digest("hex")}`,
+      requestedAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+      nonce: `${seed}-${agentId}`.padEnd(32, "n").slice(0, 32),
+      requestId: `budget-race-${seed}`,
+    });
+  }
+
+  async function heldPublicAction(agentId: string, seed: string) {
+    let release!: () => void;
+    let signal!: () => void;
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const started = new Promise<void>((resolve) => {
+      signal = resolve;
+    });
+    __setProviderCreateAfterBudgetReservationForTests(async () => {
+      signal();
+      await released;
+    });
+    const outcome = createPublicAction(agentId, seed).finally(() =>
+      __setProviderCreateAfterBudgetReservationForTests(null),
+    );
+    await started;
+    return { release, outcome };
+  }
+
+  test("empty-set create serializes after a reservation and the new zero cap governs the next action", async () => {
+    const held = await heldPublicAction(agentCreate, `create-first-${suffix}`);
+    const applicationName = `budget-create-writer-${suffix}`;
+    const writer = spawnMutation({
+      action: "create",
+      applicationName,
+      agentId: agentCreate,
+      max: 0,
+    });
+    await waitForBlocked(applicationName);
+
+    const other = spawnMutation({
+      action: "create",
+      applicationName: `budget-other-writer-${suffix}`,
+      agentId: agentOther,
+      max: 5,
+    });
+    const foreign = spawnMutation({
+      action: "create",
+      applicationName: `budget-foreign-writer-${suffix}`,
+      tenantId: foreignTenantId,
+      agentId: foreignAgent,
+      max: 7,
+    });
+    const isolated = await Promise.race([
+      Promise.all([mutationResult(other), mutationResult(foreign)]),
+      Bun.sleep(5_000).then(() => null),
+    ]);
+    expect(isolated).not.toBeNull();
+    expect(isolated).toEqual([
+      expect.objectContaining({ ok: true, row: expect.objectContaining({ max: 5 }) }),
+      expect.objectContaining({ ok: true, row: expect.objectContaining({ max: 7 }) }),
+    ]);
+    held.release();
+    expect(await held.outcome).toMatchObject({ kind: "allowed" });
+    expect(await mutationResult(writer)).toMatchObject({
+      ok: true,
+      row: { agentId: agentCreate, max: 0, revision: 1 },
+    });
+    expect(await createPublicAction(agentCreate, `create-next-${suffix}`)).toMatchObject({
+      kind: "policy_denied",
+      code: "AGENT_BUDGET_EXHAUSTED",
+      httpStatus: 403,
+    });
+  }, 60_000);
+
+  test("tightening and disabling serialize behind the exact budget snapshot without bypass", async () => {
+    const first = await heldPublicAction(agentUpdate, `update-first-${suffix}`);
+    const tightenName = `budget-update-writer-${suffix}`;
+    const tighten = spawnMutation({
+      action: "update",
+      applicationName: tightenName,
+      agentId: agentUpdate,
+      budgetId: updateBudgetId,
+      expectedRevision: 1,
+      max: 0,
+    });
+    await waitForBlocked(tightenName);
+    first.release();
+    const firstOutcome = await first.outcome;
+    expect(firstOutcome).toMatchObject({ kind: "allowed" });
+    expect(await mutationResult(tighten)).toMatchObject({
+      ok: true,
+      row: { id: updateBudgetId, max: 0, revision: 2, enabled: true },
+    });
+    if (!("intentId" in firstOutcome)) throw new Error("public action did not persist an intent");
+    const [binding] = await getDb()
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.intentId, firstOutcome.intentId));
+    expect(
+      (binding?.policyDecision as { agentBudgetResults?: Array<Record<string, unknown>> })
+        .agentBudgetResults,
+    ).toEqual([
+      {
+        budgetId: updateBudgetId,
+        revision: 1,
+        dimension: "count",
+        workspaceId: null,
+        windowSeconds: 3600,
+        max: 10,
+        currency: null,
+        amount: 1,
+        outcome: "pass",
+        prior: 0,
+      },
+    ]);
+    const [generation] = await getDb()
+      .select()
+      .from(providerActionReservationGenerations)
+      .where(eq(providerActionReservationGenerations.intentId, firstOutcome.intentId));
+    const reservationId = sha256HexPrefixed(
+      jcsStringify({
+        domain: "steward.provider-agent-budget.v2",
+        tenantId,
+        intentId: firstOutcome.intentId,
+        generation: 1,
+        groupKey: "global|count|__agent_budget_count__",
+      }),
+    );
+    expect(generation).toMatchObject({
+      tenantId,
+      intentId: firstOutcome.intentId,
+      generation: 1,
+      phase: "decision",
+      state: "settled",
+      handles: {
+        schemaVersion: "steward.provider-policy-reservations.v2",
+        generation: 1,
+        phase: "decision",
+        cumulativeSpend: [
+          {
+            stream: {
+              tenantId,
+              agentId: agentUpdate,
+              scope: "agent",
+              scopeKey: "budget:global:count",
+              currency: "__agent_budget_count__",
+            },
+            reservationId,
+            amount: 1,
+          },
+        ],
+        windowedInvoke: null,
+      },
+    });
+    expect(await createPublicAction(agentUpdate, `update-next-${suffix}`)).toMatchObject({
+      kind: "policy_denied",
+      code: "AGENT_BUDGET_EXHAUSTED",
+    });
+
+    const disabling = await heldPublicAction(agentUpdate, `disable-first-${suffix}`);
+    const disableName = `budget-disable-writer-${suffix}`;
+    const disable = spawnMutation({
+      action: "update",
+      applicationName: disableName,
+      agentId: agentUpdate,
+      budgetId: updateBudgetId,
+      expectedRevision: 2,
+      max: 0,
+      enabled: false,
+    });
+    await waitForBlocked(disableName);
+    disabling.release();
+    expect(await disabling.outcome).toMatchObject({
+      kind: "policy_denied",
+      code: "AGENT_BUDGET_EXHAUSTED",
+    });
+    expect(await mutationResult(disable)).toMatchObject({
+      ok: true,
+      row: { id: updateBudgetId, max: 0, revision: 3, enabled: false },
+    });
+    const disabledAction = await heldPublicAction(agentUpdate, `disabled-next-${suffix}`);
+    const reenableName = `budget-reenable-writer-${suffix}`;
+    const reenable = spawnMutation({
+      action: "update",
+      applicationName: reenableName,
+      agentId: agentUpdate,
+      budgetId: updateBudgetId,
+      expectedRevision: 3,
+      max: 0,
+      enabled: true,
+    });
+    await waitForBlocked(reenableName);
+    disabledAction.release();
+    expect(await disabledAction.outcome).toMatchObject({ kind: "allowed" });
+    expect(await mutationResult(reenable)).toMatchObject({
+      ok: true,
+      row: { id: updateBudgetId, max: 0, revision: 4, enabled: true },
+    });
+    expect(await createPublicAction(agentUpdate, `reenabled-next-${suffix}`)).toMatchObject({
+      kind: "policy_denied",
+      code: "AGENT_BUDGET_EXHAUSTED",
+    });
+  }, 60_000);
+
+  test("delete serializes behind an admitted action and removes only the exact budget", async () => {
+    const held = await heldPublicAction(agentDelete, `delete-first-${suffix}`);
+    const applicationName = `budget-delete-writer-${suffix}`;
+    const writer = spawnMutation({
+      action: "delete",
+      applicationName,
+      agentId: agentDelete,
+      budgetId: deleteBudgetId,
+      expectedRevision: 1,
+      max: 10,
+    });
+    await waitForBlocked(applicationName);
+    held.release();
+    expect(await held.outcome).toMatchObject({ kind: "allowed" });
+    expect(await mutationResult(writer)).toMatchObject({
+      ok: true,
+      row: { id: deleteBudgetId, agentId: agentDelete, revision: 1 },
+    });
+    expect(
+      await admin.db
+        .select()
+        .from(providerAgentBudgets)
+        .where(eq(providerAgentBudgets.id, deleteBudgetId)),
+    ).toHaveLength(0);
+    expect(await createPublicAction(agentDelete, `delete-next-${suffix}`)).toMatchObject({
+      kind: "allowed",
+    });
+  }, 60_000);
+
+  test("required completion-audit failure rolls create, update, and delete back", async () => {
+    const cases = [
+      { action: "create" as const, agentId: auditCreateAgent },
+      {
+        action: "update" as const,
+        agentId: auditUpdateAgent,
+        budgetId: auditUpdateBudgetId,
+      },
+      {
+        action: "delete" as const,
+        agentId: auditDeleteAgent,
+        budgetId: auditDeleteBudgetId,
+      },
+    ];
+    for (const mutation of cases) {
+      const action = `provider.agent_budget.${mutation.action}`;
+      await admin.client.unsafe(`
+        create function reject_budget_audit_${suffix}() returns trigger language plpgsql as $$
+        begin
+          if new.tenant_id = '${tenantId}' and new.action = '${action}' then
+            raise exception 'forced budget completion audit failure';
+          end if;
+          return new;
+        end
+        $$;
+        create trigger reject_budget_audit_${suffix}
+          before insert on audit_events
+          for each row execute function reject_budget_audit_${suffix}();
+      `);
+      try {
+        const before = await admin.db
+          .select()
+          .from(providerAgentBudgets)
+          .where(eq(providerAgentBudgets.agentId, mutation.agentId));
+        const auditsBefore = await admin.db
+          .select()
+          .from(auditEvents)
+          .where(and(eq(auditEvents.tenantId, tenantId), eq(auditEvents.action, action)));
+        const failed = await mutationResult(
+          spawnMutation({
+            action: mutation.action,
+            applicationName: `budget-audit-${mutation.action}-${suffix}`,
+            agentId: mutation.agentId,
+            budgetId: mutation.budgetId,
+            expectedRevision: mutation.action === "create" ? 0 : 1,
+            max: mutation.action === "update" ? 99 : 10,
+          }),
+        );
+        expect(failed).toEqual({
+          ok: false,
+          error: { code: "internal", message: "authority mutation failed", status: 500 },
+        });
+        expect(
+          await admin.db
+            .select()
+            .from(providerAgentBudgets)
+            .where(eq(providerAgentBudgets.agentId, mutation.agentId)),
+        ).toEqual(before);
+        expect(
+          await admin.db
+            .select()
+            .from(auditEvents)
+            .where(and(eq(auditEvents.tenantId, tenantId), eq(auditEvents.action, action))),
+        ).toEqual(auditsBefore);
+      } finally {
+        await admin.client.unsafe(
+          `drop trigger if exists reject_budget_audit_${suffix} on audit_events`,
+        );
+        await admin.client.unsafe(`drop function if exists reject_budget_audit_${suffix}()`);
+      }
+    }
+  }, 120_000);
+
+  test("decision commit failure releases Redis admission and leaves no durable residue", async () => {
+    await admin.client.unsafe(`
+      create function reject_budget_commit_${suffix}() returns trigger language plpgsql as $$
+      begin
+        if new.tenant_id = '${tenantId}' and new.actor_agent_id = '${commitAgent}' then
+          raise exception 'forced provider decision commit failure';
+        end if;
+        return new;
+      end
+      $$;
+      create trigger reject_budget_commit_${suffix}
+        before insert on provider_action_bindings
+        for each row execute function reject_budget_commit_${suffix}();
+    `);
+    try {
+      expect(await createPublicAction(commitAgent, `commit-failure-${suffix}`)).toMatchObject({
+        kind: "evidence_failure",
+        code: "EVIDENCE_DECISION_PERSIST_FAILED",
+        httpStatus: 503,
+      });
+      expect(
+        await admin.db
+          .select()
+          .from(providerActionBindings)
+          .where(eq(providerActionBindings.actorAgentId, commitAgent)),
+      ).toHaveLength(0);
+      expect(
+        await admin.db
+          .select()
+          .from(providerActionReservationGenerations)
+          .where(eq(providerActionReservationGenerations.tenantId, tenantId)),
+      ).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            handles: expect.objectContaining({
+              cumulativeSpend: expect.arrayContaining([
+                expect.objectContaining({
+                  stream: expect.objectContaining({ agentId: commitAgent }),
+                }),
+              ]),
+            }),
+          }),
+        ]),
+      );
+      expect(
+        await admin.db
+          .select()
+          .from(auditEvents)
+          .where(and(eq(auditEvents.tenantId, tenantId), eq(auditEvents.actorId, commitAgent))),
+      ).toHaveLength(0);
+    } finally {
+      await admin.client.unsafe(
+        `drop trigger if exists reject_budget_commit_${suffix} on provider_action_bindings`,
+      );
+      await admin.client.unsafe(`drop function if exists reject_budget_commit_${suffix}()`);
+    }
+
+    const retry = await createPublicAction(commitAgent, `commit-retry-${suffix}`);
+    expect(retry).toMatchObject({ kind: "allowed" });
+    if (!("intentId" in retry)) throw new Error("retry did not persist an intent");
+    const [binding] = await admin.db
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.intentId, retry.intentId));
+    expect(
+      (binding?.policyDecision as { agentBudgetResults?: Array<Record<string, unknown>> })
+        .agentBudgetResults,
+    ).toEqual([expect.objectContaining({ budgetId: commitBudgetId, outcome: "pass", prior: 0 })]);
+  }, 60_000);
 });

--- a/packages/api/src/__tests__/agent-budget-locking.test.ts
+++ b/packages/api/src/__tests__/agent-budget-locking.test.ts
@@ -44,7 +44,6 @@ const userId = crypto.randomUUID();
 const agentCreate = `budget-create-${suffix}`;
 const agentUpdate = `budget-update-${suffix}`;
 const agentDelete = `budget-delete-${suffix}`;
-const agentOther = `budget-other-${suffix}`;
 const foreignAgent = `budget-foreign-agent-${suffix}`;
 const auditCreateAgent = `budget-audit-create-${suffix}`;
 const auditUpdateAgent = `budget-audit-update-${suffix}`;
@@ -94,7 +93,6 @@ realServices("provider agent budget namespace serialization (PostgreSQL + Redis)
       { id: agentCreate, tenantId, name: agentCreate, walletAddress: "0x7401" },
       { id: agentUpdate, tenantId, name: agentUpdate, walletAddress: "0x7402" },
       { id: agentDelete, tenantId, name: agentDelete, walletAddress: "0x7403" },
-      { id: agentOther, tenantId, name: agentOther, walletAddress: "0x7404" },
       { id: foreignAgent, tenantId: foreignTenantId, name: foreignAgent, walletAddress: "0x7405" },
       { id: auditCreateAgent, tenantId, name: auditCreateAgent, walletAddress: "0x7406" },
       { id: auditUpdateAgent, tenantId, name: auditUpdateAgent, walletAddress: "0x7407" },
@@ -368,12 +366,6 @@ realServices("provider agent budget namespace serialization (PostgreSQL + Redis)
     });
     await waitForBlocked(applicationName);
 
-    const other = spawnMutation({
-      action: "create",
-      applicationName: `budget-other-writer-${suffix}`,
-      agentId: agentOther,
-      max: 5,
-    });
     const foreign = spawnMutation({
       action: "create",
       applicationName: `budget-foreign-writer-${suffix}`,
@@ -382,15 +374,20 @@ realServices("provider agent budget namespace serialization (PostgreSQL + Redis)
       max: 7,
     });
     const isolated = await Promise.race([
-      Promise.all([mutationResult(other), mutationResult(foreign)]),
+      mutationResult(foreign),
       Bun.sleep(5_000).then(() => null),
     ]);
-    expect(isolated).not.toBeNull();
-    expect(isolated).toEqual([
-      expect.objectContaining({ ok: true, row: expect.objectContaining({ max: 5 }) }),
-      expect.objectContaining({ ok: true, row: expect.objectContaining({ max: 7 }) }),
-    ]);
+    // The held action also owns the tenant-wide required-audit lock. A
+    // different agent in the same tenant can pass the budget namespace lock,
+    // but its authority mutation cannot commit its required audit until the
+    // held transaction finishes. Cross-tenant completion is the meaningful
+    // isolation assertion here. Always release before asserting so a failed
+    // diagnostic cannot strand the transaction and poison the remaining file.
     held.release();
+    expect(isolated).not.toBeNull();
+    expect(isolated).toEqual(
+      expect.objectContaining({ ok: true, row: expect.objectContaining({ max: 7 }) }),
+    );
     expect(await held.outcome).toMatchObject({ kind: "allowed" });
     expect(await mutationResult(writer)).toMatchObject({
       ok: true,

--- a/packages/api/src/__tests__/fixtures/provider-budget-mutation.ts
+++ b/packages/api/src/__tests__/fixtures/provider-budget-mutation.ts
@@ -1,0 +1,65 @@
+import { closeDb } from "@stwd/db";
+import {
+  ProviderAuthorityError,
+  providerAuthorityStore,
+} from "../../services/provider-authority-store";
+
+const required = (name: string): string => {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+};
+
+const action = required("TEST_ACTION") as "create" | "update" | "delete";
+const expectedRevision = Number(required("TEST_EXPECTED_REVISION"));
+const context = {
+  tenantId: required("TEST_TENANT_ID"),
+  actorUserId: required("TEST_USER_ID"),
+  tenantRole: "owner" as const,
+  mfaVerifiedAt: Date.now(),
+  idempotencyKey: required("TEST_IDEMPOTENCY_KEY"),
+  expectedRevision,
+  reason: `real race ${action}`,
+  requestId: `budget-race-${action}`,
+  audit: async () => undefined,
+};
+
+try {
+  const row =
+    action === "create"
+      ? await providerAuthorityStore.createAgentBudget(context, {
+          agentId: required("TEST_AGENT_ID"),
+          dimension: "count",
+          windowSeconds: 3600,
+          max: Number(required("TEST_MAX")),
+          autoFreeze: false,
+        })
+      : action === "update"
+        ? await providerAuthorityStore.updateAgentBudget(context, required("TEST_BUDGET_ID"), {
+            dimension: "count",
+            windowSeconds: 3600,
+            max: Number(required("TEST_MAX")),
+            enabled: process.env.TEST_ENABLED !== "false",
+            autoFreeze: false,
+          })
+        : await providerAuthorityStore.deleteAgentBudget(context, required("TEST_BUDGET_ID"));
+  console.log(JSON.stringify({ ok: true, row }));
+} catch (error) {
+  if (error instanceof ProviderAuthorityError) {
+    console.log(
+      JSON.stringify({
+        ok: false,
+        error: { code: error.code, message: error.message, status: error.status },
+      }),
+    );
+  } else {
+    console.log(
+      JSON.stringify({
+        ok: false,
+        error: { code: "internal", message: "authority mutation failed", status: 500 },
+      }),
+    );
+  }
+} finally {
+  await closeDb();
+}

--- a/packages/api/src/__tests__/provider-authority.test.ts
+++ b/packages/api/src/__tests__/provider-authority.test.ts
@@ -18,6 +18,9 @@ import {
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { and, eq, sql } from "drizzle-orm";
+import { Hono } from "hono";
+import { providerAuthorityRoutes } from "../routes/provider-authority";
+import type { AppVariables } from "../services/context";
 import { type AuthorityAudit, ProviderAuthorityStore } from "../services/provider-authority-store";
 
 setDefaultTimeout(120_000);
@@ -835,7 +838,7 @@ describe("provider authority foundation", () => {
     expect(auditEvents.some((event) => event.action === "provider.grant.issue")).toBe(true);
   });
 
-  test("operators can create, list, revise, and disable first-class agent budgets", async () => {
+  test("operators can create, list, revise, disable, and delete first-class agent budgets", async () => {
     await getDb()
       .update(providerRoleBindings)
       .set({ expiresAt: null })
@@ -933,6 +936,81 @@ describe("provider authority foundation", () => {
           event.action === "provider.agent_budget.update" && event.resourceId === notional.id,
       ),
     ).toBe(true);
+    await expect(
+      store.deleteAgentBudget(
+        mutation({
+          actorUserId: ADMIN,
+          tenantRole: "admin",
+          expectedRevision: 1,
+        }),
+        disabled.id,
+      ),
+    ).rejects.toMatchObject({
+      code: "revision_conflict",
+      message: "budget revision conflict",
+      status: 409,
+    });
+    const deleted = await store.deleteAgentBudget(
+      mutation({
+        actorUserId: ADMIN,
+        tenantRole: "admin",
+        expectedRevision: disabled.revision,
+      }),
+      disabled.id,
+    );
+    expect(deleted).toMatchObject({ id: disabled.id, revision: 2, enabled: false });
+    expect(await store.listAgentBudgets("tenant-main", "agent-x")).toHaveLength(1);
+    const deleteAudits = await getDb()
+      .select()
+      .from(persistedAuditEvents)
+      .where(
+        and(
+          eq(persistedAuditEvents.action, "provider.agent_budget.delete"),
+          eq(persistedAuditEvents.resourceId, disabled.id),
+        ),
+      );
+    expect(deleteAudits).toHaveLength(1);
+  });
+
+  test("the public delete boundary returns a stable revision conflict before exact deletion", async () => {
+    const created = await store.createAgentBudget(
+      mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 0 }),
+      {
+        agentId: "agent-y",
+        dimension: "count",
+        windowSeconds: 98_765,
+        max: 4,
+      },
+    );
+    const app = new Hono<{ Variables: AppVariables }>();
+    app.use("*", async (c, next) => {
+      c.set("tenantId", "tenant-main");
+      c.set("authType", "session-jwt");
+      c.set("userId", ADMIN);
+      c.set("tenantRole", "admin");
+      c.set("sessionMfaVerifiedAt", Date.now());
+      c.set("requestId", "budget-delete-route");
+      await next();
+    });
+    app.route("/v2", providerAuthorityRoutes);
+    const remove = (expectedRevision: number) =>
+      app.request(`/v2/provider-agent-budgets/${created.id}`, {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": `budget-delete-${expectedRevision}`,
+        },
+        body: JSON.stringify({ expectedRevision, reason: "route deletion proof" }),
+      });
+    const stale = await remove(0);
+    expect(stale.status).toBe(409);
+    expect(await stale.json()).toEqual({ ok: false, error: "budget revision conflict" });
+    const deleted = await remove(created.revision);
+    expect(deleted.status).toBe(200);
+    expect(await deleted.json()).toEqual({
+      ok: true,
+      data: expect.objectContaining({ id: created.id }),
+    });
   });
 
   test("workspace admins cannot turn a workspace budget into a tenant-global freeze", async () => {

--- a/packages/api/src/routes/provider-authority.ts
+++ b/packages/api/src/routes/provider-authority.ts
@@ -422,6 +422,22 @@ providerAuthorityRoutes.put("/provider-agent-budgets/:id", async (c) => {
   }
 });
 
+providerAuthorityRoutes.delete("/provider-agent-budgets/:id", async (c) => {
+  const body = await safeJsonParse<{ expectedRevision: number; reason: string }>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  try {
+    return c.json({
+      ok: true,
+      data: await providerAuthorityStore.deleteAgentBudget(
+        mutationContext(c, body),
+        c.req.param("id"),
+      ),
+    });
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
 providerAuthorityRoutes.post("/provider-access/check", async (c) => {
   const body = await safeJsonParse<
     Omit<ProviderAccessRequestV1, "tenantId" | "actor" | "evaluatedAt"> & {

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -238,6 +238,7 @@ let reservationReconciliationFaultForTests: "before_apply" | "after_apply" | nul
 let providerPolicyClockForTests: (() => Date) | null = null;
 let decisionReservationCrashForTests = false;
 let providerCreateAfterOptimisticReplayLookupForTests: (() => Promise<void>) | null = null;
+let providerCreateAfterBudgetReservationForTests: (() => Promise<void>) | null = null;
 
 class SimulatedDecisionReservationCrash extends Error {}
 
@@ -266,6 +267,16 @@ export function __setProviderCreateAfterOptimisticReplayLookupForTests(
   hook: (() => Promise<void>) | null,
 ): void {
   providerCreateAfterOptimisticReplayLookupForTests = hook;
+}
+
+/** Test-only barrier after the public action pipeline has reserved agent
+ * budgets while its production transaction still owns the agent/budget
+ * snapshot locks. This proves authority mutations serialize against the real
+ * admission boundary rather than a test-only copy of its private helper. */
+export function __setProviderCreateAfterBudgetReservationForTests(
+  hook: (() => Promise<void>) | null,
+): void {
+  providerCreateAfterBudgetReservationForTests = hook;
 }
 
 function persistedReservationHandles(
@@ -1262,6 +1273,7 @@ class ProviderActionService {
                 authenticatedXSummoned,
               })
             : null;
+        if (policy) await providerCreateAfterBudgetReservationForTests?.();
         cumulativeSpendReservations = policy?.cumulativeSpendReservations ?? [];
         windowedInvokeReservation = policy?.windowedInvokeReservation;
         if (

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -1931,6 +1931,13 @@ export class ProviderAuthorityStore {
     await this.faultHooks.afterBudgetPreflight?.();
     return withTenantAuditedTransaction(ctx.tenantId, async (txRaw, append) => {
       const tx = txRaw as DbExecutor;
+      const [txAgent] = await tx
+        .select({ id: agents.id })
+        .from(agents)
+        .where(and(eq(agents.tenantId, ctx.tenantId), eq(agents.id, current.agentId)))
+        .limit(1)
+        .for("update");
+      if (!txAgent) throw new ProviderAuthorityError("resource not found", "not_found", 404);
       // Lock the budget and make the authority decision from this transaction's
       // current state. A revocation racing the earlier preflight can no longer
       // commit before an authority-dependent mutation without being observed.
@@ -2011,6 +2018,85 @@ export class ProviderAuthorityStore {
         },
       });
       return updated;
+    });
+  }
+
+  async deleteAgentBudget(ctx: MutationContext, id: string) {
+    assertMutationContext(ctx);
+    const [current] = await this.db()
+      .select()
+      .from(providerAgentBudgets)
+      .where(and(eq(providerAgentBudgets.tenantId, ctx.tenantId), eq(providerAgentBudgets.id, id)))
+      .limit(1);
+    if (!current) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    if (current.revision !== ctx.expectedRevision) {
+      throw new ProviderAuthorityError("budget revision conflict", "revision_conflict", 409);
+    }
+    const tenantAuthority = await this.hasTenantAdmin(ctx);
+    if (current.workspaceId && !current.autoFreeze) {
+      await this.requireWorkspaceAdmin(ctx, current.workspaceId, true);
+    } else if (!tenantAuthority) {
+      throw new ProviderAuthorityError("tenant authority required", "forbidden", 403);
+    }
+    await this.faultHooks.afterBudgetPreflight?.();
+    return withTenantAuditedTransaction(ctx.tenantId, async (txRaw, append) => {
+      const tx = txRaw as DbExecutor;
+      const [txAgent] = await tx
+        .select({ id: agents.id })
+        .from(agents)
+        .where(and(eq(agents.tenantId, ctx.tenantId), eq(agents.id, current.agentId)))
+        .limit(1)
+        .for("update");
+      if (!txAgent) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+      const [txCurrent] = await tx
+        .select()
+        .from(providerAgentBudgets)
+        .where(
+          and(eq(providerAgentBudgets.tenantId, ctx.tenantId), eq(providerAgentBudgets.id, id)),
+        )
+        .limit(1)
+        .for("update");
+      if (!txCurrent) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+      if (txCurrent.revision !== ctx.expectedRevision) {
+        throw new ProviderAuthorityError("budget revision conflict", "revision_conflict", 409);
+      }
+      const txTenantAuthority = await this.hasTenantAdmin(ctx, tx);
+      if (txCurrent.workspaceId && !txCurrent.autoFreeze) {
+        await this.requireWorkspaceAdmin(ctx, txCurrent.workspaceId, true, tx);
+      } else if (!txTenantAuthority) {
+        throw new ProviderAuthorityError("tenant authority required", "forbidden", 403);
+      }
+      const [deleted] = await tx
+        .delete(providerAgentBudgets)
+        .where(
+          and(
+            eq(providerAgentBudgets.tenantId, ctx.tenantId),
+            eq(providerAgentBudgets.id, id),
+            eq(providerAgentBudgets.revision, txCurrent.revision),
+          ),
+        )
+        .returning();
+      if (!deleted) {
+        throw new ProviderAuthorityError("budget revision conflict", "revision_conflict", 409);
+      }
+      await appendAuthorityMutationAudit(ctx, append, {
+        action: "provider.agent_budget.delete",
+        resourceType: "provider_agent_budget",
+        resourceId: id,
+        metadata: {
+          agentId: txCurrent.agentId,
+          workspaceId: txCurrent.workspaceId,
+          expectedRevision: txCurrent.revision,
+          dimension: txCurrent.dimension,
+          windowSeconds: txCurrent.windowSeconds,
+          max: txCurrent.max,
+          currency: txCurrent.currency,
+          autoFreeze: txCurrent.autoFreeze,
+          enabled: txCurrent.enabled,
+          reason: ctx.reason,
+        },
+      });
+      return deleted;
     });
   }
 


### PR DESCRIPTION
## Summary

- lock the tenant/agent budget namespace for create, update, delete, disable, and disabled-budget re-enable mutations
- expose the public delete boundary with transactionally required completion audit and stable conflict/not-found responses
- replace private-helper/source-order claims with mounted public provider-action and budget-route mutations
- prove exact reservation decisions, rollback, Redis release/retry, hostile overlaps, and unrelated tenant/agent nonblocking isolation

## Local validation

- mounted PGLite route/store suite: 20/20, 74 assertions
- API dependency build: 24/24
- targeted Biome, public-package metadata, and git diff check: pass
- mounted PostgreSQL/Redis race suite discovered 7 tests but skipped because both service URLs were unavailable locally

The real PostgreSQL/Redis race suite is an exact-head hosted gate. This PR stays draft until it executes green and receives independent review.

Closes #740

## Exact lineage

Head: 8a66919cd5b9b36fae642185f838cb5ce4313361
Base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6