### PR TITLE
docs(security): describe current RLS and vault boundaries

### DIFF
--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -165,17 +165,17 @@ flowchart LR
         W2["Wallets"]
     end
 
-    MK["Master key"] --> TK1["Tenant key 1"]
-    MK --> TK2["Tenant key 2"]
-    TK1 --> S1
-    TK1 --> W1
-    TK2 --> S2
-    TK2 --> W2
+    MP["Master password + deployment KDF salt"] --> SR["Domain-separated secret-vault root"]
+    MP --> WR["Domain-separated signing-vault root"]
+    SR -->|"random per-record salt + context AAD"| S1
+    SR -->|"random per-record salt + context AAD"| S2
+    WR -->|"random per-record salt + context AAD"| W1
+    WR -->|"random per-record salt + context AAD"| W2
 ```
 
-- **Tenants** are isolated at the service layer: every tenant-scoped query filters on `tenantId` and rows carry a composite foreign key to their tenant. This is not database row-level security (RLS is not implemented).
+- **Tenants** are always scoped by authenticated service-layer predicates and ownership constraints such as composite foreign keys. Production PostgreSQL adds database RLS: operators provision distinct application, platform, migration, and bootstrap-owner roles, activate and force the inventoried policies, and configure `STEWARD_APP_DATABASE_ROLE`. Bun startup and `/ready`, plus Worker cold start, compare the connected non-owner, `NOBYPASSRLS` role and the live relation/policy catalog to the generated manifest and fail closed on drift. Trusted request middleware binds `steward.tenant_id` transaction-locally on one checked-out connection. Embedded/local PGLite does not provide the production RLS role/catalog boundary and relies on service-layer predicates and ownership constraints. See [PostgreSQL tenant RLS rollout](/security/database-rls-rollout).
 - **Agents** authenticate with JWTs scoped to their tenant and agent ID
-- **Secrets** are encrypted with per-tenant encryption keys (key hierarchy: master → tenant → secret)
+- **Secrets and signing keys** use domain-separated scrypt roots. Each record gets a random salt, and AES-GCM authenticates its tenant/agent/name/version context as AAD. There is no stored or independently rotatable per-tenant encryption-key layer. See [Secret Vault](/concepts/secret-vault) and the [root secret rotation runbook](/runbooks/key-rotation).
 - **Policies** are evaluated per-agent within their tenant context
 
 ## Tech Stack

--- a/docs/concepts/secret-vault.mdx
+++ b/docs/concepts/secret-vault.mdx
@@ -56,24 +56,25 @@ Now when an agent calls OpenAI through the proxy, Steward decrypts the key and i
 
 ## Encryption
 
-Secrets use the same AES-256-GCM encryption as the Wallet Vault, with a key hierarchy that supports per-tenant isolation:
+`SecretVault` uses the `secret-vault` domain of the same `KeyStore` primitive as the Wallet Vault. The implemented derivation and encryption path is:
 
-```
-Master Key (Argon2id from STEWARD_MASTER_PASSWORD)
-    │
-    ├── Tenant Key A (wrapped by master key)
-    │       ├── encrypts "openai-prod"
-    │       ├── encrypts "anthropic-main"
-    │       └── encrypts "birdeye-key"
-    │
-    └── Tenant Key B (wrapped by master key)
-            └── encrypts "custom-api"
+```text
+STEWARD_MASTER_PASSWORD + STEWARD_KDF_SALT
+    └── scrypt with the "secret-vault" domain label
+          └── deployment/domain root (not stored in the database)
+                └── scrypt with a fresh random salt for each record
+                      └── AES-256-GCM record key
+                            └── AAD: tenantId + name + version
 ```
 
-**Key benefits:**
-- Rotating a tenant key re-wraps it — no re-encryption of all secrets needed
-- Master key rotation is O(tenants), not O(secrets)
-- Future: BYOK (Bring Your Own Key) for enterprise customers
+The random record salt, IV, authentication tag, and ciphertext are stored with each secret version. Tenant, secret name, and version are authenticated as AES-GCM additional authenticated data (AAD), so copying ciphertext into another tenant/name/version context fails authentication. Wallet and credential records use the same primitive with their applicable tenant, agent, chain, venue, name, and version context.
+
+There is **no stored, wrapped, or independently rotatable per-tenant key**. Changing `STEWARD_MASTER_PASSWORD` or `STEWARD_KDF_SALT` changes the derivation root, so operators must stop writers and use the [root secret key rotation runbook](/runbooks/key-rotation) to authenticate and re-encrypt the complete supported ciphertext inventory before cutting every consumer over. Rotation cost follows the encrypted record inventory, not the tenant count.
+
+Two legacy compatibility paths are deliberately separate:
+
+- Secrets written before KDF domain separation may require the old undomained root. Production enables that temporary path only with `STEWARD_SECRET_VAULT_LEGACY_ROOT_FALLBACK=true`; migrate the full secret inventory and remove the flag as described in the rotation runbook.
+- Ciphertext written before context AAD may require a no-AAD decrypt retry. `STEWARD_ALLOW_LEGACY_KEYSTORE_DECRYPT_FALLBACK=true` enables that retry only outside production; production ignores the flag and fails closed. Re-encrypt legacy records with context rather than treating this as a tenant-key mechanism.
 
 ## Secret Lifecycle
 
@@ -130,10 +131,10 @@ Master Key (Argon2id from STEWARD_MASTER_PASSWORD)
 
 When the proxy forwards a request, it:
 
-1. **Decrypts** the credential (held in memory for microseconds)
+1. **Decrypts** the credential for the bounded outbound operation
 2. **Injects** it according to the route config (header, query param, or body)
 3. **Forwards** the request to the real API
-4. **Zeroes** the credential from memory
+4. **Drops** the plaintext reference after the outbound operation (JavaScript strings cannot be reliably zeroed in place)
 
 Injection methods:
 
@@ -146,8 +147,8 @@ Injection methods:
 ## Security Properties
 
 - **Secrets never leave the vault in API responses** — list/get endpoints return metadata only
-- **Decrypted credentials exist in memory for microseconds** — zeroed immediately after injection
-- **All access is logged** — every decryption event creates an audit trail entry
+- **Plaintext lifetime is bounded to the use callback or pinned injection path** — references are dropped afterward, but JavaScript strings cannot be reliably zeroed in place
+- **Auditing is enforced by governed callers, not by the cipher primitive** — new consumers use the pre-decrypt audit chokepoint, and the remaining direct-decrypt caller inventory is CI-pinned
 - **Tenant isolation** — secrets are scoped to tenants; agents can only trigger decryption of their tenant's secrets
 
 ## Related
@@ -156,3 +157,4 @@ Injection methods:
 - [Secrets API Reference](/api-reference/secrets) — Full CRUD API
 - [Routes API Reference](/api-reference/routes) — Route configuration API
 - [Managing Secrets Guide](/guides/secrets) — Step-by-step guide
+- [Root Secret Key Rotation](/runbooks/key-rotation) — Offline full-inventory root and legacy migration procedure

--- a/docs/security/threat-model.mdx
+++ b/docs/security/threat-model.mdx
@@ -11,7 +11,7 @@ claim that every signing, proxy, or plugin execution path is governed.
 
 # Steward Threat Model
 
-**Status:** Living document. Last reviewed 2026-04-24.
+**Status:** Living document. Last reviewed 2026-08-21.
 **Scope:** Steward v1 (current `develop` branch).
 
 This document enumerates the adversaries Steward is designed to defend
@@ -59,15 +59,17 @@ If any of these fails, the threat model below does not hold.
    provides limited defense.
 6. **Tenant operators are trusted with their own tenant.** A tenant
    admin can read the policies, approvals, and audit log for their
-   tenant. They cannot read another tenant's data. Isolation is
-   enforced at the service layer: every tenant-scoped query filters
-   on `tenantId` and rows carry a composite foreign key to their
-   tenant. It is NOT database row-level security (RLS is not
-   implemented). Steward ships self-hosted only, and the expected
-   topology is one tenant per deployment, where this is trivially
-   true. An operator who chooses to run multiple tenants in a single
-   self-hosted deployment relies on that service-layer scoping and
-   trusts each tenant owner with their own scope.
+   tenant. They cannot read another tenant's data. Every runtime keeps
+   authenticated service-layer `tenantId` predicates and ownership
+   constraints such as composite foreign keys. Production PostgreSQL
+   additionally requires the activated and forced policy inventory,
+   separately provisioned non-owner/`NOBYPASSRLS` application role,
+   and transaction-local trusted tenant context. Bun startup and
+   `/ready`, plus Worker cold start, fail closed if the configured role,
+   protected relations, partitions, or exact policy definitions drift.
+   Local and embedded PGLite do not supply this role/catalog boundary
+   and rely on the service layer. See the
+   [PostgreSQL tenant RLS rollout](./database-rls-rollout.mdx).
 7. **TLS is terminated in front of Steward.** The Compose file binds
    the API to `127.0.0.1`; the expected topology has Caddy / nginx /
    Traefik handling TLS. Steward does not itself terminate TLS in the
@@ -218,7 +220,12 @@ without OS-level code execution on the API host). They see the
   the master password, ciphertext is not decryptable.
 - Per-record random salt forces the attacker to run scrypt once
   per record to test a candidate master password.
-- Secrets stored via `SecretVault` use the same encryption path.
+- Secrets stored via `SecretVault` use a domain-separated scrypt root;
+  each record derives a key from its random salt and authenticates
+  tenant/name/version context as AES-GCM AAD. Wallet records bind their
+  applicable tenant/agent/chain/venue context. These bindings detect
+  ciphertext copied into a different context; they are not stored
+  per-tenant encryption keys.
 - Password hashes (for users who use email + password) are
   stored hashed with the project's password hashing util (not
   plaintext).
@@ -267,9 +274,11 @@ the master password as a crown jewel.
 - Store the master password in a real secret manager (not a
   committed `.env`).
 - Rotate it on suspicion of leak. Rotation means: generate new
-  master password, re-encrypt all stored keys with a migration,
-  retire old password. Tooling for bulk re-encryption is not
-  yet shipped — this is tracked as a follow-up.
+  master password and KDF salt, stop writers, authenticate and
+  re-encrypt the complete supported ciphertext inventory, cut every
+  consumer over together, then retire the old pair. Follow the
+  [root secret key rotation runbook](../runbooks/key-rotation.md);
+  rotation is an offline full-inventory operation, not a tenant-key re-wrap.
 - Use OS-level access controls on the Compose host to limit who
   can read the environment of the API container.
 


### PR DESCRIPTION
Closes #767

## Summary

- replace the obsolete service-only tenant-isolation claim with the exact production PostgreSQL role, activation, transaction-context, startup, and readiness boundary
- distinguish embedded/local PGLite service-layer isolation from the production PostgreSQL RLS catalog boundary
- replace the fictitious master-to-tenant-key hierarchy with the implemented domain-separated scrypt root, random per-record derivation, and AES-GCM context AAD
- document offline full-inventory root rotation and the separate legacy domain-root and no-AAD fallback gates
- correct adjacent stale claims about plaintext zeroization and unavailable rotation tooling
- link the active PostgreSQL RLS rollout and root secret rotation runbooks

## Exact candidate

- base: `201c1869d40ffca8a207a32a24eecc7eb6f24cd6`
- head: `e6b8317ec9f4abeed5243724703f6606e408e783`
- tree: `8b5c8414575e0edbb6d4651250de49cc2d8c502e`

## Validation

- independently audited every changed security claim against `packages/vault/src/keystore.ts`, `packages/vault/src/secret-vault.ts`, `packages/db/src/rls-deployment-safety.ts`, `packages/db/src/tenant-rls-context.ts`, and the Bun/Worker startup paths
- active-doc scan is empty for the retired RLS-absent, wrapped tenant-key, Argon2id, O(tenants), unavailable bulk-rotation, and reliable JavaScript-zeroization claims
- every internal link referenced by the three changed documents resolves to a tracked document
- focused Biome: pass
- `git diff --check`: pass

The sparse isolated lane intentionally contains no dependency installation, so a full docs build was not run locally. Exact hosted docs/link checks and independent PR review remain required. This PR is intentionally draft; do not ready or merge until those gates pass.