### PR TITLE
fix(api): make policy template mutations audit-atomic

### DIFF
--- a/packages/api/src/__tests__/audit-policy-hardening.test.ts
+++ b/packages/api/src/__tests__/audit-policy-hardening.test.ts
@@ -105,9 +105,9 @@ describe("audit and policy route hardening", () => {
       policiesSource.indexOf('policiesStandaloneRoutes.post("/:id/assign"'),
     );
     expect(assignRoute.indexOf('action: "policy.template.assign.authorized"')).toBeLessThan(
-      assignRoute.indexOf("await db.transaction"),
+      assignRoute.indexOf("withTenantAuditedTransaction("),
     );
-    expect(assignRoute.indexOf("await db.transaction")).toBeLessThan(
+    expect(assignRoute.indexOf("withTenantAuditedTransaction(")).toBeLessThan(
       assignRoute.indexOf('action: "policy.template.assign"'),
     );
   });

--- a/packages/api/src/__tests__/fixtures/policy-template-concurrent-writer.ts
+++ b/packages/api/src/__tests__/fixtures/policy-template-concurrent-writer.ts
@@ -1,0 +1,75 @@
+import {
+  agents,
+  createDb,
+  policies,
+  policyTemplates,
+  withTenantAuditedTransactionOnDb,
+} from "@stwd/db";
+import { and, eq, sql } from "drizzle-orm";
+
+const databaseUrl = process.env.DATABASE_URL;
+const tenantId = process.env.TEST_TENANT_ID;
+const templateId = process.env.TEST_TEMPLATE_ID;
+const agentId = process.env.TEST_AGENT_ID;
+const requestId = process.env.TEST_REQUEST_ID;
+const mode = process.env.TEST_WRITER_MODE as "create" | "update" | "delete" | "assign" | undefined;
+if (!databaseUrl || !tenantId || !templateId || !agentId || !requestId || !mode) {
+  throw new Error("concurrent policy-template writer environment is incomplete");
+}
+
+const connection = createDb(databaseUrl);
+try {
+  await withTenantAuditedTransactionOnDb(
+    connection.db,
+    tenantId,
+    async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof connection.db;
+      if (mode === "create") {
+        await tx.insert(policyTemplates).values({
+          id: templateId,
+          tenantId,
+          name: "concurrent-winner",
+          rules: [],
+        });
+      } else if (mode === "update") {
+        await tx
+          .update(policyTemplates)
+          .set({ name: "concurrent-winner", updatedAt: new Date() })
+          .where(and(eq(policyTemplates.id, templateId), eq(policyTemplates.tenantId, tenantId)));
+      } else if (mode === "delete") {
+        await tx
+          .delete(policyTemplates)
+          .where(and(eq(policyTemplates.id, templateId), eq(policyTemplates.tenantId, tenantId)));
+      } else {
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${`steward_agent_authority_${tenantId}:${agentId}`}, 0))`,
+        );
+        await tx
+          .select({ id: agents.id })
+          .from(agents)
+          .where(and(eq(agents.id, agentId), eq(agents.tenantId, tenantId)))
+          .for("update");
+        await tx.delete(policies).where(eq(policies.agentId, agentId));
+        await tx.insert(policies).values({
+          id: `concurrent-${crypto.randomUUID()}`,
+          agentId,
+          type: "spending-limit",
+          enabled: true,
+          config: { maxPerTx: "777" },
+        });
+      }
+      await appendRequiredAudit({
+        tenantId,
+        actorType: "system",
+        actorId: "concurrent-test-writer",
+        action: `policy.template.concurrent_${mode}`,
+        resourceType: "policy_template",
+        resourceId: templateId,
+        metadata: { mode },
+        requestId,
+      });
+    },
+  );
+} finally {
+  await connection.client.end();
+}

--- a/packages/api/src/__tests__/policy-template-audit-atomicity-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/policy-template-audit-atomicity-postgres.integration.test.ts
@@ -1,0 +1,270 @@
+import { expect, it } from "bun:test";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  agents,
+  auditChainHeads,
+  auditEvents,
+  createDb,
+  policies,
+  policyTemplates,
+  tenants,
+} from "@stwd/db";
+import { and, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { correlationId } from "../middleware/correlation";
+import type { AppVariables } from "../services/context";
+
+const databaseUrl = process.env.DATABASE_URL;
+const realPostgresIt = databaseUrl && process.env.STEWARD_PGLITE_MEMORY !== "true" ? it : it.skip;
+
+for (const mode of ["create", "update", "delete", "assign"] as const) {
+  realPostgresIt(
+    `preserves the concurrent ${mode} winner when mounted completion audit fails`,
+    async () => {
+      const suffix = crypto.randomUUID().replaceAll("-", "");
+      const tenantId = `policy-atomic-${suffix}`;
+      const templateId = crypto.randomUUID();
+      const agentId = `policy-agent-${suffix}`;
+      const failRequestId = `fail-${suffix}`;
+      const successRequestId = `success-${suffix}`;
+      const writerApplicationName = `policy-template-writer-${suffix}`;
+      const triggerFunction = `fail_policy_audit_${suffix}`;
+      const triggerName = `fail_policy_audit_${suffix}`;
+      const gateKey = Number.parseInt(suffix.slice(0, 12), 16);
+      const previousAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+      process.env.STEWARD_AUDIT_HMAC_KEY = `policy-template-audit-key-${suffix}`;
+      __resetAuditHmacKeyCacheForTests();
+
+      const admin = createDb(databaseUrl!);
+      const locker = await admin.client.reserve();
+      let gateLocked = false;
+      try {
+        await admin.db.insert(tenants).values({
+          id: tenantId,
+          name: tenantId,
+          apiKeyHash: `hash-${suffix}`,
+        });
+        await admin.db.insert(agents).values({
+          id: agentId,
+          tenantId,
+          name: "Policy atomicity agent",
+          walletAddress: `0x${suffix.padEnd(40, "0").slice(0, 40)}`,
+        });
+        if (mode !== "create") {
+          await admin.db.insert(policyTemplates).values({
+            id: templateId,
+            tenantId,
+            name: "initial-template",
+            rules: [{ type: "spending-limit", enabled: true, config: { maxPerTx: "123" } }],
+          });
+        }
+        await admin.db.insert(policies).values({
+          id: `initial-${suffix}`,
+          agentId,
+          type: "approved-addresses",
+          enabled: true,
+          config: { addresses: ["0x0000000000000000000000000000000000000001"] },
+        });
+
+        await admin.client.unsafe(`
+          create function "${triggerFunction}"() returns trigger language plpgsql as $$
+          begin
+            if new.request_id = '${failRequestId}' and new.action = 'policy.template.${mode}' then
+              perform pg_advisory_xact_lock(${gateKey});
+              raise exception 'forced policy template completion audit failure';
+            end if;
+            return new;
+          end
+          $$
+        `);
+        await admin.client.unsafe(`
+          create trigger "${triggerName}"
+          before insert on audit_events
+          for each row execute function "${triggerFunction}"()
+        `);
+        await locker`select pg_advisory_lock(${gateKey})`;
+        gateLocked = true;
+
+        const { policiesStandaloneRoutes } = await import("../routes/policies-standalone");
+        const app = new Hono<{ Variables: AppVariables }>();
+        app.use("*", correlationId);
+        app.use("*", async (c, next) => {
+          c.set("tenantId", tenantId);
+          c.set("authType", "session-jwt");
+          c.set("tenantRole", "admin");
+          c.set("sessionMfaVerifiedAt", Date.now());
+          c.set("userId", "11111111-1111-4111-8111-111111111111");
+          await next();
+        });
+        app.route("/policies", policiesStandaloneRoutes);
+        app.onError((error, c) => c.json({ ok: false, error: error.message }, 500));
+
+        const path =
+          mode === "create"
+            ? "/policies"
+            : mode === "assign"
+              ? `/policies/${templateId}/assign`
+              : `/policies/${templateId}`;
+        const failedRequest = app.request(path, {
+          method: mode === "update" ? "PUT" : mode === "delete" ? "DELETE" : "POST",
+          headers: { "Content-Type": "application/json", "X-Request-Id": failRequestId },
+          body:
+            mode === "create"
+              ? JSON.stringify({ name: "failed-create", rules: [] })
+              : mode === "update"
+                ? JSON.stringify({ name: "failed-update" })
+                : mode === "assign"
+                  ? JSON.stringify({ agentIds: [agentId] })
+                  : undefined,
+        });
+        let earlyResponse: Response | undefined;
+        void failedRequest.then((response) => {
+          earlyResponse = response;
+        });
+
+        for (let attempt = 0; attempt < 100; attempt++) {
+          const [waiting] = await admin.client<{ count: string }[]>`
+            select count(*)::text as count from pg_stat_activity
+            where wait_event = 'advisory' and query ilike '%INSERT INTO audit_events%'
+          `;
+          if (waiting?.count !== "0") break;
+          if (attempt === 99) {
+            throw new Error(
+              earlyResponse
+                ? `mounted route returned early (${earlyResponse.status}): ${await earlyResponse.clone().text()}`
+                : "mounted route did not reach audit trigger",
+            );
+          }
+          await Bun.sleep(10);
+        }
+
+        const writerUrl = new URL(databaseUrl!);
+        writerUrl.searchParams.set("application_name", writerApplicationName);
+        const writer = Bun.spawn(
+          [
+            process.execPath,
+            new URL("./fixtures/policy-template-concurrent-writer.ts", import.meta.url).pathname,
+          ],
+          {
+            cwd: new URL("../../../..", import.meta.url).pathname,
+            env: {
+              ...process.env,
+              DATABASE_URL: writerUrl.toString(),
+              TEST_TENANT_ID: tenantId,
+              TEST_TEMPLATE_ID: templateId,
+              TEST_AGENT_ID: agentId,
+              TEST_REQUEST_ID: successRequestId,
+              TEST_WRITER_MODE: mode,
+            },
+            stderr: "pipe",
+          },
+        );
+        for (let attempt = 0; attempt < 100; attempt++) {
+          const [waiting] = await admin.client<{ count: string }[]>`
+            select count(*)::text as count
+            from pg_stat_activity
+            where application_name = ${writerApplicationName}
+              and wait_event = 'advisory'
+              and cardinality(pg_blocking_pids(pid)) > 0
+          `;
+          if (waiting?.count !== "0") break;
+          if (attempt === 99) throw new Error("concurrent writer did not reach tenant audit lock");
+          await Bun.sleep(10);
+        }
+
+        const [interimTemplate] = await admin.db
+          .select({ name: policyTemplates.name })
+          .from(policyTemplates)
+          .where(and(eq(policyTemplates.id, templateId), eq(policyTemplates.tenantId, tenantId)));
+        if (mode === "create") {
+          const visibleCreates = await admin.db
+            .select({ name: policyTemplates.name })
+            .from(policyTemplates)
+            .where(eq(policyTemplates.tenantId, tenantId));
+          expect(visibleCreates).toEqual([]);
+        } else {
+          expect(interimTemplate?.name).toBe("initial-template");
+        }
+        if (mode === "assign") {
+          const visiblePolicies = await admin.db
+            .select({ type: policies.type })
+            .from(policies)
+            .where(eq(policies.agentId, agentId));
+          expect(visiblePolicies).toEqual([{ type: "approved-addresses" }]);
+        }
+        expect(
+          await admin.db
+            .select({ action: auditEvents.action })
+            .from(auditEvents)
+            .where(
+              and(
+                eq(auditEvents.tenantId, tenantId),
+                eq(auditEvents.requestId, failRequestId),
+                eq(auditEvents.action, `policy.template.${mode}`),
+              ),
+            ),
+        ).toEqual([]);
+
+        await locker`select pg_advisory_unlock(${gateKey})`;
+        gateLocked = false;
+        const [failedResponse, writerExit] = await Promise.all([failedRequest, writer.exited]);
+        if (writerExit !== 0) {
+          throw new Error(`concurrent writer failed: ${await new Response(writer.stderr).text()}`);
+        }
+        expect(failedResponse.status).toBeGreaterThanOrEqual(400);
+
+        const [storedTemplate] = await admin.db
+          .select({ name: policyTemplates.name })
+          .from(policyTemplates)
+          .where(and(eq(policyTemplates.id, templateId), eq(policyTemplates.tenantId, tenantId)));
+        if (mode === "create" || mode === "update") {
+          expect(storedTemplate?.name).toBe("concurrent-winner");
+        }
+        if (mode === "create") {
+          const templates = await admin.db
+            .select({ name: policyTemplates.name })
+            .from(policyTemplates)
+            .where(eq(policyTemplates.tenantId, tenantId));
+          expect(templates).toEqual([{ name: "concurrent-winner" }]);
+        }
+        if (mode === "delete") expect(storedTemplate).toBeUndefined();
+        if (mode === "assign") {
+          const storedPolicies = await admin.db
+            .select({ type: policies.type, config: policies.config })
+            .from(policies)
+            .where(eq(policies.agentId, agentId));
+          expect(storedPolicies).toEqual([{ type: "spending-limit", config: { maxPerTx: "777" } }]);
+        }
+
+        const events = await admin.db
+          .select({ action: auditEvents.action, requestId: auditEvents.requestId })
+          .from(auditEvents)
+          .where(eq(auditEvents.tenantId, tenantId));
+        expect(events).toContainEqual({
+          action: `policy.template.concurrent_${mode}`,
+          requestId: successRequestId,
+        });
+        expect(events).not.toContainEqual({
+          action: `policy.template.${mode}`,
+          requestId: failRequestId,
+        });
+      } finally {
+        if (gateLocked) await locker`select pg_advisory_unlock(${gateKey})`;
+        locker.release();
+        await admin.client.unsafe(`drop trigger if exists "${triggerName}" on audit_events`);
+        await admin.client.unsafe(`drop function if exists "${triggerFunction}"()`);
+        await admin.db.delete(auditEvents).where(eq(auditEvents.tenantId, tenantId));
+        await admin.db.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, tenantId));
+        await admin.db.delete(policies).where(eq(policies.agentId, agentId));
+        await admin.db.delete(policyTemplates).where(eq(policyTemplates.tenantId, tenantId));
+        await admin.db.delete(agents).where(eq(agents.id, agentId));
+        await admin.db.delete(tenants).where(eq(tenants.id, tenantId));
+        await admin.client.end();
+        if (previousAuditKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+        else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditKey;
+        __resetAuditHmacKeyCacheForTests();
+      }
+    },
+    120_000,
+  );
+}

--- a/packages/api/src/__tests__/policy-template-audit-rollback.test.ts
+++ b/packages/api/src/__tests__/policy-template-audit-rollback.test.ts
@@ -1,87 +1,161 @@
-import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  agents,
+  closeDb,
+  getDb,
+  policies,
+  tenants,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq, sql } from "drizzle-orm";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
 
-const routeSource = readFileSync(
-  join(import.meta.dir, "..", "routes", "policies-standalone.ts"),
-  "utf8",
-);
-const tenantConfigSource = readFileSync(
-  join(import.meta.dir, "..", "routes", "tenant-config.ts"),
-  "utf8",
-);
+const TENANT_ID = "policy-template-audit-atomic";
+const AGENT_ID = "policy-template-audit-agent";
+const TEMPLATE_ID = "11111111-1111-4111-8111-111111111111";
 
-describe("policy template audit rollback hardening", () => {
-  it("rolls back template CRUD mutations if final audit events fail", () => {
-    expect(routeSource).toContain("async function restoreTemplateSnapshot");
-    expect(routeSource).toContain("DELETE FROM policy_templates WHERE id = ${snapshot.id}::uuid");
-    expect(routeSource).toContain("INSERT INTO policy_templates");
+describe("policy template audit atomicity", () => {
+  let app: Hono<{ Variables: AppVariables }>;
 
-    const createStart =
-      routeSource.indexOf('policiesStandaloneRoutes.post("/")') >= 0
-        ? routeSource.indexOf('policiesStandaloneRoutes.post("/")')
-        : routeSource.indexOf('policiesStandaloneRoutes.post("/", async');
-    const createRoute = routeSource.slice(
-      createStart,
-      routeSource.indexOf('policiesStandaloneRoutes.get("/:id"', createStart),
-    );
-    expect(createRoute).toContain('action: "policy.template.create.authorized"');
-    expect(createRoute).toContain('action: "policy.template.create"');
-    expect(createRoute).toContain("try {");
-    expect(createRoute).toContain("deleteTemplate(tenantId, template.id)");
-
-    const updateStart = routeSource.indexOf('policiesStandaloneRoutes.put("/:id"');
-    const updateRoute = routeSource.slice(
-      updateStart,
-      routeSource.indexOf('policiesStandaloneRoutes.delete("/:id"', updateStart),
-    );
-    expect(updateRoute).toContain('action: "policy.template.update.authorized"');
-    expect(updateRoute).toContain('action: "policy.template.update"');
-    expect(updateRoute).toContain("const before = await getTemplate(tenantId, id)");
-    expect(updateRoute).toContain("restoreTemplateSnapshot(before)");
-
-    const deleteStart = routeSource.indexOf('policiesStandaloneRoutes.delete("/:id"');
-    const deleteRoute = routeSource.slice(
-      deleteStart,
-      routeSource.indexOf('policiesStandaloneRoutes.post("/:id/assign"', deleteStart),
-    );
-    expect(deleteRoute).toContain('action: "policy.template.delete.authorized"');
-    expect(deleteRoute).toContain('action: "policy.template.delete"');
-    expect(deleteRoute).toContain("const existing = await getTemplate(tenantId, id)");
-    expect(deleteRoute).toContain("restoreTemplateSnapshot(existing)");
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_MASTER_PASSWORD = "policy-template-audit-master-password";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "policy-template-audit-key-with-enough-entropy";
+    __resetAuditHmacKeyCacheForTests();
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+    await getDb().insert(tenants).values({ id: TENANT_ID, name: TENANT_ID, apiKeyHash: "hash" });
+    await getDb().insert(agents).values({
+      id: AGENT_ID,
+      tenantId: TENANT_ID,
+      name: AGENT_ID,
+      walletAddress: "0x1111111111111111111111111111111111111111",
+    });
+    await getDb().execute(sql`
+      INSERT INTO policy_templates (id, tenant_id, name, description, rules, is_default)
+      VALUES (${TEMPLATE_ID}::uuid, ${TENANT_ID}, 'original', null,
+        '[{"type":"approved-addresses","enabled":true,"config":{"mode":"whitelist","addresses":["0x1111111111111111111111111111111111111111"]}}]'::jsonb, false)
+    `);
+    const { policiesStandaloneRoutes } = await import("../routes/policies-standalone");
+    app = new Hono<{ Variables: AppVariables }>();
+    app.use("*", async (c, next) => {
+      c.set("tenantId", TENANT_ID);
+      c.set("authType", "session-jwt");
+      c.set("tenantRole", "admin");
+      c.set("sessionMfaVerifiedAt", Date.now());
+      c.set("userId", "22222222-2222-4222-8222-222222222222");
+      await next();
+    });
+    app.route("/policies", policiesStandaloneRoutes);
   });
 
-  it("restores prior agent policies if final template assignment audit fails", () => {
-    expect(routeSource).toContain("type PolicyRow = typeof policies.$inferSelect");
-    expect(routeSource).toContain("async function snapshotAgentPolicies");
-    expect(routeSource).toContain("async function restoreAgentPolicies");
-    expect(routeSource).toContain("inArray(policies.agentId, agentIds)");
-
-    const assignStart = routeSource.indexOf('policiesStandaloneRoutes.post("/:id/assign"');
-    expect(assignStart).toBeGreaterThanOrEqual(0);
-    const assignRoute = routeSource.slice(assignStart);
-
-    expect(assignRoute).toContain('action: "policy.template.assign.authorized"');
-    expect(assignRoute).toContain(
-      "const previousPolicies = await snapshotAgentPolicies(uniqueAgentIds)",
-    );
-    expect(assignRoute).toContain('action: "policy.template.assign"');
-    expect(assignRoute).toContain("try {");
-    expect(assignRoute).toContain("restoreAgentPolicies(uniqueAgentIds, previousPolicies)");
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    __resetAuditHmacKeyCacheForTests();
   });
 
-  it("applies tenant config template policies and final audit atomically", () => {
-    const applyStart = tenantConfigSource.indexOf(
-      'tenantConfigRoutes.post("/:id/config/templates/:name/apply"',
-    );
-    expect(applyStart).toBeGreaterThanOrEqual(0);
-    const applyRoute = tenantConfigSource.slice(applyStart);
-    const mutation = applyRoute.indexOf("withTenantAuditedTransaction(");
-    const finalAudit = applyRoute.indexOf('action: "policy.template.apply"', mutation);
-    const append = applyRoute.indexOf("appendRequiredAudit({", mutation);
-    expect(mutation).toBeGreaterThanOrEqual(0);
-    expect(append).toBeGreaterThan(mutation);
-    expect(finalAudit).toBeGreaterThan(mutation);
-    expect(applyRoute).not.toContain("restoreAgentPolicies");
+  async function rejectCompletion(action: string) {
+    const quotedAction = sql.raw(`'${action}'`);
+    await getDb().execute(sql`
+      CREATE OR REPLACE FUNCTION reject_policy_completion() RETURNS trigger AS $$
+      BEGIN
+        IF NEW.action = ${quotedAction} THEN RAISE EXCEPTION 'injected completion audit failure'; END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+    `);
+    await getDb().execute(sql`
+      CREATE TRIGGER reject_policy_completion BEFORE INSERT ON audit_events
+      FOR EACH ROW EXECUTE FUNCTION reject_policy_completion()
+    `);
+  }
+
+  async function allowCompletion() {
+    await getDb().execute(sql`DROP TRIGGER IF EXISTS reject_policy_completion ON audit_events`);
+    await getDb().execute(sql`DROP FUNCTION IF EXISTS reject_policy_completion()`);
+  }
+
+  it("does not commit creation when the required audit fails", async () => {
+    await rejectCompletion("policy.template.create");
+    try {
+      const creation = await app.request("/policies", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "uncommitted create", rules: [] }),
+      });
+      expect(creation.status, await creation.clone().text()).toBe(400);
+      const result = await getDb().execute(
+        sql`SELECT id FROM policy_templates WHERE tenant_id = ${TENANT_ID} AND name = 'uncommitted create'`,
+      );
+      const rows = Array.isArray(result) ? result : ((result as { rows?: unknown[] }).rows ?? []);
+      expect(rows).toHaveLength(0);
+    } finally {
+      await allowCompletion();
+    }
+  });
+
+  it("does not commit update or delete when the required audit fails", async () => {
+    await rejectCompletion("policy.template.update");
+    try {
+      const update = await app.request(`/policies/${TEMPLATE_ID}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "uncommitted" }),
+      });
+      expect(update.status, await update.clone().text()).toBe(400);
+      const result = await getDb().execute(
+        sql`SELECT name FROM policy_templates WHERE id = ${TEMPLATE_ID}::uuid`,
+      );
+      const rows = (
+        Array.isArray(result) ? result : ((result as { rows?: Array<{ name: string }> }).rows ?? [])
+      ) as Array<{ name: string }>;
+      expect(rows[0]?.name).toBe("original");
+    } finally {
+      await allowCompletion();
+    }
+
+    await rejectCompletion("policy.template.delete");
+    try {
+      const deletion = await app.request(`/policies/${TEMPLATE_ID}`, { method: "DELETE" });
+      expect(deletion.status).toBe(500);
+      const result = await getDb().execute(
+        sql`SELECT id FROM policy_templates WHERE id = ${TEMPLATE_ID}::uuid`,
+      );
+      const rows = Array.isArray(result) ? result : ((result as { rows?: unknown[] }).rows ?? []);
+      expect(rows).toHaveLength(1);
+    } finally {
+      await allowCompletion();
+    }
+  });
+
+  it("does not replace agent policy authority when assignment audit fails", async () => {
+    await getDb()
+      .insert(policies)
+      .values({
+        id: "33333333-3333-4333-8333-333333333333",
+        agentId: AGENT_ID,
+        type: "allowed-chains",
+        enabled: true,
+        config: { chainIds: [1] },
+      });
+    await rejectCompletion("policy.template.assign");
+    try {
+      const response = await app.request(`/policies/${TEMPLATE_ID}/assign`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ agentIds: [AGENT_ID] }),
+      });
+      expect(response.status, await response.clone().text()).toBe(500);
+      const stored = await getDb().select().from(policies).where(eq(policies.agentId, AGENT_ID));
+      expect(stored).toHaveLength(1);
+      expect(stored[0]?.type).toBe("allowed-chains");
+    } finally {
+      await allowCompletion();
+    }
   });
 });

--- a/packages/api/src/__tests__/policy-template-audit-rollback.test.ts
+++ b/packages/api/src/__tests__/policy-template-audit-rollback.test.ts
@@ -158,4 +158,31 @@ describe("policy template audit atomicity", () => {
       await allowCompletion();
     }
   });
+
+  it("assigns through the mounted route in persistent PGLite mode", async () => {
+    const previousDbMode = process.env.STEWARD_DB_MODE;
+    const previousPgliteMemory = process.env.STEWARD_PGLITE_MEMORY;
+    process.env.STEWARD_DB_MODE = "pglite";
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    try {
+      const response = await app.request(`/policies/${TEMPLATE_ID}/assign`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ agentIds: [AGENT_ID] }),
+      });
+      expect(response.status, await response.clone().text()).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        data: { templateId: TEMPLATE_ID, assignedAgents: [AGENT_ID], rulesApplied: 1 },
+      });
+      const stored = await getDb().select().from(policies).where(eq(policies.agentId, AGENT_ID));
+      expect(stored).toHaveLength(1);
+      expect(stored[0]?.type).toBe("approved-addresses");
+    } finally {
+      if (previousDbMode === undefined) delete process.env.STEWARD_DB_MODE;
+      else process.env.STEWARD_DB_MODE = previousDbMode;
+      if (previousPgliteMemory === undefined) delete process.env.STEWARD_PGLITE_MEMORY;
+      else process.env.STEWARD_PGLITE_MEMORY = previousPgliteMemory;
+    }
+  });
 });

--- a/packages/api/src/__tests__/policy-template-quota.test.ts
+++ b/packages/api/src/__tests__/policy-template-quota.test.ts
@@ -127,7 +127,9 @@ realPostgresIt("serializes same-tenant creates at the 100-template quota", async
       });
 
     const requests = [create("racer-a"), create("racer-b")];
-    await waitForAdvisoryWaiters(observer, holderPid, 2);
+    // The first request waits on the quota lock while holding the canonical
+    // tenant audit lock; the second waits behind it on that tenant lock.
+    await waitForAdvisoryWaiters(observer, holderPid, 1);
     releaseLock();
 
     const responses = await Promise.all(requests);

--- a/packages/api/src/routes/policies-standalone.ts
+++ b/packages/api/src/routes/policies-standalone.ts
@@ -5,12 +5,16 @@
  */
 
 import { toPersistedPolicyRule } from "@stwd/db";
-import { eq, inArray, sql } from "drizzle-orm";
+import { invalidateCache } from "@stwd/redis";
+import { redactedThrownDiagnostics } from "@stwd/shared";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { Hono } from "hono";
-import { writeAuditEvent } from "../services/audit";
+import { isRedisAvailable } from "../middleware/redis";
+import { withTenantAuditedTransaction, writeAuditEvent } from "../services/audit";
 import {
   type ApiResponse,
   type AppVariables,
+  agents,
   db,
   ensureAgentForTenant,
   getConditionSetReferenceValidationError,
@@ -93,17 +97,38 @@ interface SimulateBody {
 
 async function snapshotAgentPolicies(agentIds: string[]): Promise<PolicyRow[]> {
   if (agentIds.length === 0) return [];
-  return db.select().from(policies).where(inArray(policies.agentId, agentIds));
+  return db
+    .select()
+    .from(policies)
+    .where(inArray(policies.agentId, agentIds))
+    .orderBy(policies.agentId, policies.id);
 }
 
-async function restoreAgentPolicies(agentIds: string[], snapshot: PolicyRow[]): Promise<void> {
-  if (agentIds.length === 0) return;
-  await db.transaction(async (tx) => {
-    await tx.delete(policies).where(inArray(policies.agentId, agentIds));
-    if (snapshot.length > 0) {
-      await tx.insert(policies).values(snapshot);
+function authoritySnapshot(value: unknown): string {
+  return JSON.stringify(value, (_key, item) => (item instanceof Date ? item.toISOString() : item));
+}
+
+function policySetSnapshot(rows: PolicyRow[]): string {
+  return authoritySnapshot(
+    [...rows].sort(
+      (left, right) => left.agentId.localeCompare(right.agentId) || left.id.localeCompare(right.id),
+    ),
+  );
+}
+
+function templateRevisionSnapshot(template: PolicyTemplate): string {
+  return authoritySnapshot(template);
+}
+
+async function invalidateAgentPolicyCaches(agentIds: string[], tenantId: string): Promise<void> {
+  if (!isRedisAvailable()) return;
+  for (const agentId of agentIds) {
+    try {
+      await invalidateCache(agentId, tenantId);
+    } catch (error) {
+      console.error("[policy] Failed to invalidate policy cache", redactedThrownDiagnostics(error));
     }
-  });
+  }
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -135,6 +160,10 @@ function rowToTemplate(row: any): PolicyTemplate {
   };
 }
 
+function resultRows<T>(result: unknown): T[] {
+  return (Array.isArray(result) ? result : ((result as { rows?: T[] })?.rows ?? [])) as T[];
+}
+
 async function listTemplatesPage(
   tenantId: string,
   limit: number,
@@ -148,16 +177,22 @@ async function listTemplatesPage(
         LIMIT ${limit}
         OFFSET ${offset}`,
   );
-  return (rows as any[]).map(rowToTemplate);
+  return resultRows(rows).map(rowToTemplate);
 }
 
-async function getTemplate(tenantId: string, id: string): Promise<PolicyTemplate | null> {
-  const rows = await db.execute(
+async function getTemplate(
+  tenantId: string,
+  id: string,
+  executor: typeof db = db,
+  lock = false,
+): Promise<PolicyTemplate | null> {
+  const rows = await executor.execute(
     sql`SELECT id, tenant_id, name, description, rules, is_default, created_at, updated_at
         FROM policy_templates
-        WHERE id = ${id}::uuid AND tenant_id = ${tenantId}`,
+        WHERE id = ${id}::uuid AND tenant_id = ${tenantId}
+        ${lock ? sql`FOR UPDATE` : sql``}`,
   );
-  const row = (rows as any[])[0];
+  const row = resultRows(rows)[0];
   return row ? rowToTemplate(row) : null;
 }
 
@@ -171,46 +206,46 @@ async function _insertTemplate(
         VALUES (${id}::uuid, ${tenantId}, ${body.name}, ${body.description ?? null}, ${JSON.stringify(body.rules ?? [])}::jsonb, ${body.isDefault ?? false})
         RETURNING id, tenant_id, name, description, rules, is_default, created_at, updated_at`,
   );
-  return rowToTemplate((rows as any[])[0]);
+  return rowToTemplate(resultRows(rows)[0]);
 }
 
 async function insertTemplateWithQuota(
   tenantId: string,
   body: CreateTemplateBody,
   id: string,
+  tx: typeof db,
 ): Promise<PolicyTemplate> {
-  return db.transaction(async (tx) => {
-    if (process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true") {
-      await tx.execute(
-        sql`select pg_advisory_xact_lock(hashtext(${`policy_templates:${tenantId}`}))`,
-      );
-    }
+  if (process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true") {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtext(${`policy_templates:${tenantId}`}))`,
+    );
+  }
 
-    const countRows = await tx.execute(
-      sql`SELECT count(*)::integer AS count
+  const countRows = await tx.execute(
+    sql`SELECT count(*)::integer AS count
           FROM policy_templates
           WHERE tenant_id = ${tenantId}`,
+  );
+  const currentCount = Number(resultRows<{ count?: number | string }>(countRows)[0]?.count ?? 0);
+  if (currentCount >= MAX_POLICY_TEMPLATES_PER_TENANT) {
+    throw new Error(
+      `Tenant cannot have more than ${MAX_POLICY_TEMPLATES_PER_TENANT} policy templates`,
     );
-    const currentCount = Number((countRows as Array<{ count?: number | string }>)[0]?.count ?? 0);
-    if (currentCount >= MAX_POLICY_TEMPLATES_PER_TENANT) {
-      throw new Error(
-        `Tenant cannot have more than ${MAX_POLICY_TEMPLATES_PER_TENANT} policy templates`,
-      );
-    }
+  }
 
-    const rows = await tx.execute(
-      sql`INSERT INTO policy_templates (id, tenant_id, name, description, rules, is_default)
+  const rows = await tx.execute(
+    sql`INSERT INTO policy_templates (id, tenant_id, name, description, rules, is_default)
           VALUES (${id}::uuid, ${tenantId}, ${body.name}, ${body.description ?? null}, ${JSON.stringify(body.rules ?? [])}::jsonb, ${body.isDefault ?? false})
           RETURNING id, tenant_id, name, description, rules, is_default, created_at, updated_at`,
-    );
-    return rowToTemplate((rows as any[])[0]);
-  });
+  );
+  return rowToTemplate(resultRows(rows)[0]);
 }
 
 async function updateTemplate(
   tenantId: string,
   id: string,
   body: Partial<CreateTemplateBody>,
+  executor: typeof db = db,
 ): Promise<PolicyTemplate | null> {
   // Build parameterized update using drizzle sql template literals.
   // Each field is set conditionally via CASE/COALESCE to avoid raw SQL injection.
@@ -219,9 +254,11 @@ async function updateTemplate(
   const hasRules = body.rules !== undefined;
   const hasDefault = body.isDefault !== undefined;
 
-  if (!hasName && !hasDesc && !hasRules && !hasDefault) return getTemplate(tenantId, id);
+  if (!hasName && !hasDesc && !hasRules && !hasDefault) {
+    return getTemplate(tenantId, id, executor);
+  }
 
-  const rows = await db.execute(
+  const rows = await executor.execute(
     sql`UPDATE policy_templates SET
       name = CASE WHEN ${hasName} THEN ${body.name ?? ""} ELSE name END,
       description = CASE WHEN ${hasDesc} THEN ${body.description ?? null} ELSE description END,
@@ -231,37 +268,19 @@ async function updateTemplate(
     WHERE id = ${id}::uuid AND tenant_id = ${tenantId}
     RETURNING id, tenant_id, name, description, rules, is_default, created_at, updated_at`,
   );
-  const row = (rows as any[])[0];
+  const row = resultRows(rows)[0];
   return row ? rowToTemplate(row) : null;
 }
 
-async function deleteTemplate(tenantId: string, id: string): Promise<boolean> {
-  const result = await db.execute(
+async function deleteTemplate(
+  tenantId: string,
+  id: string,
+  executor: typeof db = db,
+): Promise<boolean> {
+  const result = await executor.execute(
     sql`DELETE FROM policy_templates WHERE id = ${id}::uuid AND tenant_id = ${tenantId} RETURNING id`,
   );
-  return (result as any[]).length > 0;
-}
-
-async function restoreTemplateSnapshot(snapshot: PolicyTemplate): Promise<void> {
-  await db.transaction(async (tx) => {
-    await tx.execute(
-      sql`DELETE FROM policy_templates WHERE id = ${snapshot.id}::uuid AND tenant_id = ${snapshot.tenantId}`,
-    );
-    await tx.execute(
-      sql`INSERT INTO policy_templates
-          (id, tenant_id, name, description, rules, is_default, created_at, updated_at)
-          VALUES (
-            ${snapshot.id}::uuid,
-            ${snapshot.tenantId},
-            ${snapshot.name},
-            ${snapshot.description},
-            ${JSON.stringify(snapshot.rules)}::jsonb,
-            ${snapshot.isDefault},
-            ${new Date(snapshot.createdAt)},
-            ${new Date(snapshot.updatedAt)}
-          )`,
-    );
-  });
+  return resultRows(result).length > 0;
 }
 
 function isWeiSimulationValue(value: unknown): value is string {
@@ -502,27 +521,29 @@ policiesStandaloneRoutes.post("/", async (c) => {
       userAgent: c.req.header("user-agent") ?? null,
       requestId: c.get("requestId") ?? null,
     });
-    const template = await insertTemplateWithQuota(tenantId, body, templateId);
-    try {
-      await writeAuditEvent({
-        tenantId,
-        ...actor,
-        action: "policy.template.create",
-        resourceType: "policy_template",
-        resourceId: template.id,
-        metadata: {
-          name: template.name,
-          ruleCount: template.rules.length,
-          isDefault: template.isDefault,
-        },
-        ipAddress: c.req.header("x-forwarded-for") ?? null,
-        userAgent: c.req.header("user-agent") ?? null,
-        requestId: c.get("requestId") ?? null,
-      });
-    } catch (error) {
-      await deleteTemplate(tenantId, template.id);
-      throw error;
-    }
+    const template = await withTenantAuditedTransaction(
+      tenantId,
+      async (txRaw, appendRequiredAudit) => {
+        const tx = txRaw as typeof db;
+        const created = await insertTemplateWithQuota(tenantId, body, templateId, tx);
+        await appendRequiredAudit({
+          tenantId,
+          ...actor,
+          action: "policy.template.create",
+          resourceType: "policy_template",
+          resourceId: created.id,
+          metadata: {
+            name: created.name,
+            ruleCount: created.rules.length,
+            isDefault: created.isDefault,
+          },
+          ipAddress: c.req.header("x-forwarded-for") ?? null,
+          userAgent: c.req.header("user-agent") ?? null,
+          requestId: c.get("requestId") ?? null,
+        });
+        return created;
+      },
+    );
     return c.json<ApiResponse<PolicyTemplate>>({ ok: true, data: template }, 201);
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : "Unknown error";
@@ -635,32 +656,46 @@ policiesStandaloneRoutes.put("/:id", async (c) => {
       userAgent: c.req.header("user-agent") ?? null,
       requestId: c.get("requestId") ?? null,
     });
-    const template = await updateTemplate(tenantId, id, body);
-    if (!template) {
+    const mutation = await withTenantAuditedTransaction(
+      tenantId,
+      async (txRaw, appendRequiredAudit) => {
+        const tx = txRaw as typeof db;
+        const locked = await getTemplate(tenantId, id, tx, true);
+        if (!locked) return { kind: "missing" as const };
+        if (templateRevisionSnapshot(locked) !== templateRevisionSnapshot(before)) {
+          return { kind: "conflict" as const };
+        }
+        const updated = await updateTemplate(tenantId, id, body, tx);
+        if (!updated) return { kind: "missing" as const };
+        await appendRequiredAudit({
+          tenantId,
+          ...actor,
+          action: "policy.template.update",
+          resourceType: "policy_template",
+          resourceId: updated.id,
+          metadata: {
+            name: updated.name,
+            ruleCount: updated.rules.length,
+            isDefault: updated.isDefault,
+            fields: Object.keys(body),
+          },
+          ipAddress: c.req.header("x-forwarded-for") ?? null,
+          userAgent: c.req.header("user-agent") ?? null,
+          requestId: c.get("requestId") ?? null,
+        });
+        return { kind: "updated" as const, template: updated };
+      },
+    );
+    if (mutation.kind === "missing") {
       return c.json<ApiResponse>({ ok: false, error: "Policy template not found" }, 404);
     }
-    try {
-      await writeAuditEvent({
-        tenantId,
-        ...actor,
-        action: "policy.template.update",
-        resourceType: "policy_template",
-        resourceId: template.id,
-        metadata: {
-          name: template.name,
-          ruleCount: template.rules.length,
-          isDefault: template.isDefault,
-          fields: Object.keys(body),
-        },
-        ipAddress: c.req.header("x-forwarded-for") ?? null,
-        userAgent: c.req.header("user-agent") ?? null,
-        requestId: c.get("requestId") ?? null,
-      });
-    } catch (error) {
-      await restoreTemplateSnapshot(before);
-      throw error;
+    if (mutation.kind === "conflict") {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Policy template changed concurrently; retry against latest revision" },
+        409,
+      );
     }
-    return c.json<ApiResponse<PolicyTemplate>>({ ok: true, data: template });
+    return c.json<ApiResponse<PolicyTemplate>>({ ok: true, data: mutation.template });
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : "Unknown error";
     return c.json<ApiResponse>({ ok: false, error: message }, 400);
@@ -699,25 +734,39 @@ policiesStandaloneRoutes.delete("/:id", async (c) => {
     userAgent: c.req.header("user-agent") ?? null,
     requestId: c.get("requestId") ?? null,
   });
-  const deleted = await deleteTemplate(tenantId, id);
-  if (!deleted) {
+  const mutation = await withTenantAuditedTransaction(
+    tenantId,
+    async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof db;
+      const locked = await getTemplate(tenantId, id, tx, true);
+      if (!locked) return { kind: "missing" as const };
+      if (templateRevisionSnapshot(locked) !== templateRevisionSnapshot(existing)) {
+        return { kind: "conflict" as const };
+      }
+      const deleted = await deleteTemplate(tenantId, id, tx);
+      if (!deleted) return { kind: "missing" as const };
+      await appendRequiredAudit({
+        tenantId,
+        ...actor,
+        action: "policy.template.delete",
+        resourceType: "policy_template",
+        resourceId: id,
+        metadata: { name: locked.name, ruleCount: locked.rules.length },
+        ipAddress: c.req.header("x-forwarded-for") ?? null,
+        userAgent: c.req.header("user-agent") ?? null,
+        requestId: c.get("requestId") ?? null,
+      });
+      return { kind: "deleted" as const };
+    },
+  );
+  if (mutation.kind === "missing") {
     return c.json<ApiResponse>({ ok: false, error: "Policy template not found" }, 404);
   }
-  try {
-    await writeAuditEvent({
-      tenantId,
-      ...actor,
-      action: "policy.template.delete",
-      resourceType: "policy_template",
-      resourceId: id,
-      metadata: { name: existing.name, ruleCount: existing.rules.length },
-      ipAddress: c.req.header("x-forwarded-for") ?? null,
-      userAgent: c.req.header("user-agent") ?? null,
-      requestId: c.get("requestId") ?? null,
-    });
-  } catch (error) {
-    await restoreTemplateSnapshot(existing);
-    throw error;
+  if (mutation.kind === "conflict") {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Policy template changed concurrently; retry against latest revision" },
+      409,
+    );
   }
 
   return c.json<ApiResponse>({ ok: true, data: { deleted: true } });
@@ -744,7 +793,7 @@ policiesStandaloneRoutes.post("/:id/assign", async (c) => {
   if (!body || !Array.isArray(body.agentIds) || body.agentIds.length === 0) {
     return c.json<ApiResponse>({ ok: false, error: "agentIds must be a non-empty array" }, 400);
   }
-  const uniqueAgentIds = Array.from(new Set(body.agentIds));
+  const uniqueAgentIds = Array.from(new Set(body.agentIds)).sort();
   if (
     uniqueAgentIds.length > MAX_POLICY_ASSIGN_AGENTS ||
     uniqueAgentIds.some((agentId) => !isValidAgentId(agentId))
@@ -789,6 +838,7 @@ policiesStandaloneRoutes.post("/:id/assign", async (c) => {
     );
   }
 
+  const previousPolicies = await snapshotAgentPolicies(uniqueAgentIds);
   const actor = policyAuditActor(c, tenantId);
   await writeAuditEvent({
     tenantId,
@@ -802,49 +852,91 @@ policiesStandaloneRoutes.post("/:id/assign", async (c) => {
     requestId: c.get("requestId") ?? null,
   });
 
-  // Copy template rules to each agent's policies (replace existing)
-  const assigned: string[] = [];
-  const previousPolicies = await snapshotAgentPolicies(uniqueAgentIds);
-  await db.transaction(async (tx) => {
-    for (const agentId of uniqueAgentIds) {
-      await tx.delete(policies).where(eq(policies.agentId, agentId));
-
-      if (persistedRules.length > 0) {
-        await tx.insert(policies).values(
-          persistedRules.map((rule) => ({
-            id: crypto.randomUUID(),
-            agentId,
-            type: rule.type,
-            enabled: rule.enabled,
-            config: rule.config,
-          })),
-        );
+  const mutation = await withTenantAuditedTransaction(
+    tenantId,
+    async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof db;
+      const lockedTemplate = await getTemplate(tenantId, id, tx, true);
+      if (!lockedTemplate) return { kind: "missing-template" as const };
+      if (templateRevisionSnapshot(lockedTemplate) !== templateRevisionSnapshot(template)) {
+        return { kind: "template-conflict" as const };
       }
-      assigned.push(agentId);
-    }
-  });
-  try {
-    await writeAuditEvent({
-      tenantId,
-      ...actor,
-      action: "policy.template.assign",
-      resourceType: "policy_template",
-      resourceId: id,
-      metadata: { assignedAgents: assigned, rulesApplied: template.rules.length },
-      ipAddress: c.req.header("x-forwarded-for") ?? null,
-      userAgent: c.req.header("user-agent") ?? null,
-      requestId: c.get("requestId") ?? null,
-    });
-  } catch (error) {
-    await restoreAgentPolicies(uniqueAgentIds, previousPolicies);
-    throw error;
+
+      for (const agentId of uniqueAgentIds) {
+        // Match the canonical authority lock used by direct agent-policy
+        // mutations (#715), in sorted agent order for multi-agent assignment.
+        if (process.env.STEWARD_PGLITE_MEMORY !== "true") {
+          await tx.execute(
+            sql`SELECT pg_advisory_xact_lock(hashtextextended(${`steward_agent_authority_${tenantId}:${agentId}`}, 0))`,
+          );
+        }
+        const [lockedAgent] = await tx
+          .select({ id: agents.id })
+          .from(agents)
+          .where(and(eq(agents.id, agentId), eq(agents.tenantId, tenantId)))
+          .for("update");
+        if (!lockedAgent) return { kind: "missing-agents" as const, agentIds: [agentId] };
+      }
+      const lockedPolicies = await tx
+        .select()
+        .from(policies)
+        .where(inArray(policies.agentId, uniqueAgentIds))
+        .orderBy(policies.agentId, policies.id)
+        .for("update");
+      if (policySetSnapshot(lockedPolicies) !== policySetSnapshot(previousPolicies)) {
+        return { kind: "policy-conflict" as const };
+      }
+
+      for (const agentId of uniqueAgentIds) {
+        await tx.delete(policies).where(eq(policies.agentId, agentId));
+        if (persistedRules.length > 0) {
+          await tx.insert(policies).values(
+            persistedRules.map((rule) => ({
+              id: crypto.randomUUID(),
+              agentId,
+              type: rule.type,
+              enabled: rule.enabled,
+              config: rule.config,
+            })),
+          );
+        }
+      }
+      await appendRequiredAudit({
+        tenantId,
+        ...actor,
+        action: "policy.template.assign",
+        resourceType: "policy_template",
+        resourceId: id,
+        metadata: { assignedAgents: uniqueAgentIds, rulesApplied: lockedTemplate.rules.length },
+        ipAddress: c.req.header("x-forwarded-for") ?? null,
+        userAgent: c.req.header("user-agent") ?? null,
+        requestId: c.get("requestId") ?? null,
+      });
+      return { kind: "assigned" as const };
+    },
+  );
+  if (mutation.kind === "missing-template") {
+    return c.json<ApiResponse>({ ok: false, error: "Policy template not found" }, 404);
   }
+  if (mutation.kind === "missing-agents") {
+    return c.json<ApiResponse>(
+      { ok: false, error: `Agents not found: ${mutation.agentIds.join(", ")}` },
+      404,
+    );
+  }
+  if (mutation.kind === "template-conflict" || mutation.kind === "policy-conflict") {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Policy authority changed concurrently; retry against latest state" },
+      409,
+    );
+  }
+  await invalidateAgentPolicyCaches(uniqueAgentIds, tenantId);
 
   return c.json<ApiResponse>({
     ok: true,
     data: {
       templateId: id,
-      assignedAgents: assigned,
+      assignedAgents: uniqueAgentIds,
       rulesApplied: template.rules.length,
     },
   });

--- a/packages/api/src/routes/policies-standalone.ts
+++ b/packages/api/src/routes/policies-standalone.ts
@@ -865,7 +865,10 @@ policiesStandaloneRoutes.post("/:id/assign", async (c) => {
       for (const agentId of uniqueAgentIds) {
         // Match the canonical authority lock used by direct agent-policy
         // mutations (#715), in sorted agent order for multi-agent assignment.
-        if (process.env.STEWARD_PGLITE_MEMORY !== "true") {
+        if (
+          process.env.STEWARD_DB_MODE !== "pglite" &&
+          process.env.STEWARD_PGLITE_MEMORY !== "true"
+        ) {
           await tx.execute(
             sql`SELECT pg_advisory_xact_lock(hashtextextended(${`steward_agent_authority_${tenantId}:${agentId}`}, 0))`,
           );


### PR DESCRIPTION
Closes #717

## Summary

- make policy-template create, update, delete, and assignment mutations commit in the same tenant-audited transaction as their required completion audit
- use locked revision/CAS checks for template changes and canonical, sorted agent-authority locks plus policy-set CAS for assignments
- remove stale snapshot/restore compensation and invalidate affected policy caches only after a successful audited commit
- normalize raw database result shapes across PostgreSQL and PGLite
- add mounted PGLite rollback coverage and deterministic PostgreSQL races for create, update, delete, and assignment

## Exact lineage

- base: `201c1869d40ffca8a207a32a24eecc7eb6f24cd6`
- head: `5745e11a5638bf12ff3881f8a9c91c67f0f14eef`

## Local validation

- focused isolated API files: 7/7 passed
- API dependency build: 24/24 passed
- Biome: 6 changed files clean
- committed diff check: clean

## Required hosted gate

The four deterministic real-PostgreSQL cases were discovered but skipped locally because no real `DATABASE_URL` was available. Hosted PostgreSQL must execute all four modes successfully before this draft can be accepted. The tests use an actual audit trigger/advisory-lock barrier, an exactly named competing connection, and independent visibility checks to prove the failed mutation never becomes visible and the audited concurrent winner survives.
