### PR TITLE
fix(api): make platform tenant creation audit-atomic

### DIFF
--- a/packages/api/src/__tests__/fixtures/tenant-create-dependent-writer.ts
+++ b/packages/api/src/__tests__/fixtures/tenant-create-dependent-writer.ts
@@ -1,0 +1,30 @@
+import { agents, createDb } from "@stwd/db";
+
+const required = (name: string): string => {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+};
+
+const databaseUrl = required("DATABASE_URL");
+const tenantId = required("TEST_TENANT_ID");
+const agentId = required("TEST_AGENT_ID");
+const database = createDb(databaseUrl);
+
+try {
+  await database.db.insert(agents).values({
+    id: agentId,
+    tenantId,
+    name: agentId,
+    walletAddress: "0x7120000000000000000000000000000000000000",
+  });
+  console.log(JSON.stringify({ ok: true }));
+} catch (error) {
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code?: unknown }).code ?? "unknown")
+      : "unknown";
+  console.log(JSON.stringify({ ok: false, code }));
+} finally {
+  await database.client.end();
+}

--- a/packages/api/src/__tests__/platform-security-hardening.test.ts
+++ b/packages/api/src/__tests__/platform-security-hardening.test.ts
@@ -110,11 +110,11 @@ describe("platform security hardening", () => {
       tenantCreateStart,
       platformSource.indexOf('platform.get("/tenants"', tenantCreateStart),
     );
-    expect(tenantCreateRoute).toContain("tenantIdHasRetainedState(body.id)");
+    expect(tenantCreateRoute).toContain("tenantIdHasRetainedState(body.id, tx)");
     expect(tenantCreateRoute).toContain(
       "Tenant id has retained historical state and cannot be reused",
     );
-    expect(tenantCreateRoute.indexOf("tenantIdHasRetainedState(body.id)")).toBeLessThan(
+    expect(tenantCreateRoute.indexOf("tenantIdHasRetainedState(body.id, tx)")).toBeLessThan(
       tenantCreateRoute.indexOf('action: "tenant.create.authorized"'),
     );
 
@@ -126,11 +126,11 @@ describe("platform security hardening", () => {
       legacyTenantCreateStart,
       tenantRoutesSource.indexOf('tenantRoutes.get("/:id"', legacyTenantCreateStart),
     );
-    expect(legacyTenantCreateRoute).toContain("tenantIdHasRetainedState(body.id)");
+    expect(legacyTenantCreateRoute).toContain("tenantIdHasRetainedState(body.id, tx)");
     expect(legacyTenantCreateRoute).toContain(
       "Tenant id has retained historical state and cannot be reused",
     );
-    expect(legacyTenantCreateRoute.indexOf("tenantIdHasRetainedState(body.id)")).toBeLessThan(
+    expect(legacyTenantCreateRoute.indexOf("tenantIdHasRetainedState(body.id, tx)")).toBeLessThan(
       legacyTenantCreateRoute.indexOf('action: "tenant.create.authorized"'),
     );
   });
@@ -298,8 +298,7 @@ describe("platform security hardening", () => {
     }
   });
 
-  it("rolls back platform tenant and agent creation when final audit events fail", () => {
-    expect(platformSource).toContain("async function deletePlatformCreatedTenant");
+  it("atomically creates tenants and compensates non-atomic agent creation", () => {
     expect(platformSource).toContain("async function deletePlatformCreatedAgent");
     expect(platformSource).toContain("tx.delete(encryptedChainKeys)");
     expect(platformSource).toContain("tx.delete(encryptedKeys)");
@@ -312,10 +311,13 @@ describe("platform security hardening", () => {
     );
     const tenantInsert = tenantCreateRoute.indexOf(".insert(tenants)");
     const finalTenantAudit = tenantCreateRoute.indexOf('action: "tenant.create"', tenantInsert);
-    const tenantRollback = tenantCreateRoute.indexOf("deletePlatformCreatedTenant(tenant.id)");
+    const auditedTransaction = tenantCreateRoute.indexOf("withTenantAuditedTransaction(body.id");
+    const requiredAudit = tenantCreateRoute.indexOf("await appendAudit({");
+    expect(auditedTransaction).toBeGreaterThanOrEqual(0);
+    expect(requiredAudit).toBeGreaterThan(auditedTransaction);
     expect(tenantInsert).toBeGreaterThanOrEqual(0);
     expect(finalTenantAudit).toBeGreaterThan(tenantInsert);
-    expect(tenantRollback).toBeGreaterThan(finalTenantAudit);
+    expect(tenantCreateRoute).not.toContain("deletePlatformCreatedTenant");
 
     const agentCreateStart = platformSource.indexOf('platform.post("/tenants/:id/agents"');
     const agentCreateRoute = platformSource.slice(

--- a/packages/api/src/__tests__/tenant-audit-rollback.test.ts
+++ b/packages/api/src/__tests__/tenant-audit-rollback.test.ts
@@ -1,36 +1,117 @@
-import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  auditChainHeads,
+  auditEvents,
+  closeDb,
+  getDb,
+  tenants,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { asc, eq } from "drizzle-orm";
 
-const routeSource = readFileSync(join(import.meta.dir, "..", "routes", "tenants.ts"), "utf8");
+const PLATFORM_KEY = "tenant-create-atomic-platform-key";
+const GOOD_AUDIT_KEY = "tenant-create-atomic-audit-key-with-enough-entropy";
+let platformRoutes: Awaited<typeof import("../routes/platform")>["platformRoutes"];
+let tenantRoutes: Awaited<typeof import("../routes/tenants")>["tenantRoutes"];
 
-describe("tenant audit rollback hardening", () => {
-  it("rolls back tenant creation if the final audit event cannot be written", () => {
-    const createStart = routeSource.indexOf('tenantRoutes.post("/", platformAuthMiddleware()');
-    expect(createStart).toBeGreaterThanOrEqual(0);
-    const createRoute = routeSource.slice(
-      createStart,
-      routeSource.indexOf('tenantRoutes.get("/:id"', createStart),
-    );
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_AUDIT_HMAC_KEY = GOOD_AUDIT_KEY;
+  process.env.STEWARD_PLATFORM_KEYS = PLATFORM_KEY;
+  process.env.STEWARD_PLATFORM_KEY_SCOPES = JSON.stringify({
+    [PLATFORM_KEY]: ["platform:write", "platform:tenant:create"],
+  });
+  __resetAuditHmacKeyCacheForTests();
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => client.close());
+  ({ platformRoutes } = await import("../routes/platform"));
+  ({ tenantRoutes } = await import("../routes/tenants"));
+});
 
-    expect(createRoute).toContain('action: "tenant.create.authorized"');
-    expect(createRoute).toContain('action: "tenant.create"');
-    expect(createRoute).toContain("try {");
-    expect(createRoute).toContain("tenantConfigs.delete(body.id)");
-    expect(createRoute).toContain("db.delete(tenants).where(eq(tenants.id, body.id))");
+afterAll(async () => {
+  await closeDb();
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_AUDIT_HMAC_KEY;
+  delete process.env.STEWARD_PLATFORM_KEYS;
+  delete process.env.STEWARD_PLATFORM_KEY_SCOPES;
+  __resetAuditHmacKeyCacheForTests();
+});
+
+const platformHeaders = {
+  "content-type": "application/json",
+  "x-steward-platform-key": PLATFORM_KEY,
+};
+
+async function platformCreate(id: string) {
+  return platformRoutes.request("/tenants", {
+    method: "POST",
+    headers: platformHeaders,
+    body: JSON.stringify({ id, name: `Tenant ${id}` }),
+  });
+}
+
+async function legacyCreate(id: string) {
+  return tenantRoutes.request("/", {
+    method: "POST",
+    headers: platformHeaders,
+    body: JSON.stringify({ id, name: `Tenant ${id}`, apiKeyHash: `raw-${id}` }),
+  });
+}
+
+async function actionsFor(tenantId: string) {
+  return getDb()
+    .select({ action: auditEvents.action })
+    .from(auditEvents)
+    .where(eq(auditEvents.tenantId, tenantId))
+    .orderBy(asc(auditEvents.seq));
+}
+
+async function withBrokenAuditKey<T>(fn: () => Promise<T>): Promise<T> {
+  process.env.STEWARD_AUDIT_HMAC_KEY = "too-weak";
+  __resetAuditHmacKeyCacheForTests();
+  try {
+    return await fn();
+  } finally {
+    process.env.STEWARD_AUDIT_HMAC_KEY = GOOD_AUDIT_KEY;
+    __resetAuditHmacKeyCacheForTests();
+  }
+}
+
+describe("tenant creation audit atomicity", () => {
+  it("commits platform tenant, API-key custody evidence, and final audits together", async () => {
+    const tenantId = "tenant-create-atomic-success";
+    const response = await platformCreate(tenantId);
+    expect(response.status).toBe(201);
+    expect(await getDb().select().from(tenants).where(eq(tenants.id, tenantId))).toHaveLength(1);
+    expect(await actionsFor(tenantId)).toEqual([
+      { action: "tenant.create.authorized" },
+      { action: "tenant.api_key.create.authorized" },
+      { action: "tenant.create" },
+      { action: "tenant.api_key.create" },
+    ]);
   });
 
-  it("restores previous tenant config state if the final update audit fails", () => {
-    const updateStart = routeSource.indexOf('tenantRoutes.put("/:id/webhook"');
-    expect(updateStart).toBeGreaterThanOrEqual(0);
-    const updateRoute = routeSource.slice(updateStart);
+  it("rolls back both creation surfaces when required audit cannot append", async () => {
+    for (const [tenantId, create] of [
+      ["tenant-create-atomic-platform-failure", platformCreate],
+      ["tenant-create-atomic-legacy-failure", legacyCreate],
+    ] as const) {
+      const response = await withBrokenAuditKey(() => create(tenantId));
+      expect(response.status, tenantId).toBe(500);
+      expect(await getDb().select().from(tenants).where(eq(tenants.id, tenantId))).toHaveLength(0);
+      expect(await actionsFor(tenantId)).toEqual([]);
+      expect(
+        await getDb().select().from(auditChainHeads).where(eq(auditChainHeads.tenantId, tenantId)),
+      ).toHaveLength(0);
+    }
+  });
 
-    expect(updateRoute).toContain('action: "tenant.update.authorized"');
-    expect(updateRoute).toContain('action: "tenant.update"');
-    expect(updateRoute).toContain("const previousConfig: TenantConfig = { ...tenantConfig }");
-    expect(updateRoute).toContain("tenantConfigs.set(tenant.id, previousConfig)");
-    expect(updateRoute).not.toContain("snapshotLegacyTenantWebhooks");
-    expect(updateRoute).not.toContain("restoreLegacyTenantWebhooks");
-    expect(updateRoute).toContain('actorId: c.get("userId") ?? tenant.id');
+  it("serializes duplicate creates to one tenant and one complete audit sequence", async () => {
+    const tenantId = "tenant-create-atomic-race";
+    const responses = await Promise.all([platformCreate(tenantId), platformCreate(tenantId)]);
+    expect(responses.map((response) => response.status).sort()).toEqual([201, 409]);
+    expect(await getDb().select().from(tenants).where(eq(tenants.id, tenantId))).toHaveLength(1);
+    expect(await actionsFor(tenantId)).toHaveLength(4);
   });
 });

--- a/packages/api/src/__tests__/tenant-create-audit-atomicity-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/tenant-create-audit-atomicity-postgres.integration.test.ts
@@ -1,0 +1,230 @@
+import { expect, it } from "bun:test";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  agents,
+  auditChainHeads,
+  auditEvents,
+  createDb,
+  tenants,
+} from "@stwd/db";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+
+const databaseUrl = process.env.DATABASE_URL;
+const realPostgresIt = databaseUrl && process.env.STEWARD_PGLITE_MEMORY !== "true" ? it : it.skip;
+const fixturePath = new URL("./fixtures/tenant-create-dependent-writer.ts", import.meta.url)
+  .pathname;
+
+realPostgresIt(
+  "keeps tenant and dependent first use invisible until the required audit commits",
+  async () => {
+    const suffix = crypto.randomUUID().replaceAll("-", "");
+    const platformKey = `tenant-create-platform-${suffix}`;
+    const previousAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+    const previousPlatformKeys = process.env.STEWARD_PLATFORM_KEYS;
+    const previousPlatformScopes = process.env.STEWARD_PLATFORM_KEY_SCOPES;
+    process.env.STEWARD_AUDIT_HMAC_KEY = `tenant-create-audit-${suffix}`;
+    process.env.STEWARD_PLATFORM_KEYS = platformKey;
+    process.env.STEWARD_PLATFORM_KEY_SCOPES = JSON.stringify({
+      [platformKey]: ["platform:write", "platform:tenant:create"],
+    });
+    __resetAuditHmacKeyCacheForTests();
+
+    const admin = createDb(databaseUrl!);
+    const locker = await admin.client.reserve();
+    const createdTenantIds: string[] = [];
+    const createdAgentIds: string[] = [];
+    let gateLocked = false;
+
+    const { platformRoutes } = await import("../routes/platform");
+    const app = new Hono();
+    app.route("/platform", platformRoutes);
+    app.onError((_error, c) => c.json({ ok: false, error: "tenant creation failed" }, 500));
+
+    async function waitForAuditBarrier(): Promise<void> {
+      for (let attempt = 0; attempt < 200; attempt++) {
+        const [waiting] = await admin.client<{ count: string }[]>`
+          select count(*)::text as count
+          from pg_stat_activity
+          where wait_event = 'advisory' and query ilike '%audit_events%'
+        `;
+        if (waiting?.count !== "0") return;
+        if (attempt === 199) throw new Error("tenant route did not reach completion-audit barrier");
+        await Bun.sleep(10);
+      }
+    }
+
+    async function waitForDependentBarrier(applicationName: string): Promise<void> {
+      for (let attempt = 0; attempt < 200; attempt++) {
+        const [waiting] = await admin.client<{ blockers: number[] }[]>`
+          select pg_blocking_pids(pid) as blockers
+          from pg_stat_activity
+          where application_name = ${applicationName} and wait_event_type = 'Lock'
+        `;
+        if (waiting && waiting.blockers.length > 0) return;
+        if (attempt === 199)
+          throw new Error("dependent first use did not block on tenant creation");
+        await Bun.sleep(10);
+      }
+    }
+
+    async function runCase(failCompletionAudit: boolean): Promise<void> {
+      const mode = failCompletionAudit ? "failure" : "success";
+      const tenantId = `tenant-create-pg-${mode}-${suffix}`;
+      const agentId = `tenant-create-agent-${mode}-${suffix}`;
+      const requestId = `tenant-create-${mode}-${suffix}`;
+      const applicationName = `tenant-create-dependent-${mode}-${suffix}`;
+      const triggerFunction = `gate_tenant_create_${mode}_${suffix}`;
+      const triggerName = `gate_tenant_create_${mode}_${suffix}`;
+      const gateKey = Number.parseInt(
+        `${failCompletionAudit ? "2" : "1"}${suffix.slice(0, 11)}`,
+        16,
+      );
+      createdTenantIds.push(tenantId);
+      createdAgentIds.push(agentId);
+
+      await admin.client.unsafe(`
+        create function "${triggerFunction}"() returns trigger language plpgsql as $$
+        begin
+          if new.tenant_id = '${tenantId}' and new.action = 'tenant.create' then
+            perform pg_advisory_xact_lock(${gateKey});
+            ${failCompletionAudit ? "raise exception 'forced tenant completion audit failure';" : "return new;"}
+          end if;
+          return new;
+        end
+        $$;
+        create trigger "${triggerName}"
+          before insert on audit_events
+          for each row execute function "${triggerFunction}"();
+      `);
+      await locker`select pg_advisory_lock(${gateKey})`;
+      gateLocked = true;
+
+      try {
+        const createRequest = app.request("/platform/tenants", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Steward-Platform-Key": platformKey,
+            "X-Request-Id": requestId,
+          },
+          body: JSON.stringify({ id: tenantId, name: tenantId }),
+        });
+        await waitForAuditBarrier();
+
+        expect(await admin.db.select().from(tenants).where(eq(tenants.id, tenantId))).toHaveLength(
+          0,
+        );
+        expect(
+          await admin.db.select().from(auditEvents).where(eq(auditEvents.tenantId, tenantId)),
+        ).toHaveLength(0);
+        expect(
+          await admin.db
+            .select()
+            .from(auditChainHeads)
+            .where(eq(auditChainHeads.tenantId, tenantId)),
+        ).toHaveLength(0);
+
+        const childUrl = new URL(databaseUrl!);
+        childUrl.searchParams.set("application_name", applicationName);
+        const dependent = Bun.spawn([process.execPath, fixturePath], {
+          cwd: new URL("../../../..", import.meta.url).pathname,
+          env: {
+            ...process.env,
+            DATABASE_URL: childUrl.toString(),
+            TEST_TENANT_ID: tenantId,
+            TEST_AGENT_ID: agentId,
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        await waitForDependentBarrier(applicationName);
+        expect(await admin.db.select().from(agents).where(eq(agents.id, agentId))).toHaveLength(0);
+
+        await locker`select pg_advisory_unlock(${gateKey})`;
+        gateLocked = false;
+        const [response, dependentExit, dependentOutput, dependentError] = await Promise.all([
+          createRequest,
+          dependent.exited,
+          new Response(dependent.stdout).text(),
+          new Response(dependent.stderr).text(),
+        ]);
+        if (dependentExit !== 0) {
+          throw new Error(`dependent writer exited ${dependentExit}: ${dependentError}`);
+        }
+        const dependentResult = JSON.parse(dependentOutput) as { ok: boolean; code?: string };
+
+        if (failCompletionAudit) {
+          expect(response.status).toBe(500);
+          expect(dependentResult).toEqual({ ok: false, code: "23503" });
+          expect(
+            await admin.db.select().from(tenants).where(eq(tenants.id, tenantId)),
+          ).toHaveLength(0);
+          expect(await admin.db.select().from(agents).where(eq(agents.id, agentId))).toHaveLength(
+            0,
+          );
+          expect(
+            await admin.db.select().from(auditEvents).where(eq(auditEvents.tenantId, tenantId)),
+          ).toHaveLength(0);
+          expect(
+            await admin.db
+              .select()
+              .from(auditChainHeads)
+              .where(eq(auditChainHeads.tenantId, tenantId)),
+          ).toHaveLength(0);
+        } else {
+          expect(response.status).toBe(201);
+          expect(dependentResult).toEqual({ ok: true });
+          expect(
+            await admin.db.select().from(tenants).where(eq(tenants.id, tenantId)),
+          ).toHaveLength(1);
+          expect(await admin.db.select().from(agents).where(eq(agents.id, agentId))).toHaveLength(
+            1,
+          );
+          expect(
+            (
+              await admin.db.select().from(auditEvents).where(eq(auditEvents.tenantId, tenantId))
+            ).map(({ action }) => action),
+          ).toEqual([
+            "tenant.create.authorized",
+            "tenant.api_key.create.authorized",
+            "tenant.create",
+            "tenant.api_key.create",
+          ]);
+        }
+      } finally {
+        if (gateLocked) {
+          await locker`select pg_advisory_unlock(${gateKey})`;
+          gateLocked = false;
+        }
+        await admin.client.unsafe(`drop trigger if exists "${triggerName}" on audit_events`);
+        await admin.client.unsafe(`drop function if exists "${triggerFunction}"()`);
+      }
+    }
+
+    try {
+      await runCase(false);
+      await runCase(true);
+    } finally {
+      if (gateLocked) await locker`select pg_advisory_unlock_all()`;
+      locker.release();
+      for (const agentId of createdAgentIds) {
+        await admin.db.delete(agents).where(eq(agents.id, agentId));
+      }
+      for (const tenantId of createdTenantIds) {
+        await admin.db.delete(auditEvents).where(eq(auditEvents.tenantId, tenantId));
+        await admin.db.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, tenantId));
+        await admin.db.delete(tenants).where(eq(tenants.id, tenantId));
+      }
+      await admin.client.end();
+      if (previousAuditKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+      else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditKey;
+      if (previousPlatformKeys === undefined) delete process.env.STEWARD_PLATFORM_KEYS;
+      else process.env.STEWARD_PLATFORM_KEYS = previousPlatformKeys;
+      if (previousPlatformScopes === undefined) delete process.env.STEWARD_PLATFORM_KEY_SCOPES;
+      else process.env.STEWARD_PLATFORM_KEY_SCOPES = previousPlatformScopes;
+      __resetAuditHmacKeyCacheForTests();
+    }
+  },
+  120_000,
+);

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -241,13 +241,6 @@ async function restorePlatformTenantConfigRow(
   });
 }
 
-async function deletePlatformCreatedTenant(tenantId: string): Promise<void> {
-  const db = getDb();
-  await db.transaction(async (tx) => {
-    await tx.delete(tenants).where(eq(tenants.id, tenantId));
-  });
-}
-
 async function deletePlatformCreatedAgent(agentId: string, tenantId: string): Promise<void> {
   const db = getDb();
   await db.transaction(async (tx) => {
@@ -261,8 +254,10 @@ async function deletePlatformCreatedAgent(agentId: string, tenantId: string): Pr
   });
 }
 
-async function tenantIdHasRetainedState(tenantId: string): Promise<boolean> {
-  const db = getDb();
+async function tenantIdHasRetainedState(
+  tenantId: string,
+  db: Pick<ReturnType<typeof getDb>, "select"> = getDb(),
+): Promise<boolean> {
   const [[secret], [secretRoute], [proxyAudit], [auditEvent]] = await Promise.all([
     db.select({ id: secrets.id }).from(secrets).where(eq(secrets.tenantId, tenantId)).limit(1),
     db
@@ -1047,60 +1042,39 @@ platform.post("/tenants", async (c) => {
     );
   }
 
-  // Check for duplicates
-  const [existing] = await db
-    .select({ id: tenants.id })
-    .from(tenants)
-    .where(eq(tenants.id, body.id));
-
-  if (existing) {
-    return c.json<ApiResponse>({ ok: false, error: "Tenant already exists" }, 409);
-  }
-  if (await tenantIdHasRetainedState(body.id)) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: "Tenant id has retained historical state and cannot be reused",
-      },
-      409,
-    );
-  }
-
   const apiKeyPair = generateApiKey();
+  const result = await withTenantAuditedTransaction(body.id, async (txRaw, appendAudit) => {
+    const tx = txRaw as typeof db;
+    const [existing] = await tx
+      .select({ id: tenants.id })
+      .from(tenants)
+      .where(eq(tenants.id, body.id));
+    if (existing) return { status: "exists" as const };
+    if (await tenantIdHasRetainedState(body.id, tx)) return { status: "retained" as const };
 
-  await writeAuditEvent({
-    tenantId: body.id,
-    actorType: "platform",
-    action: "tenant.create.authorized",
-    resourceType: "tenant",
-    resourceId: body.id,
-    metadata: { name: body.name, viaPlatform: true },
-    ...auditCtx(c),
-  });
-  await writeAuditEvent({
-    tenantId: body.id,
-    actorType: "platform",
-    action: "tenant.api_key.create.authorized",
-    resourceType: "tenant",
-    resourceId: body.id,
-    ...auditCtx(c),
-  });
-
-  const [tenant] = await db
-    .insert(tenants)
-    .values({
-      id: body.id,
-      name: body.name,
-      apiKeyHash: apiKeyPair.hash,
-    })
-    .returning();
-
-  if (!tenant) {
-    return c.json<ApiResponse>({ ok: false, error: "Failed to create tenant" }, 500);
-  }
-
-  try {
-    await writeAuditEvent({
+    await appendAudit({
+      tenantId: body.id,
+      actorType: "platform",
+      action: "tenant.create.authorized",
+      resourceType: "tenant",
+      resourceId: body.id,
+      metadata: { name: body.name, viaPlatform: true },
+      ...auditCtx(c),
+    });
+    await appendAudit({
+      tenantId: body.id,
+      actorType: "platform",
+      action: "tenant.api_key.create.authorized",
+      resourceType: "tenant",
+      resourceId: body.id,
+      ...auditCtx(c),
+    });
+    const [tenant] = await tx
+      .insert(tenants)
+      .values({ id: body.id, name: body.name, apiKeyHash: apiKeyPair.hash })
+      .returning();
+    if (!tenant) throw new Error("Failed to create tenant");
+    await appendAudit({
       tenantId: tenant.id,
       actorType: "platform",
       action: "tenant.create",
@@ -1109,7 +1083,7 @@ platform.post("/tenants", async (c) => {
       metadata: { name: tenant.name, viaPlatform: true },
       ...auditCtx(c),
     });
-    await writeAuditEvent({
+    await appendAudit({
       tenantId: tenant.id,
       actorType: "platform",
       action: "tenant.api_key.create",
@@ -1117,10 +1091,18 @@ platform.post("/tenants", async (c) => {
       resourceId: tenant.id,
       ...auditCtx(c),
     });
-  } catch (error) {
-    await deletePlatformCreatedTenant(tenant.id);
-    throw error;
+    return { status: "created" as const, tenant };
+  });
+  if (result.status === "exists") {
+    return c.json<ApiResponse>({ ok: false, error: "Tenant already exists" }, 409);
   }
+  if (result.status === "retained") {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Tenant id has retained historical state and cannot be reused" },
+      409,
+    );
+  }
+  const { tenant } = result;
 
   return c.json<
     ApiResponse<{

--- a/packages/api/src/routes/tenants.ts
+++ b/packages/api/src/routes/tenants.ts
@@ -13,12 +13,11 @@ import {
 } from "@stwd/db";
 import { eq } from "drizzle-orm";
 import { type Context, Hono, type Next } from "hono";
-import { writeAuditEvent } from "../services/audit";
+import { withTenantAuditedTransaction, writeAuditEvent } from "../services/audit";
 import {
   type ApiResponse,
   type AppVariables,
   db,
-  findTenant,
   getConditionSetReferenceValidationError,
   getTenantPayload,
   isNonEmptyString,
@@ -61,24 +60,27 @@ function isReservedTenantId(id: string): boolean {
   );
 }
 
-async function tenantIdHasRetainedState(tenantId: string): Promise<boolean> {
+async function tenantIdHasRetainedState(
+  tenantId: string,
+  executor: Pick<typeof db, "select"> = db,
+): Promise<boolean> {
   const [[secret], [secretRoute], [proxyAudit], [auditEvent]] = await Promise.all([
-    db
+    executor
       .select({ id: secretRows.id })
       .from(secretRows)
       .where(eq(secretRows.tenantId, tenantId))
       .limit(1),
-    db
+    executor
       .select({ id: secretRouteRows.id })
       .from(secretRouteRows)
       .where(eq(secretRouteRows.tenantId, tenantId))
       .limit(1),
-    db
+    executor
       .select({ id: proxyAuditLogRows.id })
       .from(proxyAuditLogRows)
       .where(eq(proxyAuditLogRows.tenantId, tenantId))
       .limit(1),
-    db
+    executor
       .select({ id: auditEventRows.id })
       .from(auditEventRows)
       .where(eq(auditEventRows.tenantId, tenantId))
@@ -196,78 +198,71 @@ tenantRoutes.post("/", platformAuthMiddleware(), async (c) => {
     if (conditionSetError) return c.json<ApiResponse>({ ok: false, error: conditionSetError }, 400);
   }
 
-  const existingTenant = await findTenant(body.id);
-  if (existingTenant) {
-    return c.json<ApiResponse>({ ok: false, error: "Tenant already exists" }, 400);
-  }
-  if (await tenantIdHasRetainedState(body.id)) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: "Tenant id has retained historical state and cannot be reused",
-      },
-      409,
-    );
-  }
-
   const apiKeyHash =
     body.apiKeyHash && !body.apiKeyHash.match(/^[0-9a-f]{64}$/)
       ? hashApiKey(body.apiKeyHash)
       : body.apiKeyHash;
 
-  await writeAuditEvent({
-    tenantId: body.id,
-    actorType: "platform",
-    action: "tenant.create.authorized",
-    resourceType: "tenant",
-    resourceId: body.id,
-    metadata: {
+  const result = await withTenantAuditedTransaction(body.id, async (txRaw, appendAudit) => {
+    const tx = txRaw as typeof db;
+    const [existing] = await tx
+      .select({ id: tenants.id })
+      .from(tenants)
+      .where(eq(tenants.id, body.id));
+    if (existing) return { status: "exists" as const };
+    if (await tenantIdHasRetainedState(body.id, tx)) return { status: "retained" as const };
+    const metadata = {
       name: body.name,
       hasWebhook: !!body.webhookUrl,
       defaultPolicyCount: body.defaultPolicies?.length ?? 0,
-    },
-    ipAddress: c.req.header("x-forwarded-for") ?? null,
-    userAgent: c.req.header("user-agent") ?? null,
-    requestId: c.get("requestId") ?? null,
+    };
+    await appendAudit({
+      tenantId: body.id,
+      actorType: "platform",
+      action: "tenant.create.authorized",
+      resourceType: "tenant",
+      resourceId: body.id,
+      metadata,
+      ipAddress: c.req.header("x-forwarded-for") ?? null,
+      userAgent: c.req.header("user-agent") ?? null,
+      requestId: c.get("requestId") ?? null,
+    });
+    const [tenant] = await tx
+      .insert(tenants)
+      .values({ id: body.id, name: body.name, apiKeyHash })
+      .returning();
+    if (!tenant) throw new Error("Failed to create tenant");
+    await appendAudit({
+      tenantId: body.id,
+      actorType: "platform",
+      action: "tenant.create",
+      resourceType: "tenant",
+      resourceId: body.id,
+      metadata,
+      ipAddress: c.req.header("x-forwarded-for") ?? null,
+      userAgent: c.req.header("user-agent") ?? null,
+      requestId: c.get("requestId") ?? null,
+    });
+    return { status: "created" as const, tenant };
   });
-
-  const [tenant] = await db
-    .insert(tenants)
-    .values({
-      id: body.id,
-      name: body.name,
-      apiKeyHash,
-    })
-    .returning();
-
+  if (result.status === "exists") {
+    return c.json<ApiResponse>({ ok: false, error: "Tenant already exists" }, 400);
+  }
+  if (result.status === "retained") {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Tenant id has retained historical state and cannot be reused" },
+      409,
+    );
+  }
+  const { tenant } = result;
+  // Presentation cache only: populate after the audited database transaction
+  // commits so another replica can never observe uncommitted authority.
   tenantConfigs.set(body.id, {
     id: body.id,
     name: body.name,
     webhookUrl: body.webhookUrl,
     defaultPolicies: body.defaultPolicies,
   });
-
-  try {
-    await writeAuditEvent({
-      tenantId: body.id,
-      actorType: "platform",
-      action: "tenant.create",
-      resourceType: "tenant",
-      resourceId: body.id,
-      metadata: {
-        name: body.name,
-        hasWebhook: !!body.webhookUrl,
-        defaultPolicyCount: body.defaultPolicies?.length ?? 0,
-      },
-      ipAddress: c.req.header("x-forwarded-for") ?? null,
-      userAgent: c.req.header("user-agent") ?? null,
-      requestId: c.get("requestId") ?? null,
-    });
-  } catch (error) {
-    tenantConfigs.delete(body.id);
-    await db.delete(tenants).where(eq(tenants.id, body.id));
-    throw error;
-  }
 
   return c.json<ApiResponse<Omit<Tenant, "apiKeyHash"> & TenantConfig>>({
     ok: true,


### PR DESCRIPTION
Closes #712.

Moves platform and legacy tenant creation, API-key custody evidence, and required completion audits into a single audited database transaction; publishes tenant cache state only after commit and removes compensating deletion. Adds a mounted PostgreSQL completion barrier with independent observer and dependent child writer to prove invisibility before commit, coherent success, and full rollback on audit failure.

Exact head: 52d64d1ddcc220015afc1fbb988b86673f35c024
Exact base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6

Local acceptance:
- focused tenant/platform suites: 3/3 file processes pass
- API dependency build: 24/24
- targeted Biome, diff check, public-package metadata: pass
- mounted PostgreSQL proof: locally skipped because DATABASE_URL is unavailable and required in hosted Integration Tests

Keep draft until exact hosted PostgreSQL, full matrix, and independent review pass.