### PR TITLE
test(api): mount tenant app-client boundaries

### DIFF
--- a/packages/api/src/__tests__/fixtures/tenant-app-client-request.ts
+++ b/packages/api/src/__tests__/fixtures/tenant-app-client-request.ts
@@ -1,0 +1,27 @@
+import { closeDb } from "@stwd/db";
+import { Hono } from "hono";
+import { tenantConfigRoutes } from "../../routes/tenant-config";
+
+const tenantId = process.env.TEST_TENANT_ID;
+const token = process.env.TEST_SESSION_TOKEN;
+const method = process.env.TEST_METHOD;
+const path = process.env.TEST_PATH;
+if (!tenantId || !token || !method || !path) {
+  throw new Error("tenant app-client request fixture is missing required environment");
+}
+
+const app = new Hono();
+app.route("/tenants", tenantConfigRoutes);
+app.onError((error, c) => c.json({ ok: false, error: error.message }, 500));
+const body = process.env.TEST_BODY;
+const response = await app.request(`/tenants/${tenantId}${path}`, {
+  method,
+  headers: {
+    Authorization: `Bearer ${token}`,
+    ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+  },
+  body,
+});
+process.stdout.write(JSON.stringify({ status: response.status, body: await response.text() }));
+await closeDb();
+process.exit(0);

--- a/packages/api/src/__tests__/tenant-app-client-races-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/tenant-app-client-races-postgres.integration.test.ts
@@ -1,0 +1,207 @@
+import { expect, it } from "bun:test";
+import { generateApiKey } from "@stwd/auth";
+import {
+  auditChainHeads,
+  auditEvents,
+  createDb,
+  tenantAppClientSecrets,
+  tenantAppClients,
+  tenants,
+  users,
+  userTenants,
+} from "@stwd/db";
+import { and, eq } from "drizzle-orm";
+
+const databaseUrl = process.env.DATABASE_URL;
+const realPostgresIt = databaseUrl && !process.env.STEWARD_PGLITE_MEMORY ? it : it.skip;
+
+realPostgresIt(
+  "serializes duplicate create, secret rotation, and an ordered delete/replace race",
+  async () => {
+    const suffix = crypto.randomUUID().replaceAll("-", "");
+    const tenantId = `app-client-race-${suffix}`;
+    const userId = crypto.randomUUID();
+    const gateKey = Number.parseInt(suffix.slice(0, 12), 16);
+    const triggerFunction = `gate_app_client_delete_${suffix}`;
+    const triggerName = `gate_app_client_delete_${suffix}`;
+    const previousJwtSecret = process.env.STEWARD_JWT_SECRET;
+    const previousMasterPassword = process.env.STEWARD_MASTER_PASSWORD;
+    const previousAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+    process.env.STEWARD_JWT_SECRET = `app-client-race-jwt-${suffix}`;
+    process.env.STEWARD_MASTER_PASSWORD = `app-client-race-master-${suffix}`;
+    process.env.STEWARD_AUDIT_HMAC_KEY = `app-client-race-audit-${suffix}`;
+
+    const admin = createDb(databaseUrl!);
+    const locker = await admin.client.reserve();
+    let gateLocked = false;
+    try {
+      const keyPair = generateApiKey();
+      await admin.db
+        .insert(tenants)
+        .values({ id: tenantId, name: tenantId, apiKeyHash: keyPair.hash });
+      await admin.db.insert(users).values({
+        id: userId,
+        email: `${suffix}@example.test`,
+        emailVerified: true,
+      });
+      await admin.db.insert(userTenants).values({ userId, tenantId, role: "owner" });
+
+      const { createSessionToken } = await import("../routes/auth");
+      const token = await createSessionToken(
+        "0x0000000000000000000000000000000000000000",
+        tenantId,
+        { userId, tenantId, mfaVerifiedAt: Date.now(), mfaMethod: "totp" },
+      );
+      const spawnRequest = (path: string, method: string, body?: unknown) =>
+        Bun.spawn(
+          [
+            process.execPath,
+            new URL("./fixtures/tenant-app-client-request.ts", import.meta.url).pathname,
+          ],
+          {
+            cwd: new URL("../../../..", import.meta.url).pathname,
+            env: {
+              ...process.env,
+              DATABASE_URL: databaseUrl!,
+              TEST_TENANT_ID: tenantId,
+              TEST_SESSION_TOKEN: token,
+              TEST_METHOD: method,
+              TEST_PATH: path,
+              ...(body === undefined ? {} : { TEST_BODY: JSON.stringify(body) }),
+            },
+            stdout: "pipe",
+            stderr: "pipe",
+          },
+        );
+      const finishRequest = async (process: ReturnType<typeof spawnRequest>) => {
+        const exit = await process.exited;
+        if (exit !== 0) {
+          throw new Error(
+            `app-client request failed: ${await new Response(process.stderr).text()}`,
+          );
+        }
+        return JSON.parse(await new Response(process.stdout).text()) as {
+          status: number;
+          body: string;
+        };
+      };
+      const client = {
+        id: "race-client",
+        name: "Race Client",
+        environment: "production",
+        enabled: true,
+        isDefault: true,
+        allowedOrigins: ["https://race.example.test"],
+        allowedRedirectUrls: ["https://race.example.test/callback"],
+        allowedBundleIds: ["com.example.race"],
+        allowedPackageNames: ["com.example.race"],
+      };
+
+      const createProcesses = [
+        spawnRequest("/app-clients", "POST", { client }),
+        spawnRequest("/app-clients", "POST", { client }),
+      ];
+      const createResponses = await Promise.all(createProcesses.map(finishRequest));
+      expect(createResponses.map((response) => response.status).sort()).toEqual([201, 409]);
+      expect(
+        await admin.db
+          .select()
+          .from(tenantAppClients)
+          .where(eq(tenantAppClients.tenantId, tenantId)),
+      ).toHaveLength(1);
+
+      const rotateProcesses = [
+        spawnRequest("/app-clients/race-client/secrets", "POST", {}),
+        spawnRequest("/app-clients/race-client/secrets", "POST", {}),
+      ];
+      const rotateResponses = await Promise.all(rotateProcesses.map(finishRequest));
+      expect(rotateResponses.map((response) => response.status)).toEqual([201, 201]);
+      const rotated = await admin.db
+        .select({ status: tenantAppClientSecrets.status })
+        .from(tenantAppClientSecrets)
+        .where(eq(tenantAppClientSecrets.tenantId, tenantId));
+      expect(rotated.map((row) => row.status).sort()).toEqual(["active", "retiring"]);
+
+      await admin.client.unsafe(`
+        create function "${triggerFunction}"() returns trigger language plpgsql as $$
+        begin
+          if new.tenant_id = '${tenantId}' and new.action = 'tenant.app_client.delete' then
+            perform pg_advisory_xact_lock(${gateKey});
+          end if;
+          return new;
+        end
+        $$
+      `);
+      await admin.client.unsafe(`
+        create trigger "${triggerName}"
+        before insert on audit_events
+        for each row execute function "${triggerFunction}"()
+      `);
+      await locker`select pg_advisory_lock(${gateKey})`;
+      gateLocked = true;
+
+      const deleting = spawnRequest("/app-clients/race-client", "DELETE");
+      for (let attempt = 0; attempt < 100; attempt++) {
+        const [waiting] = await admin.client<{ count: string }[]>`
+          select count(*)::text as count
+          from pg_stat_activity
+          where wait_event = 'advisory' and query ilike '%INSERT INTO audit_events%'
+        `;
+        if (Number(waiting?.count ?? "0") > 0) break;
+        if (attempt === 99) throw new Error("delete did not reach the completion-audit gate");
+        await Bun.sleep(10);
+      }
+
+      const replacing = spawnRequest("/app-clients", "PUT", {
+        clients: [{ ...client, name: "Recreated After Delete" }],
+      });
+      for (let attempt = 0; attempt < 100; attempt++) {
+        const [waiting] = await admin.client<{ count: string }[]>`
+          select count(*)::text as count from pg_stat_activity where wait_event = 'advisory'
+        `;
+        if (Number(waiting?.count ?? "0") >= 2) break;
+        if (attempt === 99) throw new Error("replace did not queue behind delete");
+        await Bun.sleep(10);
+      }
+
+      await locker`select pg_advisory_unlock(${gateKey})`;
+      gateLocked = false;
+      const [deleted, replaced] = await Promise.all([
+        finishRequest(deleting),
+        finishRequest(replacing),
+      ]);
+      expect([deleted.status, replaced.status]).toEqual([200, 200]);
+      const [finalClient] = await admin.db
+        .select()
+        .from(tenantAppClients)
+        .where(
+          and(eq(tenantAppClients.tenantId, tenantId), eq(tenantAppClients.id, "race-client")),
+        );
+      expect(finalClient?.name).toBe("Recreated After Delete");
+      expect(
+        await admin.db
+          .select()
+          .from(tenantAppClientSecrets)
+          .where(eq(tenantAppClientSecrets.tenantId, tenantId)),
+      ).toHaveLength(0);
+    } finally {
+      if (gateLocked) await locker`select pg_advisory_unlock(${gateKey})`;
+      locker.release();
+      await admin.client.unsafe(`drop trigger if exists "${triggerName}" on audit_events`);
+      await admin.client.unsafe(`drop function if exists "${triggerFunction}"()`);
+      await admin.db.delete(auditEvents).where(eq(auditEvents.tenantId, tenantId));
+      await admin.db.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, tenantId));
+      await admin.db.delete(userTenants).where(eq(userTenants.tenantId, tenantId));
+      await admin.db.delete(tenants).where(eq(tenants.id, tenantId));
+      await admin.db.delete(users).where(eq(users.id, userId));
+      await admin.client.end();
+      if (previousJwtSecret === undefined) delete process.env.STEWARD_JWT_SECRET;
+      else process.env.STEWARD_JWT_SECRET = previousJwtSecret;
+      if (previousMasterPassword === undefined) delete process.env.STEWARD_MASTER_PASSWORD;
+      else process.env.STEWARD_MASTER_PASSWORD = previousMasterPassword;
+      if (previousAuditKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+      else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditKey;
+    }
+  },
+  120_000,
+);

--- a/packages/api/src/__tests__/tenant-app-clients.test.ts
+++ b/packages/api/src/__tests__/tenant-app-clients.test.ts
@@ -1,202 +1,368 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { generateApiKey, hashSha256Hex } from "@stwd/auth";
+import {
+  auditEvents,
+  closeDb,
+  getDb,
+  tenantAppClientSecrets,
+  tenantAppClients,
+  tenants,
+  users,
+  userTenants,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq, sql } from "drizzle-orm";
+import { Hono } from "hono";
 
 const ROOT = join(import.meta.dir, "../../../..");
+const TENANT_ID = "tenant-app-client-behavior";
+const CLIENT = {
+  id: "web-prod",
+  name: "Web Production",
+  environment: "production",
+  enabled: true,
+  isDefault: true,
+  allowedOrigins: ["https://app.example.test"],
+  allowedRedirectUrls: ["https://app.example.test/callback"],
+  allowedBundleIds: ["com.example.steward"],
+  allowedPackageNames: ["com.example.steward"],
+};
 
-function read(path: string): string {
-  return readFileSync(join(ROOT, path), "utf-8");
-}
-
-// Assert the composed DDL contract against
-// the full set of migration files rather than a single hard-coded filename.
 function allMigrations(): string {
   const dir = join(ROOT, "packages/db/drizzle");
   return readdirSync(dir)
-    .filter((f) => f.endsWith(".sql"))
-    .map((f) => readFileSync(join(dir, f), "utf-8"))
+    .filter((file) => file.endsWith(".sql"))
+    .map((file) => readFileSync(join(dir, file), "utf8"))
     .join("\n");
 }
 
-describe("tenant app clients hardening", () => {
-  it("persists app clients as a tenant-scoped registry with exact allowlists", () => {
-    const schema = read("packages/db/src/schema.ts");
-    const migration = allMigrations();
+describe("tenant app-client mounted behavior", () => {
+  let tenantConfigRoutes: typeof import("../routes/tenant-config").tenantConfigRoutes;
+  let authRoutes: typeof import("../routes/auth").authRoutes;
+  let createSessionToken: typeof import("../routes/auth").createSessionToken;
+  let tenantCors: typeof import("../middleware/tenant-cors").tenantCors;
+  let ownerId = "";
+  let memberId = "";
+  let apiKey = "";
 
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_MASTER_PASSWORD = "tenant-app-client-master-password";
+    process.env.STEWARD_JWT_SECRET = "tenant-app-client-jwt-secret-with-enough-bytes";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "tenant-app-client-audit-hmac-key";
+    process.env.APP_URL = "https://api.example.test";
+    process.env.GOOGLE_CLIENT_ID = "google-client";
+    process.env.GOOGLE_CLIENT_SECRET = "google-secret";
+
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+    const generated = generateApiKey();
+    apiKey = generated.key;
+    await getDb().insert(tenants).values({
+      id: TENANT_ID,
+      name: "Tenant App Client Behavior",
+      apiKeyHash: generated.hash,
+    });
+    const [owner, member] = await getDb()
+      .insert(users)
+      .values([
+        { email: "app-client-owner@example.test", emailVerified: true },
+        { email: "app-client-member@example.test", emailVerified: true },
+      ])
+      .returning({ id: users.id });
+    ownerId = owner.id;
+    memberId = member.id;
+    await getDb()
+      .insert(userTenants)
+      .values([
+        { userId: ownerId, tenantId: TENANT_ID, role: "owner" },
+        { userId: memberId, tenantId: TENANT_ID, role: "member" },
+      ]);
+
+    ({ tenantConfigRoutes } = await import("../routes/tenant-config"));
+    ({ authRoutes, createSessionToken } = await import("../routes/auth"));
+    ({ tenantCors } = await import("../middleware/tenant-cors"));
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeDb();
+    for (const name of [
+      "STEWARD_PGLITE_MEMORY",
+      "STEWARD_MASTER_PASSWORD",
+      "STEWARD_JWT_SECRET",
+      "STEWARD_AUDIT_HMAC_KEY",
+      "APP_URL",
+      "GOOGLE_CLIENT_ID",
+      "GOOGLE_CLIENT_SECRET",
+    ])
+      delete process.env[name];
+  });
+
+  async function tokenFor(userId: string, mfaVerifiedAt = Date.now()): Promise<string> {
+    return createSessionToken("0x0000000000000000000000000000000000000000", TENANT_ID, {
+      userId,
+      tenantId: TENANT_ID,
+      mfaVerifiedAt,
+      mfaMethod: "totp",
+    });
+  }
+
+  function request(path: string, token: string, method = "GET", body?: unknown) {
+    return tenantConfigRoutes.request(`/${TENANT_ID}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+  }
+
+  it("retains only narrow schema and migration inventory assertions", () => {
+    const schema = readFileSync(join(ROOT, "packages/db/src/schema.ts"), "utf8");
+    const migrations = allMigrations();
     expect(schema).toContain("export const tenantAppClients");
-    expect(schema).toContain('varchar("tenant_id"');
-    expect(schema).toContain(
-      'allowedOrigins: text("allowed_origins").array().notNull().default([])',
-    );
-    expect(schema).toContain(
-      'allowedRedirectUrls: text("allowed_redirect_urls").array().notNull().default([])',
-    );
-    expect(schema).toContain(
-      'allowedBundleIds: text("allowed_bundle_ids").array().notNull().default([])',
-    );
-    expect(schema).toContain(
-      'allowedPackageNames: text("allowed_package_names").array().notNull().default([])',
-    );
-    expect(migration).toContain('CREATE TABLE IF NOT EXISTS "tenant_app_clients"');
-    expect(migration).toContain('"tenant_id" varchar(64) NOT NULL');
-    expect(migration).toContain('"tenant_app_clients_tenant_id_tenants_id_fk"');
-    expect(migration).toContain('"allowed_redirect_urls" text[] DEFAULT');
-    expect(read("packages/db/drizzle/0071_app_client_native_allowlists.sql")).toContain(
-      '"allowed_bundle_ids" text[] DEFAULT',
-    );
-  });
-
-  it("keeps app-client mutations behind owner/admin recent MFA and validates redirect/origin inputs", () => {
-    const source = read("packages/api/src/routes/tenant-config.ts");
-
-    expect(source).toContain('tenantConfigRoutes.get("/:id/app-clients"');
-    expect(source).toContain('tenantConfigRoutes.put("/:id/app-clients"');
-    expect(source).toContain('tenantConfigRoutes.post("/:id/app-clients"');
-    expect(source).toContain('tenantConfigRoutes.delete("/:id/app-clients/:clientId"');
-    expect(source).toContain('requireRecentTenantAdminMfa(c, "App client updates")');
-    expect(source).toContain("normalizeTenantAppClients");
-    expect(source).toContain("normalizeAllowedOrigins(raw.allowedOrigins ?? [])");
-    expect(source).toContain("normalizeAllowedRedirectUrls(raw.allowedRedirectUrls ?? [])");
-    expect(source).toContain("normalizeAllowedBundleIds(raw.allowedBundleIds ?? [])");
-    expect(source).toContain("normalizeAllowedPackageNames(raw.allowedPackageNames ?? [])");
-    expect(source).toContain("allowedOrigins cannot include wildcard");
-    expect(source).toContain("allowedOrigins entries cannot be wildcard");
-    expect(source).toContain(
-      "allowedOrigins entries must use https except for loopback development origins",
-    );
-    expect(source).toContain("allowedBundleIds entries cannot be wildcard");
-    expect(source).toContain("allowedBundleIds entries must be explicit iOS bundle identifiers");
-    expect(source).toContain("allowedPackageNames entries cannot be wildcard");
-    expect(source).toContain("allowedPackageNames entries must be explicit Android package names");
-  });
-
-  it("audits app-client create/delete in the same transaction as mutation", () => {
-    const source = read("packages/api/src/routes/tenant-config.ts");
-
-    for (const [marker, authorizedAction, finalAction] of [
-      [
-        'tenantConfigRoutes.post("/:id/app-clients"',
-        'action: "tenant.app_client.create.authorized"',
-        'action: "tenant.app_client.create"',
-      ],
-      [
-        'tenantConfigRoutes.delete("/:id/app-clients/:clientId"',
-        'action: "tenant.app_client.delete.authorized"',
-        'action: "tenant.app_client.delete"',
-      ],
-    ] as const) {
-      const start = source.indexOf(marker);
-      expect(start).toBeGreaterThanOrEqual(0);
-      const nextRoute = source.indexOf("\ntenantConfigRoutes.", start + marker.length);
-      const route = source.slice(start, nextRoute === -1 ? undefined : nextRoute);
-      expect(route.indexOf(authorizedAction)).toBeGreaterThanOrEqual(0);
-      expect(route.indexOf(authorizedAction)).toBeLessThan(
-        route.indexOf("persistTenantAppClientsForTenant"),
-      );
-      expect(route).toContain("withTenantAuditedTransaction(");
-      expect(route).toContain("appendRequiredAudit({");
-      expect(route).toContain(finalAction);
-      expect(route).not.toContain("restoreTenantAppClients");
-    }
-  });
-
-  it("preserves secrets for surviving app clients during registry rewrites", () => {
-    const source = read("packages/api/src/routes/tenant-config.ts");
-    const helperStart = source.indexOf("async function persistTenantAppClientsForTenant");
-    expect(helperStart).toBeGreaterThanOrEqual(0);
-    const helperEnd = source.indexOf(
-      "\nasync function validatePolicyTemplatesForTenant",
-      helperStart,
-    );
-    const helper = source.slice(helperStart, helperEnd);
-
-    expect(helper).toContain(".from(tenantAppClientSecrets)");
-    expect(helper).toContain(
-      "const nextClientIds = new Set(normalized.map((client) => client.id))",
-    );
-    expect(helper).toContain("const secretsToPreserve = existingSecrets.filter");
-    expect(helper).toContain("nextClientIds.has(secret.clientId)");
-    expect(helper).toContain(
-      "await executor.insert(tenantAppClientSecrets).values(secretsToPreserve)",
-    );
-  });
-
-  it("folds enabled app clients into runtime CORS and OAuth redirect enforcement", () => {
-    const cors = read("packages/api/src/middleware/tenant-cors.ts");
-    const auth = read("packages/api/src/routes/auth.ts");
-
-    expect(cors).toContain("tenantAppClientsTable");
-    expect(cors).toContain("eq(tenantAppClientsTable.enabled, true)");
-    expect(auth).toContain("authAppClientSubjects(resolvedTenantId)");
-    expect(auth).toContain("client_id");
-    expect(auth).toContain("stateData.clientId");
-    expect(auth).toContain("getTenantAppClientLoginMethods");
-    expect(auth).toContain("assertAllowedOAuthRedirectUri(redirectUri, tenantId, clientId)");
-    expect(auth).not.toContain(": (client.allowedOrigins ?? [])");
-    expect(auth).not.toContain(": (row?.allowedOrigins ?? [])");
-  });
-
-  it("enforces supplied native identifiers against enabled app clients at auth runtime", () => {
-    const auth = read("packages/api/src/routes/auth.ts");
-
-    expect(auth).toContain("readNativeClientAssertion(c, body)");
-    expect(auth).toContain('c.req.header("X-Steward-Native-Bundle-Id")');
-    expect(auth).toContain('c.req.header("X-Steward-Native-Package-Name")');
-    expect(auth).toContain("native bundle id is not allowed for this app client");
-    expect(auth).toContain("native package name is not allowed for this app client");
-    expect(auth).toContain("record.nativeBundleId && nativeBundleId !== record.nativeBundleId");
-    expect(auth).toContain(
-      "record.nativePackageName && nativePackageName !== record.nativePackageName",
-    );
-  });
-
-  it("adds Privy-style app-client secrets without weakening session-MFA control plane", () => {
-    const schema = read("packages/db/src/schema.ts");
-    const migration = allMigrations();
-    const tenantConfig = read("packages/api/src/routes/tenant-config.ts");
-    const context = read("packages/api/src/services/context.ts");
-
     expect(schema).toContain("export const tenantAppClientSecrets");
-    expect(migration).toContain('CREATE TABLE IF NOT EXISTS "tenant_app_client_secrets"');
-    expect(migration).toContain('"secret_hash" text NOT NULL');
-    expect(tenantConfig).toContain('tenantConfigRoutes.post("/:id/app-clients/:clientId/secrets"');
-    expect(tenantConfig).toContain("appSecret: generated.secret");
-    expect(tenantConfig).toContain("withTenantAuditedTransaction");
-    expect(tenantConfig).toContain("tenant.app_client_secret.rotate.authorized");
-    expect(tenantConfig).toContain("tenant.app_client_secret.rotate");
-    expect(tenantConfig).toContain("tenant.app_client_secret.revoke.authorized");
-    expect(tenantConfig).toContain("tenant.app_client_secret.revoke");
-    expect(context).toContain('authType", "app-secret"');
-    expect(context).toContain("App secret auth requires Basic auth and X-Steward-App-Id");
+    expect(migrations).toContain('CREATE TABLE IF NOT EXISTS "tenant_app_clients"');
+    expect(migrations).toContain('CREATE TABLE IF NOT EXISTS "tenant_app_client_secrets"');
+    expect(migrations).toContain('"secret_hash" text NOT NULL');
   });
 
-  it("makes app-client secret mutations atomic with final audits", () => {
-    const tenantConfig = read("packages/api/src/routes/tenant-config.ts");
+  it("enforces API-key, membership, and recent-MFA authorization on mounted routes", async () => {
+    const apiKeyResponse = await tenantConfigRoutes.request(`/${TENANT_ID}/app-clients`, {
+      headers: { "X-Steward-Key": apiKey, "X-Steward-Tenant": TENANT_ID },
+    });
+    expect(apiKeyResponse.status).toBe(403);
+    expect((await request("/app-clients", await tokenFor(memberId))).status).toBe(403);
+    const stale = await request("/app-clients", await tokenFor(ownerId, Date.now() - 60 * 60_000));
+    expect(stale.status).toBe(403);
+    expect(await stale.json()).toEqual(
+      expect.objectContaining({ error: expect.stringContaining("recent MFA") }),
+    );
+    const fresh = await request("/app-clients", await tokenFor(ownerId));
+    expect(fresh.status).toBe(200);
+    expect(fresh.headers.get("cache-control")).toContain("no-store");
+  });
 
-    for (const [marker, finalAction] of [
-      [
-        'tenantConfigRoutes.post("/:id/app-clients/:clientId/secrets"',
-        'action: "tenant.app_client_secret.rotate"',
+  it("creates, normalizes, lists, replaces, and deletes clients through mounted routes", async () => {
+    const token = await tokenFor(ownerId);
+    const create = await request("/app-clients", token, "POST", {
+      client: { ...CLIENT, id: " Web-Prod ", allowedOrigins: ["https://app.example.test/"] },
+    });
+    expect(create.status).toBe(201);
+    const created = (await create.json()) as { data: { client: typeof CLIENT } };
+    expect(created.data.client).toEqual(
+      expect.objectContaining({ id: "web-prod", allowedOrigins: ["https://app.example.test"] }),
+    );
+    expect(
+      (
+        await request("/app-clients", token, "POST", {
+          client: { ...CLIENT, id: "wildcard", allowedOrigins: ["*"] },
+        })
+      ).status,
+    ).toBe(400);
+
+    const replace = await request("/app-clients", token, "PUT", {
+      clients: [
+        { ...CLIENT, name: "Renamed" },
+        {
+          ...CLIENT,
+          id: "native-app",
+          name: "Native",
+          isDefault: false,
+          allowedOrigins: [],
+          allowedRedirectUrls: [],
+        },
       ],
-      [
-        'tenantConfigRoutes.delete("/:id/app-clients/:clientId/secrets/:secretId"',
-        'action: "tenant.app_client_secret.revoke"',
+    });
+    expect(replace.status).toBe(200);
+    const listed = (await (await request("/app-clients", token)).json()) as {
+      data: { clients: Array<{ id: string }> };
+    };
+    expect(listed.data.clients.map((client) => client.id)).toEqual(["web-prod", "native-app"]);
+    expect((await request("/app-clients/native-app", token, "DELETE")).status).toBe(200);
+    expect(await getDb().select().from(tenantAppClients)).toHaveLength(1);
+  });
+
+  it("rolls client and secret mutations back when their required audit append fails", async () => {
+    const token = await tokenFor(ownerId);
+    const installFailure = async (action: string) => {
+      await getDb().execute(
+        sql.raw(`
+        CREATE OR REPLACE FUNCTION fail_app_client_completion_audit()
+        RETURNS trigger AS $$
+        BEGIN
+          IF NEW.action = '${action}' THEN
+            RAISE EXCEPTION 'forced app-client completion audit failure';
+          END IF;
+          RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+      `),
+      );
+      await getDb().execute(
+        sql.raw("DROP TRIGGER IF EXISTS app_client_completion_audit_failure ON audit_events"),
+      );
+      await getDb().execute(
+        sql.raw(`
+        CREATE TRIGGER app_client_completion_audit_failure
+        BEFORE INSERT ON audit_events
+        FOR EACH ROW EXECUTE FUNCTION fail_app_client_completion_audit();
+      `),
+      );
+    };
+    const clearFailure = async () => {
+      await getDb().execute(
+        sql.raw("DROP TRIGGER IF EXISTS app_client_completion_audit_failure ON audit_events"),
+      );
+      await getDb().execute(sql.raw("DROP FUNCTION IF EXISTS fail_app_client_completion_audit()"));
+    };
+
+    await installFailure("tenant.app_client.replace");
+    const failedReplace = await request("/app-clients", token, "PUT", {
+      clients: [{ ...CLIENT, name: "Must Roll Back" }],
+    });
+    expect(failedReplace.status).toBe(500);
+    expect((await getDb().select().from(tenantAppClients))[0]?.name).toBe("Renamed");
+    await clearFailure();
+
+    await installFailure("tenant.app_client_secret.rotate");
+    const failedRotate = await request("/app-clients/web-prod/secrets", token, "POST", {});
+    expect(failedRotate.status).toBe(500);
+    expect(await getDb().select().from(tenantAppClientSecrets)).toHaveLength(0);
+    await clearFailure();
+  });
+
+  it("returns a secret once, persists only its hash, and preserves it on replacement", async () => {
+    const token = await tokenFor(ownerId);
+    const rotate = await request("/app-clients/web-prod/secrets", token, "POST", {});
+    expect(rotate.status).toBe(201);
+    expect(rotate.headers.get("cache-control")).toContain("no-store");
+    expect(rotate.headers.get("pragma")).toBe("no-cache");
+    const rotated = (await rotate.json()) as {
+      data: { appSecret: string; secret: { id: string } };
+    };
+    expect(rotated.data.appSecret).toStartWith("stw_app_");
+    const [stored] = await getDb().select().from(tenantAppClientSecrets);
+    expect(stored.secretHash).toBe(hashSha256Hex(rotated.data.appSecret));
+    expect(JSON.stringify(stored)).not.toContain(rotated.data.appSecret);
+
+    expect(
+      (
+        await request("/app-clients", token, "PUT", {
+          clients: [{ ...CLIENT, name: "Still here" }],
+        })
+      ).status,
+    ).toBe(200);
+    expect(await getDb().select().from(tenantAppClientSecrets)).toHaveLength(1);
+    const listed = (await (await request("/app-clients/web-prod/secrets", token)).json()) as {
+      data: { secrets: unknown[] };
+    };
+    expect(JSON.stringify(listed)).not.toContain(rotated.data.appSecret);
+    expect(listed.data.secrets).toHaveLength(1);
+    expect(
+      (await request(`/app-clients/web-prod/secrets/${rotated.data.secret.id}`, token, "DELETE"))
+        .status,
+    ).toBe(200);
+    expect((await getDb().select().from(tenantAppClientSecrets))[0]?.status).toBe("revoked");
+  });
+
+  it("uses enabled client allowlists at CORS and OAuth runtime", async () => {
+    const token = await tokenFor(ownerId);
+    await request("/app-clients", token, "PUT", {
+      clients: [
+        CLIENT,
+        {
+          ...CLIENT,
+          id: "disabled",
+          name: "Disabled",
+          enabled: false,
+          isDefault: false,
+          allowedOrigins: ["https://disabled.example.test"],
+          allowedRedirectUrls: ["https://disabled.example.test/callback"],
+        },
       ],
-    ] as const) {
-      let start = tenantConfig.indexOf(marker);
-      if (start < 0 && marker.includes("delete")) {
-        start = tenantConfig.indexOf(
-          'tenantConfigRoutes.delete(\n  "/:id/app-clients/:clientId/secrets/:secretId"',
-        );
-      }
-      if (start < 0) start = tenantConfig.indexOf(marker.slice(0, -2));
-      expect(start).toBeGreaterThanOrEqual(0);
-      const nextRoute = tenantConfig.indexOf("\ntenantConfigRoutes.", start + marker.length);
-      const route = tenantConfig.slice(start, nextRoute === -1 ? undefined : nextRoute);
-      expect(route).toContain("withTenantAuditedTransaction(");
-      expect(route).toContain("appendRequiredAudit({");
-      expect(route).toContain(finalAction);
-      expect(route).not.toContain("restoreTenantAppClientSecrets");
+    });
+    const corsApp = new Hono();
+    corsApp.use("*", tenantCors);
+    corsApp.get("/resource", (c) => c.json({ ok: true }));
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    const allowedCors = await corsApp.request("/resource", {
+      headers: { Origin: "https://app.example.test", "X-Steward-Tenant": TENANT_ID },
+    });
+    expect(allowedCors.headers.get("access-control-allow-origin")).toBe("https://app.example.test");
+    const disabledCors = await corsApp.request("/resource", {
+      headers: { Origin: "https://disabled.example.test", "X-Steward-Tenant": TENANT_ID },
+    });
+    expect(disabledCors.headers.get("access-control-allow-origin")).toBeNull();
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = previousNodeEnv;
+
+    const pkce =
+      "&response_type=code&code_challenge=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&code_challenge_method=S256";
+    expect(
+      (
+        await authRoutes.request(
+          `/oauth/google/authorize?tenant_id=${TENANT_ID}&client_id=web-prod&redirect_uri=${encodeURIComponent("https://app.example.test/callback")}${pkce}`,
+        )
+      ).status,
+    ).toBe(302);
+    for (const [clientId, redirect] of [
+      ["disabled", "https://app.example.test/callback"],
+      ["disabled", "https://disabled.example.test/callback"],
+    ]) {
+      expect(
+        (
+          await authRoutes.request(
+            `/oauth/google/authorize?tenant_id=${TENANT_ID}&client_id=${clientId}&redirect_uri=${encodeURIComponent(redirect)}${pkce}`,
+          )
+        ).status,
+      ).toBe(400);
     }
+
+    const deviceCode = (clientId: string, bundleId: string, packageName: string) =>
+      authRoutes.request("/device/code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tenantId: TENANT_ID,
+          client_id: clientId,
+          native_bundle_id: bundleId,
+          native_package_name: packageName,
+        }),
+      });
+    expect(
+      (await deviceCode("web-prod", "com.example.steward", "com.example.steward")).status,
+    ).toBe(200);
+    expect(
+      (await deviceCode("web-prod", "com.disabled.steward", "com.example.steward")).status,
+    ).toBe(400);
+    expect(
+      (await deviceCode("web-prod", "com.example.steward", "com.disabled.steward")).status,
+    ).toBe(400);
+    expect(
+      (await deviceCode("disabled", "com.example.steward", "com.example.steward")).status,
+    ).toBe(404);
+  });
+
+  it("records mounted completion audits for client and secret mutations", async () => {
+    const actions = (
+      await getDb()
+        .select({ action: auditEvents.action })
+        .from(auditEvents)
+        .where(eq(auditEvents.tenantId, TENANT_ID))
+    ).map((event) => event.action);
+    expect(actions).toEqual(
+      expect.arrayContaining([
+        "tenant.app_client.create",
+        "tenant.app_client.replace",
+        "tenant.app_client.delete",
+        "tenant.app_client_secret.rotate",
+        "tenant.app_client_secret.revoke",
+      ]),
+    );
   });
 });


### PR DESCRIPTION
Closes #738.

Replaces broad tenant app-client source scans with mounted authorization, normalization, atomic rollback, one-time secret, CORS, OAuth, native-client, and completion-audit behavior. Adds a deterministic mounted PostgreSQL create/rotate/delete-replace race.

Exact head: a0c4906d5b3da86d8318531851ba2ad65553263a
Exact base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6

Local acceptance:
- mounted PGLite app-client behavior: 7 pass, 44 assertions
- mounted PostgreSQL race: 1 locally skipped and required in hosted Integration Tests
- API build, targeted Biome, diff check, public-package metadata: pass

Keep draft until the exact hosted PostgreSQL race, full matrix, and independent review pass.