### PR TITLE
fix(api): make ERC-8004 registration audit-atomic

### DIFF
--- a/packages/api/src/__tests__/erc8004-audit-atomicity-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/erc8004-audit-atomicity-postgres.integration.test.ts
@@ -1,0 +1,304 @@
+import { expect, it } from "bun:test";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  agentRegistrations,
+  agents,
+  auditChainHeads,
+  auditEvents,
+  createDb,
+  tenants,
+} from "@stwd/db";
+import { and, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { correlationId } from "../middleware/correlation";
+
+const databaseUrl = process.env.DATABASE_URL;
+const realPostgresIt = databaseUrl && !process.env.STEWARD_PGLITE_MEMORY ? it : it.skip;
+const registryAddress = "0x0000000000000000000000000000000000008004";
+
+realPostgresIt(
+  "rolls back a mounted ERC-8004 registration when its required audit fails",
+  async () => {
+    const suffix = crypto.randomUUID().replaceAll("-", "");
+    const tenantId = `erc8004-atomic-${suffix}`;
+    const agentId = `erc8004-agent-${suffix}`;
+    const requestId = `failed-${suffix}`;
+    const triggerFunction = `fail_erc8004_audit_${suffix}`;
+    const triggerName = `fail_erc8004_audit_${suffix}`;
+    const previousAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+    const previousMasterPassword = process.env.STEWARD_MASTER_PASSWORD;
+    process.env.STEWARD_AUDIT_HMAC_KEY = `erc8004-audit-key-${suffix}`;
+    process.env.STEWARD_MASTER_PASSWORD = `erc8004-master-password-${suffix}`;
+    __resetAuditHmacKeyCacheForTests();
+
+    const admin = createDb(databaseUrl!);
+    try {
+      await admin.db.insert(tenants).values({
+        id: tenantId,
+        name: tenantId,
+        apiKeyHash: `hash-${tenantId}`,
+      });
+      await admin.db.insert(agents).values({
+        id: agentId,
+        tenantId,
+        name: agentId,
+        walletAddress: "0x00000000000000000000000000000000000000aa",
+      });
+      await admin.client.unsafe(`
+        create function "${triggerFunction}"() returns trigger language plpgsql as $$
+        begin
+          if new.tenant_id = '${tenantId}'
+             and new.request_id = '${requestId}'
+             and new.action = 'erc8004.register' then
+            raise exception 'forced ERC-8004 completion audit failure';
+          end if;
+          return new;
+        end
+        $$
+      `);
+      await admin.client.unsafe(`
+        create trigger "${triggerName}"
+        before insert on audit_events
+        for each row execute function "${triggerFunction}"()
+      `);
+
+      const { erc8004Routes } = await import("../routes/erc8004");
+      const app = mountedApp(tenantId, erc8004Routes);
+      const response = await app.request(`/agents/${agentId}/register-onchain`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Request-Id": requestId,
+        },
+        body: JSON.stringify({ capabilities: ["must-rollback"] }),
+      });
+
+      expect(response.status).toBe(500);
+      const registrations = await admin.db
+        .select()
+        .from(agentRegistrations)
+        .where(
+          and(
+            eq(agentRegistrations.tenantId, tenantId),
+            eq(agentRegistrations.agentId, agentId),
+            eq(agentRegistrations.chainId, 8453),
+          ),
+        );
+      expect(registrations).toHaveLength(0);
+
+      const events = await admin.db
+        .select({ action: auditEvents.action, requestId: auditEvents.requestId })
+        .from(auditEvents)
+        .where(eq(auditEvents.tenantId, tenantId));
+      expect(events).toEqual([{ action: "erc8004.register.authorized", requestId }]);
+    } finally {
+      await admin.client.unsafe(`drop trigger if exists "${triggerName}" on audit_events`);
+      await admin.client.unsafe(`drop function if exists "${triggerFunction}"()`);
+      await cleanup(admin, tenantId);
+      await admin.client.end();
+      restoreAuditKey(previousAuditKey);
+      restoreEnvironment("STEWARD_MASTER_PASSWORD", previousMasterPassword);
+    }
+  },
+  120_000,
+);
+
+realPostgresIt(
+  "keeps the concurrent ERC-8004 winner and exact audit after a mounted update audit fails",
+  async () => {
+    const suffix = crypto.randomUUID().replaceAll("-", "");
+    const tenantId = `erc8004-race-${suffix}`;
+    const agentId = `erc8004-agent-${suffix}`;
+    const failedRequestId = `failed-${suffix}`;
+    const successRequestId = `success-${suffix}`;
+    const winnerUrl = `https://winner-${suffix}.example.test/api`;
+    const triggerFunction = `fail_erc8004_audit_${suffix}`;
+    const triggerName = `fail_erc8004_audit_${suffix}`;
+    const gateKey = Number.parseInt(suffix.slice(0, 12), 16);
+    const previousAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+    const previousMasterPassword = process.env.STEWARD_MASTER_PASSWORD;
+    process.env.STEWARD_AUDIT_HMAC_KEY = `erc8004-audit-key-${suffix}`;
+    process.env.STEWARD_MASTER_PASSWORD = `erc8004-master-password-${suffix}`;
+    __resetAuditHmacKeyCacheForTests();
+
+    const admin = createDb(databaseUrl!);
+    const locker = await admin.client.reserve();
+    let gateLocked = false;
+    try {
+      await admin.db.insert(tenants).values({
+        id: tenantId,
+        name: tenantId,
+        apiKeyHash: `hash-${tenantId}`,
+      });
+      await admin.db.insert(agents).values({
+        id: agentId,
+        tenantId,
+        name: agentId,
+        walletAddress: "0x00000000000000000000000000000000000000aa",
+      });
+      await admin.db.insert(agentRegistrations).values({
+        tenantId,
+        agentId,
+        chainId: 8453,
+        registryAddress,
+        agentCardJson: { name: agentId, apiUrl: "https://initial.example.test/api" },
+        status: "pending",
+      });
+      await admin.client.unsafe(`
+        create function "${triggerFunction}"() returns trigger language plpgsql as $$
+        begin
+          if new.tenant_id = '${tenantId}'
+             and new.request_id = '${failedRequestId}'
+             and new.action = 'erc8004.register' then
+            perform pg_advisory_xact_lock(${gateKey});
+            raise exception 'forced ERC-8004 completion audit failure';
+          end if;
+          return new;
+        end
+        $$
+      `);
+      await admin.client.unsafe(`
+        create trigger "${triggerName}"
+        before insert on audit_events
+        for each row execute function "${triggerFunction}"()
+      `);
+      await locker`select pg_advisory_lock(${gateKey})`;
+      gateLocked = true;
+
+      const { erc8004Routes } = await import("../routes/erc8004");
+      const app = mountedApp(tenantId, erc8004Routes);
+      const failedRequest = app.request(`/agents/${agentId}/register-onchain`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Request-Id": failedRequestId,
+        },
+        body: JSON.stringify({ capabilities: ["must-rollback"] }),
+      });
+
+      await waitForAdvisoryWaiters(
+        admin,
+        1,
+        "mounted ERC-8004 route did not reach the blocked audit trigger",
+      );
+      const writer = Bun.spawn(
+        [
+          process.execPath,
+          new URL("./fixtures/erc8004-concurrent-writer.ts", import.meta.url).pathname,
+        ],
+        {
+          cwd: new URL("../../../..", import.meta.url).pathname,
+          env: {
+            ...process.env,
+            DATABASE_URL: databaseUrl!,
+            STEWARD_AUDIT_HMAC_KEY: process.env.STEWARD_AUDIT_HMAC_KEY!,
+            TEST_TENANT_ID: tenantId,
+            TEST_AGENT_ID: agentId,
+            TEST_REQUEST_ID: successRequestId,
+            TEST_API_URL: winnerUrl,
+          },
+          stderr: "pipe",
+        },
+      );
+      await waitForAdvisoryWaiters(
+        admin,
+        2,
+        "concurrent ERC-8004 writer did not reach the database serialization lock",
+      );
+
+      await locker`select pg_advisory_unlock(${gateKey})`;
+      gateLocked = false;
+      const [failedResponse, writerExit] = await Promise.all([failedRequest, writer.exited]);
+      if (writerExit !== 0) {
+        throw new Error(
+          `concurrent ERC-8004 writer failed: ${await new Response(writer.stderr).text()}`,
+        );
+      }
+      expect(failedResponse.status).toBe(500);
+
+      const [stored] = await admin.db
+        .select({ agentCardJson: agentRegistrations.agentCardJson })
+        .from(agentRegistrations)
+        .where(
+          and(
+            eq(agentRegistrations.tenantId, tenantId),
+            eq(agentRegistrations.agentId, agentId),
+            eq(agentRegistrations.chainId, 8453),
+          ),
+        );
+      expect(stored?.agentCardJson).toMatchObject({
+        apiUrl: winnerUrl,
+        capabilities: ["concurrent-winner"],
+      });
+
+      const events = await admin.db
+        .select({ action: auditEvents.action, requestId: auditEvents.requestId })
+        .from(auditEvents)
+        .where(eq(auditEvents.tenantId, tenantId));
+      expect(events.filter((event) => event.requestId === failedRequestId)).toEqual([
+        { action: "erc8004.register.authorized", requestId: failedRequestId },
+      ]);
+      expect(events.filter((event) => event.requestId === successRequestId)).toEqual([
+        { action: "erc8004.register", requestId: successRequestId },
+      ]);
+    } finally {
+      if (gateLocked) await locker`select pg_advisory_unlock(${gateKey})`;
+      locker.release();
+      await admin.client.unsafe(`drop trigger if exists "${triggerName}" on audit_events`);
+      await admin.client.unsafe(`drop function if exists "${triggerFunction}"()`);
+      await cleanup(admin, tenantId);
+      await admin.client.end();
+      restoreAuditKey(previousAuditKey);
+      restoreEnvironment("STEWARD_MASTER_PASSWORD", previousMasterPassword);
+    }
+  },
+  120_000,
+);
+
+function mountedApp(tenantId: string, routes: typeof import("../routes/erc8004").erc8004Routes) {
+  const app = new Hono();
+  app.use("*", correlationId);
+  app.use("*", async (c, next) => {
+    c.set("tenantId", tenantId);
+    c.set("userId", "erc8004-test-owner");
+    c.set("authType", "session-jwt");
+    c.set("tenantRole", "owner");
+    c.set("sessionMfaVerifiedAt", Date.now());
+    await next();
+  });
+  app.route("/agents", routes);
+  return app;
+}
+
+async function waitForAdvisoryWaiters(
+  admin: ReturnType<typeof createDb>,
+  minimum: number,
+  failureMessage: string,
+) {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    const [waiting] = await admin.client<{ count: string }[]>`
+      select count(*)::text as count
+      from pg_stat_activity
+      where wait_event = 'advisory'
+    `;
+    if (Number(waiting?.count ?? "0") >= minimum) return;
+    if (attempt === 199) throw new Error(failureMessage);
+    await Bun.sleep(10);
+  }
+}
+
+async function cleanup(admin: ReturnType<typeof createDb>, tenantId: string) {
+  await admin.db.delete(auditEvents).where(eq(auditEvents.tenantId, tenantId));
+  await admin.db.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, tenantId));
+  await admin.db.delete(tenants).where(eq(tenants.id, tenantId));
+}
+
+function restoreAuditKey(previousAuditKey: string | undefined) {
+  restoreEnvironment("STEWARD_AUDIT_HMAC_KEY", previousAuditKey);
+  __resetAuditHmacKeyCacheForTests();
+}
+
+function restoreEnvironment(name: string, previousValue: string | undefined) {
+  if (previousValue === undefined) delete process.env[name];
+  else process.env[name] = previousValue;
+}

--- a/packages/api/src/__tests__/erc8004-audit-order.test.ts
+++ b/packages/api/src/__tests__/erc8004-audit-order.test.ts
@@ -42,25 +42,20 @@ describe("ERC-8004 audit ordering", () => {
     ).toBeLessThan(routeSource.indexOf("INSERT INTO reputation_cache", feedbackStart));
   });
 
-  it("restores the previous agent registration when final registration audit fails", () => {
-    expect(routeSource).toContain(
-      "type AgentRegistrationRow = typeof agentRegistrations.$inferSelect",
-    );
-    expect(routeSource).toContain("async function snapshotAgentRegistration");
-    expect(routeSource).toContain("async function restoreAgentRegistration");
-
+  it("commits registration and its required audit in one tenant-audited transaction", () => {
     const registerStart = routeSource.indexOf('erc8004Routes.post("/:id/register-onchain"');
     expect(registerStart).toBeGreaterThanOrEqual(0);
     const registerRoute = routeSource.slice(
       registerStart,
       routeSource.indexOf('erc8004Routes.get("/:id/onchain"', registerStart),
     );
-    expect(registerRoute).toContain("snapshotAgentRegistration(tenantId, agentId, chainId)");
+    expect(registerRoute).toContain("withTenantAuditedTransaction(");
+    expect(registerRoute).toContain("async (txRaw, appendRequiredAudit)");
+    expect(registerRoute).toContain("const result = await tx.execute");
     expect(registerRoute).toContain('action: "erc8004.register"');
-    expect(registerRoute).toContain("try {");
-    expect(registerRoute).toContain(
-      "restoreAgentRegistration(tenantId, agentId, chainId, previousRegistration)",
-    );
+    expect(registerRoute).toContain("await appendRequiredAudit");
+    expect(registerRoute).not.toContain("snapshotAgentRegistration");
+    expect(registerRoute).not.toContain("restoreAgentRegistration");
   });
 
   it("rejects replayed feedback before reputation aggregate mutation", () => {

--- a/packages/api/src/__tests__/fixtures/erc8004-concurrent-writer.ts
+++ b/packages/api/src/__tests__/fixtures/erc8004-concurrent-writer.ts
@@ -1,0 +1,67 @@
+import {
+  __resetAuditHmacKeyCacheForTests,
+  agentRegistrations,
+  createDb,
+  withTenantAuditedTransactionOnDb,
+} from "@stwd/db";
+
+const databaseUrl = process.env.DATABASE_URL;
+const tenantId = process.env.TEST_TENANT_ID;
+const agentId = process.env.TEST_AGENT_ID;
+const requestId = process.env.TEST_REQUEST_ID;
+const apiUrl = process.env.TEST_API_URL;
+
+if (!databaseUrl || !tenantId || !agentId || !requestId || !apiUrl) {
+  throw new Error("ERC-8004 concurrent writer fixture is missing required environment");
+}
+
+__resetAuditHmacKeyCacheForTests();
+const handle = createDb(databaseUrl);
+
+try {
+  await withTenantAuditedTransactionOnDb(
+    handle.db,
+    tenantId,
+    async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof handle.db;
+      await tx
+        .insert(agentRegistrations)
+        .values({
+          tenantId,
+          agentId,
+          chainId: 8453,
+          registryAddress: "0x0000000000000000000000000000000000008004",
+          agentCardJson: { name: agentId, apiUrl, capabilities: ["concurrent-winner"] },
+          status: "pending",
+        })
+        .onConflictDoUpdate({
+          target: [
+            agentRegistrations.tenantId,
+            agentRegistrations.agentId,
+            agentRegistrations.chainId,
+          ],
+          set: {
+            agentCardJson: { name: agentId, apiUrl, capabilities: ["concurrent-winner"] },
+            status: "pending",
+            updatedAt: new Date(),
+          },
+        });
+      await appendRequiredAudit({
+        tenantId,
+        actorType: "user",
+        actorId: "concurrent-writer",
+        action: "erc8004.register",
+        resourceType: "agent",
+        resourceId: agentId,
+        metadata: {
+          chainId: 8453,
+          registryAddress: "0x0000000000000000000000000000000000008004",
+          source: "concurrent-writer",
+        },
+        requestId,
+      });
+    },
+  );
+} finally {
+  await handle.client.end();
+}

--- a/packages/api/src/routes/erc8004.ts
+++ b/packages/api/src/routes/erc8004.ts
@@ -8,12 +8,12 @@
  * so tenantAuth is already applied by the parent middleware.
  */
 
-import { agentRegistrations, registryIndex } from "@stwd/db";
+import { registryIndex } from "@stwd/db";
 import { redactedThrownDiagnostics } from "@stwd/shared";
-import { and, eq, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
-import { writeAuditEvent } from "../services/audit";
+import { withTenantAuditedTransaction, writeAuditEvent } from "../services/audit";
 import {
   type ApiResponse,
   type AppVariables,
@@ -26,7 +26,6 @@ import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import { validateWebhookUrlResolved } from "../services/webhook-url";
 
 export const erc8004Routes = new Hono<{ Variables: AppVariables }>();
-type AgentRegistrationRow = typeof agentRegistrations.$inferSelect;
 
 const agentCardTextSchema = z
   .string()
@@ -104,46 +103,6 @@ function publicDiscoveryAgentRow(row: Record<string, unknown>) {
   };
 }
 
-async function snapshotAgentRegistration(
-  tenantId: string,
-  agentId: string,
-  chainId: number,
-): Promise<AgentRegistrationRow | null> {
-  const [row] = await db
-    .select()
-    .from(agentRegistrations)
-    .where(
-      and(
-        eq(agentRegistrations.tenantId, tenantId),
-        eq(agentRegistrations.agentId, agentId),
-        eq(agentRegistrations.chainId, chainId),
-      ),
-    );
-  return row ?? null;
-}
-
-async function restoreAgentRegistration(
-  tenantId: string,
-  agentId: string,
-  chainId: number,
-  snapshot: AgentRegistrationRow | null,
-): Promise<void> {
-  await db.transaction(async (tx) => {
-    await tx
-      .delete(agentRegistrations)
-      .where(
-        and(
-          eq(agentRegistrations.tenantId, tenantId),
-          eq(agentRegistrations.agentId, agentId),
-          eq(agentRegistrations.chainId, chainId),
-        ),
-      );
-    if (snapshot) {
-      await tx.insert(agentRegistrations).values(snapshot);
-    }
-  });
-}
-
 function canReadAgentOnchain(
   c: Parameters<typeof requireTenantLevel>[0],
   agentId: string,
@@ -211,33 +170,32 @@ erc8004Routes.post("/:id/register-onchain", async (c) => {
       requestId: c.get("requestId") ?? null,
     });
 
-    const previousRegistration = await snapshotAgentRegistration(tenantId, agentId, chainId);
-    const result = await db.execute(sql`
-      INSERT INTO agent_registrations (tenant_id, agent_id, chain_id, registry_address, agent_card_json, status)
-      VALUES (${tenantId}, ${agentId}, ${chainId}, ${registryAddress}, ${JSON.stringify(agentCard)}::jsonb, 'pending')
-      ON CONFLICT (tenant_id, agent_id, chain_id)
-      DO UPDATE SET agent_card_json = ${JSON.stringify(agentCard)}::jsonb, status = 'pending', updated_at = NOW()
-      RETURNING id, status, created_at
-    `);
-    const rows = getRows(result);
-
-    try {
-      await writeAuditEvent({
-        tenantId,
-        actorType: "user",
-        actorId: c.get("userId") ?? tenantId,
-        action: "erc8004.register",
-        resourceType: "agent",
-        resourceId: agentId,
-        metadata: { chainId, registryAddress, walletAddress: agent.walletAddress },
-        ipAddress: c.req.header("x-forwarded-for") ?? null,
-        userAgent: c.req.header("user-agent") ?? null,
-        requestId: c.get("requestId") ?? null,
-      });
-    } catch (error) {
-      await restoreAgentRegistration(tenantId, agentId, chainId, previousRegistration);
-      throw error;
-    }
+    const rows = await withTenantAuditedTransaction(
+      tenantId,
+      async (txRaw, appendRequiredAudit) => {
+        const tx = txRaw as typeof db;
+        const result = await tx.execute(sql`
+          INSERT INTO agent_registrations (tenant_id, agent_id, chain_id, registry_address, agent_card_json, status)
+          VALUES (${tenantId}, ${agentId}, ${chainId}, ${registryAddress}, ${JSON.stringify(agentCard)}::jsonb, 'pending')
+          ON CONFLICT (tenant_id, agent_id, chain_id)
+          DO UPDATE SET agent_card_json = ${JSON.stringify(agentCard)}::jsonb, status = 'pending', updated_at = NOW()
+          RETURNING id, status, created_at
+        `);
+        await appendRequiredAudit({
+          tenantId,
+          actorType: "user",
+          actorId: c.get("userId") ?? tenantId,
+          action: "erc8004.register",
+          resourceType: "agent",
+          resourceId: agentId,
+          metadata: { chainId, registryAddress, walletAddress: agent.walletAddress },
+          ipAddress: c.req.header("x-forwarded-for") ?? null,
+          userAgent: c.req.header("user-agent") ?? null,
+          requestId: c.get("requestId") ?? null,
+        });
+        return getRows(result);
+      },
+    );
 
     return c.json<ApiResponse>({
       ok: true,


### PR DESCRIPTION
Closes #718.

Moves the locked ERC-8004 registration upsert and required completion audit into one tenant-audited transaction and removes stale snapshot compensation. Adds mounted deterministic PostgreSQL rollback and concurrent-winner proofs.

Exact head: cbcb0e34b2f6b8bdd7215d17167bab0a48f1879e
Exact base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6

Local acceptance:
- focused audit ordering: 8 pass, 38 assertions
- mounted PostgreSQL: 2 locally skipped and required in hosted Integration Tests
- API build, targeted Biome, diff check, public-package metadata: pass

Keep draft until exact hosted PostgreSQL, full matrix, and independent review pass.