### PR TITLE
fix(auth): preserve JSON fallback for non-navigation OAuth callbacks

### DIFF
--- a/packages/api/src/__tests__/auth-oauth-callback-browser.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-callback-browser.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, mock } from "bun:test";
-import { closeDb } from "@stwd/db";
+import { accounts, closeDb, getDb, users } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
 
 const REDIRECT_URI = "https://app.example.test/callback?from=oauth";
 const ORIGINAL_FETCH = globalThis.fetch;
@@ -34,6 +35,8 @@ beforeAll(async () => {
   process.env.NODE_ENV = "test";
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = "oauth-callback-browser-master-password";
+  process.env.STEWARD_JWT_SECRET = "oauth-callback-browser-jwt-secret-with-enough-bytes";
+  process.env.STEWARD_AUDIT_HMAC_KEY = "b".repeat(64);
   const { db, client } = await createPGLiteDb("memory://");
   setPGLiteOverride(db, async () => {
     await client.close();
@@ -55,9 +58,81 @@ afterAll(async () => {
   delete process.env.NODE_ENV;
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_MASTER_PASSWORD;
+  delete process.env.STEWARD_JWT_SECRET;
+  delete process.env.STEWARD_AUDIT_HMAC_KEY;
 });
 
 describe("OAuth browser callback failures", () => {
+  for (const client of [
+    { name: "a browser navigation", suffix: "browser", headers: browserHeaders() },
+    { name: "an explicit JSON client", suffix: "json", headers: { accept: "application/json" } },
+  ]) {
+    it(`completes wallet-backed OAuth for ${client.name} without exposing tokens`, async () => {
+      const { suffix } = client;
+      const state = `successful-${suffix}-state`;
+      const providerAccountId = `google-success-${suffix}`;
+      const email = `oauth-success-${suffix}@example.test`;
+      process.env.APP_URL = "https://api.example.test";
+      process.env.GOOGLE_CLIENT_ID = "google-client";
+      process.env.GOOGLE_CLIENT_SECRET = "google-secret";
+      process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS = REDIRECT_URI;
+      await getAuthChallengeStore().set(
+        `oauth:${state}`,
+        JSON.stringify({
+          provider: "google",
+          redirectUri: REDIRECT_URI,
+          appState: `client-${suffix}-state`,
+        }),
+      );
+      globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "https://oauth2.googleapis.com/token") {
+          return Response.json({
+            access_token: `provider-access-${suffix}`,
+            refresh_token: `provider-refresh-${suffix}`,
+            expires_in: 3600,
+            token_type: "Bearer",
+          });
+        }
+        if (url === "https://www.googleapis.com/oauth2/v3/userinfo") {
+          return Response.json({
+            id: providerAccountId,
+            email,
+            name: `OAuth Success ${suffix}`,
+            verified_email: true,
+          });
+        }
+        return new Response("unexpected provider request", { status: 500 });
+      }) as unknown as typeof fetch;
+
+      const response = await authRoutes.request(
+        `/oauth/google/callback?code=provider-code&state=${state}`,
+        { headers: client.headers },
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location");
+      expect(location).toStartWith(`${REDIRECT_URI}#`);
+      expect(location).toContain(`state=client-${suffix}-state`);
+      expect(location).not.toContain("token=");
+      expect(location).not.toContain(`provider-access-${suffix}`);
+      expect(location).not.toContain(`provider-refresh-${suffix}`);
+
+      const [account] = await getDb()
+        .select({ userId: accounts.userId, accessTokenEncrypted: accounts.accessTokenEncrypted })
+        .from(accounts)
+        .where(eq(accounts.providerAccountId, providerAccountId));
+      expect(account?.accessTokenEncrypted).toBeTruthy();
+      expect(account?.accessTokenEncrypted).not.toBe(`provider-access-${suffix}`);
+      const [user] = await getDb()
+        .select({ walletAddress: users.walletAddress, stewardWalletId: users.stewardWalletId })
+        .from(users)
+        .where(eq(users.id, account?.userId ?? "00000000-0000-0000-0000-000000000000"));
+      expect(user?.walletAddress).toMatch(/^0x[0-9a-f]{40}$/i);
+      expect(user?.stewardWalletId).toBeTruthy();
+    });
+  }
+
   it("renders a non-reflective HTML page for provider errors", async () => {
     const attackerText = '<img src=x onerror="fetch(`https://attacker.test`) ">';
     process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS = REDIRECT_URI;
@@ -104,6 +179,25 @@ describe("OAuth browser callback failures", () => {
       error: "This sign-in attempt is invalid or has expired.",
       code: "oauth_state_expired",
     });
+  });
+
+  it("uses HTML for a navigation with no Accept header", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-no-accept-navigation-state",
+      { headers: { "sec-fetch-mode": "navigate" } },
+    );
+
+    await expectBrowserError(response, { status: 401, code: "oauth_state_expired" });
+  });
+
+  it("keeps JSON with no Accept header when the request is not a navigation", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-no-accept-client-state",
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toMatchObject({ ok: false, code: "oauth_state_expired" });
   });
 
   it("honors an explicit q=0 rejection of HTML even for navigation-shaped requests", async () => {

--- a/packages/api/src/__tests__/auth-oauth-token-encryption.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-token-encryption.test.ts
@@ -1,16 +1,15 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import { accounts, closeDb, tenantConfigs, tenants, users } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { eq } from "drizzle-orm";
-import {
-  authRoutes,
-  clearOAuthTokenKeyStoreForTests,
-  decryptOAuthProviderToken,
-  encryptOAuthProviderTokens,
-} from "../routes/auth";
 
 const MASTER_PASSWORD = "oauth-token-test-master";
 const originalFetch = globalThis.fetch;
+
+let authRoutes: typeof import("../routes/auth").authRoutes;
+let clearOAuthTokenKeyStoreForTests: typeof import("../routes/auth").clearOAuthTokenKeyStoreForTests;
+let decryptOAuthProviderToken: typeof import("../routes/auth").decryptOAuthProviderToken;
+let encryptOAuthProviderTokens: typeof import("../routes/auth").encryptOAuthProviderTokens;
 
 async function setupDb() {
   process.env.STEWARD_PGLITE_MEMORY = "true";
@@ -21,10 +20,24 @@ async function setupDb() {
   return db;
 }
 
+beforeAll(async () => {
+  process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
+  process.env.STEWARD_JWT_SECRET = "oauth-token-test-jwt-secret-with-enough-bytes";
+  process.env.STEWARD_AUDIT_HMAC_KEY = "a".repeat(64);
+  await setupDb();
+  ({
+    authRoutes,
+    clearOAuthTokenKeyStoreForTests,
+    decryptOAuthProviderToken,
+    encryptOAuthProviderTokens,
+  } = await import("../routes/auth"));
+});
+
 describe("OAuth provider token encryption", () => {
   beforeEach(() => {
     process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
-    process.env.JWT_SECRET = "oauth-token-test-jwt-secret-with-enough-bytes";
+    process.env.STEWARD_JWT_SECRET = "oauth-token-test-jwt-secret-with-enough-bytes";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "a".repeat(64);
     process.env.APP_URL = "https://api.example.test";
     process.env.GOOGLE_CLIENT_ID = "google-client";
     process.env.GOOGLE_CLIENT_SECRET = "google-secret";
@@ -38,7 +51,8 @@ describe("OAuth provider token encryption", () => {
     clearOAuthTokenKeyStoreForTests();
     await closeDb().catch(() => {});
     delete process.env.STEWARD_MASTER_PASSWORD;
-    delete process.env.JWT_SECRET;
+    delete process.env.STEWARD_JWT_SECRET;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
     delete process.env.APP_URL;
     delete process.env.GOOGLE_CLIENT_ID;
     delete process.env.GOOGLE_CLIENT_SECRET;

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -4065,6 +4065,9 @@ function escapeOAuthCallbackHtml(value: string): string {
 
 function oauthCallbackPrefersHtml(c: Context): boolean {
   const accept = c.req.header("accept")?.toLowerCase() ?? "";
+  if (!accept.trim()) {
+    return c.req.header("sec-fetch-mode")?.toLowerCase() === "navigate";
+  }
   const qualityFor = (target: "application/json" | "text/html"): number | undefined => {
     const [targetType] = target.split("/");
     let bestMatch: { specificity: number; quality: number } | undefined;


### PR DESCRIPTION
Closes #695

## Summary
- keep no-Accept OAuth callbacks on JSON unless the request is an actual browser navigation
- preserve explicit content-negotiation quality and q=0 behavior
- add mounted browser and JSON OAuth success proofs without exposing provider tokens
- use canonical JWT and audit-HMAC fixture authority

## Exact lineage
- base: `201c1869d40ffca8a207a32a24eecc7eb6f24cd6`
- head: `f79f9e26bc88b06bc4190f08f7f891bd62e048ef`
- tree: `ff6ad21755b7406b866dda8f1c3f0cea583ca0d8`
- stable patch-id: `7739a4bce08ecefb48e7169f171f9e5df9742a08` (identical to prior independently accepted `a5da7ec`)

## Validation
- OAuth callback + token-encryption focused tests: 21/21
- API dependency build: 24/24
- API TypeScript build: green
- Biome (3 files): green
- `git diff --check`: green

Independent source audit: ACCEPT. Keep draft until exact hosted checks and required review are complete.