### PR TITLE
test(api): prove secret-bearing responses are non-cacheable

### DIFF
--- a/packages/api/src/__tests__/auth-oauth-nonce-exchange.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-nonce-exchange.test.ts
@@ -62,13 +62,17 @@ function makeApp(): Hono {
 async function postExchange(
   app: Hono,
   body: Record<string, unknown>,
-): Promise<{ status: number; json: Record<string, unknown> }> {
+): Promise<{ status: number; json: Record<string, unknown>; headers: Headers }> {
   const res = await app.request("/auth/oauth/exchange", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  return { status: res.status, json: (await res.json()) as Record<string, unknown> };
+  return {
+    status: res.status,
+    json: (await res.json()) as Record<string, unknown>,
+    headers: res.headers,
+  };
 }
 
 describe("POST /auth/oauth/exchange", () => {
@@ -143,13 +147,16 @@ describe("POST /auth/oauth/exchange", () => {
       tenantId: TENANT_ID,
     });
 
-    const { status, json } = await postExchange(app, {
+    const { status, json, headers } = await postExchange(app, {
       code: "nonce-happy-path",
       redirect_uri: REDIRECT_URI,
       tenant_id: TENANT_ID,
     });
 
     expect(status).toBe(200);
+    expect(headers.get("Cache-Control")).toBe("no-store, max-age=0");
+    expect(headers.get("Pragma")).toBe("no-cache");
+    expect(headers.get("Expires")).toBe("0");
     expect(json.ok).toBe(true);
     expect(json.token).toBe("access-jwt");
     expect(json.refreshToken).toBe("refresh-raw");

--- a/packages/api/src/__tests__/auth-oauth-token-encryption.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-token-encryption.test.ts
@@ -135,6 +135,9 @@ describe("OAuth provider token encryption", () => {
     });
 
     expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+    expect(res.headers.get("Pragma")).toBe("no-cache");
+    expect(res.headers.get("Expires")).toBe("0");
     const body = (await res.json()) as { ok: boolean; token?: string; refreshToken?: string };
     expect(body.ok).toBe(true);
     expect(body.token).toBeTruthy();

--- a/packages/api/src/__tests__/dashboard-auth.test.ts
+++ b/packages/api/src/__tests__/dashboard-auth.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { signAccessToken, signAgentToken } from "@stwd/auth";
-import { getDb, tenants, users, userTenants } from "@stwd/db";
+import { agents, getDb, tenants, users, userTenants } from "@stwd/db";
 import { eq } from "drizzle-orm";
 
 setDefaultTimeout(30000);
@@ -19,6 +19,7 @@ setDefaultTimeout(30000);
 const TENANT_ID = "test-dashboard-auth";
 const OWNER_USER_ID = crypto.randomUUID();
 const MEMBER_USER_ID = crypto.randomUUID();
+const AGENT_ID = `dashboard-cache-${crypto.randomUUID()}`;
 const hasDatabaseUrl = Boolean(process.env.DATABASE_URL);
 const describeWithDatabase = hasDatabaseUrl ? describe : describe.skip;
 
@@ -51,10 +52,20 @@ beforeAll(async () => {
       { userId: MEMBER_USER_ID, tenantId: TENANT_ID, role: "member" },
     ])
     .onConflictDoNothing();
+  await getDb().insert(agents).values({
+    id: AGENT_ID,
+    tenantId: TENANT_ID,
+    name: "Dashboard cache contract",
+    walletAddress: "0x1234567890123456789012345678901234567890",
+  });
 });
 
 afterAll(async () => {
   if (!hasDatabaseUrl) return;
+  await getDb()
+    .delete(agents)
+    .where(eq(agents.id, AGENT_ID))
+    .catch(() => {});
   await getDb()
     .delete(userTenants)
     .where(eq(userTenants.tenantId, TENANT_ID))
@@ -135,6 +146,28 @@ describeWithDatabase("dashboardAuthMiddleware", () => {
     const body = (await res.json()) as { ok: boolean; error: string };
     expect(body.ok).toBe(false);
     expect(body.error).toContain("Agent not found");
+  });
+
+  it("returns dashboard data with the complete non-cacheable response contract", async () => {
+    const token = await signAccessToken(
+      {
+        address: `0x${"1".repeat(40)}`,
+        tenantId: TENANT_ID,
+        userId: OWNER_USER_ID,
+        mfaVerifiedAt: Date.now(),
+      },
+      "1h",
+    );
+
+    const res = await app.request(`/dashboard/${AGENT_ID}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+    expect(res.headers.get("Pragma")).toBe("no-cache");
+    expect(res.headers.get("Expires")).toBe("0");
+    expect((await res.json()) as object).toHaveProperty("data.agent.id", AGENT_ID);
   });
 
   it("rejects member sessions before returning dashboard data", async () => {

--- a/packages/api/src/__tests__/global-wallet.test.ts
+++ b/packages/api/src/__tests__/global-wallet.test.ts
@@ -702,6 +702,9 @@ describe("global wallet routes", () => {
       }),
     });
     expect(signed.status).toBe(200);
+    expect(signed.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+    expect(signed.headers.get("Pragma")).toBe("no-cache");
+    expect(signed.headers.get("Expires")).toBe("0");
     const signedBody = (await signed.json()) as { data: { id: number; result: string } };
     expect(signedBody.data.id).toBe(3);
     expect(signedBody.data.result).toMatch(/^0x[0-9a-fA-F]{130}$/);
@@ -915,6 +918,9 @@ describe("global wallet routes", () => {
       }),
     });
     expect(signed.status).toBe(200);
+    expect(signed.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+    expect(signed.headers.get("Pragma")).toBe("no-cache");
+    expect(signed.headers.get("Expires")).toBe("0");
     const signedBody = (await signed.json()) as { data: { id: number; result: `0x${string}` } };
     expect(signedBody.data.id).toBe(4);
     expect(signedBody.data.result).toMatch(/^0x[0-9a-fA-F]{130}$/);

--- a/packages/api/src/__tests__/identity-discovery.test.ts
+++ b/packages/api/src/__tests__/identity-discovery.test.ts
@@ -108,6 +108,9 @@ describe("identity JWKS discovery", () => {
         headers: { Authorization: `Bearer ${sessionToken}` },
       });
       expect(identityResponse.status).toBe(200);
+      expect(identityResponse.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+      expect(identityResponse.headers.get("Pragma")).toBe("no-cache");
+      expect(identityResponse.headers.get("Expires")).toBe("0");
       const identity = (await identityResponse.json()) as { token: string };
 
       const rootJwksResponse = await identityDiscoveryRoutes.request(

--- a/packages/api/src/__tests__/secret-bearing-cache-control.test.ts
+++ b/packages/api/src/__tests__/secret-bearing-cache-control.test.ts
@@ -1,96 +1,345 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { closeDb, getDb, tenantAppClients, tenants, users, userTenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
 
-function source(path: string): string {
-  return readFileSync(join(import.meta.dir, "..", ...path.split("/")), "utf8");
+const TENANT_ID = "secret-cache-runtime";
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+const CLIENT_ID = "runtime-client";
+setDefaultTimeout(30_000);
+
+function expectNoStore(response: Response): void {
+  expect(response.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+  expect(response.headers.get("Pragma")).toBe("no-cache");
+  expect(response.headers.get("Expires")).toBe("0");
 }
 
-function expectNoStoreBeforeReturn(src: string, marker: string, returnedSecret: string) {
-  const start = src.indexOf(marker);
-  expect(start).toBeGreaterThanOrEqual(0);
-  const noStore = src.indexOf("setNoStoreHeaders(c)", start);
-  const returned = src.indexOf(returnedSecret, start);
-  expect(noStore).toBeGreaterThan(start);
-  expect(returned).toBeGreaterThan(noStore);
-}
+const SECRET_RESPONSE_INVENTORY = [
+  [
+    "app-client-secret",
+    "/:tenantId/app-clients/:clientId/secrets",
+    "secret-bearing-cache-control.test.ts",
+    true,
+  ],
+  [
+    "user-invitation-token",
+    "/me/tenants/:tenantId/invitations",
+    "secret-bearing-cache-control.test.ts",
+    true,
+  ],
+  [
+    "platform-invitation-token",
+    "/tenants/:tenantId/invitations",
+    "secret-bearing-cache-control.test.ts",
+    true,
+  ],
+  ["vault-message", "/:agentId/sign-message", "vault-raw-signing.test.ts", true],
+  ["vault-raw-hash", "/:agentId/sign-raw-hash", "vault-raw-signing.test.ts", true],
+  ["vault-raw-digest", "/:agentId/sign-raw-digest", "vault-raw-digest-signing.test.ts", true],
+  ["vault-typed-data", "/:agentId/sign-typed-data", "vault-raw-signing.test.ts", true],
+  [
+    "vault-user-operation",
+    "/:agentId/sign-user-operation",
+    "secret-bearing-cache-control.test.ts",
+    false,
+  ],
+  [
+    "vault-authorization",
+    "/:agentId/sign-authorization",
+    "secret-bearing-cache-control.test.ts",
+    false,
+  ],
+  ["vault-solana", "/:agentId/sign-solana", "sign-solana-priority-fee.test.ts", true],
+  ["user-wallet-signing", "/me/wallet/sign", "user-wallet-signers.test.ts", true],
+  ["global-wallet-personal-sign", "personal_sign", "global-wallet.test.ts", true],
+  ["global-wallet-typed-data", "eth_signTypedData_v4", "global-wallet.test.ts", true],
+  ["audit-read", "/events", "audit-events-filters.test.ts", true],
+  ["dashboard-read", "/dashboard/:agentId", "dashboard-auth.test.ts", true],
+  ["auth-identity-token", "/identity-token", "identity-discovery.test.ts", true],
+  ["auth-refresh", "/refresh", "session-revocation.test.ts", true],
+  ["auth-oauth-exchange", "/oauth/exchange", "auth-oauth-nonce-exchange.test.ts", true],
+  ["auth-provider-token", "/oauth/:provider/token", "auth-oauth-token-encryption.test.ts", true],
+] as const satisfies ReadonlyArray<
+  readonly [id: string, route: string, evidenceFile: string, secretSuccessReachable: boolean]
+>;
 
-describe("secret-bearing responses", () => {
-  it("marks one-time app secrets and invitation tokens as non-cacheable", () => {
-    expectNoStoreBeforeReturn(
-      source("routes/tenant-config.ts"),
-      'action: "tenant.app_client_secret.rotate"',
-      "appSecret: generated.secret",
-    );
-    expectNoStoreBeforeReturn(
-      source("routes/user.ts"),
-      "sendTenantInvitation(email",
-      "token, emailSent",
-    );
-    expectNoStoreBeforeReturn(
-      source("routes/platform.ts"),
-      "sendTenantInvitation(email",
-      "token, emailSent",
-    );
+let tenantConfigApp: Hono<{ Variables: AppVariables }>;
+let userRoutes: Awaited<typeof import("../routes/user")>["userRoutes"];
+let platformRoutes: Awaited<typeof import("../routes/platform")>["platformRoutes"];
+let vaultRoutes: Awaited<typeof import("../routes/vault")>["vaultRoutes"];
+let vaultApp: Hono<{ Variables: AppVariables }>;
+let globalWalletRoutes: Awaited<typeof import("../routes/global-wallet")>["globalWalletRoutes"];
+let authRoutes: Awaited<typeof import("../routes/auth")>["authRoutes"];
+let sessionToken: string;
+let personalSessionToken: string;
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = "secret-cache-runtime-master-password-32chars";
+  process.env.STEWARD_JWT_SECRET = "secret-cache-runtime-jwt-key-32chars";
+  process.env.STEWARD_AUDIT_HMAC_KEY = "secret-cache-runtime-audit-key-32chars";
+  process.env.STEWARD_PLATFORM_KEYS = "secret-cache-platform-key";
+  process.env.STEWARD_PLATFORM_KEY_SCOPES = JSON.stringify({
+    "secret-cache-platform-key": [
+      "platform:read",
+      "platform:write",
+      "platform:tenant-member:write",
+    ],
+  });
+  process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING = "true";
+  process.env.STEWARD_ALLOW_VAULT_UNSAFE_MESSAGE_SIGNING = "true";
+  process.env.STEWARD_ALLOW_UNSAFE_RAW_SIGNING = "true";
+  process.env.STEWARD_ALLOW_VAULT_UNSAFE_RAW_SIGNING = "true";
+  process.env.STEWARD_ALLOW_UNSAFE_USER_OPERATION_SIGNING = "true";
+  process.env.STEWARD_ALLOW_UNSAFE_AUTHORIZATION_SIGNING = "true";
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => client.close());
+  await getDb()
+    .insert(tenants)
+    .values([
+      { id: TENANT_ID, name: "Secret cache runtime", apiKeyHash: "hash-runtime" },
+      { id: `personal-${USER_ID}`, name: "Personal", apiKeyHash: "hash-personal" },
+    ]);
+  await getDb().insert(users).values({ id: USER_ID, email: "secret-cache@example.test" });
+  await getDb()
+    .insert(userTenants)
+    .values([
+      { userId: USER_ID, tenantId: TENANT_ID, role: "owner" },
+      { userId: USER_ID, tenantId: `personal-${USER_ID}`, role: "owner" },
+    ]);
+  await getDb().insert(tenantAppClients).values({
+    tenantId: TENANT_ID,
+    id: CLIENT_ID,
+    name: "Runtime client",
+    enabled: true,
+    isDefault: true,
   });
 
-  it("marks wallet signature responses as non-cacheable", () => {
-    const vault = source("routes/vault.ts");
-    for (const marker of [
-      'action: "vault.message.signed"',
-      'action: "vault.raw_hash.signed"',
-      'action: "vault.raw_digest.signed"',
-      'action: "vault.sign.typed_data"',
-      'action: "vault.sign.user_operation"',
-      'action: "vault.sign.authorization"',
-      'action: "vault.sign.solana"',
-    ]) {
-      expectNoStoreBeforeReturn(vault, marker, "return c.json");
+  const tenantConfig = await import("../routes/tenant-config");
+  tenantConfigApp = new Hono<{ Variables: AppVariables }>();
+  tenantConfigApp.use("*", async (c, next) => {
+    c.set("tenantId", TENANT_ID);
+    c.set("authType", "session-jwt");
+    c.set("tenantRole", "owner");
+    c.set("userId", USER_ID);
+    c.set("sessionMfaVerifiedAt", Date.now());
+    await next();
+  });
+  tenantConfigApp.route("/", tenantConfig.tenantConfigRoutes);
+
+  ({ userRoutes } = await import("../routes/user"));
+  ({ platformRoutes } = await import("../routes/platform"));
+  ({ vaultRoutes } = await import("../routes/vault"));
+  ({ globalWalletRoutes } = await import("../routes/global-wallet"));
+  const auth = await import("../routes/auth");
+  authRoutes = auth.authRoutes;
+  sessionToken = await auth.createSessionToken(
+    "0x1111111111111111111111111111111111111111",
+    TENANT_ID,
+    { userId: USER_ID, mfaVerifiedAt: Date.now(), mfaMethod: "totp" },
+  );
+  personalSessionToken = await auth.createSessionToken(
+    "0x1111111111111111111111111111111111111111",
+    `personal-${USER_ID}`,
+    { userId: USER_ID, mfaVerifiedAt: Date.now(), mfaMethod: "totp" },
+  );
+  vaultApp = new Hono<{ Variables: AppVariables }>();
+  vaultApp.use("*", async (c, next) => {
+    c.set("tenantId", TENANT_ID);
+    c.set("authType", "session-jwt");
+    c.set("tenantRole", "owner");
+    c.set("userId", USER_ID);
+    c.set("sessionMfaVerifiedAt", Date.now());
+    await next();
+  });
+  vaultApp.route("/", vaultRoutes);
+});
+
+afterAll(async () => {
+  await closeDb();
+  for (const name of [
+    "STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING",
+    "STEWARD_ALLOW_VAULT_UNSAFE_MESSAGE_SIGNING",
+    "STEWARD_ALLOW_UNSAFE_RAW_SIGNING",
+    "STEWARD_ALLOW_VAULT_UNSAFE_RAW_SIGNING",
+    "STEWARD_ALLOW_UNSAFE_USER_OPERATION_SIGNING",
+    "STEWARD_ALLOW_UNSAFE_AUTHORIZATION_SIGNING",
+  ]) {
+    delete process.env[name];
+  }
+});
+
+describe("secret-bearing response cache control", () => {
+  it("keeps every family bound to explicit mounted evidence and honest reachability", () => {
+    expect(SECRET_RESPONSE_INVENTORY).toHaveLength(19);
+    expect(new Set(SECRET_RESPONSE_INVENTORY.map(([id]) => id)).size).toBe(19);
+    for (const [id, _route, evidenceFile, secretSuccessReachable] of SECRET_RESPONSE_INVENTORY) {
+      const evidence = readFileSync(new URL(evidenceFile, import.meta.url), "utf8");
+      if (secretSuccessReachable) {
+        expect(evidence, `${id}: missing mounted success status assertion`).toMatch(
+          /\.status\)?\.toBe\((?:200|201)\)|status\)\.toBe\((?:200|201)\)/,
+        );
+      } else {
+        expect(evidence, `${id}: missing mounted fail-closed response assertion`).toContain(
+          "toBeGreaterThanOrEqual(400)",
+        );
+      }
+      expect(evidence, `${id}: Cache-Control`).toContain('"Cache-Control"');
+      expect(evidence, `${id}: Pragma`).toContain('"Pragma"');
+      expect(evidence, `${id}: Expires`).toContain('"Expires"');
+      expect(typeof secretSuccessReachable).toBe("boolean");
     }
-
-    expectNoStoreBeforeReturn(
-      source("routes/user.ts"),
-      'action: "user.wallet.sign_message"',
-      "signature, address",
-    );
-    const globalWallet = source("routes/global-wallet.ts");
-    expectNoStoreBeforeReturn(globalWallet, 'method === "personal_sign"', "result: signature");
-    expectNoStoreBeforeReturn(
-      globalWallet,
-      'method === "eth_signTypedData_v4"',
-      "result: signature",
-    );
+    expect(
+      SECRET_RESPONSE_INVENTORY.filter(([, , , reachable]) => !reachable).map(([id]) => id),
+    ).toEqual(["vault-user-operation", "vault-authorization"]);
   });
 
-  it("marks MFA-gated audit and dashboard reads as non-cacheable", () => {
-    // Audit routes get no-store via the shared owner/admin+MFA gate
-    // (middleware/audit-gate.ts), wired onto every /audit route with
-    // `.use("*", auditOwnerAdminMfaGate)`. The gate sets no-store only AFTER the
-    // auth checks pass, so a 403 rejection never emits cacheable secret bodies.
-    expect(source("routes/audit.ts")).toContain('auditRoutes.use("*", auditOwnerAdminMfaGate)');
-    expect(source("middleware/audit-gate.ts")).toContain("setNoStoreHeaders(c);");
-    expectNoStoreBeforeReturn(
-      source("routes/dashboard.ts"),
-      "Dashboard data requires recent MFA verification",
-      "AgentDashboardResponse",
+  it("returns an app-client secret and protects its post-auth missing-client error", async () => {
+    const appSecret = await tenantConfigApp.request(
+      `/${TENANT_ID}/app-clients/${CLIENT_ID}/secrets`,
+      { method: "POST", headers: { Authorization: `Bearer ${sessionToken}` } },
     );
+    expect(appSecret.status).toBe(201);
+    expectNoStore(appSecret);
+    expect((await appSecret.json()) as object).toHaveProperty("data.appSecret");
+    const missing = await tenantConfigApp.request(`/${TENANT_ID}/app-clients/missing/secrets`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${sessionToken}` },
+    });
+    expect(missing.status).toBe(404);
+    expectNoStore(missing);
   });
 
-  it("marks auth routes as non-cacheable before token responses can be returned", () => {
-    const auth = source("routes/auth.ts");
-    expect(auth).toContain("function setAuthNoStoreHeaders");
-    const middleware = auth.indexOf('auth.use("*"');
-    const header = auth.indexOf("setAuthNoStoreHeaders(c)", middleware);
-    expect(middleware).toBeGreaterThanOrEqual(0);
-    expect(header).toBeGreaterThan(middleware);
-    for (const marker of [
-      "buildAuthResponse",
-      'auth.get("/identity-token"',
-      'auth.post("/refresh"',
-      'auth.post("/oauth/exchange"',
-      'auth.post("/oauth/:provider/token"',
-    ]) {
-      expect(auth.indexOf(marker, middleware)).toBeGreaterThan(header);
+  it("returns a user invitation token and protects its post-auth validation error", async () => {
+    const userInvitation = await userRoutes.request(`/me/tenants/${TENANT_ID}/invitations`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${sessionToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "user-invite@example.test" }),
+    });
+    expect(userInvitation.status).toBe(201);
+    expectNoStore(userInvitation);
+    expect((await userInvitation.json()) as object).toHaveProperty("data.token");
+    const invalid = await userRoutes.request(`/me/tenants/${TENANT_ID}/invitations`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${sessionToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "invalid" }),
+    });
+    expect(invalid.status).toBe(400);
+    expectNoStore(invalid);
+  });
+
+  it("returns a platform invitation token and protects its post-auth validation error", async () => {
+    const platformInvitation = await platformRoutes.request(`/tenants/${TENANT_ID}/invitations`, {
+      method: "POST",
+      headers: {
+        "X-Steward-Platform-Key": "secret-cache-platform-key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email: "platform-invite@example.test" }),
+    });
+    expect(platformInvitation.status).toBe(201);
+    expectNoStore(platformInvitation);
+    expect((await platformInvitation.json()) as object).toHaveProperty("data.token");
+    const invalid = await platformRoutes.request(`/tenants/${TENANT_ID}/invitations`, {
+      method: "POST",
+      headers: {
+        "X-Steward-Platform-Key": "secret-cache-platform-key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email: "invalid" }),
+    });
+    expect(invalid.status).toBe(400);
+    expectNoStore(invalid);
+  });
+
+  for (const [family, path, body] of [
+    ["vault-message", "/missing/sign-message", { message: "hello" }],
+    ["vault-raw-hash", "/missing/sign-raw-hash", { hash: `0x${"11".repeat(32)}` }],
+    [
+      "vault-raw-digest",
+      "/missing/sign-raw-digest",
+      { chain: "sui", curve: "ed25519", payloadHex: `0x${"11".repeat(32)}` },
+    ],
+    ["vault-typed-data", "/missing/sign-typed-data", {}],
+    ["vault-user-operation", "/missing/sign-user-operation", {}],
+    ["vault-authorization", "/missing/sign-authorization", {}],
+    ["vault-solana", "/missing/sign-solana", {}],
+  ] as const) {
+    it(`${family} protects its mounted post-auth error branch`, async () => {
+      const response = await vaultApp.request(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expectNoStore(response);
+    });
+  }
+
+  it("user-wallet signing protects each authenticated validation error", async () => {
+    for (const path of ["/me/wallet/sign", "/me/wallet/sign-message"] as const) {
+      const response = await userRoutes.request(path, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${personalSessionToken}`,
+          "Content-Type": "application/json",
+        },
+        body: path.endsWith("sign-message") ? JSON.stringify({ message: "hello" }) : "{}",
+      });
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expectNoStore(response);
     }
   });
+
+  for (const method of ["personal_sign", "eth_signTypedData_v4"] as const) {
+    it(`global-wallet ${method} protects its authenticated validation error`, async () => {
+      const response = await globalWalletRoutes.request("/rpc", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${personalSessionToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ method }),
+      });
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expectNoStore(response);
+    });
+  }
+
+  it("audit read protects its mounted successful response", async () => {
+    const { auditRoutes } = await import("../routes/audit");
+    const auditApp = new Hono<{ Variables: AppVariables }>();
+    auditApp.use("*", async (c, next) => {
+      c.set("tenantId", TENANT_ID);
+      c.set("authType", "session-jwt");
+      c.set("tenantRole", "owner");
+      c.set("sessionMfaVerifiedAt", Date.now());
+      await next();
+    });
+    auditApp.route("/", auditRoutes);
+    const response = await auditApp.request("/events");
+    expect(response.status).toBe(200);
+    expectNoStore(response);
+    const invalid = await auditApp.request("/events?limit=not-a-number");
+    expect(invalid.status).toBe(400);
+    expectNoStore(invalid);
+  });
+
+  for (const [family, path, init] of [
+    ["auth-identity-token", "/identity-token", { method: "GET" }],
+    ["auth-refresh", "/refresh", { method: "POST", body: "{}" }],
+    ["auth-oauth-exchange", "/oauth/exchange", { method: "POST", body: "{}" }],
+    ["auth-provider-token", "/oauth/google/token", { method: "POST", body: "{}" }],
+  ] as const) {
+    it(`${family} protects its mounted validation or authorization error`, async () => {
+      const response = await authRoutes.request(path, {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expectNoStore(response);
+    });
+  }
 });

--- a/packages/api/src/__tests__/session-revocation.test.ts
+++ b/packages/api/src/__tests__/session-revocation.test.ts
@@ -129,6 +129,9 @@ describe("API access-token revocation", () => {
     });
 
     expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+    expect(res.headers.get("Pragma")).toBe("no-cache");
+    expect(res.headers.get("Expires")).toBe("0");
     const json = (await res.json()) as {
       ok: boolean;
       token: string;

--- a/packages/api/src/__tests__/sign-solana-priority-fee.test.ts
+++ b/packages/api/src/__tests__/sign-solana-priority-fee.test.ts
@@ -1,8 +1,10 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { agents, closeDb, getDb, policies, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
+
+setDefaultTimeout(30_000);
 
 const TENANT_ID = `solana-priority-fee-tenant-${Date.now()}`;
 const AGENT_ID = `solana-priority-fee-agent-${Date.now()}`;
@@ -158,6 +160,9 @@ describe("sign-solana priority-fee cap", () => {
       });
 
       expect(response.status).toBe(200);
+      expect(response.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+      expect(response.headers.get("Pragma")).toBe("no-cache");
+      expect(response.headers.get("Expires")).toBe("0");
       const body = (await response.json()) as {
         ok: boolean;
         data?: { signature: string; broadcast: boolean; chainId: number };

--- a/packages/api/src/__tests__/user-wallet-signers.test.ts
+++ b/packages/api/src/__tests__/user-wallet-signers.test.ts
@@ -260,6 +260,9 @@ describe("user wallet additional signers API", () => {
       const body = (await response.json()) as { ok: boolean; data?: { txHash: string } };
 
       expect(response.status).toBe(200);
+      expect(response.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+      expect(response.headers.get("Pragma")).toBe("no-cache");
+      expect(response.headers.get("Expires")).toBe("0");
       expect(body.ok).toBe(true);
       expect(body.data?.txHash).toBe("0xsigned");
       expect(signSpy).toHaveBeenCalled();
@@ -316,6 +319,9 @@ describe("user wallet additional signers API", () => {
         body: JSON.stringify({ walletIndex: 2, message: "hello from signer" }),
       });
       expect(signed.status).toBe(200);
+      expect(signed.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+      expect(signed.headers.get("Pragma")).toBe("no-cache");
+      expect(signed.headers.get("Expires")).toBe("0");
       expect(signSpy).toHaveBeenCalledWith(
         PERSONAL_TENANT_ID,
         WALLET_AGENT_ID,

--- a/packages/api/src/__tests__/vault-raw-digest-signing.test.ts
+++ b/packages/api/src/__tests__/vault-raw-digest-signing.test.ts
@@ -13,7 +13,7 @@
  * non-32-byte payload is rejected (400).
  */
 
-import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, mock, setDefaultTimeout } from "bun:test";
 import { createPublicKey, verify as cryptoVerify } from "node:crypto";
 import { closeDb, getDb, policies, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
@@ -21,6 +21,8 @@ import { Vault } from "@stwd/vault";
 import { Hono } from "hono";
 import { recoverAddress } from "viem";
 import type { AppVariables } from "../services/context";
+
+setDefaultTimeout(30_000);
 
 const dispatchWebhookMock = mock(() => {});
 mock.module("../services/webhook-dispatch", () => ({
@@ -146,6 +148,9 @@ describe("vault cross-curve raw digest signing", () => {
       }),
     });
     expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+    expect(response.headers.get("Pragma")).toBe("no-cache");
+    expect(response.headers.get("Expires")).toBe("0");
     const body = (await response.json()) as {
       ok: boolean;
       data: {
@@ -190,6 +195,9 @@ describe("vault cross-curve raw digest signing", () => {
       }),
     });
     expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+    expect(response.headers.get("Pragma")).toBe("no-cache");
+    expect(response.headers.get("Expires")).toBe("0");
     const body = (await response.json()) as {
       ok: boolean;
       data: { signature: string; curve: string; payloadHex: typeof DIGEST; publicKey: string };

--- a/packages/api/src/__tests__/vault-raw-signing.test.ts
+++ b/packages/api/src/__tests__/vault-raw-signing.test.ts
@@ -1,10 +1,12 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { agentSigners, closeDb, getDb, tenants } from "@stwd/db";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { agentSigners, closeDb, getDb, policies, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { Vault } from "@stwd/vault";
 import { Hono } from "hono";
 import { recoverAddress } from "viem";
 import type { AppVariables } from "../services/context";
+
+setDefaultTimeout(30_000);
 
 const TENANT_ID = `raw-sign-tenant-${Date.now()}`;
 const AGENT_ID = `raw-sign-agent-${Date.now()}`;
@@ -41,6 +43,8 @@ describe("vault raw secp256k1 signing", () => {
     process.env.STEWARD_AUDIT_HMAC_KEY ??= "a".repeat(64);
     process.env.STEWARD_ALLOW_UNSAFE_RAW_SIGNING = "true";
     process.env.STEWARD_ALLOW_VAULT_UNSAFE_RAW_SIGNING = "true";
+    process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING = "true";
+    process.env.STEWARD_ALLOW_VAULT_UNSAFE_MESSAGE_SIGNING = "true";
     const { db, client } = await createPGLiteDb("memory://");
     setPGLiteOverride(db, async () => {
       await client.close();
@@ -54,6 +58,20 @@ describe("vault raw secp256k1 signing", () => {
       masterPassword: process.env.STEWARD_MASTER_PASSWORD,
     }).createAgent(TENANT_ID, AGENT_ID, "Raw Signing Agent");
     walletAddress = identity.walletAddress;
+    await getDb()
+      .insert(policies)
+      .values({
+        id: `${AGENT_ID}-typed-data`,
+        agentId: AGENT_ID,
+        type: "typed-data",
+        enabled: true,
+        config: {
+          verifyingContractAllowlist: ["0x000000000022d473030f116ddee9f6b43ac78ba3"],
+          allowedChainIds: [8453],
+          allowedDomainNames: ["CacheContract"],
+          allowedPrimaryTypes: ["Mail"],
+        },
+      });
     const [signer] = await getDb()
       .insert(agentSigners)
       .values({
@@ -87,6 +105,44 @@ describe("vault raw secp256k1 signing", () => {
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_ALLOW_UNSAFE_RAW_SIGNING;
     delete process.env.STEWARD_ALLOW_VAULT_UNSAFE_RAW_SIGNING;
+    delete process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING;
+    delete process.env.STEWARD_ALLOW_VAULT_UNSAFE_MESSAGE_SIGNING;
+  });
+
+  it("returns a message signature with the complete non-cacheable response contract", async () => {
+    const response = await app.request(`/vault/${AGENT_ID}/sign-message`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "cache contract" }),
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+    expect(response.headers.get("Pragma")).toBe("no-cache");
+    expect(response.headers.get("Expires")).toBe("0");
+    expect((await response.json()) as object).toHaveProperty("data.signature");
+  });
+
+  it("returns a typed-data signature with the complete non-cacheable response contract", async () => {
+    const response = await app.request(`/vault/${AGENT_ID}/sign-typed-data`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        domain: {
+          name: "CacheContract",
+          version: "1",
+          chainId: 8453,
+          verifyingContract: "0x000000000022d473030f116ddee9f6b43ac78ba3",
+        },
+        types: { Mail: [{ name: "contents", type: "string" }] },
+        primaryType: "Mail",
+        value: { contents: "non-cacheable" },
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+    expect(response.headers.get("Pragma")).toBe("no-cache");
+    expect(response.headers.get("Expires")).toBe("0");
+    expect((await response.json()) as object).toHaveProperty("data.signature");
   });
 
   it("signs a 32-byte digest and recovers the agent EVM address", async () => {
@@ -96,6 +152,9 @@ describe("vault raw secp256k1 signing", () => {
       body: JSON.stringify({ hash: HASH, referenceId: "raw-ref-1" }),
     });
     expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+    expect(response.headers.get("Pragma")).toBe("no-cache");
+    expect(response.headers.get("Expires")).toBe("0");
     const body = (await response.json()) as {
       ok: boolean;
       data: { signature: `0x${string}`; hash: typeof HASH; walletAddress: string };

--- a/packages/api/src/routes/global-wallet.ts
+++ b/packages/api/src/routes/global-wallet.ts
@@ -105,6 +105,13 @@ async function userSessionAuth(
 }
 
 globalWalletRoutes.use("*", userSessionAuth);
+globalWalletRoutes.use("*", async (c, next) => {
+  // Authenticated global-wallet responses can contain signatures, confirmation
+  // handles, or wallet authority metadata. Apply the contract before any RPC
+  // validation so post-auth failures are non-cacheable too.
+  setNoStoreHeaders(c);
+  await next();
+});
 
 function getVault(): Vault {
   return getConfiguredVault();

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -4980,6 +4980,7 @@ user.delete("/me/wallet/signers/:signerId", async (c) => {
 // ─── POST /me/wallet/sign ─────────────────────────────────────────────────────
 
 user.post("/me/wallet/sign", async (c) => {
+  setNoStoreHeaders(c);
   const personalSessionResponse = requirePersonalUserSession(c);
   if (personalSessionResponse) return personalSessionResponse;
   const userId = c.get("userId");
@@ -5388,6 +5389,7 @@ user.get("/me/wallet/policies", async (c) => {
 // ─── POST /me/wallet/sign-message ─────────────────────────────────────────────
 
 user.post("/me/wallet/sign-message", async (c) => {
+  setNoStoreHeaders(c);
   const personalSessionResponse = requirePersonalUserSession(c);
   if (personalSessionResponse) return personalSessionResponse;
   if (!allowUnsafeMessageSigning() || !allowUserUnsafeMessageSigning()) {
@@ -6599,6 +6601,7 @@ user.post("/me/tenants/:tenantId/invitations", async (c) => {
     "Tenant invitation creation requires recent MFA verification",
   );
   if (!admin.ok) return admin.response;
+  setNoStoreHeaders(c);
 
   const body = await safeJsonParse<{
     email?: unknown;


### PR DESCRIPTION
Closes #732.

Replaces the secret-bearing cache source scan with a mounted 19-family runtime inventory. Exercises actual app-client and invitation secrets, Vault signature modes, user/global-wallet signing, audit/dashboard reads, and auth token responses; production-disabled user-operation and authorization branches are represented by mounted post-auth fail-closed evidence rather than fabricated success. Adds route-level no-store coverage where reachable responses lacked it.

Exact head: 55fd0b96b0e00ff4090c08045ac459e720a44481
Exact base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6

Local acceptance:
- runtime inventory: 19 pass, 193 assertions
- isolated supporting files: 13 pass
- API dependency build: 24/24
- targeted Biome, diff check, public-package metadata: pass
- dashboard mounted PostgreSQL: 5 locally skipped and required in hosted Integration Tests

Keep draft until exact hosted PostgreSQL, full matrix, and independent review pass.