### PR TITLE
fix(api): make webhook mutations audit-atomic

### DIFF
--- a/packages/api/src/__tests__/fixtures/webhook-concurrent-request.ts
+++ b/packages/api/src/__tests__/fixtures/webhook-concurrent-request.ts
@@ -1,0 +1,49 @@
+import { closeDb } from "@stwd/db";
+import { Hono } from "hono";
+import { correlationId } from "../../middleware/correlation";
+import type { AppVariables } from "../../services/context";
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+const tenantId = required("TEST_TENANT_ID");
+const userId = required("TEST_USER_ID");
+const requestId = required("TEST_REQUEST_ID");
+const method = required("TEST_REQUEST_METHOD");
+const path = required("TEST_REQUEST_PATH");
+const requestBody = process.env.TEST_REQUEST_BODY;
+
+const [{ createSessionToken }, { tenantAuth }, { webhookRoutes }] = await Promise.all([
+  import("../../routes/auth"),
+  import("../../services/context"),
+  import("../../routes/webhooks"),
+]);
+
+const token = await createSessionToken("0x0000000000000000000000000000000000000719", tenantId, {
+  userId,
+  tenantId,
+  mfaVerifiedAt: Date.now(),
+  mfaMethod: "totp",
+});
+const app = new Hono<{ Variables: AppVariables }>();
+app.onError((error, c) => c.json({ ok: false, error: error.message }, 500));
+app.use("*", correlationId);
+app.use("*", tenantAuth);
+app.route("/webhooks", webhookRoutes);
+
+const response = await app.request(path, {
+  method,
+  headers: {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    "X-Request-Id": requestId,
+  },
+  ...(requestBody === undefined ? {} : { body: requestBody }),
+});
+const body = await response.json();
+await closeDb();
+process.stdout.write(JSON.stringify({ status: response.status, body }));
+process.exit(0);

--- a/packages/api/src/__tests__/webhook-audit-atomicity-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/webhook-audit-atomicity-postgres.integration.test.ts
@@ -1,0 +1,498 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { generateApiKey } from "@stwd/auth";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  auditChainHeads,
+  auditEvents,
+  createDb,
+  tenants,
+  users,
+  userTenants,
+  webhookConfigs,
+  webhookDeliveries,
+} from "@stwd/db";
+import { and, asc, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { correlationId } from "../middleware/correlation";
+import type { AppVariables } from "../services/context";
+
+const databaseUrl = process.env.DATABASE_URL;
+const realPostgres = databaseUrl && !process.env.STEWARD_PGLITE_MEMORY ? describe : describe.skip;
+const suffix = crypto.randomUUID().replaceAll("-", "");
+const tenantId = `webhook-atomic-${suffix}`;
+const userId = crypto.randomUUID();
+const fixturePath = new URL("./fixtures/webhook-concurrent-request.ts", import.meta.url).pathname;
+
+type WriterResult = { status: number; body: { ok: boolean; data?: Record<string, unknown> } };
+
+realPostgres("webhook mutation audit atomicity (mounted Postgres)", () => {
+  const admin = createDb(databaseUrl!);
+  let app: Hono<{ Variables: AppVariables }>;
+  let token: string;
+  let previousJwtSecret: string | undefined;
+  let previousMasterPassword: string | undefined;
+  let previousAuditKey: string | undefined;
+
+  beforeAll(async () => {
+    previousJwtSecret = process.env.STEWARD_JWT_SECRET;
+    previousMasterPassword = process.env.STEWARD_MASTER_PASSWORD;
+    previousAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+    process.env.STEWARD_JWT_SECRET = `webhook-jwt-${suffix}`;
+    process.env.STEWARD_MASTER_PASSWORD = `webhook-master-${suffix}`;
+    process.env.STEWARD_AUDIT_HMAC_KEY = `webhook-audit-key-${suffix}`;
+    __resetAuditHmacKeyCacheForTests();
+
+    const apiKey = generateApiKey();
+    await admin.db.insert(tenants).values({
+      id: tenantId,
+      name: tenantId,
+      apiKeyHash: apiKey.hash,
+    });
+    await admin.db.insert(users).values({
+      id: userId,
+      email: `${suffix}@example.test`,
+      emailVerified: true,
+    });
+    await admin.db.insert(userTenants).values({ userId, tenantId, role: "owner" });
+
+    const [{ createSessionToken }, { tenantAuth }, { webhookRoutes }] = await Promise.all([
+      import("../routes/auth"),
+      import("../services/context"),
+      import("../routes/webhooks"),
+    ]);
+    token = await createSessionToken("0x0000000000000000000000000000000000000719", tenantId, {
+      userId,
+      tenantId,
+      mfaVerifiedAt: Date.now(),
+      mfaMethod: "totp",
+    });
+    app = new Hono<{ Variables: AppVariables }>();
+    app.onError((error, c) => c.json({ ok: false, error: error.message }, 500));
+    app.use("*", correlationId);
+    app.use("*", tenantAuth);
+    app.route("/webhooks", webhookRoutes);
+  }, 120_000);
+
+  afterEach(async () => {
+    await admin.db.delete(webhookDeliveries).where(eq(webhookDeliveries.tenantId, tenantId));
+    await admin.db.delete(webhookConfigs).where(eq(webhookConfigs.tenantId, tenantId));
+    await admin.db.delete(auditEvents).where(eq(auditEvents.tenantId, tenantId));
+    await admin.db.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, tenantId));
+  });
+
+  afterAll(async () => {
+    await admin.db.delete(webhookDeliveries).where(eq(webhookDeliveries.tenantId, tenantId));
+    await admin.db.delete(webhookConfigs).where(eq(webhookConfigs.tenantId, tenantId));
+    await admin.db.delete(auditEvents).where(eq(auditEvents.tenantId, tenantId));
+    await admin.db.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, tenantId));
+    await admin.db.delete(userTenants).where(eq(userTenants.tenantId, tenantId));
+    await admin.db.delete(tenants).where(eq(tenants.id, tenantId));
+    await admin.db.delete(users).where(eq(users.id, userId));
+    await admin.client.end();
+    if (previousJwtSecret === undefined) delete process.env.STEWARD_JWT_SECRET;
+    else process.env.STEWARD_JWT_SECRET = previousJwtSecret;
+    if (previousMasterPassword === undefined) delete process.env.STEWARD_MASTER_PASSWORD;
+    else process.env.STEWARD_MASTER_PASSWORD = previousMasterPassword;
+    if (previousAuditKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditKey;
+    __resetAuditHmacKeyCacheForTests();
+  });
+
+  function request(
+    method: string,
+    path: string,
+    body: Record<string, unknown> | undefined,
+    requestId: string,
+  ): Promise<Response> {
+    return app.request(path, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-Request-Id": requestId,
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+  }
+
+  function spawnWriter(
+    method: string,
+    path: string,
+    body: Record<string, unknown> | undefined,
+    requestId: string,
+  ) {
+    return Bun.spawn([process.execPath, fixturePath], {
+      cwd: new URL("../../../..", import.meta.url).pathname,
+      env: {
+        ...process.env,
+        DATABASE_URL: `${databaseUrl!}?application_name=${writerApplication(requestId)}`,
+        TEST_TENANT_ID: tenantId,
+        TEST_USER_ID: userId,
+        TEST_REQUEST_ID: requestId,
+        TEST_REQUEST_METHOD: method,
+        TEST_REQUEST_PATH: path,
+        ...(body === undefined ? {} : { TEST_REQUEST_BODY: JSON.stringify(body) }),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  }
+
+  function writerApplication(requestId: string) {
+    return `webhook_writer_${requestId}`.slice(0, 63);
+  }
+
+  async function writerResult(writer: ReturnType<typeof spawnWriter>): Promise<WriterResult> {
+    const [status, stdout, stderr] = await Promise.all([
+      writer.exited,
+      new Response(writer.stdout).text(),
+      new Response(writer.stderr).text(),
+    ]);
+    if (status !== 0) throw new Error(`concurrent writer failed (${status}): ${stderr}`);
+    return JSON.parse(stdout) as WriterResult;
+  }
+
+  async function waitForGate(gateKey: number) {
+    const classId = Math.floor(gateKey / 4_294_967_296);
+    const objectId = gateKey % 4_294_967_296;
+    for (let attempt = 0; attempt < 600; attempt++) {
+      const [row] = await admin.client<{ count: string }[]>`
+        select count(*)::text as count from pg_locks
+        where locktype = 'advisory'
+          and classid::bigint = ${classId}
+          and objid::bigint = ${objectId}
+          and granted = false
+      `;
+      if (Number(row?.count ?? "0") >= 1) return;
+      if (attempt === 599)
+        throw new Error(`expected a request blocked on advisory gate ${gateKey}`);
+      await Bun.sleep(10);
+    }
+  }
+
+  async function waitForBlockedApplication(applicationName: string) {
+    for (let attempt = 0; attempt < 600; attempt++) {
+      const [row] = await admin.client<
+        { state: string; wait_event_type: string | null; wait_event: string | null }[]
+      >`
+        select state, wait_event_type, wait_event from pg_stat_activity
+        where datname = current_database() and application_name = ${applicationName}
+      `;
+      if (row?.wait_event_type === "Lock") return;
+      if (attempt === 599) {
+        throw new Error(
+          `expected ${applicationName} to block on the delivery row; observed ${JSON.stringify(row)}`,
+        );
+      }
+      await Bun.sleep(10);
+    }
+  }
+
+  async function installAuditGate(input: {
+    requestId: string;
+    action: string;
+    gateKey: number;
+    name: string;
+    fail?: boolean;
+  }) {
+    await admin.client.unsafe(`
+      create function "${input.name}"() returns trigger language plpgsql as $$
+      begin
+        if new.tenant_id = '${tenantId}'
+           and new.request_id = '${input.requestId}'
+           and new.action = '${input.action}' then
+          perform pg_advisory_xact_lock(${input.gateKey});
+          ${input.fail ? "raise exception 'forced webhook completion audit failure';" : ""}
+        end if;
+        return new;
+      end
+      $$
+    `);
+    await admin.client.unsafe(`
+      create trigger "${input.name}" before insert on audit_events
+      for each row execute function "${input.name}"()
+    `);
+  }
+
+  async function removeGate(name: string) {
+    await admin.client.unsafe(`drop trigger if exists "${name}" on audit_events`);
+    await admin.client.unsafe(`drop function if exists "${name}"()`);
+  }
+
+  async function seedWebhook(url: string, secret = `ciphertext-${suffix}`) {
+    const [row] = await admin.db
+      .insert(webhookConfigs)
+      .values({ tenantId, url, secret, events: ["tx.pending"], enabled: true })
+      .returning();
+    return row;
+  }
+
+  test("returns the one-time secret only after the final enabled row and both audits commit", async () => {
+    const requestId = `mounted-create-${suffix}`;
+    const response = await request(
+      "POST",
+      "/webhooks",
+      { url: `https://example.com/${suffix}/mounted`, events: ["tx.pending"] },
+      requestId,
+    );
+    expect(response.status).toBe(201);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    const body = (await response.json()) as WriterResult["body"];
+    expect(body.data?.secret).toMatch(/^whsec_/);
+    const [stored] = await admin.db
+      .select()
+      .from(webhookConfigs)
+      .where(eq(webhookConfigs.tenantId, tenantId));
+    expect(stored).toMatchObject({ enabled: true });
+    expect(stored?.secret).not.toBe(body.data?.secret);
+    const events = await admin.db
+      .select({ action: auditEvents.action })
+      .from(auditEvents)
+      .where(and(eq(auditEvents.tenantId, tenantId), eq(auditEvents.requestId, requestId)))
+      .orderBy(asc(auditEvents.seq));
+    expect(events.map(({ action }) => action)).toEqual([
+      "webhook.create.authorized",
+      "webhook.create",
+    ]);
+  });
+
+  test("create-vs-create exposes no partial row and commits one audited winner", async () => {
+    const firstId = `create-first-${suffix}`;
+    const secondId = `create-second-${suffix}`;
+    const url = `https://example.com/${suffix}/same`;
+    const gateKey = Number.parseInt(suffix.slice(0, 12), 16);
+    const name = `webhook_create_gate_${suffix}`;
+    const locker = await admin.client.reserve();
+    let locked = false;
+    try {
+      await installAuditGate({ requestId: firstId, action: "webhook.create", gateKey, name });
+      await locker`select pg_advisory_lock(${gateKey})`;
+      locked = true;
+      const first = request("POST", "/webhooks", { url }, firstId);
+      await waitForGate(gateKey);
+      expect(
+        await admin.db.select().from(webhookConfigs).where(eq(webhookConfigs.tenantId, tenantId)),
+      ).toHaveLength(0);
+      const second = spawnWriter("POST", "/webhooks", { url }, secondId);
+      await waitForBlockedApplication(writerApplication(secondId));
+      await locker`select pg_advisory_unlock(${gateKey})`;
+      locked = false;
+      const [firstResponse, secondResponse] = await Promise.all([first, writerResult(second)]);
+      expect(firstResponse.status).toBe(201);
+      expect(secondResponse.status).toBe(409);
+      const rows = await admin.db
+        .select()
+        .from(webhookConfigs)
+        .where(eq(webhookConfigs.tenantId, tenantId));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.enabled).toBe(true);
+      const completions = await admin.db
+        .select({ requestId: auditEvents.requestId })
+        .from(auditEvents)
+        .where(and(eq(auditEvents.tenantId, tenantId), eq(auditEvents.action, "webhook.create")));
+      expect(completions).toEqual([{ requestId: firstId }]);
+    } finally {
+      if (locked) await locker`select pg_advisory_unlock(${gateKey})`;
+      locker.release();
+      await removeGate(name);
+    }
+  }, 120_000);
+
+  test("failed update cannot overwrite a concurrent update winner", async () => {
+    const webhook = await seedWebhook(`https://example.com/${suffix}/update`);
+    const failedId = `update-failed-${suffix}`;
+    const winnerId = `update-winner-${suffix}`;
+    const gateKey = Number.parseInt(suffix.slice(12, 24), 16);
+    const name = `webhook_update_gate_${suffix}`;
+    const locker = await admin.client.reserve();
+    let locked = false;
+    try {
+      await installAuditGate({
+        requestId: failedId,
+        action: "webhook.update",
+        gateKey,
+        name,
+        fail: true,
+      });
+      await locker`select pg_advisory_lock(${gateKey})`;
+      locked = true;
+      const failed = request("PUT", `/webhooks/${webhook.id}`, { description: "stale" }, failedId);
+      await waitForGate(gateKey);
+      const winner = spawnWriter(
+        "PUT",
+        `/webhooks/${webhook.id}`,
+        { description: "winner" },
+        winnerId,
+      );
+      await waitForBlockedApplication(writerApplication(winnerId));
+      await locker`select pg_advisory_unlock(${gateKey})`;
+      locked = false;
+      const [failedResponse, winnerResponse] = await Promise.all([failed, writerResult(winner)]);
+      expect(failedResponse.status).toBe(500);
+      expect(winnerResponse.status).toBe(200);
+      const [stored] = await admin.db
+        .select()
+        .from(webhookConfigs)
+        .where(eq(webhookConfigs.id, webhook.id));
+      expect(stored?.description).toBe("winner");
+    } finally {
+      if (locked) await locker`select pg_advisory_unlock(${gateKey})`;
+      locker.release();
+      await removeGate(name);
+    }
+  }, 120_000);
+
+  test("failed delete cannot resurrect a stale secret over a concurrent recreate", async () => {
+    const oldSecret = `old-ciphertext-${suffix}`;
+    const url = `https://example.com/${suffix}/delete-recreate`;
+    const webhook = await seedWebhook(url, oldSecret);
+    const deleteId = `delete-failed-${suffix}`;
+    const createId = `recreate-${suffix}`;
+    const gateKey = Number.parseInt(suffix.slice(4, 16), 16);
+    const name = `webhook_delete_gate_${suffix}`;
+    const locker = await admin.client.reserve();
+    let locked = false;
+    try {
+      await installAuditGate({
+        requestId: deleteId,
+        action: "webhook.delete",
+        gateKey,
+        name,
+        fail: true,
+      });
+      await locker`select pg_advisory_lock(${gateKey})`;
+      locked = true;
+      const failedDelete = request("DELETE", `/webhooks/${webhook.id}`, undefined, deleteId);
+      await waitForGate(gateKey);
+      const recreate = spawnWriter("POST", "/webhooks", { url }, createId);
+      await waitForBlockedApplication(writerApplication(createId));
+      await locker`select pg_advisory_unlock(${gateKey})`;
+      locked = false;
+      const [deleteResponse, recreateResponse] = await Promise.all([
+        failedDelete,
+        writerResult(recreate),
+      ]);
+      expect(deleteResponse.status).toBe(500);
+      expect(recreateResponse.status).toBe(409);
+      const [stored] = await admin.db
+        .select()
+        .from(webhookConfigs)
+        .where(eq(webhookConfigs.id, webhook.id));
+      expect(stored?.secret).toBe(oldSecret);
+      expect(stored?.url).toBe(url);
+    } finally {
+      if (locked) await locker`select pg_advisory_unlock(${gateKey})`;
+      locker.release();
+      await removeGate(name);
+    }
+  }, 120_000);
+
+  test("retry audit failure releases the row lock to the worker's exact terminal winner", async () => {
+    const webhook = await seedWebhook(`https://example.com/${suffix}/retry`);
+    const [delivery] = await admin.db
+      .insert(webhookDeliveries)
+      .values({
+        tenantId,
+        webhookConfigId: webhook.id,
+        eventType: "tx.pending",
+        payload: { webhookConfigId: webhook.id },
+        url: webhook.url,
+        secret: webhook.secret,
+        events: webhook.events,
+        status: "failed",
+        attempts: 1,
+        maxAttempts: 3,
+        lastError: "retry me",
+      })
+      .returning();
+    const requestId = `retry-failed-${suffix}`;
+    const gateKey = Number.parseInt(suffix.slice(8, 20), 16);
+    const name = `webhook_retry_gate_${suffix}`;
+    const locker = await admin.client.reserve();
+    const workerClient = await admin.client.reserve();
+    let locked = false;
+    try {
+      await installAuditGate({
+        requestId,
+        action: "webhook_delivery.retry",
+        gateKey,
+        name,
+        fail: true,
+      });
+      await locker`select pg_advisory_lock(${gateKey})`;
+      locked = true;
+      const retry = request("POST", `/webhooks/deliveries/${delivery.id}/retry`, {}, requestId);
+      await waitForGate(gateKey);
+      const workerApplication = `webhook_719_worker_${suffix}`;
+      await workerClient`select set_config('application_name', ${workerApplication}, false)`;
+      const worker = workerClient<{ status: string }[]>`
+        update webhook_deliveries
+        set status = 'delivered', delivered_at = now(), last_error = null
+        where id = ${delivery.id}
+        returning status
+      `.then((rows) => rows);
+      await waitForBlockedApplication(workerApplication);
+      await locker`select pg_advisory_unlock(${gateKey})`;
+      locked = false;
+      const [retryResponse, workerRows] = await Promise.all([retry, worker]);
+      expect(retryResponse.status).toBe(500);
+      expect(workerRows[0]?.status).toBe("delivered");
+      const [stored] = await admin.db
+        .select()
+        .from(webhookDeliveries)
+        .where(eq(webhookDeliveries.id, delivery.id));
+      expect(stored).toMatchObject({ status: "delivered", lastError: null });
+      expect(
+        await admin.db
+          .select()
+          .from(auditEvents)
+          .where(and(eq(auditEvents.tenantId, tenantId), eq(auditEvents.requestId, requestId))),
+      ).toHaveLength(0);
+    } finally {
+      if (locked) await locker`select pg_advisory_unlock(${gateKey})`;
+      locker.release();
+      workerClient.release();
+      await removeGate(name);
+    }
+  }, 120_000);
+
+  test("a deferred completion-audit failure commits neither authority nor secret", async () => {
+    const requestId = `deferred-create-${suffix}`;
+    const name = `webhook_deferred_${suffix}`;
+    await admin.client.unsafe(`
+      create function "${name}"() returns trigger language plpgsql as $$
+      begin
+        if new.tenant_id = '${tenantId}' and new.request_id = '${requestId}'
+           and new.action = 'webhook.create' then
+          raise exception 'forced deferred webhook commit failure';
+        end if;
+        return new;
+      end
+      $$
+    `);
+    await admin.client.unsafe(`
+      create constraint trigger "${name}" after insert on audit_events
+      deferrable initially deferred for each row execute function "${name}"()
+    `);
+    try {
+      const response = await request(
+        "POST",
+        "/webhooks",
+        { url: `https://example.com/${suffix}/deferred` },
+        requestId,
+      );
+      expect(response.status).toBe(500);
+      expect(
+        await admin.db.select().from(webhookConfigs).where(eq(webhookConfigs.tenantId, tenantId)),
+      ).toHaveLength(0);
+      expect(
+        await admin.db
+          .select()
+          .from(auditEvents)
+          .where(and(eq(auditEvents.tenantId, tenantId), eq(auditEvents.requestId, requestId))),
+      ).toHaveLength(0);
+    } finally {
+      await removeGate(name);
+    }
+  }, 120_000);
+});

--- a/packages/api/src/__tests__/webhook-audit-atomicity-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/webhook-audit-atomicity-postgres.integration.test.ts
@@ -26,7 +26,7 @@ const fixturePath = new URL("./fixtures/webhook-concurrent-request.ts", import.m
 type WriterResult = { status: number; body: { ok: boolean; data?: Record<string, unknown> } };
 
 realPostgres("webhook mutation audit atomicity (mounted Postgres)", () => {
-  const admin = createDb(databaseUrl!);
+  let admin: ReturnType<typeof createDb>;
   let app: Hono<{ Variables: AppVariables }>;
   let token: string;
   let previousJwtSecret: string | undefined;
@@ -34,6 +34,7 @@ realPostgres("webhook mutation audit atomicity (mounted Postgres)", () => {
   let previousAuditKey: string | undefined;
 
   beforeAll(async () => {
+    admin = createDb(databaseUrl!);
     previousJwtSecret = process.env.STEWARD_JWT_SECRET;
     previousMasterPassword = process.env.STEWARD_MASTER_PASSWORD;
     previousAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
@@ -152,40 +153,74 @@ realPostgres("webhook mutation audit atomicity (mounted Postgres)", () => {
     return JSON.parse(stdout) as WriterResult;
   }
 
-  async function waitForGate(gateKey: number) {
+  async function backendPid(client: Awaited<ReturnType<typeof admin.client.reserve>>) {
+    const [row] = await client<{ pid: number }[]>`select pg_backend_pid()::int as pid`;
+    if (!row) throw new Error("expected a PostgreSQL backend PID");
+    return row.pid;
+  }
+
+  async function waitForGate(gateKey: number, holderPid: number) {
     const classId = Math.floor(gateKey / 4_294_967_296);
     const objectId = gateKey % 4_294_967_296;
     for (let attempt = 0; attempt < 600; attempt++) {
-      const [row] = await admin.client<{ count: string }[]>`
-        select count(*)::text as count from pg_locks
+      const [row] = await admin.client<{ pid: number; blockers: number[] }[]>`
+        select pid::int as pid, pg_blocking_pids(pid)::int[] as blockers
+        from pg_locks
         where locktype = 'advisory'
           and classid::bigint = ${classId}
           and objid::bigint = ${objectId}
+          and objsubid = 1
           and granted = false
       `;
-      if (Number(row?.count ?? "0") >= 1) return;
+      if (row?.blockers.map(Number).includes(holderPid)) return row.pid;
       if (attempt === 599)
-        throw new Error(`expected a request blocked on advisory gate ${gateKey}`);
+        throw new Error(
+          `expected a request blocked by backend ${holderPid} on advisory gate ${gateKey}`,
+        );
       await Bun.sleep(10);
     }
+    throw new Error("unreachable advisory-gate wait");
   }
 
-  async function waitForBlockedApplication(applicationName: string) {
+  async function waitForTenantAuditBlockedBy(applicationName: string, blockerPid: number) {
     for (let attempt = 0; attempt < 600; attempt++) {
       const [row] = await admin.client<
-        { state: string; wait_event_type: string | null; wait_event: string | null }[]
+        { pid: number; blockers: number[]; waits_on_tenant_audit: boolean }[]
       >`
-        select state, wait_event_type, wait_event from pg_stat_activity
-        where datname = current_database() and application_name = ${applicationName}
+        select
+          activity.pid::int as pid,
+          pg_blocking_pids(activity.pid)::int[] as blockers,
+          exists (
+            select 1
+            from pg_locks waiting
+            where waiting.pid = activity.pid
+              and waiting.locktype = 'advisory'
+              and waiting.classid::bigint =
+                ((hashtextextended(${`steward_audit_${tenantId}`}, 0) >> 32) & 4294967295)
+              and waiting.objid::bigint =
+                (hashtextextended(${`steward_audit_${tenantId}`}, 0) & 4294967295)
+              and waiting.objsubid = 1
+              and waiting.granted = false
+          ) as waits_on_tenant_audit
+        from pg_stat_activity activity
+        where activity.datname = current_database()
+          and activity.application_name = ${applicationName}
       `;
-      if (row?.wait_event_type === "Lock") return;
+      if (
+        row?.waits_on_tenant_audit &&
+        row.blockers.map(Number).includes(blockerPid) &&
+        row.pid !== blockerPid
+      ) {
+        return row.pid;
+      }
       if (attempt === 599) {
         throw new Error(
-          `expected ${applicationName} to block on the delivery row; observed ${JSON.stringify(row)}`,
+          `expected ${applicationName} to wait on tenant audit backend ${blockerPid}; observed ${JSON.stringify(row)}`,
         );
       }
       await Bun.sleep(10);
     }
+    throw new Error("unreachable tenant-audit wait");
   }
 
   async function installAuditGate(input: {
@@ -266,15 +301,17 @@ realPostgres("webhook mutation audit atomicity (mounted Postgres)", () => {
     let locked = false;
     try {
       await installAuditGate({ requestId: firstId, action: "webhook.create", gateKey, name });
+      const lockerPid = await backendPid(locker);
       await locker`select pg_advisory_lock(${gateKey})`;
       locked = true;
       const first = request("POST", "/webhooks", { url }, firstId);
-      await waitForGate(gateKey);
+      const firstPid = await waitForGate(gateKey, lockerPid);
       expect(
         await admin.db.select().from(webhookConfigs).where(eq(webhookConfigs.tenantId, tenantId)),
       ).toHaveLength(0);
       const second = spawnWriter("POST", "/webhooks", { url }, secondId);
-      await waitForBlockedApplication(writerApplication(secondId));
+      const secondPid = await waitForTenantAuditBlockedBy(writerApplication(secondId), firstPid);
+      expect(new Set([lockerPid, firstPid, secondPid]).size).toBe(3);
       await locker`select pg_advisory_unlock(${gateKey})`;
       locked = false;
       const [firstResponse, secondResponse] = await Promise.all([first, writerResult(second)]);
@@ -314,17 +351,19 @@ realPostgres("webhook mutation audit atomicity (mounted Postgres)", () => {
         name,
         fail: true,
       });
+      const lockerPid = await backendPid(locker);
       await locker`select pg_advisory_lock(${gateKey})`;
       locked = true;
       const failed = request("PUT", `/webhooks/${webhook.id}`, { description: "stale" }, failedId);
-      await waitForGate(gateKey);
+      const failedPid = await waitForGate(gateKey, lockerPid);
       const winner = spawnWriter(
         "PUT",
         `/webhooks/${webhook.id}`,
         { description: "winner" },
         winnerId,
       );
-      await waitForBlockedApplication(writerApplication(winnerId));
+      const winnerPid = await waitForTenantAuditBlockedBy(writerApplication(winnerId), failedPid);
+      expect(new Set([lockerPid, failedPid, winnerPid]).size).toBe(3);
       await locker`select pg_advisory_unlock(${gateKey})`;
       locked = false;
       const [failedResponse, winnerResponse] = await Promise.all([failed, writerResult(winner)]);
@@ -335,6 +374,104 @@ realPostgres("webhook mutation audit atomicity (mounted Postgres)", () => {
         .from(webhookConfigs)
         .where(eq(webhookConfigs.id, webhook.id));
       expect(stored?.description).toBe("winner");
+    } finally {
+      if (locked) await locker`select pg_advisory_unlock(${gateKey})`;
+      locker.release();
+      await removeGate(name);
+    }
+  }, 120_000);
+
+  test("update-first serializes delete after the committed update and its audits", async () => {
+    const webhook = await seedWebhook(`https://example.com/${suffix}/update-delete-update-first`);
+    const updateId = `update-delete-first-${suffix}`;
+    const deleteId = `update-delete-second-${suffix}`;
+    const gateKey = Number.parseInt(suffix.slice(2, 14), 16);
+    const name = `webhook_update_delete_first_${suffix}`;
+    const locker = await admin.client.reserve();
+    let locked = false;
+    try {
+      await installAuditGate({ requestId: updateId, action: "webhook.update", gateKey, name });
+      const lockerPid = await backendPid(locker);
+      await locker`select pg_advisory_lock(${gateKey})`;
+      locked = true;
+      const update = request(
+        "PUT",
+        `/webhooks/${webhook.id}`,
+        { description: "committed-before-delete" },
+        updateId,
+      );
+      const updatePid = await waitForGate(gateKey, lockerPid);
+      const deletion = spawnWriter("DELETE", `/webhooks/${webhook.id}`, undefined, deleteId);
+      const deletePid = await waitForTenantAuditBlockedBy(writerApplication(deleteId), updatePid);
+      expect(new Set([lockerPid, updatePid, deletePid]).size).toBe(3);
+      await locker`select pg_advisory_unlock(${gateKey})`;
+      locked = false;
+
+      const [updateResponse, deleteResponse] = await Promise.all([update, writerResult(deletion)]);
+      expect(updateResponse.status).toBe(200);
+      expect(deleteResponse.status).toBe(200);
+      expect(
+        await admin.db.select().from(webhookConfigs).where(eq(webhookConfigs.id, webhook.id)),
+      ).toHaveLength(0);
+      const events = await admin.db
+        .select({ action: auditEvents.action, requestId: auditEvents.requestId })
+        .from(auditEvents)
+        .where(eq(auditEvents.tenantId, tenantId))
+        .orderBy(asc(auditEvents.seq));
+      expect(events).toEqual([
+        { action: "webhook.update.authorized", requestId: updateId },
+        { action: "webhook.update", requestId: updateId },
+        { action: "webhook.delete.authorized", requestId: deleteId },
+        { action: "webhook.delete", requestId: deleteId },
+      ]);
+    } finally {
+      if (locked) await locker`select pg_advisory_unlock(${gateKey})`;
+      locker.release();
+      await removeGate(name);
+    }
+  }, 120_000);
+
+  test("delete-first makes the waiting update re-read the committed absence", async () => {
+    const webhook = await seedWebhook(`https://example.com/${suffix}/update-delete-delete-first`);
+    const deleteId = `delete-update-first-${suffix}`;
+    const updateId = `delete-update-second-${suffix}`;
+    const gateKey = Number.parseInt(suffix.slice(6, 18), 16);
+    const name = `webhook_delete_update_first_${suffix}`;
+    const locker = await admin.client.reserve();
+    let locked = false;
+    try {
+      await installAuditGate({ requestId: deleteId, action: "webhook.delete", gateKey, name });
+      const lockerPid = await backendPid(locker);
+      await locker`select pg_advisory_lock(${gateKey})`;
+      locked = true;
+      const deletion = request("DELETE", `/webhooks/${webhook.id}`, undefined, deleteId);
+      const deletePid = await waitForGate(gateKey, lockerPid);
+      const update = spawnWriter(
+        "PUT",
+        `/webhooks/${webhook.id}`,
+        { description: "must-not-resurrect" },
+        updateId,
+      );
+      const updatePid = await waitForTenantAuditBlockedBy(writerApplication(updateId), deletePid);
+      expect(new Set([lockerPid, deletePid, updatePid]).size).toBe(3);
+      await locker`select pg_advisory_unlock(${gateKey})`;
+      locked = false;
+
+      const [deleteResponse, updateResponse] = await Promise.all([deletion, writerResult(update)]);
+      expect(deleteResponse.status).toBe(200);
+      expect(updateResponse.status).toBe(404);
+      expect(
+        await admin.db.select().from(webhookConfigs).where(eq(webhookConfigs.id, webhook.id)),
+      ).toHaveLength(0);
+      const events = await admin.db
+        .select({ action: auditEvents.action, requestId: auditEvents.requestId })
+        .from(auditEvents)
+        .where(eq(auditEvents.tenantId, tenantId))
+        .orderBy(asc(auditEvents.seq));
+      expect(events).toEqual([
+        { action: "webhook.delete.authorized", requestId: deleteId },
+        { action: "webhook.delete", requestId: deleteId },
+      ]);
     } finally {
       if (locked) await locker`select pg_advisory_unlock(${gateKey})`;
       locker.release();
@@ -360,12 +497,17 @@ realPostgres("webhook mutation audit atomicity (mounted Postgres)", () => {
         name,
         fail: true,
       });
+      const lockerPid = await backendPid(locker);
       await locker`select pg_advisory_lock(${gateKey})`;
       locked = true;
       const failedDelete = request("DELETE", `/webhooks/${webhook.id}`, undefined, deleteId);
-      await waitForGate(gateKey);
+      const failedDeletePid = await waitForGate(gateKey, lockerPid);
       const recreate = spawnWriter("POST", "/webhooks", { url }, createId);
-      await waitForBlockedApplication(writerApplication(createId));
+      const recreatePid = await waitForTenantAuditBlockedBy(
+        writerApplication(createId),
+        failedDeletePid,
+      );
+      expect(new Set([lockerPid, failedDeletePid, recreatePid]).size).toBe(3);
       await locker`select pg_advisory_unlock(${gateKey})`;
       locked = false;
       const [deleteResponse, recreateResponse] = await Promise.all([
@@ -419,19 +561,40 @@ realPostgres("webhook mutation audit atomicity (mounted Postgres)", () => {
         name,
         fail: true,
       });
+      const lockerPid = await backendPid(locker);
       await locker`select pg_advisory_lock(${gateKey})`;
       locked = true;
       const retry = request("POST", `/webhooks/deliveries/${delivery.id}/retry`, {}, requestId);
-      await waitForGate(gateKey);
+      const retryPid = await waitForGate(gateKey, lockerPid);
       const workerApplication = `webhook_719_worker_${suffix}`;
       await workerClient`select set_config('application_name', ${workerApplication}, false)`;
+      const workerPid = await backendPid(workerClient);
       const worker = workerClient<{ status: string }[]>`
         update webhook_deliveries
         set status = 'delivered', delivered_at = now(), last_error = null
         where id = ${delivery.id}
         returning status
       `.then((rows) => rows);
-      await waitForBlockedApplication(workerApplication);
+      for (let attempt = 0; attempt < 600; attempt++) {
+        const [row] = await admin.client<{ blockers: number[]; waits_on_tuple: boolean }[]>`
+          select
+            pg_blocking_pids(${workerPid})::int[] as blockers,
+            exists (
+              select 1 from pg_locks
+              where pid = ${workerPid}
+                and locktype in ('transactionid', 'tuple')
+                and granted = false
+            ) as waits_on_tuple
+        `;
+        if (row?.waits_on_tuple && row.blockers.map(Number).includes(retryPid)) break;
+        if (attempt === 599) {
+          throw new Error(
+            `expected worker backend ${workerPid} to wait on retry backend ${retryPid}; observed ${JSON.stringify(row)}`,
+          );
+        }
+        await Bun.sleep(10);
+      }
+      expect(new Set([lockerPid, retryPid, workerPid]).size).toBe(3);
       await locker`select pg_advisory_unlock(${gateKey})`;
       locked = false;
       const [retryResponse, workerRows] = await Promise.all([retry, worker]);

--- a/packages/api/src/__tests__/webhook-audit-order.test.ts
+++ b/packages/api/src/__tests__/webhook-audit-order.test.ts
@@ -49,19 +49,18 @@ describe("webhook audit ordering", () => {
     expectBefore('action: "webhook_delivery.retry.authorized"', ".update(webhookDeliveries)");
   });
 
-  it("rolls back webhook mutations when final audit writes fail", () => {
+  it("commits webhook mutations and completion audits in one transaction", () => {
     const updateStart = routeSource.indexOf('webhookRoutes.put("/:id"');
     expect(updateStart).toBeGreaterThanOrEqual(0);
     const updateRoute = routeSource.slice(
       updateStart,
       routeSource.indexOf('webhookRoutes.delete("/:id"', updateStart),
     );
+    expect(updateRoute).toContain("withTenantAuditedTransaction");
     expect(updateRoute).toContain('action: "webhook.update"');
-    expect(updateRoute).toContain("} catch (err) {");
     expect(updateRoute).toContain(".update(webhookConfigs)");
-    expect(updateRoute).toContain("url: existing.url");
-    expect(updateRoute).toContain("secret: existing.secret");
-    expect(updateRoute).toContain("updatedAt: existing.updatedAt");
+    expect(updateRoute).not.toContain("secret: existing.secret");
+    expect(updateRoute).not.toContain("updatedAt: existing.updatedAt");
 
     const deleteStart = routeSource.indexOf('webhookRoutes.delete("/:id"');
     expect(deleteStart).toBeGreaterThanOrEqual(0);
@@ -69,24 +68,21 @@ describe("webhook audit ordering", () => {
       deleteStart,
       routeSource.indexOf('webhookRoutes.get("/:id/deliveries"', deleteStart),
     );
+    expect(deleteRoute).toContain("withTenantAuditedTransaction");
     expect(deleteRoute).toContain('action: "webhook.delete"');
-    expect(deleteRoute).toContain("} catch (err) {");
-    expect(deleteRoute).toContain("db.insert(webhookConfigs).values");
-    expect(deleteRoute).toContain("id: deleted.id");
-    expect(deleteRoute).toContain("secret: deleted.secret");
-    expect(deleteRoute).toContain("updatedAt: deleted.updatedAt");
+    expect(deleteRoute).not.toContain("db.insert(webhookConfigs).values");
+    expect(deleteRoute).not.toContain("secret: deleted.secret");
 
     const retryStart = routeSource.indexOf('webhookRoutes.post("/deliveries/:id/retry"');
     expect(retryStart).toBeGreaterThanOrEqual(0);
     const retryRoute = routeSource.slice(retryStart);
     const mutation = retryRoute.indexOf(".update(webhookDeliveries)");
     const finalAudit = retryRoute.indexOf('action: "webhook_delivery.retry"', mutation);
-    const rollback = retryRoute.indexOf("status: delivery.status", finalAudit);
     expect(mutation).toBeGreaterThanOrEqual(0);
     expect(finalAudit).toBeGreaterThan(mutation);
-    expect(rollback).toBeGreaterThan(finalAudit);
-    expect(retryRoute).toContain("nextRetryAt: delivery.nextRetryAt");
-    expect(retryRoute).toContain("lastError: delivery.lastError");
+    expect(retryRoute).toContain("withTenantAuditedTransaction");
+    expect(retryRoute).not.toContain("status: delivery.status");
+    expect(retryRoute).not.toContain("nextRetryAt: delivery.nextRetryAt");
   });
 
   it("does not report test or replay dispatch success when final audit fails", () => {
@@ -187,7 +183,7 @@ describe("webhook audit ordering", () => {
     expect(retryRouteIndex).toBeGreaterThanOrEqual(0);
     const retryRoute = routeSource.slice(retryRouteIndex);
 
-    expect(retryRoute).toContain("attempt budget");
+    expect(retryRoute).toContain("retry budget");
     expect(retryRoute).not.toContain("attempts: 0");
   });
 

--- a/packages/api/src/__tests__/webhook-audit-order.test.ts
+++ b/packages/api/src/__tests__/webhook-audit-order.test.ts
@@ -26,20 +26,22 @@ describe("webhook audit ordering", () => {
   // so they require a recent owner/admin MFA session before
   // the tenant-level check — a tenant API key or stale admin session cannot
   // create, modify, or replay persistent webhooks.
-  it("requires recent owner/admin MFA for webhook control-plane routes", () => {
+  it("requires recent owner/admin MFA for webhook mutation and delivery-control routes", () => {
     for (const marker of [
       'webhookRoutes.post("/",',
-      'webhookRoutes.get("/",',
       'webhookRoutes.put("/:id",',
       'webhookRoutes.delete("/:id",',
+      'webhookRoutes.post("/:id/test",',
       'webhookRoutes.get("/:id/deliveries",',
+      'webhookRoutes.get("/:id/deliveries/export",',
+      'webhookRoutes.post("/deliveries/:id/replay",',
       'webhookRoutes.post("/deliveries/:id/retry",',
     ] as const) {
       const start = routeSource.indexOf(marker);
       expect(start).toBeGreaterThanOrEqual(0);
-      // Each control-plane route gates on a recent owner/admin MFA session.
-      const mfaCheck = routeSource.indexOf("requireRecentTenantAdminMfa(c", start);
-      expect(mfaCheck).toBeGreaterThan(start);
+      const nextRoute = routeSource.indexOf("\nwebhookRoutes.", start + marker.length);
+      const route = routeSource.slice(start, nextRoute === -1 ? undefined : nextRoute);
+      expect(route).toContain("requireRecentTenantAdminMfa(c");
     }
   });
 

--- a/packages/api/src/__tests__/webhook-retry-hardening.test.ts
+++ b/packages/api/src/__tests__/webhook-retry-hardening.test.ts
@@ -75,7 +75,7 @@ describe("webhook retry hardening", () => {
     expect(webhookRoutesSource).toContain("${webhookDeliveries.status} = 'processing'");
   });
 
-  it("writes webhook creation authorization before insert and enables only after create audit", () => {
+  it("creates only the final enabled row with both audits in the same transaction", () => {
     const createStart = webhookRoutesSource.indexOf('webhookRoutes.post("/",');
     expect(createStart).toBeGreaterThanOrEqual(0);
     const authorized = webhookRoutesSource.indexOf(
@@ -83,14 +83,13 @@ describe("webhook retry hardening", () => {
       createStart,
     );
     const insert = webhookRoutesSource.indexOf(".insert(webhookConfigs)", createStart);
-    const disabledInsert = webhookRoutesSource.indexOf("enabled: false", insert);
+    const enabledInsert = webhookRoutesSource.indexOf("enabled: true", insert);
     const created = webhookRoutesSource.indexOf('action: "webhook.create"', insert);
-    const enable = webhookRoutesSource.indexOf(".update(webhookConfigs)", created);
     expect(authorized).toBeGreaterThan(createStart);
     expect(authorized).toBeLessThan(insert);
-    expect(disabledInsert).toBeGreaterThan(insert);
+    expect(enabledInsert).toBeGreaterThan(insert);
     expect(created).toBeGreaterThan(insert);
-    expect(enable).toBeGreaterThan(created);
+    expect(webhookRoutesSource.slice(createStart, created)).not.toContain("enabled: false");
   });
 
   it("rejects retired tenant webhook secrets instead of storing them", () => {

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -10,7 +10,7 @@ import { redactedThrownDiagnostics, type TenantAuthAbuseConfig } from "@stwd/sha
 import { encryptWebhookSecret } from "@stwd/webhooks";
 import { and, count, desc, eq, or, type SQL, sql } from "drizzle-orm";
 import { Hono } from "hono";
-import { writeAuditEvent } from "../services/audit";
+import { withTenantAuditedTransaction, writeAuditEvent } from "../services/audit";
 import {
   type ApiResponse,
   type AppVariables,
@@ -207,13 +207,26 @@ function deliveryCsv(rows: ReturnType<typeof redactDelivery>[]): string {
   return [header.join(","), ...lines].join("\n");
 }
 
-async function lockWebhookConfigTenant(
-  tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
-  tenantId: string,
-): Promise<void> {
-  await tx.execute(
-    sql`select pg_advisory_xact_lock(hashtextextended(${`webhook_config_${tenantId}`}, 0))`,
-  );
+type WebhookAuditEvent = {
+  action: string;
+  resourceType: "webhook" | "webhook_delivery";
+  resourceId: string | null;
+  metadata: Record<string, unknown>;
+};
+
+function webhookAuditEvent(c: Parameters<typeof requireTenantLevel>[0], event: WebhookAuditEvent) {
+  return {
+    tenantId: c.get("tenantId"),
+    actorType: "user" as const,
+    actorId: c.get("userId") ?? c.get("authType") ?? null,
+    action: event.action,
+    resourceType: event.resourceType,
+    resourceId: event.resourceId,
+    metadata: event.metadata,
+    ipAddress: c.req.header("x-forwarded-for") ?? null,
+    userAgent: c.req.header("user-agent") ?? null,
+    requestId: c.get("requestId") ?? null,
+  };
 }
 
 function validateWebhookRetryConfig(body: {
@@ -368,30 +381,11 @@ webhookRoutes.post("/", async (c) => {
   if (retryConfigError) {
     return c.json<ApiResponse>({ ok: false, error: retryConfigError }, 400);
   }
-  await writeAuditEvent({
-    tenantId,
-    actorType: "user",
-    actorId: c.get("userId") ?? c.get("authType") ?? null,
-    action: "webhook.create.authorized",
-    resourceType: "webhook",
-    resourceId: null,
-    metadata: {
-      url: body.url,
-      events: body.events || [...VALID_EVENTS],
-      enabled: true,
-      maxRetries: body.maxRetries ?? 5,
-      retryBackoffMs: body.retryBackoffMs ?? 60000,
-    },
-    ipAddress: c.req.header("x-forwarded-for") ?? null,
-    userAgent: c.req.header("user-agent") ?? null,
-    requestId: c.get("requestId") ?? null,
-  });
-
+  const rawSecret = generateSecret();
   let webhook: typeof webhookConfigs.$inferSelect;
   try {
-    webhook = await db.transaction(async (tx) => {
-      await lockWebhookConfigTenant(tx, tenantId);
-
+    webhook = await withTenantAuditedTransaction(tenantId, async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof db;
       const [{ count: existingCount } = { count: 0 }] = await tx
         .select({ count: count() })
         .from(webhookConfigs)
@@ -411,7 +405,21 @@ webhookRoutes.post("/", async (c) => {
         throw new WebhookConfigError("Webhook URL already registered", 409);
       }
 
-      const rawSecret = generateSecret();
+      await appendRequiredAudit(
+        webhookAuditEvent(c, {
+          action: "webhook.create.authorized",
+          resourceType: "webhook",
+          resourceId: null,
+          metadata: {
+            url: body.url,
+            events: body.events || [...VALID_EVENTS],
+            enabled: true,
+            maxRetries: body.maxRetries ?? 5,
+            retryBackoffMs: body.retryBackoffMs ?? 60000,
+          },
+        }),
+      );
+
       const [created] = await tx
         .insert(webhookConfigs)
         .values({
@@ -420,13 +428,27 @@ webhookRoutes.post("/", async (c) => {
           secret: encryptWebhookSecret(rawSecret),
           events: body.events || [...VALID_EVENTS],
           description: body.description,
-          enabled: false,
+          enabled: true,
           maxRetries: body.maxRetries ?? 5,
           retryBackoffMs: body.retryBackoffMs ?? 60000,
         })
         .returning();
 
-      return { ...created, secret: rawSecret };
+      await appendRequiredAudit(
+        webhookAuditEvent(c, {
+          action: "webhook.create",
+          resourceType: "webhook",
+          resourceId: created.id,
+          metadata: {
+            url: created.url,
+            events: created.events,
+            enabled: created.enabled,
+            maxRetries: created.maxRetries,
+            retryBackoffMs: created.retryBackoffMs,
+          },
+        }),
+      );
+      return created;
     });
   } catch (err) {
     if (err instanceof WebhookConfigError) {
@@ -434,43 +456,10 @@ webhookRoutes.post("/", async (c) => {
     }
     throw err;
   }
-  const oneTimeSecret = webhook.secret;
-  try {
-    await writeAuditEvent({
-      tenantId,
-      actorType: "user",
-      actorId: c.get("userId") ?? c.get("authType") ?? null,
-      action: "webhook.create",
-      resourceType: "webhook",
-      resourceId: webhook.id,
-      metadata: {
-        url: webhook.url,
-        events: webhook.events,
-        enabled: true,
-        maxRetries: webhook.maxRetries,
-        retryBackoffMs: webhook.retryBackoffMs,
-      },
-      ipAddress: c.req.header("x-forwarded-for") ?? null,
-      userAgent: c.req.header("user-agent") ?? null,
-      requestId: c.get("requestId") ?? null,
-    });
-  } catch (err) {
-    await db
-      .delete(webhookConfigs)
-      .where(and(eq(webhookConfigs.id, webhook.id), eq(webhookConfigs.tenantId, tenantId)));
-    throw err;
-  }
-  const [enabledWebhook] = await db
-    .update(webhookConfigs)
-    .set({ enabled: true, updatedAt: new Date() })
-    .where(and(eq(webhookConfigs.id, webhook.id), eq(webhookConfigs.tenantId, tenantId)))
-    .returning();
-  webhook = enabledWebhook ?? webhook;
-
   return c.json<ApiResponse>(
     {
       ok: true,
-      data: { ...redactWebhookSecret(webhook), secret: oneTimeSecret },
+      data: { ...redactWebhookSecret(webhook), secret: rawSecret },
     },
     201,
   );
@@ -565,18 +554,15 @@ webhookRoutes.put("/:id", async (c) => {
   if (body.description !== undefined) updates.description = body.description;
   if (body.maxRetries !== undefined) updates.maxRetries = body.maxRetries;
   if (body.retryBackoffMs !== undefined) updates.retryBackoffMs = body.retryBackoffMs;
-  updates.updatedAt = new Date();
-
-  let existing: typeof webhookConfigs.$inferSelect;
   let updated: typeof webhookConfigs.$inferSelect;
   try {
-    const result = await db.transaction(async (tx) => {
-      await lockWebhookConfigTenant(tx, tenantId);
-
+    updated = await withTenantAuditedTransaction(tenantId, async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof db;
       const [current] = await tx
         .select()
         .from(webhookConfigs)
-        .where(and(eq(webhookConfigs.id, webhookId), eq(webhookConfigs.tenantId, tenantId)));
+        .where(and(eq(webhookConfigs.id, webhookId), eq(webhookConfigs.tenantId, tenantId)))
+        .for("update");
 
       if (!current) {
         throw new WebhookConfigError("Webhook not found", 404);
@@ -592,70 +578,39 @@ webhookRoutes.put("/:id", async (c) => {
         }
       }
 
-      await writeAuditEvent({
-        tenantId,
-        actorType: "user",
-        actorId: c.get("userId") ?? c.get("authType") ?? null,
-        action: "webhook.update.authorized",
-        resourceType: "webhook",
-        resourceId: webhookId,
-        metadata: {
-          before: redactWebhookSecret(current),
-          updates,
-        },
-        ipAddress: c.req.header("x-forwarded-for") ?? null,
-        userAgent: c.req.header("user-agent") ?? null,
-        requestId: c.get("requestId") ?? null,
-      });
+      const committedUpdates = { ...updates, updatedAt: new Date() };
+      await appendRequiredAudit(
+        webhookAuditEvent(c, {
+          action: "webhook.update.authorized",
+          resourceType: "webhook",
+          resourceId: webhookId,
+          metadata: { before: redactWebhookSecret(current), updates: committedUpdates },
+        }),
+      );
 
       const [next] = await tx
         .update(webhookConfigs)
-        .set(updates)
+        .set(committedUpdates)
         .where(and(eq(webhookConfigs.id, webhookId), eq(webhookConfigs.tenantId, tenantId)))
         .returning();
 
-      return { existing: current, updated: next };
+      await appendRequiredAudit(
+        webhookAuditEvent(c, {
+          action: "webhook.update",
+          resourceType: "webhook",
+          resourceId: webhookId,
+          metadata: {
+            before: redactWebhookSecret(current),
+            after: redactWebhookSecret(next),
+          },
+        }),
+      );
+      return next;
     });
-    existing = result.existing;
-    updated = result.updated;
   } catch (err) {
     if (err instanceof WebhookConfigError) {
       return c.json<ApiResponse>({ ok: false, error: err.message }, err.status);
     }
-    throw err;
-  }
-
-  try {
-    await writeAuditEvent({
-      tenantId,
-      actorType: "user",
-      actorId: c.get("userId") ?? c.get("authType") ?? null,
-      action: "webhook.update",
-      resourceType: "webhook",
-      resourceId: webhookId,
-      metadata: {
-        before: redactWebhookSecret(existing),
-        after: redactWebhookSecret(updated),
-      },
-      ipAddress: c.req.header("x-forwarded-for") ?? null,
-      userAgent: c.req.header("user-agent") ?? null,
-      requestId: c.get("requestId") ?? null,
-    });
-  } catch (err) {
-    await db
-      .update(webhookConfigs)
-      .set({
-        url: existing.url,
-        secret: existing.secret,
-        events: existing.events,
-        enabled: existing.enabled,
-        maxRetries: existing.maxRetries,
-        retryBackoffMs: existing.retryBackoffMs,
-        description: existing.description,
-        createdAt: existing.createdAt,
-        updatedAt: existing.updatedAt,
-      })
-      .where(and(eq(webhookConfigs.id, webhookId), eq(webhookConfigs.tenantId, tenantId)));
     throw err;
   }
 
@@ -674,61 +629,43 @@ webhookRoutes.delete("/:id", async (c) => {
   const tenantId = c.get("tenantId");
   const webhookId = c.req.param("id");
 
-  const [existing] = await db
-    .select()
-    .from(webhookConfigs)
-    .where(and(eq(webhookConfigs.id, webhookId), eq(webhookConfigs.tenantId, tenantId)));
-
-  if (!existing) {
-    return c.json<ApiResponse>({ ok: false, error: "Webhook not found" }, 404);
-  }
-
-  await writeAuditEvent({
-    tenantId,
-    actorType: "user",
-    actorId: c.get("userId") ?? c.get("authType") ?? null,
-    action: "webhook.delete.authorized",
-    resourceType: "webhook",
-    resourceId: webhookId,
-    metadata: { deleted: redactWebhookSecret(existing) },
-    ipAddress: c.req.header("x-forwarded-for") ?? null,
-    userAgent: c.req.header("user-agent") ?? null,
-    requestId: c.get("requestId") ?? null,
-  });
-
-  const [deleted] = await db
-    .delete(webhookConfigs)
-    .where(and(eq(webhookConfigs.id, webhookId), eq(webhookConfigs.tenantId, tenantId)))
-    .returning();
-
-  if (!deleted) return c.json<ApiResponse>({ ok: false, error: "Webhook not found" }, 404);
   try {
-    await writeAuditEvent({
-      tenantId,
-      actorType: "user",
-      actorId: c.get("userId") ?? c.get("authType") ?? null,
-      action: "webhook.delete",
-      resourceType: "webhook",
-      resourceId: webhookId,
-      metadata: { deleted: redactWebhookSecret(deleted) },
-      ipAddress: c.req.header("x-forwarded-for") ?? null,
-      userAgent: c.req.header("user-agent") ?? null,
-      requestId: c.get("requestId") ?? null,
+    await withTenantAuditedTransaction(tenantId, async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof db;
+      const [existing] = await tx
+        .select()
+        .from(webhookConfigs)
+        .where(and(eq(webhookConfigs.id, webhookId), eq(webhookConfigs.tenantId, tenantId)))
+        .for("update");
+      if (!existing) throw new WebhookConfigError("Webhook not found", 404);
+
+      await appendRequiredAudit(
+        webhookAuditEvent(c, {
+          action: "webhook.delete.authorized",
+          resourceType: "webhook",
+          resourceId: webhookId,
+          metadata: { deleted: redactWebhookSecret(existing) },
+        }),
+      );
+      const [deleted] = await tx
+        .delete(webhookConfigs)
+        .where(and(eq(webhookConfigs.id, webhookId), eq(webhookConfigs.tenantId, tenantId)))
+        .returning();
+      if (!deleted) throw new WebhookConfigError("Webhook not found", 404);
+
+      await appendRequiredAudit(
+        webhookAuditEvent(c, {
+          action: "webhook.delete",
+          resourceType: "webhook",
+          resourceId: webhookId,
+          metadata: { deleted: redactWebhookSecret(deleted) },
+        }),
+      );
     });
   } catch (err) {
-    await db.insert(webhookConfigs).values({
-      id: deleted.id,
-      tenantId: deleted.tenantId,
-      url: deleted.url,
-      secret: deleted.secret,
-      events: deleted.events,
-      enabled: deleted.enabled,
-      maxRetries: deleted.maxRetries,
-      retryBackoffMs: deleted.retryBackoffMs,
-      description: deleted.description,
-      createdAt: deleted.createdAt,
-      updatedAt: deleted.updatedAt,
-    });
+    if (err instanceof WebhookConfigError) {
+      return c.json<ApiResponse>({ ok: false, error: err.message }, err.status);
+    }
     throw err;
   }
 
@@ -1057,134 +994,113 @@ webhookRoutes.post("/deliveries/:id/retry", async (c) => {
   const tenantId = c.get("tenantId");
   const deliveryId = c.req.param("id");
 
-  const [delivery] = await db
-    .select()
-    .from(webhookDeliveries)
-    .where(and(eq(webhookDeliveries.id, deliveryId), eq(webhookDeliveries.tenantId, tenantId)));
-
-  if (!delivery) {
-    return c.json<ApiResponse>({ ok: false, error: "Delivery not found" }, 404);
-  }
-
-  if (delivery.status === "delivered") {
-    return c.json<ApiResponse>({ ok: false, error: "Delivery already succeeded" }, 400);
-  }
-  if (
-    delivery.status === "processing" &&
-    delivery.nextRetryAt &&
-    delivery.nextRetryAt > new Date()
-  ) {
-    return c.json<ApiResponse>({ ok: false, error: "Delivery is currently in flight" }, 409);
-  }
-  if (delivery.attempts >= delivery.maxAttempts) {
-    return c.json<ApiResponse>(
-      { ok: false, error: "Delivery retry budget has been exhausted" },
-      409,
-    );
-  }
-
-  if (!delivery.webhookConfigId) {
-    return c.json<ApiResponse>(
-      { ok: false, error: "Delivery cannot be retried because its original webhook is unknown" },
-      409,
-    );
-  }
-
-  const [activeWebhook] = await db
-    .select({ id: webhookConfigs.id, url: webhookConfigs.url, events: webhookConfigs.events })
-    .from(webhookConfigs)
-    .where(
-      and(
-        eq(webhookConfigs.tenantId, tenantId),
-        eq(webhookConfigs.id, delivery.webhookConfigId),
-        eq(webhookConfigs.enabled, true),
-      ),
-    );
-
-  if (!activeWebhook) {
-    return c.json<ApiResponse>(
-      { ok: false, error: "Delivery cannot be retried because the webhook is disabled or deleted" },
-      409,
-    );
-  }
-  if (activeWebhook.url !== delivery.url) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: "Delivery cannot be retried because the webhook URL has changed",
-      },
-      409,
-    );
-  }
-  if (!currentWebhookAcceptsDelivery(activeWebhook.events, delivery.eventType)) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: "Delivery cannot be retried because the webhook no longer subscribes to this event",
-      },
-      409,
-    );
-  }
-
-  await writeAuditEvent({
-    tenantId,
-    actorType: "user",
-    actorId: c.get("userId") ?? c.get("authType") ?? null,
-    action: "webhook_delivery.retry.authorized",
-    resourceType: "webhook_delivery",
-    resourceId: deliveryId,
-    metadata: { webhookUrl: delivery.url, previousStatus: delivery.status },
-    ipAddress: c.req.header("x-forwarded-for") ?? null,
-    userAgent: c.req.header("user-agent") ?? null,
-    requestId: c.get("requestId") ?? null,
-  });
-
-  // Re-queue for an immediate manual retry without resetting the delivery's
-  // attempt budget. Resetting attempts would let repeated manual retries bypass
-  // the configured maxAttempts cap.
-  const manualRetryAt = new Date();
-  const [updated] = await db
-    .update(webhookDeliveries)
-    .set({
-      status: "pending",
-      nextRetryAt: manualRetryAt,
-      lastError: null,
-    })
-    .where(
-      and(
-        eq(webhookDeliveries.id, deliveryId),
-        eq(webhookDeliveries.tenantId, tenantId),
-        sql`${webhookDeliveries.status} <> 'delivered'`,
-        sql`${webhookDeliveries.attempts} < ${webhookDeliveries.maxAttempts}`,
-        sql`not (${webhookDeliveries.status} = 'processing' and ${webhookDeliveries.nextRetryAt} > ${manualRetryAt})`,
-      ),
-    )
-    .returning();
-  if (!updated) {
-    return c.json<ApiResponse>({ ok: false, error: "Delivery is no longer retryable" }, 409);
-  }
+  let updated: typeof webhookDeliveries.$inferSelect;
   try {
-    await writeAuditEvent({
-      tenantId,
-      actorType: "user",
-      actorId: c.get("userId") ?? c.get("authType") ?? null,
-      action: "webhook_delivery.retry",
-      resourceType: "webhook_delivery",
-      resourceId: deliveryId,
-      metadata: { webhookUrl: delivery.url, previousStatus: delivery.status },
-      ipAddress: c.req.header("x-forwarded-for") ?? null,
-      userAgent: c.req.header("user-agent") ?? null,
-      requestId: c.get("requestId") ?? null,
+    updated = await withTenantAuditedTransaction(tenantId, async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof db;
+      const [delivery] = await tx
+        .select()
+        .from(webhookDeliveries)
+        .where(and(eq(webhookDeliveries.id, deliveryId), eq(webhookDeliveries.tenantId, tenantId)))
+        .for("update");
+      if (!delivery) throw new WebhookConfigError("Delivery not found", 404);
+      if (delivery.status === "delivered") {
+        throw new WebhookConfigError("Delivery already succeeded", 400);
+      }
+
+      const manualRetryAt = new Date();
+      const manualRetryAtIso = manualRetryAt.toISOString();
+      if (
+        delivery.status === "processing" &&
+        delivery.nextRetryAt &&
+        delivery.nextRetryAt > manualRetryAt
+      ) {
+        throw new WebhookConfigError("Delivery is currently in flight", 409);
+      }
+      if (delivery.attempts >= delivery.maxAttempts) {
+        throw new WebhookConfigError("Delivery retry budget has been exhausted", 409);
+      }
+      if (!delivery.webhookConfigId) {
+        throw new WebhookConfigError(
+          "Delivery cannot be retried because its original webhook is unknown",
+          409,
+        );
+      }
+
+      const [activeWebhook] = await tx
+        .select({ id: webhookConfigs.id, url: webhookConfigs.url, events: webhookConfigs.events })
+        .from(webhookConfigs)
+        .where(
+          and(
+            eq(webhookConfigs.tenantId, tenantId),
+            eq(webhookConfigs.id, delivery.webhookConfigId),
+            eq(webhookConfigs.enabled, true),
+          ),
+        )
+        .for("share");
+      if (!activeWebhook) {
+        throw new WebhookConfigError(
+          "Delivery cannot be retried because the webhook is disabled or deleted",
+          409,
+        );
+      }
+      if (activeWebhook.url !== delivery.url) {
+        throw new WebhookConfigError(
+          "Delivery cannot be retried because the webhook URL has changed",
+          409,
+        );
+      }
+      if (!currentWebhookAcceptsDelivery(activeWebhook.events, delivery.eventType)) {
+        throw new WebhookConfigError(
+          "Delivery cannot be retried because the webhook no longer subscribes to this event",
+          409,
+        );
+      }
+
+      await appendRequiredAudit(
+        webhookAuditEvent(c, {
+          action: "webhook_delivery.retry.authorized",
+          resourceType: "webhook_delivery",
+          resourceId: deliveryId,
+          metadata: { webhookUrl: delivery.url, previousStatus: delivery.status },
+        }),
+      );
+
+      // The row lock fences the retry worker until the pending state and both
+      // required audits commit. Attempts are deliberately preserved.
+      const [next] = await tx
+        .update(webhookDeliveries)
+        .set({ status: "pending", nextRetryAt: manualRetryAt, lastError: null })
+        .where(
+          and(
+            eq(webhookDeliveries.id, deliveryId),
+            eq(webhookDeliveries.tenantId, tenantId),
+            sql`${webhookDeliveries.status} <> 'delivered'`,
+            sql`${webhookDeliveries.attempts} < ${webhookDeliveries.maxAttempts}`,
+            sql`not (${webhookDeliveries.status} = 'processing' and ${webhookDeliveries.nextRetryAt} > ${manualRetryAtIso})`,
+          ),
+        )
+        .returning();
+      if (!next) throw new WebhookConfigError("Delivery is no longer retryable", 409);
+
+      await appendRequiredAudit(
+        webhookAuditEvent(c, {
+          action: "webhook_delivery.retry",
+          resourceType: "webhook_delivery",
+          resourceId: deliveryId,
+          metadata: {
+            webhookUrl: delivery.url,
+            previousStatus: delivery.status,
+            status: next.status,
+          },
+        }),
+      );
+      return next;
     });
   } catch (err) {
-    await db
-      .update(webhookDeliveries)
-      .set({
-        status: delivery.status,
-        nextRetryAt: delivery.nextRetryAt,
-        lastError: delivery.lastError,
-      })
-      .where(and(eq(webhookDeliveries.id, deliveryId), eq(webhookDeliveries.tenantId, tenantId)));
+    if (err instanceof WebhookConfigError) {
+      return c.json<ApiResponse>({ ok: false, error: err.message }, err.status);
+    }
     throw err;
   }
 


### PR DESCRIPTION
Closes #719.

Moves webhook create, update, delete, and retry state changes plus required completion audits into locked audited transactions. Removes stale compensation, returns one-time secrets only after the final enabled row commits, and adds mounted PostgreSQL create/update/delete/retry races. The PostgreSQL suite now registers safely when DATABASE_URL is absent.

Exact head: cfd601b20b60783134401f7a8dca990dc695586a
Exact base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6

Local acceptance:
- webhook behavior/order: 23 pass, 162 assertions
- mounted PostgreSQL races: 10 locally skipped and required in hosted Integration Tests
- API build, targeted Biome, diff check, public-package metadata: pass

Keep draft until exact hosted PostgreSQL, full matrix, and independent review pass.