### PR TITLE
fix(api): make approval mutations audit-atomic

### DIFF
--- a/packages/api/src/__tests__/approval-generic-decision-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/approval-generic-decision-postgres.integration.test.ts
@@ -1,0 +1,272 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { generateApiKey } from "@stwd/auth";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  agents,
+  approvalQueue,
+  auditChainHeads,
+  auditEvents,
+  createDb,
+  tenants,
+  transactions,
+  users,
+  userTenants,
+} from "@stwd/db";
+import { and, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { correlationId } from "../middleware/correlation";
+import type { AppVariables } from "../services/context";
+
+const databaseUrl = process.env.DATABASE_URL;
+const realPostgres = databaseUrl && !process.env.STEWARD_PGLITE_MEMORY ? describe : describe.skip;
+const suffix = crypto.randomUUID().replaceAll("-", "");
+const tenantId = `approval-decision-${suffix}`;
+const userId = crypto.randomUUID();
+const agentId = `approval-agent-${suffix}`;
+const txId = `approval-tx-${suffix}`;
+const approvalId = `approval-entry-${suffix}`;
+const fixturePath = new URL("./fixtures/approval-generic-deny-request.ts", import.meta.url)
+  .pathname;
+
+type WriterResult = { status: number; body: { ok: boolean; error?: string } };
+
+realPostgres("generic approval decision races (mounted PostgreSQL)", () => {
+  let admin: ReturnType<typeof createDb>;
+  let app: Hono<{ Variables: AppVariables }>;
+  let token: string;
+  let previousJwtSecret: string | undefined;
+  let previousMasterPassword: string | undefined;
+  let previousAuditKey: string | undefined;
+
+  beforeAll(async () => {
+    admin = createDb(databaseUrl!);
+    previousJwtSecret = process.env.STEWARD_JWT_SECRET;
+    previousMasterPassword = process.env.STEWARD_MASTER_PASSWORD;
+    previousAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+    process.env.STEWARD_JWT_SECRET = `approval-decision-jwt-${suffix}`;
+    process.env.STEWARD_MASTER_PASSWORD = `approval-decision-master-${suffix}`;
+    process.env.STEWARD_AUDIT_HMAC_KEY = `approval-decision-audit-${suffix}`;
+    __resetAuditHmacKeyCacheForTests();
+
+    const apiKey = generateApiKey();
+    await admin.db
+      .insert(tenants)
+      .values({ id: tenantId, name: tenantId, apiKeyHash: apiKey.hash });
+    await admin.db.insert(users).values({
+      id: userId,
+      email: `${suffix}@example.test`,
+      emailVerified: true,
+    });
+    await admin.db.insert(userTenants).values({ userId, tenantId, role: "owner" });
+    await admin.db.insert(agents).values({
+      id: agentId,
+      tenantId,
+      name: agentId,
+      walletAddress: "0x0000000000000000000000000000000000000737",
+    });
+
+    const [{ createSessionToken }, { tenantAuth }, { approvalRoutes }] = await Promise.all([
+      import("../routes/auth"),
+      import("../services/context"),
+      import("../routes/approvals"),
+    ]);
+    token = await createSessionToken("0x0000000000000000000000000000000000000737", tenantId, {
+      userId,
+      tenantId,
+      mfaVerifiedAt: Date.now(),
+      mfaMethod: "totp",
+    });
+    app = new Hono<{ Variables: AppVariables }>();
+    app.onError((error, c) => c.json({ ok: false, error: error.message }, 500));
+    app.use("*", correlationId);
+    app.use("*", tenantAuth);
+    app.route("/approvals", approvalRoutes);
+  }, 120_000);
+
+  afterEach(async () => {
+    await admin.db.delete(approvalQueue).where(eq(approvalQueue.agentId, agentId));
+    await admin.db.delete(transactions).where(eq(transactions.agentId, agentId));
+    await admin.db.delete(auditEvents).where(eq(auditEvents.tenantId, tenantId));
+    await admin.db.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, tenantId));
+  });
+
+  afterAll(async () => {
+    await admin.db.delete(approvalQueue).where(eq(approvalQueue.agentId, agentId));
+    await admin.db.delete(transactions).where(eq(transactions.agentId, agentId));
+    await admin.db.delete(auditEvents).where(eq(auditEvents.tenantId, tenantId));
+    await admin.db.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, tenantId));
+    await admin.db.delete(agents).where(eq(agents.id, agentId));
+    await admin.db.delete(userTenants).where(eq(userTenants.tenantId, tenantId));
+    await admin.db.delete(tenants).where(eq(tenants.id, tenantId));
+    await admin.db.delete(users).where(eq(users.id, userId));
+    await admin.client.end();
+    if (previousJwtSecret === undefined) delete process.env.STEWARD_JWT_SECRET;
+    else process.env.STEWARD_JWT_SECRET = previousJwtSecret;
+    if (previousMasterPassword === undefined) delete process.env.STEWARD_MASTER_PASSWORD;
+    else process.env.STEWARD_MASTER_PASSWORD = previousMasterPassword;
+    if (previousAuditKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditKey;
+    __resetAuditHmacKeyCacheForTests();
+  });
+
+  async function seedPending(): Promise<void> {
+    await admin.db.insert(transactions).values({
+      id: txId,
+      agentId,
+      status: "pending",
+      toAddress: "0x0000000000000000000000000000000000000001",
+      value: "1",
+      chainId: 8453,
+    });
+    await admin.db
+      .insert(approvalQueue)
+      .values({ id: approvalId, txId, agentId, status: "pending" });
+  }
+
+  function spawnDeny(requestId: string, applicationName: string) {
+    const writerDatabaseUrl = new URL(databaseUrl!);
+    writerDatabaseUrl.searchParams.set("application_name", applicationName);
+    return Bun.spawn([process.execPath, fixturePath], {
+      cwd: new URL("../../../..", import.meta.url).pathname,
+      env: {
+        ...process.env,
+        DATABASE_URL: writerDatabaseUrl.toString(),
+        TEST_TENANT_ID: tenantId,
+        TEST_USER_ID: userId,
+        TEST_TX_ID: txId,
+        TEST_REQUEST_ID: requestId,
+        TEST_DENY_REASON: "concurrent denial",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  }
+
+  async function writerResult(writer: ReturnType<typeof spawnDeny>): Promise<WriterResult> {
+    const [status, stdout, stderr] = await Promise.all([
+      writer.exited,
+      new Response(writer.stdout).text(),
+      new Response(writer.stderr).text(),
+    ]);
+    if (status !== 0) throw new Error(`concurrent denial failed (${status}): ${stderr}`);
+    return JSON.parse(stdout) as WriterResult;
+  }
+
+  async function waitForAuditWaiter(applicationName: string, blockerPid: number): Promise<void> {
+    for (let attempt = 0; attempt < 2_000; attempt++) {
+      const [row] = await admin.client<{ blocker_pids: number[] }[]>`
+        select pg_blocking_pids(activity.pid) as blocker_pids
+        from pg_stat_activity activity
+        join pg_locks lock on lock.pid = activity.pid
+        where activity.datname = current_database()
+          and activity.application_name = ${applicationName}
+          and activity.wait_event = 'advisory'
+          and lock.locktype = 'advisory'
+          and not lock.granted
+          and lock.classid::bigint =
+            ((hashtextextended(${`steward_audit_${tenantId}`}, 0) >> 32) & 4294967295)
+          and lock.objid::bigint =
+            (hashtextextended(${`steward_audit_${tenantId}`}, 0) & 4294967295)
+          and lock.objsubid = 1
+      `;
+      if (row?.blocker_pids.includes(blockerPid)) return;
+      if (attempt === 1_999) throw new Error("denial never reached tenant audit lock");
+      await Bun.sleep(10);
+    }
+  }
+
+  async function approve(): Promise<Response> {
+    return app.request(`/approvals/${txId}/approve`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-Request-Id": `approve-${suffix}`,
+      },
+      body: "{}",
+    });
+  }
+
+  async function completionAudits() {
+    return admin.db
+      .select()
+      .from(auditEvents)
+      .where(and(eq(auditEvents.tenantId, tenantId), eq(auditEvents.action, "approval.deny")));
+  }
+
+  test("concurrent generic approve is a stable loser and denial commits one coherent decision", async () => {
+    await seedPending();
+    const blocker = await admin.client.reserve();
+    const [{ pid: blockerPid }] = await blocker<{ pid: number }[]>`select pg_backend_pid() as pid`;
+    await blocker`select pg_advisory_lock(hashtextextended(${`steward_audit_${tenantId}`}, 0))`;
+    const applicationName = `approval-deny-${suffix}`;
+    const deny = spawnDeny(`deny-${suffix}`, applicationName);
+    try {
+      await waitForAuditWaiter(applicationName, blockerPid);
+      const approveResponse = await approve();
+      expect(approveResponse.status).toBe(409);
+      const [queueBefore] = await admin.db
+        .select()
+        .from(approvalQueue)
+        .where(eq(approvalQueue.id, approvalId));
+      const [txBefore] = await admin.db
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, txId));
+      expect({ queue: queueBefore?.status, transaction: txBefore?.status }).toEqual({
+        queue: "pending",
+        transaction: "pending",
+      });
+    } finally {
+      await blocker`select pg_advisory_unlock(hashtextextended(${`steward_audit_${tenantId}`}, 0))`;
+      blocker.release();
+    }
+    expect((await writerResult(deny)).status).toBe(200);
+    const [queue] = await admin.db
+      .select()
+      .from(approvalQueue)
+      .where(eq(approvalQueue.id, approvalId));
+    const [transaction] = await admin.db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, txId));
+    expect({ queue: queue?.status, transaction: transaction?.status }).toEqual({
+      queue: "rejected",
+      transaction: "rejected",
+    });
+    expect(await completionAudits()).toHaveLength(1);
+  }, 60_000);
+
+  test("a terminal transaction race rolls denial back without splitting queue state", async () => {
+    await seedPending();
+    const blocker = await admin.client.reserve();
+    const [{ pid: blockerPid }] = await blocker<{ pid: number }[]>`select pg_backend_pid() as pid`;
+    await blocker`select pg_advisory_lock(hashtextextended(${`steward_audit_${tenantId}`}, 0))`;
+    const applicationName = `approval-terminal-${suffix}`;
+    const deny = spawnDeny(`terminal-${suffix}`, applicationName);
+    try {
+      await waitForAuditWaiter(applicationName, blockerPid);
+      await admin.db
+        .update(transactions)
+        .set({ status: "confirmed" })
+        .where(eq(transactions.id, txId));
+    } finally {
+      await blocker`select pg_advisory_unlock(hashtextextended(${`steward_audit_${tenantId}`}, 0))`;
+      blocker.release();
+    }
+    expect((await writerResult(deny)).status).toBe(409);
+    const [queue] = await admin.db
+      .select()
+      .from(approvalQueue)
+      .where(eq(approvalQueue.id, approvalId));
+    const [transaction] = await admin.db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, txId));
+    expect({ queue: queue?.status, transaction: transaction?.status }).toEqual({
+      queue: "pending",
+      transaction: "confirmed",
+    });
+    expect(await completionAudits()).toHaveLength(0);
+  }, 60_000);
+});

--- a/packages/api/src/__tests__/approval-rule-audit-atomicity-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/approval-rule-audit-atomicity-postgres.integration.test.ts
@@ -136,12 +136,14 @@ realPostgres("auto-approval rule audit atomicity (mounted Postgres)", () => {
     });
   }
 
-  function spawnWriter(body: Record<string, unknown>, requestId: string) {
+  function spawnWriter(body: Record<string, unknown>, requestId: string, applicationName: string) {
+    const writerDatabaseUrl = new URL(databaseUrl!);
+    writerDatabaseUrl.searchParams.set("application_name", applicationName);
     return Bun.spawn([process.execPath, fixturePath], {
       cwd: new URL("../../../..", import.meta.url).pathname,
       env: {
         ...process.env,
-        DATABASE_URL: databaseUrl!,
+        DATABASE_URL: writerDatabaseUrl.toString(),
         TEST_TENANT_ID: tenantId,
         TEST_USER_ID: userId,
         TEST_REQUEST_ID: requestId,
@@ -162,17 +164,57 @@ realPostgres("auto-approval rule audit atomicity (mounted Postgres)", () => {
     return JSON.parse(stdout) as WriterResult;
   }
 
-  async function waitForAdvisoryWaiters(minimum: number, message: string): Promise<void> {
+  async function waitForNamedTenantAuditWaiter(
+    applicationName: string,
+    blockerPids: number[],
+    message: string,
+  ): Promise<number> {
     for (let attempt = 0; attempt < 2_000; attempt++) {
-      const [row] = await admin.client<{ count: string }[]>`
-        select count(*)::text as count
-        from pg_stat_activity
-        where datname = current_database() and wait_event = 'advisory'
+      const [row] = await admin.client<{ pid: number; blocker_pids: number[] }[]>`
+        select activity.pid, pg_blocking_pids(activity.pid) as blocker_pids
+        from pg_stat_activity activity
+        join pg_locks lock on lock.pid = activity.pid
+        where activity.datname = current_database()
+          and activity.application_name = ${applicationName}
+          and activity.wait_event = 'advisory'
+          and lock.locktype = 'advisory'
+          and not lock.granted
+          and lock.classid::bigint =
+            ((hashtextextended(${`steward_audit_${tenantId}`}, 0) >> 32) & 4294967295)
+          and lock.objid::bigint =
+            (hashtextextended(${`steward_audit_${tenantId}`}, 0) & 4294967295)
+          and lock.objsubid = 1
       `;
-      if (Number(row?.count ?? "0") >= minimum) return;
+      if (row && blockerPids.some((pid) => row.blocker_pids.includes(pid))) return row.pid;
       if (attempt === 1_999) throw new Error(message);
       await Bun.sleep(10);
     }
+    throw new Error(message);
+  }
+
+  async function waitForExactBigintAdvisoryWaiter(
+    gateKey: number,
+    blockerPid: number,
+    message: string,
+  ): Promise<number> {
+    for (let attempt = 0; attempt < 2_000; attempt++) {
+      const [row] = await admin.client<{ pid: number; blocker_pids: number[] }[]>`
+        select activity.pid, pg_blocking_pids(activity.pid) as blocker_pids
+        from pg_stat_activity activity
+        join pg_locks lock on lock.pid = activity.pid
+        where activity.datname = current_database()
+          and activity.wait_event = 'advisory'
+          and lock.locktype = 'advisory'
+          and not lock.granted
+          and lock.classid::bigint = ((${gateKey}::bigint >> 32) & 4294967295)
+          and lock.objid::bigint = (${gateKey}::bigint & 4294967295)
+          and lock.objsubid = 1
+      `;
+      if (row?.blocker_pids.includes(blockerPid)) return row.pid;
+      if (attempt === 1_999) throw new Error(message);
+      await Bun.sleep(10);
+    }
+    throw new Error(message);
   }
 
   async function installBlockingAuditFailure(input: {
@@ -222,6 +264,14 @@ realPostgres("auto-approval rule audit atomicity (mounted Postgres)", () => {
 
   async function lockTenantAudit(locker: Awaited<ReturnType<typeof admin.client.reserve>>) {
     await locker`select pg_advisory_lock(hashtextextended(${`steward_audit_${tenantId}`}, 0))`;
+  }
+
+  async function backendPid(
+    connection: Awaited<ReturnType<typeof admin.client.reserve>>,
+  ): Promise<number> {
+    const [row] = await connection<{ pid: number }[]>`select pg_backend_pid() as pid`;
+    if (!row) throw new Error("reserved Postgres connection has no backend PID");
+    return row.pid;
   }
 
   async function unlockTenantAudit(locker: Awaited<ReturnType<typeof admin.client.reserve>>) {
@@ -299,15 +349,34 @@ realPostgres("auto-approval rule audit atomicity (mounted Postgres)", () => {
   test("successful create-vs-create pairs authoritative authorization and completion audits", async () => {
     const firstRequestId = `create-pair-a-${suffix}`;
     const secondRequestId = `create-pair-b-${suffix}`;
+    const firstApplicationName = `approval-rule-create-a-${suffix}`;
+    const secondApplicationName = `approval-rule-create-b-${suffix}`;
     const locker = await admin.client.reserve();
     let locked = false;
     try {
       await lockTenantAudit(locker);
       locked = true;
-      const firstWriter = spawnWriter({ maxAmountWei: "111" }, firstRequestId);
-      await waitForAdvisoryWaiters(1, "first create did not reach the tenant audit lock");
-      const secondWriter = spawnWriter({ maxAmountWei: "222" }, secondRequestId);
-      await waitForAdvisoryWaiters(2, "second create did not reach the tenant audit lock");
+      const lockerPid = await backendPid(locker);
+      const firstWriter = spawnWriter(
+        { maxAmountWei: "111" },
+        firstRequestId,
+        firstApplicationName,
+      );
+      const firstWriterPid = await waitForNamedTenantAuditWaiter(
+        firstApplicationName,
+        [lockerPid],
+        "first create did not reach the tenant audit lock behind its holder",
+      );
+      const secondWriter = spawnWriter(
+        { maxAmountWei: "222" },
+        secondRequestId,
+        secondApplicationName,
+      );
+      await waitForNamedTenantAuditWaiter(
+        secondApplicationName,
+        [lockerPid, firstWriterPid],
+        "second create did not reach the tenant audit lock behind the holder or first writer",
+      );
       await unlockTenantAudit(locker);
       locked = false;
 
@@ -352,15 +421,30 @@ realPostgres("auto-approval rule audit atomicity (mounted Postgres)", () => {
       .returning();
     const firstRequestId = `update-pair-a-${suffix}`;
     const secondRequestId = `update-pair-b-${suffix}`;
+    const firstApplicationName = `approval-rule-update-a-${suffix}`;
+    const secondApplicationName = `approval-rule-update-b-${suffix}`;
     const locker = await admin.client.reserve();
     let locked = false;
     try {
       await lockTenantAudit(locker);
       locked = true;
-      const firstWriter = spawnWriter({ maxAmountWei: "111" }, firstRequestId);
-      await waitForAdvisoryWaiters(1, "first update did not reach the tenant audit lock");
-      const secondWriter = spawnWriter({ enabled: false }, secondRequestId);
-      await waitForAdvisoryWaiters(2, "second update did not reach the tenant audit lock");
+      const lockerPid = await backendPid(locker);
+      const firstWriter = spawnWriter(
+        { maxAmountWei: "111" },
+        firstRequestId,
+        firstApplicationName,
+      );
+      const firstWriterPid = await waitForNamedTenantAuditWaiter(
+        firstApplicationName,
+        [lockerPid],
+        "first update did not reach the tenant audit lock behind its holder",
+      );
+      const secondWriter = spawnWriter({ enabled: false }, secondRequestId, secondApplicationName);
+      await waitForNamedTenantAuditWaiter(
+        secondApplicationName,
+        [lockerPid, firstWriterPid],
+        "second update did not reach the tenant audit lock behind the holder or first writer",
+      );
       await unlockTenantAudit(locker);
       locked = false;
 
@@ -404,6 +488,7 @@ realPostgres("auto-approval rule audit atomicity (mounted Postgres)", () => {
     const successRequestId = `create-success-${suffix}`;
     const gateKey = Number.parseInt(suffix.slice(0, 12), 16);
     const triggerName = `fail_rule_create_${suffix}`;
+    const writerApplicationName = `approval-rule-create-winner-${suffix}`;
     const locker = await admin.client.reserve();
     let gateLocked = false;
     try {
@@ -415,11 +500,20 @@ realPostgres("auto-approval rule audit atomicity (mounted Postgres)", () => {
       });
       await locker`select pg_advisory_lock(${gateKey})`;
       gateLocked = true;
+      const lockerPid = await backendPid(locker);
 
       const failedRequest = putRule({ maxAmountWei: "111" }, failRequestId);
-      await waitForAdvisoryWaiters(1, "failed create did not reach its audit gate");
-      const writer = spawnWriter({ maxAmountWei: "222" }, successRequestId);
-      await waitForAdvisoryWaiters(2, "concurrent create did not reach the tenant audit lock");
+      const failedRequestPid = await waitForExactBigintAdvisoryWaiter(
+        gateKey,
+        lockerPid,
+        "failed create did not reach its exact audit gate behind the gate holder",
+      );
+      const writer = spawnWriter({ maxAmountWei: "222" }, successRequestId, writerApplicationName);
+      await waitForNamedTenantAuditWaiter(
+        writerApplicationName,
+        [failedRequestPid],
+        "concurrent create did not reach the tenant audit lock behind the failed writer",
+      );
       await locker`select pg_advisory_unlock(${gateKey})`;
       gateLocked = false;
 
@@ -462,6 +556,7 @@ realPostgres("auto-approval rule audit atomicity (mounted Postgres)", () => {
     const successRequestId = `update-success-${suffix}`;
     const gateKey = Number.parseInt(suffix.slice(12, 24), 16);
     const triggerName = `fail_rule_update_${suffix}`;
+    const writerApplicationName = `approval-rule-update-winner-${suffix}`;
     const locker = await admin.client.reserve();
     let gateLocked = false;
     try {
@@ -473,11 +568,20 @@ realPostgres("auto-approval rule audit atomicity (mounted Postgres)", () => {
       });
       await locker`select pg_advisory_lock(${gateKey})`;
       gateLocked = true;
+      const lockerPid = await backendPid(locker);
 
       const failedRequest = putRule({ maxAmountWei: "999" }, failRequestId);
-      await waitForAdvisoryWaiters(1, "failed update did not reach its audit gate");
-      const writer = spawnWriter({ enabled: false }, successRequestId);
-      await waitForAdvisoryWaiters(2, "concurrent update did not reach the tenant audit lock");
+      const failedRequestPid = await waitForExactBigintAdvisoryWaiter(
+        gateKey,
+        lockerPid,
+        "failed update did not reach its exact audit gate behind the gate holder",
+      );
+      const writer = spawnWriter({ enabled: false }, successRequestId, writerApplicationName);
+      await waitForNamedTenantAuditWaiter(
+        writerApplicationName,
+        [failedRequestPid],
+        "concurrent update did not reach the tenant audit lock behind the failed writer",
+      );
       await locker`select pg_advisory_unlock(${gateKey})`;
       gateLocked = false;
 

--- a/packages/api/src/__tests__/approval-rule-audit-atomicity-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/approval-rule-audit-atomicity-postgres.integration.test.ts
@@ -1,0 +1,552 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { generateApiKey } from "@stwd/auth";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  auditChainHeads,
+  auditEvents,
+  autoApprovalRules,
+  createDb,
+  tenants,
+  users,
+  userTenants,
+} from "@stwd/db";
+import { and, asc, eq, inArray } from "drizzle-orm";
+import { Hono } from "hono";
+import { correlationId } from "../middleware/correlation";
+import type { AppVariables } from "../services/context";
+
+const databaseUrl = process.env.DATABASE_URL;
+const realPostgres = databaseUrl && !process.env.STEWARD_PGLITE_MEMORY ? describe : describe.skip;
+const suffix = crypto.randomUUID().replaceAll("-", "");
+const tenantId = `approval-rule-atomic-${suffix}`;
+const userId = crypto.randomUUID();
+const fixturePath = new URL("./fixtures/approval-rule-concurrent-request.ts", import.meta.url)
+  .pathname;
+
+type RuleResponse = {
+  ok: boolean;
+  data?: {
+    id: string;
+    tenantId: string;
+    maxAmountWei: string;
+    autoDenyAfterHours: number | null;
+    escalateAboveWei: string | null;
+    enabled: boolean;
+  };
+  error?: string;
+};
+
+type WriterResult = { status: number; body: RuleResponse };
+type RuleAudit = {
+  seq: number;
+  action: string;
+  resourceId: string;
+  metadata: Record<string, unknown>;
+  requestId: string | null;
+};
+
+realPostgres("auto-approval rule audit atomicity (mounted Postgres)", () => {
+  let admin: ReturnType<typeof createDb>;
+  let app: Hono<{ Variables: AppVariables }>;
+  let token: string;
+  let noMfaToken: string;
+  let apiKey: string;
+  let previousJwtSecret: string | undefined;
+  let previousMasterPassword: string | undefined;
+  let previousAuditKey: string | undefined;
+
+  beforeAll(async () => {
+    admin = createDb(databaseUrl!);
+    previousJwtSecret = process.env.STEWARD_JWT_SECRET;
+    previousMasterPassword = process.env.STEWARD_MASTER_PASSWORD;
+    previousAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+    process.env.STEWARD_JWT_SECRET = `approval-rule-jwt-${suffix}`;
+    process.env.STEWARD_MASTER_PASSWORD = `approval-rule-master-${suffix}`;
+    process.env.STEWARD_AUDIT_HMAC_KEY = `approval-rule-audit-key-${suffix}`;
+    __resetAuditHmacKeyCacheForTests();
+
+    const apiKeyPair = generateApiKey();
+    apiKey = apiKeyPair.key;
+    await admin.db.insert(tenants).values({
+      id: tenantId,
+      name: tenantId,
+      apiKeyHash: apiKeyPair.hash,
+    });
+    await admin.db.insert(users).values({
+      id: userId,
+      email: `${suffix}@example.test`,
+      emailVerified: true,
+    });
+    await admin.db.insert(userTenants).values({ userId, tenantId, role: "owner" });
+
+    const [{ createSessionToken }, { tenantAuth }, { approvalRoutes }] = await Promise.all([
+      import("../routes/auth"),
+      import("../services/context"),
+      import("../routes/approvals"),
+    ]);
+    token = await createSessionToken("0x0000000000000000000000000000000000000720", tenantId, {
+      userId,
+      tenantId,
+      mfaVerifiedAt: Date.now(),
+      mfaMethod: "totp",
+    });
+    noMfaToken = await createSessionToken("0x0000000000000000000000000000000000000720", tenantId, {
+      userId,
+      tenantId,
+    });
+    app = new Hono<{ Variables: AppVariables }>();
+    app.onError((error, c) => c.json({ ok: false, error: error.message }, 500));
+    app.use("*", correlationId);
+    app.use("*", tenantAuth);
+    app.route("/approvals", approvalRoutes);
+  }, 120_000);
+
+  afterEach(async () => {
+    await admin.db.delete(autoApprovalRules).where(eq(autoApprovalRules.tenantId, tenantId));
+    await admin.db.delete(auditEvents).where(eq(auditEvents.tenantId, tenantId));
+    await admin.db.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, tenantId));
+  });
+
+  afterAll(async () => {
+    await admin.db.delete(autoApprovalRules).where(eq(autoApprovalRules.tenantId, tenantId));
+    await admin.db.delete(auditEvents).where(eq(auditEvents.tenantId, tenantId));
+    await admin.db.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, tenantId));
+    await admin.db.delete(userTenants).where(eq(userTenants.tenantId, tenantId));
+    await admin.db.delete(tenants).where(eq(tenants.id, tenantId));
+    await admin.db.delete(users).where(eq(users.id, userId));
+    await admin.client.end();
+    if (previousJwtSecret === undefined) delete process.env.STEWARD_JWT_SECRET;
+    else process.env.STEWARD_JWT_SECRET = previousJwtSecret;
+    if (previousMasterPassword === undefined) delete process.env.STEWARD_MASTER_PASSWORD;
+    else process.env.STEWARD_MASTER_PASSWORD = previousMasterPassword;
+    if (previousAuditKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditKey;
+    __resetAuditHmacKeyCacheForTests();
+  });
+
+  async function putRule(body: Record<string, unknown>, requestId: string): Promise<Response> {
+    return app.request("/approvals/rules", {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-Request-Id": requestId,
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  function spawnWriter(body: Record<string, unknown>, requestId: string) {
+    return Bun.spawn([process.execPath, fixturePath], {
+      cwd: new URL("../../../..", import.meta.url).pathname,
+      env: {
+        ...process.env,
+        DATABASE_URL: databaseUrl!,
+        TEST_TENANT_ID: tenantId,
+        TEST_USER_ID: userId,
+        TEST_REQUEST_ID: requestId,
+        TEST_REQUEST_BODY: JSON.stringify(body),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  }
+
+  async function writerResult(writer: ReturnType<typeof spawnWriter>): Promise<WriterResult> {
+    const [status, stdout, stderr] = await Promise.all([
+      writer.exited,
+      new Response(writer.stdout).text(),
+      new Response(writer.stderr).text(),
+    ]);
+    if (status !== 0) throw new Error(`concurrent writer failed (${status}): ${stderr}`);
+    return JSON.parse(stdout) as WriterResult;
+  }
+
+  async function waitForAdvisoryWaiters(minimum: number, message: string): Promise<void> {
+    for (let attempt = 0; attempt < 2_000; attempt++) {
+      const [row] = await admin.client<{ count: string }[]>`
+        select count(*)::text as count
+        from pg_stat_activity
+        where datname = current_database() and wait_event = 'advisory'
+      `;
+      if (Number(row?.count ?? "0") >= minimum) return;
+      if (attempt === 1_999) throw new Error(message);
+      await Bun.sleep(10);
+    }
+  }
+
+  async function installBlockingAuditFailure(input: {
+    requestId: string;
+    action: "approval_rule.create" | "approval_rule.update";
+    gateKey: number;
+    name: string;
+  }): Promise<void> {
+    await admin.client.unsafe(`
+      create function "${input.name}"() returns trigger language plpgsql as $$
+      begin
+        if new.tenant_id = '${tenantId}'
+           and new.request_id = '${input.requestId}'
+           and new.action = '${input.action}' then
+          perform pg_advisory_xact_lock(${input.gateKey});
+          raise exception 'forced approval rule completion audit failure';
+        end if;
+        return new;
+      end
+      $$
+    `);
+    await admin.client.unsafe(`
+      create trigger "${input.name}"
+      before insert on audit_events
+      for each row execute function "${input.name}"()
+    `);
+  }
+
+  async function removeAuditFailure(name: string): Promise<void> {
+    await admin.client.unsafe(`drop trigger if exists "${name}" on audit_events`);
+    await admin.client.unsafe(`drop function if exists "${name}"()`);
+  }
+
+  async function ruleAudits(...requestIds: string[]): Promise<RuleAudit[]> {
+    return admin.db
+      .select({
+        seq: auditEvents.seq,
+        action: auditEvents.action,
+        resourceId: auditEvents.resourceId,
+        metadata: auditEvents.metadata,
+        requestId: auditEvents.requestId,
+      })
+      .from(auditEvents)
+      .where(and(eq(auditEvents.tenantId, tenantId), inArray(auditEvents.requestId, requestIds)))
+      .orderBy(asc(auditEvents.seq)) as Promise<RuleAudit[]>;
+  }
+
+  async function lockTenantAudit(locker: Awaited<ReturnType<typeof admin.client.reserve>>) {
+    await locker`select pg_advisory_lock(hashtextextended(${`steward_audit_${tenantId}`}, 0))`;
+  }
+
+  async function unlockTenantAudit(locker: Awaited<ReturnType<typeof admin.client.reserve>>) {
+    await locker`select pg_advisory_unlock(hashtextextended(${`steward_audit_${tenantId}`}, 0))`;
+  }
+
+  test("preserves mounted auth, MFA, no-store, response, and partial-update semantics", async () => {
+    const apiKeyDenied = await app.request("/approvals/rules", {
+      method: "PUT",
+      headers: {
+        "X-Steward-Tenant": tenantId,
+        "X-Steward-Key": apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ maxAmountWei: "1" }),
+    });
+    expect(apiKeyDenied.status).toBe(403);
+    const noMfaDenied = await app.request("/approvals/rules", {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${noMfaToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ maxAmountWei: "1" }),
+    });
+    expect(noMfaDenied.status).toBe(403);
+
+    const createdResponse = await putRule(
+      {
+        maxAmountWei: "100",
+        autoDenyAfterHours: 24,
+        escalateAboveWei: "1000",
+        enabled: true,
+      },
+      `create-${suffix}`,
+    );
+    expect(createdResponse.status).toBe(201);
+    expect(createdResponse.headers.get("cache-control")).toContain("no-store");
+    const created = (await createdResponse.json()) as RuleResponse;
+    expect(created.data).toMatchObject({ maxAmountWei: "100", enabled: true });
+
+    const readResponse = await app.request("/approvals/rules", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(readResponse.status).toBe(200);
+    expect(readResponse.headers.get("cache-control")).toContain("no-store");
+
+    const updatedResponse = await putRule({ enabled: false }, `update-${suffix}`);
+    expect(updatedResponse.status).toBe(200);
+    const updated = (await updatedResponse.json()) as RuleResponse;
+    expect(updated.data).toMatchObject({
+      id: created.data?.id,
+      maxAmountWei: "100",
+      autoDenyAfterHours: 24,
+      escalateAboveWei: "1000",
+      enabled: false,
+    });
+
+    const completions = await admin.db
+      .select({ action: auditEvents.action })
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.tenantId, tenantId),
+          inArray(auditEvents.action, ["approval_rule.create", "approval_rule.update"]),
+        ),
+      )
+      .orderBy(asc(auditEvents.seq));
+    expect(completions.map(({ action }) => action)).toEqual([
+      "approval_rule.create",
+      "approval_rule.update",
+    ]);
+  });
+
+  test("successful create-vs-create pairs authoritative authorization and completion audits", async () => {
+    const firstRequestId = `create-pair-a-${suffix}`;
+    const secondRequestId = `create-pair-b-${suffix}`;
+    const locker = await admin.client.reserve();
+    let locked = false;
+    try {
+      await lockTenantAudit(locker);
+      locked = true;
+      const firstWriter = spawnWriter({ maxAmountWei: "111" }, firstRequestId);
+      await waitForAdvisoryWaiters(1, "first create did not reach the tenant audit lock");
+      const secondWriter = spawnWriter({ maxAmountWei: "222" }, secondRequestId);
+      await waitForAdvisoryWaiters(2, "second create did not reach the tenant audit lock");
+      await unlockTenantAudit(locker);
+      locked = false;
+
+      const results = await Promise.all([writerResult(firstWriter), writerResult(secondWriter)]);
+      expect(results.map(({ status }) => status).sort()).toEqual([200, 201]);
+      const createdIndex = results.findIndex(({ status }) => status === 201);
+      const updatedIndex = 1 - createdIndex;
+      const requestIds = [firstRequestId, secondRequestId];
+      const createdRequestId = requestIds[createdIndex]!;
+      const updatedRequestId = requestIds[updatedIndex]!;
+      const created = results[createdIndex]!.body.data!;
+      const updated = results[updatedIndex]!.body.data!;
+      expect(created.id).toBe(updated.id);
+
+      const events = await ruleAudits(firstRequestId, secondRequestId);
+      const createdEvents = events.filter(({ requestId }) => requestId === createdRequestId);
+      const updatedEvents = events.filter(({ requestId }) => requestId === updatedRequestId);
+      expect(createdEvents.map(({ action }) => action)).toEqual([
+        "approval_rule.create.authorized",
+        "approval_rule.create",
+      ]);
+      expect(createdEvents.map(({ resourceId }) => resourceId)).toEqual([created.id, created.id]);
+      expect(createdEvents[1]?.metadata.after).toMatchObject(created);
+      expect(updatedEvents.map(({ action }) => action)).toEqual([
+        "approval_rule.update.authorized",
+        "approval_rule.update",
+      ]);
+      expect(updatedEvents.map(({ resourceId }) => resourceId)).toEqual([updated.id, updated.id]);
+      expect(updatedEvents[0]?.metadata.before).toEqual(updatedEvents[1]?.metadata.before);
+      expect(updatedEvents[0]?.metadata.before).toMatchObject(created);
+      expect(updatedEvents[1]?.metadata.after).toMatchObject(updated);
+    } finally {
+      if (locked) await unlockTenantAudit(locker);
+      locker.release();
+    }
+  }, 120_000);
+
+  test("successful update-vs-update preserves exact serialized before metadata", async () => {
+    const [initial] = await admin.db
+      .insert(autoApprovalRules)
+      .values({ tenantId, maxAmountWei: "10", enabled: true })
+      .returning();
+    const firstRequestId = `update-pair-a-${suffix}`;
+    const secondRequestId = `update-pair-b-${suffix}`;
+    const locker = await admin.client.reserve();
+    let locked = false;
+    try {
+      await lockTenantAudit(locker);
+      locked = true;
+      const firstWriter = spawnWriter({ maxAmountWei: "111" }, firstRequestId);
+      await waitForAdvisoryWaiters(1, "first update did not reach the tenant audit lock");
+      const secondWriter = spawnWriter({ enabled: false }, secondRequestId);
+      await waitForAdvisoryWaiters(2, "second update did not reach the tenant audit lock");
+      await unlockTenantAudit(locker);
+      locked = false;
+
+      const results = await Promise.all([writerResult(firstWriter), writerResult(secondWriter)]);
+      expect(results.map(({ status }) => status)).toEqual([200, 200]);
+      const events = await ruleAudits(firstRequestId, secondRequestId);
+      for (const [index, requestId] of [firstRequestId, secondRequestId].entries()) {
+        const pair = events.filter((event) => event.requestId === requestId);
+        expect(pair.map(({ action }) => action)).toEqual([
+          "approval_rule.update.authorized",
+          "approval_rule.update",
+        ]);
+        expect(pair.map(({ resourceId }) => resourceId)).toEqual([initial.id, initial.id]);
+        expect(pair[0]?.metadata.before).toEqual(pair[1]?.metadata.before);
+        expect(pair[1]?.metadata.after).toMatchObject(results[index]!.body.data!);
+      }
+      const completions = events.filter(({ action }) => action === "approval_rule.update");
+      expect(completions[0]?.metadata.before).toMatchObject({
+        id: initial.id,
+        maxAmountWei: "10",
+        enabled: true,
+      });
+      expect(completions[1]?.metadata.before).toEqual(completions[0]?.metadata.after);
+      const [stored] = await admin.db
+        .select()
+        .from(autoApprovalRules)
+        .where(eq(autoApprovalRules.tenantId, tenantId));
+      expect(completions[1]?.metadata.after).toMatchObject({
+        id: stored?.id,
+        maxAmountWei: stored?.maxAmountWei,
+        enabled: stored?.enabled,
+      });
+    } finally {
+      if (locked) await unlockTenantAudit(locker);
+      locker.release();
+    }
+  }, 120_000);
+
+  test("create-vs-create: failed completion audit cannot delete the concurrent winner", async () => {
+    const failRequestId = `create-fail-${suffix}`;
+    const successRequestId = `create-success-${suffix}`;
+    const gateKey = Number.parseInt(suffix.slice(0, 12), 16);
+    const triggerName = `fail_rule_create_${suffix}`;
+    const locker = await admin.client.reserve();
+    let gateLocked = false;
+    try {
+      await installBlockingAuditFailure({
+        requestId: failRequestId,
+        action: "approval_rule.create",
+        gateKey,
+        name: triggerName,
+      });
+      await locker`select pg_advisory_lock(${gateKey})`;
+      gateLocked = true;
+
+      const failedRequest = putRule({ maxAmountWei: "111" }, failRequestId);
+      await waitForAdvisoryWaiters(1, "failed create did not reach its audit gate");
+      const writer = spawnWriter({ maxAmountWei: "222" }, successRequestId);
+      await waitForAdvisoryWaiters(2, "concurrent create did not reach the tenant audit lock");
+      await locker`select pg_advisory_unlock(${gateKey})`;
+      gateLocked = false;
+
+      const [failedResponse, winner] = await Promise.all([failedRequest, writerResult(writer)]);
+      expect(failedResponse.status).toBe(500);
+      expect(winner.status).toBe(201);
+      expect(winner.body.data?.maxAmountWei).toBe("222");
+
+      const rules = await admin.db
+        .select()
+        .from(autoApprovalRules)
+        .where(eq(autoApprovalRules.tenantId, tenantId));
+      expect(rules).toHaveLength(1);
+      expect(rules[0]?.maxAmountWei).toBe("222");
+      const completions = await admin.db
+        .select({ requestId: auditEvents.requestId })
+        .from(auditEvents)
+        .where(
+          and(eq(auditEvents.tenantId, tenantId), eq(auditEvents.action, "approval_rule.create")),
+        );
+      expect(completions).toEqual([{ requestId: successRequestId }]);
+      const failedEvents = await ruleAudits(failRequestId);
+      expect(failedEvents.map(({ action }) => action)).toEqual(["approval_rule.create.authorized"]);
+      expect(failedEvents[0]?.resourceId).not.toBe(tenantId);
+      expect(failedEvents[0]?.metadata.requested).toEqual({ maxAmountWei: "111" });
+    } finally {
+      if (gateLocked) await locker`select pg_advisory_unlock(${gateKey})`;
+      locker.release();
+      await removeAuditFailure(triggerName);
+    }
+  }, 120_000);
+
+  test("update-vs-update: failed completion audit cannot overwrite the concurrent winner", async () => {
+    await admin.db.insert(autoApprovalRules).values({
+      tenantId,
+      maxAmountWei: "10",
+      enabled: true,
+    });
+    const failRequestId = `update-fail-${suffix}`;
+    const successRequestId = `update-success-${suffix}`;
+    const gateKey = Number.parseInt(suffix.slice(12, 24), 16);
+    const triggerName = `fail_rule_update_${suffix}`;
+    const locker = await admin.client.reserve();
+    let gateLocked = false;
+    try {
+      await installBlockingAuditFailure({
+        requestId: failRequestId,
+        action: "approval_rule.update",
+        gateKey,
+        name: triggerName,
+      });
+      await locker`select pg_advisory_lock(${gateKey})`;
+      gateLocked = true;
+
+      const failedRequest = putRule({ maxAmountWei: "999" }, failRequestId);
+      await waitForAdvisoryWaiters(1, "failed update did not reach its audit gate");
+      const writer = spawnWriter({ enabled: false }, successRequestId);
+      await waitForAdvisoryWaiters(2, "concurrent update did not reach the tenant audit lock");
+      await locker`select pg_advisory_unlock(${gateKey})`;
+      gateLocked = false;
+
+      const [failedResponse, winner] = await Promise.all([failedRequest, writerResult(writer)]);
+      expect(failedResponse.status).toBe(500);
+      expect(winner.status).toBe(200);
+      expect(winner.body.data).toMatchObject({ maxAmountWei: "10", enabled: false });
+
+      const [stored] = await admin.db
+        .select()
+        .from(autoApprovalRules)
+        .where(eq(autoApprovalRules.tenantId, tenantId));
+      expect(stored).toMatchObject({ maxAmountWei: "10", enabled: false });
+      const completions = await admin.db
+        .select({ requestId: auditEvents.requestId })
+        .from(auditEvents)
+        .where(
+          and(eq(auditEvents.tenantId, tenantId), eq(auditEvents.action, "approval_rule.update")),
+        );
+      expect(completions).toEqual([{ requestId: successRequestId }]);
+      const failedEvents = await ruleAudits(failRequestId);
+      expect(failedEvents.map(({ action }) => action)).toEqual(["approval_rule.update.authorized"]);
+      expect(failedEvents[0]?.resourceId).toBe(stored?.id);
+      expect(failedEvents[0]?.metadata.before).toMatchObject({ maxAmountWei: "10", enabled: true });
+    } finally {
+      if (gateLocked) await locker`select pg_advisory_unlock(${gateKey})`;
+      locker.release();
+      await removeAuditFailure(triggerName);
+    }
+  }, 120_000);
+
+  test("a deferred commit failure rolls back the rule and preserves only its authorization attempt", async () => {
+    const requestId = `commit-fail-${suffix}`;
+    const triggerName = `fail_rule_commit_${suffix}`;
+    await admin.client.unsafe(`
+      create function "${triggerName}"() returns trigger language plpgsql as $$
+      begin
+        if new.tenant_id = '${tenantId}'
+           and new.request_id = '${requestId}'
+           and new.action = 'approval_rule.create' then
+          raise exception 'forced approval rule commit failure';
+        end if;
+        return new;
+      end
+      $$
+    `);
+    await admin.client.unsafe(`
+      create constraint trigger "${triggerName}"
+      after insert on audit_events
+      deferrable initially deferred
+      for each row execute function "${triggerName}"()
+    `);
+    try {
+      const response = await putRule({ maxAmountWei: "333" }, requestId);
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toMatchObject({
+        ok: false,
+        error: "Failed to update approval rule",
+      });
+      expect(
+        await admin.db
+          .select()
+          .from(autoApprovalRules)
+          .where(eq(autoApprovalRules.tenantId, tenantId)),
+      ).toHaveLength(0);
+      const events = await ruleAudits(requestId);
+      expect(events.map(({ action }) => action)).toEqual(["approval_rule.create.authorized"]);
+    } finally {
+      await removeAuditFailure(triggerName);
+    }
+  }, 120_000);
+});

--- a/packages/api/src/__tests__/approvals-audit-order.test.ts
+++ b/packages/api/src/__tests__/approvals-audit-order.test.ts
@@ -64,6 +64,38 @@ describe("approval route audit ordering", () => {
     expectBefore('action: "approval_rule.create.authorized"', ".insert(autoApprovalRules)");
   });
 
+  it("serializes rule upserts and commits each mutation with its completion audit", () => {
+    const ruleBody = routeBody('approvalRoutes.put("/rules", async');
+    const transactionStart = ruleBody.indexOf("withTenantAuditedTransaction(");
+    const lockedRead = ruleBody.indexOf('.for("update")', transactionStart);
+    const updateAuthorization = ruleBody.indexOf(
+      'action: "approval_rule.update.authorized"',
+      lockedRead,
+    );
+    const update = ruleBody.indexOf(".update(autoApprovalRules)", lockedRead);
+    const updateAudit = ruleBody.indexOf('action: "approval_rule.update"', update);
+    const createAuthorization = ruleBody.indexOf(
+      'action: "approval_rule.create.authorized"',
+      lockedRead,
+    );
+    const create = ruleBody.indexOf(".insert(autoApprovalRules)", lockedRead);
+    const createAudit = ruleBody.indexOf('action: "approval_rule.create"', create);
+
+    expect(transactionStart).toBeGreaterThanOrEqual(0);
+    expect(lockedRead).toBeGreaterThan(transactionStart);
+    expect(updateAuthorization).toBeGreaterThan(lockedRead);
+    expect(update).toBeGreaterThan(updateAuthorization);
+    expect(updateAudit).toBeGreaterThan(update);
+    expect(createAuthorization).toBeGreaterThan(lockedRead);
+    expect(create).toBeGreaterThan(createAuthorization);
+    expect(createAudit).toBeGreaterThan(create);
+    expect(ruleBody).toContain("return await tx.transaction");
+    expect(ruleBody).toContain('return { kind: "failed" as const }');
+    expect(ruleBody).toContain('mutation.kind === "failed"');
+    expect(ruleBody).not.toContain("await db.delete(autoApprovalRules)");
+    expect(ruleBody).not.toContain("maxAmountWei: existing.maxAmountWei");
+  });
+
   it("does not let the generic approval route authorize vault-executable transactions", () => {
     const body = routeBody('approvalRoutes.post("/:txId/approve", async');
     expect(body).toContain(

--- a/packages/api/src/__tests__/approvals-audit-order.test.ts
+++ b/packages/api/src/__tests__/approvals-audit-order.test.ts
@@ -1,148 +1,273 @@
-import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  agents,
+  approvalQueue,
+  auditEvents,
+  autoApprovalRules,
+  closeDb,
+  getDb,
+  tenants,
+  transactions,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { and, eq, sql } from "drizzle-orm";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
 
-const routeSource = readFileSync(join(import.meta.dir, "..", "routes", "approvals.ts"), "utf8");
+mock.module("../services/webhook-dispatch", () => ({ dispatchWebhook: () => undefined }));
 
-function expectBefore(first: string, second: string) {
-  const firstIndex = routeSource.indexOf(first);
-  const secondIndex = routeSource.indexOf(second);
-  expect(firstIndex).toBeGreaterThanOrEqual(0);
-  expect(secondIndex).toBeGreaterThanOrEqual(0);
-  expect(firstIndex).toBeLessThan(secondIndex);
+const TENANT_ID = "approval-mounted-audit";
+const AGENT_ID = "approval-mounted-agent";
+const USER_ID = "11111111-1111-4111-8111-111111111737";
+const TX_ID = "approval-mounted-transaction";
+const APPROVAL_ID = "approval-mounted-entry";
+
+let app: Hono<{ Variables: AppVariables }>;
+
+function principal(path: string) {
+  const value = new URL(path, "http://localhost").searchParams.get("principal");
+  return value ?? "fresh";
 }
 
-function routeBody(marker: string): string {
-  const start = routeSource.indexOf(marker);
-  expect(start).toBeGreaterThanOrEqual(0);
-  const nextRoute = routeSource.indexOf("approvalRoutes.", start + marker.length);
-  return routeSource.slice(start, nextRoute === -1 ? undefined : nextRoute);
+function assertNoStore(response: Response) {
+  expect(response.headers.get("cache-control")).toBe("no-store, max-age=0");
+  expect(response.headers.get("pragma")).toBe("no-cache");
+  expect(response.headers.get("expires")).toBe("0");
 }
 
-describe("approval route audit ordering", () => {
-  it("marks approval control-plane responses as non-cacheable", () => {
-    expect(routeSource).toContain("setNoStoreHeaders");
-    expect(routeSource).toContain('approvalRoutes.use("*"');
-    expect(routeSource).toContain("setNoStoreHeaders(c)");
+async function seedPending(txId = TX_ID, approvalId = APPROVAL_ID) {
+  await getDb().insert(transactions).values({
+    id: txId,
+    agentId: AGENT_ID,
+    status: "pending",
+    toAddress: "0x0000000000000000000000000000000000000001",
+    value: "1",
+    chainId: 8453,
+  });
+  await getDb().insert(approvalQueue).values({
+    id: approvalId,
+    txId,
+    agentId: AGENT_ID,
+    status: "pending",
+  });
+}
+
+async function request(
+  path: string,
+  init: RequestInit = {},
+  selectedPrincipal = "fresh",
+): Promise<Response> {
+  const separator = path.includes("?") ? "&" : "?";
+  const response = await app.request(`${path}${separator}principal=${selectedPrincipal}`, {
+    ...init,
+    headers: { "content-type": "application/json", ...init.headers },
+  });
+  assertNoStore(response);
+  return response;
+}
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = "approval-mounted-master-password";
+  process.env.STEWARD_AUDIT_HMAC_KEY = "approval-mounted-audit-hmac-key-with-enough-entropy";
+  __resetAuditHmacKeyCacheForTests();
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => client.close());
+  await getDb().insert(tenants).values({ id: TENANT_ID, name: TENANT_ID, apiKeyHash: "hash" });
+  await getDb().insert(agents).values({
+    id: AGENT_ID,
+    tenantId: TENANT_ID,
+    name: AGENT_ID,
+    walletAddress: "0x0000000000000000000000000000000000000737",
   });
 
-  it("keeps approval queue reads and writes behind a human approver session", () => {
-    for (const marker of [
-      'approvalRoutes.get("/", async',
-      'approvalRoutes.get("/stats", async',
-      'approvalRoutes.get("/rules", async',
-      'approvalRoutes.post("/:txId/approve", async',
-      'approvalRoutes.post("/:txId/deny", async',
-      'approvalRoutes.put("/rules", async',
-    ]) {
-      const start = routeSource.indexOf(marker);
-      expect(start).toBeGreaterThanOrEqual(0);
-      expect(routeSource.indexOf("requireHumanApprover(c)", start)).toBeGreaterThan(start);
+  const { approvalRoutes } = await import("../routes/approvals");
+  app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("tenantId", TENANT_ID);
+    const selected = principal(c.req.url);
+    if (selected === "api-key") c.set("authType", "api-key");
+    else if (selected === "agent") {
+      c.set("authType", "agent-token");
+      c.set("agentScope", AGENT_ID);
+    } else {
+      c.set("authType", "session-jwt");
+      c.set("userId", USER_ID);
+      c.set("tenantRole", selected === "member" ? "member" : "owner");
+      c.set("sessionMfaVerifiedAt", selected === "stale" ? Date.now() - 10 * 60_000 : Date.now());
     }
+    await next();
   });
+  app.route("/approvals", approvalRoutes);
+  app.onError((_error, c) => c.json({ ok: false, error: "Internal server error" }, 500));
+});
 
-  it("requires recent MFA before approval reads, decisions, and approval rule changes", () => {
-    for (const marker of [
-      'approvalRoutes.get("/", async',
-      'approvalRoutes.get("/stats", async',
-      'approvalRoutes.get("/rules", async',
-      'approvalRoutes.post("/:txId/approve", async',
-      'approvalRoutes.post("/:txId/deny", async',
-      'approvalRoutes.put("/rules", async',
-    ]) {
-      const body = routeBody(marker);
-      const approverCheck = body.indexOf("requireHumanApprover(c)");
-      const mfaCheck = body.indexOf("hasRecentSessionMfa(c)");
-      expect(approverCheck).toBeGreaterThanOrEqual(0);
-      expect(mfaCheck).toBeGreaterThan(approverCheck);
-    }
-  });
+beforeEach(async () => {
+  await getDb().delete(approvalQueue).where(eq(approvalQueue.agentId, AGENT_ID));
+  await getDb().delete(transactions).where(eq(transactions.agentId, AGENT_ID));
+  await getDb().delete(autoApprovalRules).where(eq(autoApprovalRules.tenantId, TENANT_ID));
+  await seedPending();
+});
 
-  it("writes durable authorization audit events before sensitive mutations", () => {
-    expectBefore('action: "approval.deny.authorized"', ".update(approvalQueue)");
-    expectBefore('action: "approval_rule.update.authorized"', ".update(autoApprovalRules)");
-    expectBefore('action: "approval_rule.create.authorized"', ".insert(autoApprovalRules)");
-  });
+afterAll(async () => {
+  await closeDb();
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_MASTER_PASSWORD;
+  delete process.env.STEWARD_AUDIT_HMAC_KEY;
+  __resetAuditHmacKeyCacheForTests();
+});
 
-  it("serializes rule upserts and commits each mutation with its completion audit", () => {
-    const ruleBody = routeBody('approvalRoutes.put("/rules", async');
-    const transactionStart = ruleBody.indexOf("withTenantAuditedTransaction(");
-    const lockedRead = ruleBody.indexOf('.for("update")', transactionStart);
-    const updateAuthorization = ruleBody.indexOf(
-      'action: "approval_rule.update.authorized"',
-      lockedRead,
-    );
-    const update = ruleBody.indexOf(".update(autoApprovalRules)", lockedRead);
-    const updateAudit = ruleBody.indexOf('action: "approval_rule.update"', update);
-    const createAuthorization = ruleBody.indexOf(
-      'action: "approval_rule.create.authorized"',
-      lockedRead,
-    );
-    const create = ruleBody.indexOf(".insert(autoApprovalRules)", lockedRead);
-    const createAudit = ruleBody.indexOf('action: "approval_rule.create"', create);
-
-    expect(transactionStart).toBeGreaterThanOrEqual(0);
-    expect(lockedRead).toBeGreaterThan(transactionStart);
-    expect(updateAuthorization).toBeGreaterThan(lockedRead);
-    expect(update).toBeGreaterThan(updateAuthorization);
-    expect(updateAudit).toBeGreaterThan(update);
-    expect(createAuthorization).toBeGreaterThan(lockedRead);
-    expect(create).toBeGreaterThan(createAuthorization);
-    expect(createAudit).toBeGreaterThan(create);
-    expect(ruleBody).toContain("return await tx.transaction");
-    expect(ruleBody).toContain('return { kind: "failed" as const }');
-    expect(ruleBody).toContain('mutation.kind === "failed"');
-    expect(ruleBody).not.toContain("await db.delete(autoApprovalRules)");
-    expect(ruleBody).not.toContain("maxAmountWei: existing.maxAmountWei");
-  });
-
-  it("does not let the generic approval route authorize vault-executable transactions", () => {
-    const body = routeBody('approvalRoutes.post("/:txId/approve", async');
-    expect(body).toContain(
-      "Vault transaction approvals must be executed through POST /vault/:agentId/approve/:txId",
-    );
-    expect(body).not.toContain('status: "approved"');
-    expect(body).not.toContain('set({ status: "approved" })');
-    expect(body).not.toContain("intent.authorized");
-  });
-
-  it("updates denied approval, transaction status, and completion audit in one transaction", () => {
-    // The queue+transaction rejection AND the completion `approval.deny` audit
-    // event now commit in a single audited transaction (invariant I14). The
-    // audit append lives INSIDE the transaction callback, before the return,
-    // so state and evidence are both-or-neither.
-    const denyBody = routeBody('approvalRoutes.post("/:txId/deny", async');
-    expect(denyBody).toContain(
-      "withTenantAuditedTransaction(tenantId, async (tx, appendRequiredAudit)",
-    );
-    expect(denyBody).toContain(".update(transactions)");
-    expect(denyBody).toContain('status: "rejected"');
-    // The completion audit is appended within the transaction, not after it.
-    const txStart = denyBody.indexOf("withTenantAuditedTransaction(tenantId");
-    const auditWithinTx = denyBody.indexOf('action: "approval.deny"', txStart);
-    const txReturn = denyBody.indexOf("return updatedRows[0];", txStart);
-    expect(auditWithinTx).toBeGreaterThan(txStart);
-    expect(txReturn).toBeGreaterThan(auditWithinTx);
-    // No post-commit best-effort audit + compensating rollback remains.
-    expect(denyBody).not.toContain('.set({ status: "pending", resolvedAt: null');
-  });
-
-  it("does not resolve stale approval rows for terminal transactions", () => {
-    for (const marker of [
-      'approvalRoutes.post("/:txId/approve", async',
-      'approvalRoutes.post("/:txId/deny", async',
-    ]) {
-      const body = routeBody(marker);
-      expect(body).toContain("transactionStatus: transactions.status");
-      expect(body).toContain('entry.transactionStatus !== "pending"');
-      if (marker.includes("/deny")) {
-        expect(body).toContain('eq(transactions.status, "pending")');
-        // A concurrent resolution rolls back the WHOLE audited transaction via
-        // the sentinel error, so the queue rejection cannot commit without the
-        // transaction rejection (and its audit).
-        expect(body).toContain("throw new ApprovalAlreadyResolvedError()");
-        expect(body).toContain("instanceof ApprovalAlreadyResolvedError");
+describe("mounted generic approval boundary", () => {
+  it("rejects non-human and stale-MFA principals across reads and writes", async () => {
+    const operations: Array<[string, RequestInit]> = [
+      ["/approvals", {}],
+      ["/approvals/stats", {}],
+      ["/approvals/rules", {}],
+      [`/approvals/${TX_ID}/approve`, { method: "POST", body: "{}" }],
+      [`/approvals/${TX_ID}/deny`, { method: "POST", body: JSON.stringify({ reason: "blocked" }) }],
+      [
+        "/approvals/rules",
+        { method: "PUT", body: JSON.stringify({ maxAmountWei: "10", enabled: true }) },
+      ],
+    ];
+    for (const selected of ["api-key", "agent", "member", "stale"]) {
+      for (const [path, init] of operations) {
+        const response = await request(path, init, selected);
+        expect(response.status, `${selected} ${path}`).toBe(403);
       }
     }
+  });
+
+  it("serves list, stats, rules, and rule mutations to a fresh human approver", async () => {
+    for (const path of ["/approvals", "/approvals/stats", "/approvals/rules"]) {
+      const response = await request(path);
+      expect(response.status, path).toBe(200);
+    }
+    const created = await request("/approvals/rules", {
+      method: "PUT",
+      body: JSON.stringify({ maxAmountWei: "10", autoDenyAfterHours: 2, enabled: true }),
+    });
+    expect(created.status).toBe(201);
+    const updated = await request("/approvals/rules", {
+      method: "PUT",
+      body: JSON.stringify({ maxAmountWei: "20" }),
+    });
+    expect(updated.status).toBe(200);
+    const [stored] = await getDb()
+      .select()
+      .from(autoApprovalRules)
+      .where(eq(autoApprovalRules.tenantId, TENANT_ID));
+    expect(stored?.maxAmountWei).toBe("20");
+  });
+
+  it("refuses generic approval of a Vault transaction without mutating state or audit", async () => {
+    const beforeAudits = await getDb()
+      .select()
+      .from(auditEvents)
+      .where(eq(auditEvents.tenantId, TENANT_ID));
+    const response = await request(`/approvals/${TX_ID}/approve`, {
+      method: "POST",
+      body: JSON.stringify({ comment: "approve" }),
+    });
+    expect(response.status).toBe(409);
+    expect((await response.json()) as { error: string }).toMatchObject({
+      error: expect.stringContaining("/vault/:agentId/approve/:txId"),
+    });
+    const [queue] = await getDb()
+      .select()
+      .from(approvalQueue)
+      .where(eq(approvalQueue.id, APPROVAL_ID));
+    const [transaction] = await getDb()
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, TX_ID));
+    expect(queue?.status).toBe("pending");
+    expect(transaction?.status).toBe("pending");
+    const afterAudits = await getDb()
+      .select()
+      .from(auditEvents)
+      .where(eq(auditEvents.tenantId, TENANT_ID));
+    expect(afterAudits).toEqual(beforeAudits);
+  });
+
+  it("rolls back queue and transaction denial when the required completion audit fails", async () => {
+    await getDb().execute(sql`
+      CREATE FUNCTION reject_approval_deny_completion() RETURNS trigger AS $$
+      BEGIN
+        IF NEW.action = 'approval.deny' THEN RAISE EXCEPTION 'injected audit failure'; END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+    `);
+    await getDb().execute(sql`
+      CREATE TRIGGER reject_approval_deny_completion BEFORE INSERT ON audit_events
+      FOR EACH ROW EXECUTE FUNCTION reject_approval_deny_completion()
+    `);
+    try {
+      const response = await request(`/approvals/${TX_ID}/deny`, {
+        method: "POST",
+        body: JSON.stringify({ reason: "policy denied" }),
+      });
+      expect(response.status).toBe(500);
+      const [queue] = await getDb()
+        .select()
+        .from(approvalQueue)
+        .where(eq(approvalQueue.id, APPROVAL_ID));
+      const [transaction] = await getDb()
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, TX_ID));
+      expect(queue?.status).toBe("pending");
+      expect(transaction?.status).toBe("pending");
+      const completion = await getDb()
+        .select()
+        .from(auditEvents)
+        .where(and(eq(auditEvents.tenantId, TENANT_ID), eq(auditEvents.action, "approval.deny")));
+      expect(completion).toHaveLength(0);
+    } finally {
+      await getDb().execute(sql`DROP TRIGGER reject_approval_deny_completion ON audit_events`);
+      await getDb().execute(sql`DROP FUNCTION reject_approval_deny_completion()`);
+    }
+  });
+
+  it("keeps stale terminal transactions and their queue rows unchanged", async () => {
+    await getDb()
+      .update(transactions)
+      .set({ status: "rejected" })
+      .where(eq(transactions.id, TX_ID));
+    const response = await request(`/approvals/${TX_ID}/deny`, {
+      method: "POST",
+      body: JSON.stringify({ reason: "too late" }),
+    });
+    expect(response.status).toBe(409);
+    const [queue] = await getDb()
+      .select()
+      .from(approvalQueue)
+      .where(eq(approvalQueue.id, APPROVAL_ID));
+    expect(queue?.status).toBe("pending");
+  });
+
+  it("atomically denies a pending transaction with exactly one completion audit", async () => {
+    const response = await request(`/approvals/${TX_ID}/deny`, {
+      method: "POST",
+      body: JSON.stringify({ reason: "operator denied" }),
+    });
+    expect(response.status).toBe(200);
+    const [queue] = await getDb()
+      .select()
+      .from(approvalQueue)
+      .where(eq(approvalQueue.id, APPROVAL_ID));
+    const [transaction] = await getDb()
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, TX_ID));
+    expect(queue?.status).toBe("rejected");
+    expect(transaction?.status).toBe("rejected");
+    const completion = await getDb()
+      .select()
+      .from(auditEvents)
+      .where(and(eq(auditEvents.tenantId, TENANT_ID), eq(auditEvents.action, "approval.deny")));
+    expect(completion).toHaveLength(1);
   });
 });

--- a/packages/api/src/__tests__/fixtures/approval-generic-deny-request.ts
+++ b/packages/api/src/__tests__/fixtures/approval-generic-deny-request.ts
@@ -1,0 +1,46 @@
+import { closeDb } from "@stwd/db";
+import { Hono } from "hono";
+import { correlationId } from "../../middleware/correlation";
+import type { AppVariables } from "../../services/context";
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+const tenantId = required("TEST_TENANT_ID");
+const userId = required("TEST_USER_ID");
+const txId = required("TEST_TX_ID");
+
+const [{ createSessionToken }, { tenantAuth }, { approvalRoutes }] = await Promise.all([
+  import("../../routes/auth"),
+  import("../../services/context"),
+  import("../../routes/approvals"),
+]);
+
+const token = await createSessionToken("0x0000000000000000000000000000000000000737", tenantId, {
+  userId,
+  tenantId,
+  mfaVerifiedAt: Date.now(),
+  mfaMethod: "totp",
+});
+const app = new Hono<{ Variables: AppVariables }>();
+app.onError((error, c) => c.json({ ok: false, error: error.message }, 500));
+app.use("*", correlationId);
+app.use("*", tenantAuth);
+app.route("/approvals", approvalRoutes);
+
+const response = await app.request(`/approvals/${txId}/deny`, {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    "X-Request-Id": required("TEST_REQUEST_ID"),
+  },
+  body: JSON.stringify({ reason: required("TEST_DENY_REASON") }),
+});
+const body = await response.json();
+await closeDb();
+process.stdout.write(JSON.stringify({ status: response.status, body }));
+process.exit(0);

--- a/packages/api/src/__tests__/fixtures/approval-rule-concurrent-request.ts
+++ b/packages/api/src/__tests__/fixtures/approval-rule-concurrent-request.ts
@@ -1,0 +1,50 @@
+import { closeDb } from "@stwd/db";
+import { Hono } from "hono";
+import { correlationId } from "../../middleware/correlation";
+import type { AppVariables } from "../../services/context";
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+const tenantId = required("TEST_TENANT_ID");
+const userId = required("TEST_USER_ID");
+const requestId = required("TEST_REQUEST_ID");
+const requestBody = JSON.parse(required("TEST_REQUEST_BODY")) as Record<string, unknown>;
+
+const [{ createSessionToken }, { tenantAuth }, { approvalRoutes }] = await Promise.all([
+  import("../../routes/auth"),
+  import("../../services/context"),
+  import("../../routes/approvals"),
+]);
+
+const token = await createSessionToken("0x0000000000000000000000000000000000000720", tenantId, {
+  userId,
+  tenantId,
+  mfaVerifiedAt: Date.now(),
+  mfaMethod: "totp",
+});
+const app = new Hono<{ Variables: AppVariables }>();
+app.onError((error, c) => c.json({ ok: false, error: error.message }, 500));
+app.use("*", correlationId);
+app.use("*", tenantAuth);
+app.route("/approvals", approvalRoutes);
+
+const response = await app.request("/approvals/rules", {
+  method: "PUT",
+  headers: {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    "X-Request-Id": requestId,
+  },
+  body: JSON.stringify(requestBody),
+});
+const body = await response.json();
+await closeDb();
+process.stdout.write(JSON.stringify({ status: response.status, body }));
+// postgres.js keeps its pool timer alive after this single-purpose process has
+// returned the mounted response. The request transaction is already committed;
+// force a clean helper exit so Bun's test runner never has to reap it.
+process.exit(0);

--- a/packages/api/src/routes/approvals.ts
+++ b/packages/api/src/routes/approvals.ts
@@ -4,9 +4,14 @@
  * Mount: app.route("/approvals", approvalRoutes)
  */
 
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { and, desc, eq, inArray, lt, or, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
-import { withTenantAuditedTransaction, writeAuditEvent } from "../services/audit";
+import {
+  appendAuditEventWithinTx,
+  withTenantAuditedTransaction,
+  writeAuditEvent,
+} from "../services/audit";
 import {
   type ApiResponse,
   type AppVariables,
@@ -1051,83 +1056,113 @@ approvalRoutes.put("/rules", async (c) => {
     }
   }
 
-  // Upsert
-  const [existing] = await db
-    .select()
-    .from(autoApprovalRules)
-    .where(eq(autoApprovalRules.tenantId, tenantId));
+  const updates: Record<string, unknown> = { updatedAt: new Date() };
+  if (body.maxAmountWei !== undefined) updates.maxAmountWei = body.maxAmountWei;
+  if (body.autoDenyAfterHours !== undefined) updates.autoDenyAfterHours = body.autoDenyAfterHours;
+  if (body.escalateAboveWei !== undefined) updates.escalateAboveWei = body.escalateAboveWei;
+  if (body.enabled !== undefined) updates.enabled = body.enabled;
 
-  if (existing) {
-    const updates: Record<string, unknown> = { updatedAt: new Date() };
-    if (body.maxAmountWei !== undefined) updates.maxAmountWei = body.maxAmountWei;
-    if (body.autoDenyAfterHours !== undefined) updates.autoDenyAfterHours = body.autoDenyAfterHours;
-    if (body.escalateAboveWei !== undefined) updates.escalateAboveWei = body.escalateAboveWei;
-    if (body.enabled !== undefined) updates.enabled = body.enabled;
+  const mutation = await withTenantAuditedTransaction(
+    tenantId,
+    async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof db;
+      // The audited transaction acquires the same real-Postgres advisory lock
+      // used by every tenant audit append before this re-read. That lock also
+      // serializes the missing-row create case, which SELECT FOR UPDATE alone
+      // cannot protect.
+      const [existing] = await tx
+        .select()
+        .from(autoApprovalRules)
+        .where(eq(autoApprovalRules.tenantId, tenantId))
+        .for("update");
 
-    await writeApprovalAudit(c, {
-      action: "approval_rule.update.authorized",
-      resourceType: "approval_rule",
-      resourceId: existing.id,
-      metadata: { before: existing, updates },
-    });
+      if (existing) {
+        const authorizationAttempt = {
+          action: "approval_rule.update.authorized",
+          resourceType: "approval_rule",
+          resourceId: existing.id,
+          metadata: { before: existing, updates },
+        };
+        await appendRequiredAudit(approvalAuditEvent(c, authorizationAttempt));
+        try {
+          return await tx.transaction(async (mutationTxRaw) => {
+            const mutationTx = mutationTxRaw as unknown as typeof db;
+            const [updated] = await mutationTx
+              .update(autoApprovalRules)
+              .set(updates)
+              .where(eq(autoApprovalRules.id, existing.id))
+              .returning();
+            await appendAuditEventWithinTx(
+              mutationTx as never,
+              approvalAuditEvent(c, {
+                action: "approval_rule.update",
+                resourceType: "approval_rule",
+                resourceId: updated.id,
+                metadata: { before: existing, after: updated },
+              }),
+            );
+            // Surface deferred database failures inside the mutation
+            // savepoint so the authorization attempt can still commit.
+            await mutationTx.execute(sql`SET CONSTRAINTS ALL IMMEDIATE`);
+            return { kind: "updated" as const, row: updated };
+          });
+        } catch (error) {
+          console.error(
+            "[approvals] auto-approval rule update failed",
+            redactedThrownDiagnostics(error),
+          );
+          return { kind: "failed" as const };
+        }
+      }
 
-    const [updated] = await db
-      .update(autoApprovalRules)
-      .set(updates)
-      .where(eq(autoApprovalRules.tenantId, tenantId))
-      .returning();
-    try {
-      await writeApprovalAudit(c, {
-        action: "approval_rule.update",
+      const createdId = crypto.randomUUID();
+      const authorizationAttempt = {
+        action: "approval_rule.create.authorized",
         resourceType: "approval_rule",
-        resourceId: updated.id,
-        metadata: { before: existing, after: updated },
-      });
-    } catch (err) {
-      await db
-        .update(autoApprovalRules)
-        .set({
-          maxAmountWei: existing.maxAmountWei,
-          autoDenyAfterHours: existing.autoDenyAfterHours,
-          escalateAboveWei: existing.escalateAboveWei,
-          enabled: existing.enabled,
-          updatedAt: existing.updatedAt,
-        })
-        .where(eq(autoApprovalRules.id, existing.id));
-      throw err;
-    }
+        resourceId: createdId,
+        metadata: { requested: body },
+      };
+      await appendRequiredAudit(approvalAuditEvent(c, authorizationAttempt));
+      try {
+        return await tx.transaction(async (mutationTxRaw) => {
+          const mutationTx = mutationTxRaw as unknown as typeof db;
+          const [created] = await mutationTx
+            .insert(autoApprovalRules)
+            .values({
+              id: createdId,
+              tenantId,
+              maxAmountWei: body.maxAmountWei || "0",
+              autoDenyAfterHours: body.autoDenyAfterHours ?? null,
+              escalateAboveWei: body.escalateAboveWei ?? null,
+              enabled: body.enabled ?? true,
+            })
+            .returning();
+          await appendAuditEventWithinTx(
+            mutationTx as never,
+            approvalAuditEvent(c, {
+              action: "approval_rule.create",
+              resourceType: "approval_rule",
+              resourceId: created.id,
+              metadata: { after: created },
+            }),
+          );
+          await mutationTx.execute(sql`SET CONSTRAINTS ALL IMMEDIATE`);
+          return { kind: "created" as const, row: created };
+        });
+      } catch (error) {
+        console.error(
+          "[approvals] auto-approval rule create failed",
+          redactedThrownDiagnostics(error),
+        );
+        return { kind: "failed" as const };
+      }
+    },
+  );
 
-    return c.json<ApiResponse>({ ok: true, data: updated });
+  if (mutation.kind === "failed") {
+    return c.json<ApiResponse>({ ok: false, error: "Failed to update approval rule" }, 500);
   }
-
-  await writeApprovalAudit(c, {
-    action: "approval_rule.create.authorized",
-    resourceType: "approval_rule",
-    resourceId: tenantId,
-    metadata: { requested: body },
-  });
-
-  const [created] = await db
-    .insert(autoApprovalRules)
-    .values({
-      tenantId,
-      maxAmountWei: body.maxAmountWei || "0",
-      autoDenyAfterHours: body.autoDenyAfterHours ?? null,
-      escalateAboveWei: body.escalateAboveWei ?? null,
-      enabled: body.enabled ?? true,
-    })
-    .returning();
-  try {
-    await writeApprovalAudit(c, {
-      action: "approval_rule.create",
-      resourceType: "approval_rule",
-      resourceId: created.id,
-      metadata: { after: created },
-    });
-  } catch (err) {
-    await db.delete(autoApprovalRules).where(eq(autoApprovalRules.id, created.id));
-    throw err;
-  }
-
-  return c.json<ApiResponse>({ ok: true, data: created }, 201);
+  return mutation.kind === "created"
+    ? c.json<ApiResponse>({ ok: true, data: mutation.row }, 201)
+    : c.json<ApiResponse>({ ok: true, data: mutation.row });
 });


### PR DESCRIPTION
Closes #737.
Closes #720.

Replaces generic approval source-order assertions with mounted behavior and makes auto-approval rule create/update mutations audit-atomic. Adds deterministic mounted PostgreSQL races for rule mutations and generic approve/deny terminal-state decisions.

Exact head: f119933cf360316ddbd9e0c0fb2972a82b9ab679
Exact base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6

Local acceptance:
- mounted PGLite approval behavior: 6 pass, 144 assertions
- mounted PostgreSQL race cases: 12 locally skipped and required in hosted Integration Tests
- API build, targeted Biome, diff check, public-package metadata: pass

Keep draft until the exact hosted PostgreSQL races, full matrix, and independent review pass.