### PR TITLE
cleanup(code): replace stale planning comments with current contracts

### DIFF
--- a/packages/api/scripts/cumulative-spend-mutation-proofs.sh
+++ b/packages/api/scripts/cumulative-spend-mutation-proofs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# #206 cumulativeSpend + configurable-window mutation-strength proofs. Each
+# cumulativeSpend + configurable-window mutation-strength proofs. Each
 # mutation weakens ONE load-bearing guard; a proof is valid iff the named test
 # PASSES clean AND FAILS after the mutation. The target file is restored after
 # each proof.

--- a/packages/api/scripts/cumulative-spend-mutation-proofs.sh
+++ b/packages/api/scripts/cumulative-spend-mutation-proofs.sh
@@ -87,10 +87,10 @@ proof "M5 drop reservation atomicity (cap check before add)" "$TRACKER" run_trac
   "100 parallel reserves of 100k against a 1M cap admit exactly 10" \
   's/if (sum + amount) > maxv then/if false then/'
 
-# M6: DROP THE OVER-RETENTION WINDOW REJECT (codex P1) - a window beyond the 30d
+# M6: DROP THE OVER-RETENTION WINDOW REJECT - a window beyond the 30d
 # retention would silently clamp + under-enforce; removing the guard lets it
 # reserve, so the over-retention test no longer throws.
-proof "M6 drop over-retention window reject (P1)" "$TRACKER" run_tracker_test \
+proof "M6 drop over-retention window reject" "$TRACKER" run_tracker_test \
   "over-retention window" \
   's/w > 0 \&\& w <= MAX_WINDOW_SECONDS/w > 0/'
 

--- a/packages/api/scripts/quorum-mutation-proofs.sh
+++ b/packages/api/scripts/quorum-mutation-proofs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# #205 quorum mutation-strength proofs. Each mutation weakens ONE security
+# Quorum mutation-strength proofs. Each mutation weakens ONE security
 # predicate of the M-of-N quorum lifecycle; a proof is valid iff the named test
 # PASSES clean AND FAILS after the mutation. The file is restored after each
 # proof (no .bak residue). Run from packages/api:

--- a/packages/api/src/compose.ts
+++ b/packages/api/src/compose.ts
@@ -12,8 +12,7 @@
  * by environment: `composeApp()` consults `resolveEnabledPlugins()`
  * (`plugin-config.ts`, reading `STEWARD_PLUGINS` / legacy `STEWARD_ENABLE_TRADING`)
  * and only registers the trading plugin when it is enabled. that keeps the library
- * core lean, the deploy configurable, and — in FULL mode — behavior-identical to
- * the historical hardcoded composition.
+ * core lean while keeping the deploy configurable.
  *
  * ORDERING (load-bearing — money rail)
  * ------------------------------------
@@ -128,9 +127,8 @@ export async function composeApp(): Promise<Hono<{ Variables: AppVariables }>> {
     return app;
   }
 
-  // FULL MODE: register this deploy's enabled opt-in plugins. behavior-identical
-  // to the historical hardcoded path for trading — same registration, same
-  // ordering, same migrations — plus any other enabled plugin (capabilities).
+  // FULL MODE: register this deploy's enabled opt-in plugins with the same
+  // middleware, route, and migration ordering contract for every plugin.
   //
   // 2) plugin auth-middleware phase + buffered routes. each plugin's auth mw lands
   //    now, before idempotency; its routes are buffered for after.
@@ -199,7 +197,7 @@ export async function composeApp(): Promise<Hono<{ Variables: AppVariables }>> {
 }
 
 /**
- * Apply this deploy's opt-in plugins' OWN migrations (Phase 2c), into per-plugin
+ * Apply this deploy's opt-in plugins' OWN migrations into per-plugin
  * NAMESPACED bookkeeping tables (`drizzle.__drizzle_migrations_plugin_<id>`),
  * totally isolated from the core's `drizzle.__drizzle_migrations` journal.
  *

--- a/packages/api/src/compose.ts
+++ b/packages/api/src/compose.ts
@@ -8,10 +8,11 @@
  * `app.ts`'s `createApp()` is the LEAN CORE: trading-free, with no dependency on
  * the trading stack. a third party importing `@stwd/api` and calling `createApp()`
  * gets exactly that. THIS repo's deployed server (index.ts / worker.ts /
- * embedded.ts) can run the SAME image LEAN (core only) or FULL (core + trading)
+ * embedded.ts) can run the SAME image LEAN (core only) or FULL (core plus the
+ * configured first-party plugins)
  * by environment: `composeApp()` consults `resolveEnabledPlugins()`
  * (`plugin-config.ts`, reading `STEWARD_PLUGINS` / legacy `STEWARD_ENABLE_TRADING`)
- * and only registers the trading plugin when it is enabled. that keeps the library
+ * and registers only the named plugins. that keeps the library
  * core lean while keeping the deploy configurable.
  *
  * ORDERING (load-bearing — money rail)
@@ -97,15 +98,16 @@ function makeDeferredRouteApp(app: StewardApp): {
  * Build the fully-composed deployable Steward app: lean core + this repo's opt-in
  * plugins, with the canonical middleware/route ordering preserved.
  *
- * the trading plugin is imported with a static, bundler-discoverable specifier
- * (so the deployed Worker bundle includes it); only this deploy-only composition
- * root references `@stwd/plugin-trading`. the lean core graph in `app.ts` / the
- * library entry `lib.ts` never reference it, so a consumer importing `@stwd/api`
- * stays trading-free.
+ * enabled first-party plugins are imported with static, bundler-discoverable
+ * specifiers so the deployed Worker bundle includes them. only this deploy-only
+ * composition root references those plugin packages; the lean core graph in
+ * `app.ts` / the library entry `lib.ts` never does, so a consumer importing
+ * `@stwd/api` stays free of their transitive dependencies.
  */
 export async function composeApp(): Promise<Hono<{ Variables: AppVariables }>> {
   // which opt-in plugins this deploy enables (env-driven). LEAN = empty set
-  // (core only); FULL = { "trading" }. resolveEnabledPlugins fails closed on an
+  // (core only); FULL = the configured subset of trading, capabilities, and wxmr.
+  // resolveEnabledPlugins fails closed on an
   // unknown plugin name, so a typo'd STEWARD_PLUGINS aborts boot here rather than
   // silently shipping a wrong feature profile. composeApp reads process.env
   // directly (prod signature unchanged); the resolver itself is env-injectable

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -332,7 +332,7 @@ if (shouldUsePGLite()) {
       console.log("[steward] Migrations already up to date.");
     }
 
-    // Plugin-owned migrations (Phase 2c): applied AFTER the core migrator so a
+    // Plugin-owned migrations are applied AFTER the core migrator so a
     // plugin migration may reference core tables via FK. Each plugin's migrations
     // land in its OWN namespaced bookkeeping table
     // (drizzle.__drizzle_migrations_plugin_<id>), totally isolated from the core's

--- a/packages/api/src/middleware/sensitive-paths.ts
+++ b/packages/api/src/middleware/sensitive-paths.ts
@@ -4,17 +4,11 @@
  * that MUST be both freshness-checked (request-expiry) AND signature-checked
  * (authorization-signature) when those guards are enabled.
  *
- * Previously this predicate was duplicated byte-for-byte in
- * `request-expiry.ts` and `authorization-signature.ts`. Keeping two copies in
- * lockstep is a drift hazard: if one copy gained or dropped a prefix, a path
- * could be freshness-checked but not signature-checked (or vice-versa),
- * silently weakening a load-bearing guard. Both middlewares now import this
- * one helper so the two guards always cover the exact same surface.
+ * Both request-expiry.ts and authorization-signature.ts import this helper so
+ * the two guards always cover the exact same surface.
  *
- * The prefix set is the conservative UNION of what each copy historically
- * treated as sensitive (the two copies were already identical, so the union is
- * that same set), plus the money-/key-/auth-adjacent surfaces added in SEC-150
- * (`/v1/kms`, `/v2/provider-actions`, `/dashboard`, `/agent-enroll`). Adding a
+ * The prefix set conservatively covers money-, key-, auth-, and
+ * tenant-administration surfaces. Adding a
  * prefix here tightens BOTH guards together; never narrow it without auditing
  * both call sites.
  */

--- a/packages/api/src/plugin-config.ts
+++ b/packages/api/src/plugin-config.ts
@@ -1,18 +1,13 @@
 /**
  * plugin-config.ts — deploy-time plugin enablement resolver.
  *
- * WHY THIS EXISTS
- * ---------------
+ * ENABLEMENT CONTRACT
+ * -------------------
  * the composition root (`compose.ts`) assembles the deployable server: the lean
- * core (`createApp()`) plus this deploy's opt-in plugins. historically that set
- * was HARDCODED — `composeApp()` always registered the trading plugin and
- * `runComposedPluginMigrations()` always collected its migrations. that coupled
- * the SHIPPED IMAGE to a single feature profile: every deploy ran trading,
- * whether or not it was wanted.
- *
- * this resolver makes the same image run LEAN (core only) or FULL (core + opt-in
- * plugins) purely by ENVIRONMENT, with NO change to what any plugin does. it only
- * answers ONE question: "which opt-in plugins should the composition root
+ * core (`createApp()`) plus this deploy's opt-in plugins. This resolver makes the
+ * same image run LEAN (core only) or FULL (core + opt-in plugins) purely by
+ * environment. It answers ONE question: "which opt-in plugins should the
+ * composition root
  * register?" the actual registration, ordering, and migration logic is untouched
  * (see compose.ts) — this only gates WHETHER trading is composed in, never HOW.
  *

--- a/packages/api/src/plugin-config.ts
+++ b/packages/api/src/plugin-config.ts
@@ -9,7 +9,7 @@
  * environment. It answers ONE question: "which opt-in plugins should the
  * composition root
  * register?" the actual registration, ordering, and migration logic is untouched
- * (see compose.ts) — this only gates WHETHER trading is composed in, never HOW.
+ * (see compose.ts) — this gates WHICH plugins are composed in, never HOW.
  *
  * THE CONTRACT
  * ------------

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -1,19 +1,13 @@
 /**
  * plugin.ts — the lean-core + opt-in-plugin seam for the Steward app.
  *
- * WHY THIS EXISTS
- * ---------------
+ * OWNERSHIP CONTRACT
+ * ------------------
  * steward serves two audiences from one codebase: teams that want only the auth +
  * embedded-wallet + policy core, and teams that ALSO want agent trading (venue
- * execution + trade sessions). historically these were coupled: `@stwd/api`
- * hard-depended on the trading stack (`@stwd/trade-sessions`, `@stwd/venue-*`) and
- * the trade routes imported the venue adapters directly, so an auth-only install
- * still compiled + shipped the entire trading stack (the venue SDKs, ethers, clob
- * clients) — an unnecessary install-size, supply-chain, and audit-surface cost for
- * the majority of installs that never trade.
- *
- * the architecture here is a LEAN OPEN CORE (auth + vault + policy + proxy +
- * webhooks) plus OPT-IN PLUGINS that a host registers. trading is the first such
+ * execution + trade sessions). The architecture is a LEAN OPEN CORE (auth +
+ * vault + policy + proxy + webhooks) plus OPT-IN PLUGINS that a host registers.
+ * trading is the first such
  * plugin (`@stwd/plugin-trading`). this mirrors the plugin model of mature
  * frameworks (fastify/vite/hono-style `app.register(plugin)`): take only what you
  * need, and anyone can write + register their own plugin.

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -3,12 +3,11 @@
  *
  * OWNERSHIP CONTRACT
  * ------------------
- * steward serves two audiences from one codebase: teams that want only the auth +
- * embedded-wallet + policy core, and teams that ALSO want agent trading (venue
- * execution + trade sessions). The architecture is a LEAN OPEN CORE (auth +
- * vault + policy + proxy + webhooks) plus OPT-IN PLUGINS that a host registers.
- * trading is the first such
- * plugin (`@stwd/plugin-trading`). this mirrors the plugin model of mature
+ * steward serves teams that want only the auth + embedded-wallet + policy core
+ * and teams that also enable first-party or third-party extensions. The
+ * architecture is a LEAN OPEN CORE (auth + vault + policy + proxy + webhooks)
+ * plus OPT-IN PLUGINS that a host registers. This repository ships trading,
+ * capabilities, and wxmr plugins. this mirrors the plugin model of mature
  * frameworks (fastify/vite/hono-style `app.register(plugin)`): take only what you
  * need, and anyone can write + register their own plugin.
  *

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -1508,7 +1508,7 @@ agentRoutes.post("/:agentId/token", async (c) => {
   }
 });
 
-// Create venue-scoped wallet (Sprint 4)
+// Create a venue-scoped wallet.
 //
 // POST /agents/:agentId/wallets
 // Body: { venue?: string, scope?: string, chainType: "evm" | "solana" | "bitcoin", purpose?: string }

--- a/packages/api/src/routes/approvals.ts
+++ b/packages/api/src/routes/approvals.ts
@@ -416,14 +416,10 @@ async function requireProxyOperator(
 }
 
 async function expireProxyApprovals(tenantId: string): Promise<void> {
-  // Atomicity: the expiry state transition for every row and its
-  // `proxy.approval.expired` audit event commit in ONE transaction. Previously
-  // the bulk UPDATE committed first and the per-row audits were written after in
-  // separate transactions, so a crash mid-loop left expired rows with no audit
-  // record (spec section 11 item #10). Now a crash before commit leaves nothing
-  // expired and the next sweep/API call retries the whole batch idempotently
-  // (the `status IN ('pending','approved')` guard means already-expired rows are
-  // not re-selected and cannot be double-audited).
+  // The expiry state transition for every row and its `proxy.approval.expired`
+  // audit event commit in one transaction. A crash before commit leaves nothing
+  // expired, and the `status IN ('pending','approved')` guard makes retries
+  // idempotent without double-auditing already-expired rows.
   await withTenantAuditedTransaction(tenantId, async (tx, appendRequiredAudit) => {
     const dbTx = tx as typeof db;
     const expired = await dbTx
@@ -532,14 +528,10 @@ approvalRoutes.post("/proxy/:id/approve", async (c) => {
   const tenantId = c.get("tenantId");
   await expireProxyApprovals(tenantId);
   const actor = approvalActor(c);
-  // Atomicity: the pending -> approved transition and its
-  // `proxy.approval.approved` audit event commit in ONE transaction. Previously
-  // the UPDATE committed first and the audit was written in a separate
-  // transaction, so an audit failure or crash between them could leave an
-  // approved request with no audit record (spec section 11 item #10, invariant
-  // I14). The guarded `status = 'pending'` predicate keeps a retry after a crash
-  // idempotent: only one transaction can flip the row, and a replayed approve of
-  // an already-approved row returns 409 without a second transition or audit.
+  // The pending -> approved transition and its `proxy.approval.approved` audit
+  // event commit in one transaction. The guarded `status = 'pending'` predicate
+  // makes retries idempotent: only one transaction can flip the row, and a
+  // replayed approve returns 409 without a second transition or audit.
   const row = await withTenantAuditedTransaction(tenantId, async (tx, appendRequiredAudit) => {
     const dbTx = tx as typeof db;
     // Agent deletion takes the tenant fence before the parent agent and pending
@@ -600,14 +592,12 @@ approvalRoutes.post("/proxy/:id/deny", async (c) => {
       400,
     );
   const actor = approvalActor(c);
-  // Atomicity + race determinism: the deny/revoke transition and its audit event
-  // commit in ONE transaction (spec section 11 item #10, invariant I14).
+  // The deny/revoke transition and its audit event commit in one transaction.
   //
   // Denying an ALREADY-APPROVED-but-unconsumed request is a deliberate,
   // load-bearing admin action: it revokes an approval before the agent's release
-  // poll can claim+execute it (release.ts executes ONLY `status === 'approved'`;
-  // the deny-of-approved semantic was introduced and behaviorally tested in
-  // #181 / af1b330). It is therefore a DISTINCT transition from denying a
+  // poll can claim+execute it (release.ts executes ONLY `status === 'approved'`).
+  // It is therefore a DISTINCT transition from denying a
   // still-pending request, and it emits a DISTINCT audit event
   // (`proxy.approval.revoked` vs `proxy.approval.denied`).
   //
@@ -877,17 +867,11 @@ approvalRoutes.post("/:txId/deny", async (c) => {
     },
   });
 
-  // Atomicity: the queue+transaction rejection AND its completion
-  // `approval.deny` audit event commit in ONE transaction (invariant I14).
-  // Previously the state change committed in its own transaction and the
-  // completion audit was written afterwards, guarded only by a best-effort
-  // compensating rollback — a crash between the state commit and either the
-  // audit or the compensation left a rejected transaction with no completion
-  // audit and no rollback. Folding the audit into the same transaction removes
-  // that window entirely; the pre-mutation `approval.deny.authorized` intent log
-  // above is still written first as a durable record that the decision was
-  // attempted. The guarded `status = 'pending'` predicates keep a retry after a
-  // crash idempotent (already-rejected rows are not re-selected).
+  // The queue+transaction rejection and its completion `approval.deny` audit
+  // event commit in one transaction. The pre-mutation
+  // `approval.deny.authorized` intent log remains a durable record that the
+  // decision was attempted. Guarded `status = 'pending'` predicates make crash
+  // retries idempotent because already-rejected rows are not re-selected.
   const updated = await withTenantAuditedTransaction(tenantId, async (tx, appendRequiredAudit) => {
     const dbTx = tx as typeof db;
     const updatedRows = await dbTx

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -422,7 +422,7 @@ let coarseSubjectWarnedAt = 0;
  * that edge invariant, so deployments should prefer STEWARD_TRUSTED_PROXY_HOPS
  * or a socket-bearing entry. checkAuthRateLimit widens the coarse budget by
  * AUTH_RATE_LIMIT_FALLBACK_HEADROOM because many clients share each bucket.
- * No configuration yields the old literal "global" chokepoint (#268), and no
+ * No configuration yields the literal "global" chokepoint, and no
  * client-controlled free text ever reaches Redis unhashed.
  */
 function authRateLimitSubject(c: Context): { subject: string; coarse: boolean } {
@@ -1901,7 +1901,7 @@ function invalidTestAccountCredentials() {
 
 /**
  * Map typed email-delivery failures to fail-closed HTTP responses
- * (elizaOS/eliza#18452): 503 when no delivery-capable provider is configured
+ * Returns 503 when no delivery-capable provider is configured
  * (challenge never issued), 502 when the provider rejected the send (the
  * challenge was already invalidated by EmailAuth). Returns null for any other
  * error so it propagates unchanged. Response bodies are generic — no

--- a/packages/api/src/routes/provider-google-connect.ts
+++ b/packages/api/src/routes/provider-google-connect.ts
@@ -1,5 +1,5 @@
 /**
- * Google Workspace provider-account OAuth connect routes (#203).
+ * Google Workspace provider-account OAuth connect routes.
  *
  * Mounted under `/v2/provider-accounts/connect/google`. Every route requires a human
  * session (session-jwt) with MFA verified within five minutes AND workspace

--- a/packages/api/src/routes/provider-x-connect.ts
+++ b/packages/api/src/routes/provider-x-connect.ts
@@ -1,5 +1,5 @@
 /**
- * Provider-account X (Twitter) OAuth connect routes (issue #195 workstream A).
+ * Provider-account X (Twitter) OAuth connect routes.
  *
  * Mounted under `/v2/provider-accounts/connect/x`. Every route requires a human
  * session (session-jwt) AND workspace admin/approver authority (or tenant

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -4214,10 +4214,8 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
 
       // Compute the replay digest inside a guarded block. The shared normalizer
       // throws ExecutionPayloadNormalizationError on any malformed numeric caller
-      // field (e.g. an unsafe-integer nonce). Previously this threw BEFORE the
-      // failClosed helper and the outer catch only handles GovernedVaultError, so
-      // signing was prevented but no specific rejection audit was produced. We now
-      // convert it into the same fail-closed 409 path with a specific reason.
+      // field (e.g. an unsafe-integer nonce). Convert it into the audited,
+      // fail-closed 409 path with a specific reason.
       let approvalExecutionPayloadDigest: string | null = null;
       let approvalExecutionTarget: Awaited<ReturnType<typeof vault.resolveExecutionTarget>> = {
         backend: "local-vault",

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -671,7 +671,7 @@ export async function getTransactionStats(agentId: string, chainId?: number) {
   // Spend caps for native value are denominated in a single chain's base unit
   // (wei for EVM, lamports/SPL base units for Solana). The `value` column holds
   // raw per-chain base units, so summing across chains and re-pricing the total
-  // at one chain's native price corrupts the cap (issue #110). When a chainId is
+  // at one chain's native price corrupts the cap. When a chainId is
   // supplied, scope the spend aggregates to that chain so the counters stay in a
   // single consistent unit. When omitted, the fragment is empty and the result
   // is byte-for-byte the prior cross-chain sum (used by display-only callers).

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -569,7 +569,7 @@ export class ProviderAuthorityStore {
   }
 
   /**
-   * Provider-account CONNECT authority (issue #195 workstream A): a caller may
+   * Provider-account connect authority: a caller may
    * initiate/complete/disconnect an X (or other provider) OAuth connection when
    * they are a tenant authority admin OR hold an active workspace_admin /
    * workspace_approver binding for the target workspace (environment + temporal

--- a/packages/api/src/services/provider-google-connect.ts
+++ b/packages/api/src/services/provider-google-connect.ts
@@ -1,5 +1,5 @@
 /**
- * Google Workspace provider-account OAuth connect + token lifecycle (#203).
+ * Google Workspace provider-account OAuth connect + token lifecycle.
  *
  * This is the PROVIDER-CONNECTION plane (agent execution authority), NOT the
  * user sign-in plane. A user-login OAuth provider authenticates a human; this

--- a/packages/api/src/services/webhook-dispatch.ts
+++ b/packages/api/src/services/webhook-dispatch.ts
@@ -29,8 +29,8 @@ export function dispatchWebhook(
   data: Record<string, unknown>,
 ): void {
   const configuredType = toConfiguredWebhookEventType(type);
-  // EMISSION-PATH WIDENING (Phase 2b): a plugin-declared event is one that is NOT
-  // a core configured/alias type but IS present in the runtime
+  // A plugin-declared event is not a core configured/alias type but is present
+  // in the runtime
   // WebhookEventRegistry (core ∪ plugin-declared) because the plugin host merged
   // it in. We thread the raw plugin event name into the configured fan-out so a
   // tenant can subscribe to a plugin event specifically (events: ["plugin.evt"]).

--- a/packages/db/src/plugin-migrate.ts
+++ b/packages/db/src/plugin-migrate.ts
@@ -1,7 +1,7 @@
 /**
  * plugin-migrate.ts — plugin-owned database migrations with NAMESPACED journals.
  *
- * WHY THIS EXISTS (Phase 2c)
+ * PLUGIN MIGRATION OWNERSHIP
  * --------------------------
  * a steward plugin (e.g. trading) may own tables the lean core does not know
  * about. it declares its schema via a {@link PluginMigrationSource}: its OWN

--- a/packages/eliza-plugin/CHANGELOG.md
+++ b/packages/eliza-plugin/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 - Fail closed on non-JSON provider-action arguments, sanitize lifecycle failures, and keep concurrent polling results bound to their original action IDs.
 - Reject nested password, passphrase, auth, client-secret-value, and cookie-header fields through the shared credential-key classifier before provider submission.
+- Refresh action descriptions and source comments to describe the current leverage-policy, native-transfer, plugin-composition, and trust contracts without changing execution behavior.
 
 ### Docs
 - Make the opt-in live integration suite (`STEWARD_LIVE_TESTS=1`) target env-configurable (`STEWARD_URL` / `STEWARD_API_KEY` / `STEWARD_TENANT_ID`) with self-host defaults (`http://localhost:3200`, `my-app`) instead of a hardcoded hosted `api.steward.fi` URL and production tenant/key. Steward is self-host-first today; there is no shared hosted API. Test-fixture only, no runtime change.

--- a/packages/eliza-plugin/src/actions/submit-trade.ts
+++ b/packages/eliza-plugin/src/actions/submit-trade.ts
@@ -400,7 +400,7 @@ export const submitTradeAction: Action = {
     },
     {
       name: "leverage",
-      description: "Order leverage, max 2x by Phase 1 policy",
+      description: "Order leverage, subject to the agent's leverage-cap policy",
       required: false,
       schema: { type: "number", default: DEFAULT_LEVERAGE },
     },

--- a/packages/eliza-plugin/src/actions/transfer.ts
+++ b/packages/eliza-plugin/src/actions/transfer.ts
@@ -32,8 +32,8 @@ const MAX_UINT256 = (1n << 256n) - 1n;
 
 /**
  * Parse a human-readable amount like "0.1 ETH" or "50 USDC" into wei.
- * Handles native token amounts (ETH/BNB); ERC-20 transfers are not accepted by
- * this action.
+ * Handles native-currency amounts for the supported EVM chains; ERC-20 transfers
+ * are not accepted by this action.
  */
 function parseAmount(amountStr: string): { valueWei: string; symbol: string | null } {
   const cleaned = amountStr.trim();

--- a/packages/eliza-plugin/src/actions/transfer.ts
+++ b/packages/eliza-plugin/src/actions/transfer.ts
@@ -32,8 +32,8 @@ const MAX_UINT256 = (1n << 256n) - 1n;
 
 /**
  * Parse a human-readable amount like "0.1 ETH" or "50 USDC" into wei.
- * For now we only handle native token amounts (ETH/BNB).
- * ERC-20 transfers would need contract interaction — future work.
+ * Handles native token amounts (ETH/BNB); ERC-20 transfers are not accepted by
+ * this action.
  */
 function parseAmount(amountStr: string): { valueWei: string; symbol: string | null } {
   const cleaned = amountStr.trim();

--- a/packages/eliza-plugin/src/services/StewardService.ts
+++ b/packages/eliza-plugin/src/services/StewardService.ts
@@ -174,9 +174,8 @@ export class StewardService extends Service {
       agentId: settings.agentId ?? env.STEWARD_AGENT_ID ?? runtimeState.agentId ?? "default",
       tenantId: settings.tenantId ?? env.STEWARD_TENANT_ID,
       autoRegister: settings.autoRegister ?? env.STEWARD_AUTO_REGISTER !== "false",
-      // `fallbackLocal` only gates a single informational log line (see connect()):
-      // it does not itself create or expose a local signing key, so the
-      // historical default of `true` is inert and left as-is.
+      // `fallbackLocal` only gates a single informational log line (see connect());
+      // it does not create or expose a local signing key.
       fallbackLocal: settings.fallbackLocal ?? env.STEWARD_FALLBACK_LOCAL !== "false",
     };
   }

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -133,8 +133,10 @@ to require eligible human sessions and recent MFA, with case and evidence
 further limited to owner/admin. The agent-readable route does not weaken or
 stand in for any of those human gates.
 
-These tools **do not implement MCP OAuth 2.1 resource-server semantics**. That
-separate authorization-layer work is tracked by issue #219.
+These tools **do not implement MCP OAuth 2.1 resource-server semantics**. They
+authenticate through Steward's configured API credential and tenant boundary;
+deployments that require an OAuth resource server must place one in front of
+this transport.
 
 ## Development
 

--- a/packages/plugin-capabilities/src/context.ts
+++ b/packages/plugin-capabilities/src/context.ts
@@ -11,7 +11,7 @@
  *
  * this shape mirrors `@stwd/api`'s `StewardAppContext` (identical to
  * `@stwd/plugin-trading`'s), so the context the core BUILDS (`buildPluginContext()`)
- * is assignable to it at the W-1c composition root. every member is typed against
+ * is assignable to it at the composition root. every member is typed against
  * the underlying `@stwd/*` package types, never `@stwd/api`.
  */
 

--- a/packages/plugin-capabilities/src/index.ts
+++ b/packages/plugin-capabilities/src/index.ts
@@ -9,17 +9,15 @@
  * credential outbound. the plugin NEVER decrypts a secret and NEVER injects a
  * credential itself; it maintains the route rows the proxy matches.
  *
- * this package uses the shipped plugin SDK contribution points:
- *   - migrations (2c): plugin-owned, namespaced-journal `capabilities` +
+ * this package uses the plugin SDK contribution points:
+ *   - migrations: plugin-owned, namespaced-journal `capabilities` +
  *     `capability_grants` tables (isolated from the core migration ledger).
- *   - routes (2a register): operator/tenant-auth capability + grant CRUD, plus
- *     the agent-scoped "what may this agent use" read.
- *   - webhookEvents (2a): the events THIS package emits at CRUD time.
- *
- * SCOPE (W-1a): schema + CRUD + grants + paired-route lifecycle ONLY. there is
- * NO policy evaluation and NO invoke/forward path here (those are W-1b / W-1c).
- * the package builds + tests STANDALONE and is NOT registered in the api
- * composition root yet (that wiring is W-1c's job).
+ *   - routes: operator capability/grant CRUD and agent-scoped manifest, token,
+ *     OpenAI-compatible, and invoke surfaces.
+ *   - policyRules: the fail-closed capability-intent evaluator.
+ *   - webhookEvents: CRUD and invoke outcome events emitted by this package.
+ * The deploy composition root registers this plugin only when capabilities are
+ * enabled.
  *
  * the core never imports this package, and this package never imports `@stwd/api`:
  * the shared service singletons + auth middleware the routes need are INJECTED via
@@ -108,15 +106,12 @@ export type StewardApiPlugin = StewardPlugin<StewardApp, StewardAppContext>;
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("../drizzle", import.meta.url));
 
 /**
- * Webhook event-type names this package emits (Phase 2a contribution). Only the
- * CRUD lifecycle events W-1a produces are declared here; the invoke-time events
- * (capability.invoked / .denied / .approval_queued) are declared by W-1c, the
- * package that emits them.
+ * Webhook event-type names emitted by this package across CRUD and invoke
+ * outcomes. The plugin host registers the complete set before route dispatch.
  */
 export const CAPABILITY_WEBHOOK_EVENTS = [
   "capability.created",
   "capability.revoked",
-  // invoke-time events (W-1c). declared by THIS package because it emits them.
   "capability.invoked",
   "capability.denied",
   "capability.approval_queued",
@@ -131,16 +126,15 @@ export const CAPABILITY_WEBHOOK_EVENTS = [
  *   2. mounts the capability + grant CRUD router at /capabilities and /v1/capabilities.
  *   3. mounts the agent-scoped "usable capabilities" read at /agents and /v1/agents.
  *
- * NOTE: this plugin is NOT registered in the api composition root during W-1a; it
- * is verified STANDALONE (its own tests register it onto a bare hono app with an
- * injected context). the composition-root registration (compose.ts) is W-1c.
+ * The API composition root registers this plugin when the capabilities feature
+ * is enabled and injects the core context without a package dependency cycle.
  */
 export const capabilitiesPlugin: StewardApiPlugin = {
   name: "capabilities",
   version: "0.1.0",
   webhookEvents: CAPABILITY_WEBHOOK_EVENTS,
-  // the `capability-intent` policy rule (W-1b, shipped in @stwd/policy-engine as a
-  // PolicyRuleContribution). the plugin host registers it into the policy-engine
+  // The `capability-intent` PolicyRuleContribution is owned by
+  // @stwd/policy-engine. The plugin host registers it into the policy-engine
   // evaluator registry BEFORE any route runs, so the engine can evaluate a
   // capability-intent rule (via the registry's default arm) instead of denying it
   // as an unknown type. the invoke path (invoke.ts) still owns the effective

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -1,5 +1,5 @@
 /**
- * invoke.ts - the AGENT-FACING capability invoke path (W-1c).
+ * invoke.ts - the agent-facing capability invoke path.
  *
  * POST /capabilities/:name/invoke  { args?, body?, query? }
  * POST /capabilities/:name/openai/v1/chat/completions  <OpenAI chat body>
@@ -333,7 +333,7 @@ async function recordAndJson(
 }
 
 /**
- * Shared capability invoke core. This preserves the W-1c invariants for both the
+ * Shared capability invoke core. This preserves the invoke invariants for both the
  * envelope invoke route and the OpenAI-compatible adapter: resolve enabled
  * capability + active grant, count invocations, default-deny capability-intent
  * policy, approval 202, proxy env 503, server-side proxy signing, and exactly one

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -164,7 +164,7 @@ async function capabilityMapsToGovernedRoute(
 ): Promise<boolean> {
   const { and, eq, gt, isNull, or } = await import("drizzle-orm");
   const now = new Date();
-  // Mirror the proxy's route SELECTION (codex P2): only ENABLED governed routes
+  // Mirror the proxy's route selection: only ENABLED governed routes
   // whose backing secret is currently active (not deleted, not expired) can ever
   // be selected by the proxy, so only those should gate the plugin. A disabled
   // governed route or one backed by a deleted/expired secret is unselectable and
@@ -447,7 +447,7 @@ export async function invokeCapabilityThroughProxy(
   try {
     await engine.evaluate(capRules, evaluatorCtx);
 
-    // CANONICAL PRECEDENCE (master-plan §5.3): the policy-engine helper composes
+    // CANONICAL PRECEDENCE: the policy-engine helper composes
     // ALL enabled capability-intent rules in the one true order — hard deny
     // (incl. malformed config / failed hard constraint) > approval_required >
     // allow > default-deny. This is the single source of truth: an applicable

--- a/packages/plugin-capabilities/src/routes.ts
+++ b/packages/plugin-capabilities/src/routes.ts
@@ -3,7 +3,7 @@
  *
  * these are the OPERATOR-facing management routes (create/list/read/update/delete
  * a capability, grant/revoke, and "what may an agent use"). the agent-facing
- * invoke route is W-1c and is NOT here. mounted by the plugin's `register` behind
+ * invoke route lives in invoke.ts. These routes are mounted by `register` behind
  * the tenant gate (see index.ts), and each mutation additionally requires a
  * recent tenant-admin MFA verification - the SAME bar the core /secrets + route
  * CRUD requires, because capabilities drive live credential injection.
@@ -479,7 +479,7 @@ export function createCapabilityRoutes(ctx: StewardAppContext): Hono<{ Variables
 
 /**
  * The agent-scoped read: what capabilities an agent may USE (active, unexpired
- * grants to enabled capabilities). This is what the W-1c invoke path consults. It
+ * grants to enabled capabilities). This is what the invoke path consults. It
  * is a SEPARATE router mounted under a different prefix (/agents) - see index.ts.
  * Never returns a secret value.
  */

--- a/packages/plugin-capabilities/src/schema.ts
+++ b/packages/plugin-capabilities/src/schema.ts
@@ -15,7 +15,7 @@
  * a grant is: agent X may use capability Y (optionally until expiresAt). the
  * grant carries the id of its paired secret_route (per-GRANT pairing - the proxy
  * matches secret_routes by exact agentId, and capabilities are tenant-wide with
- * per-agent grants, so a route materializes once per grant; see PR / index.ts).
+ * per-agent grants, so a route materializes once per grant; see index.ts).
  */
 
 import { relations, sql } from "drizzle-orm";
@@ -96,7 +96,7 @@ export const capabilityGrants = pgTable(
 
 /**
  * capability_invocations - the append-only audit + rate-limit source for the
- * agent invoke path (W-1c). EVERY invoke attempt records exactly one row with its
+ * agent invoke path. EVERY invoke attempt records exactly one row with its
  * terminal decision (allow / deny / approval / error), regardless of outcome:
  *   - it is the audit trail (who invoked what, and how it was decided),
  *   - it is the source of the trailing-hour invoke count the `capability-intent`

--- a/packages/plugin-capabilities/src/store.ts
+++ b/packages/plugin-capabilities/src/store.ts
@@ -424,7 +424,7 @@ export class CapabilityStore {
 
   /**
    * The capabilities an agent may USE right now: an ACTIVE, unexpired grant to an
-   * ENABLED capability. This is what the W-1c invoke path will consult. Expired
+   * ENABLED capability. This is what the invoke path consults. Expired
    * or revoked grants, and disabled capabilities, are excluded (fail-closed).
    */
   async listUsableCapabilitiesForAgent(

--- a/packages/plugin-capabilities/src/validate.ts
+++ b/packages/plugin-capabilities/src/validate.ts
@@ -27,7 +27,7 @@ import type { CapabilitySpec } from "./store";
 const CAPABILITY_NAME = /^[a-z0-9]+([-][a-z0-9]+)*(\.[a-z0-9]+([-][a-z0-9]+)*)*$/;
 const MAX_CAPABILITY_NAME_LENGTH = 200;
 
-/** v1 constraints bag: intentionally small + opaque; the policy layer (W-1b) reads it. */
+/** v1 constraints bag: intentionally small and opaque; the policy layer reads it. */
 const constraintsSchema = z.record(z.string(), z.unknown());
 
 /** create body: the full capability spec (all routing/inject fields required). */

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -6,7 +6,7 @@
  * a `capability-intent` rule governs whether an agent may INVOKE a named
  * capability (e.g. `github.pr.comment`) through Steward's capability layer. it
  * is the per-call-intent policy the credential plane leans on before delegating
- * to the proxy: the invoke route (W-1c) populates `ctx.capability` with the
+ * to the proxy: the invoke route populates `ctx.capability` with the
  * capability name/args/host/path/method, and this rule decides allow / deny /
  * require-approval, plus argument- and rate-constraints.
  *
@@ -15,10 +15,9 @@
  * it is authored AS a {@link PolicyRuleContribution} — the exact shape a plugin
  * registers via the provider-mode registry — so the capability plugin can register
  * it through the plugin host with ZERO rework. but the evaluator + config schema
- * + tests are a library export of `@stwd/policy-engine` (not a route, not a
- * package): W-1b ships the decision logic; the plugin package (W-1a) owns
- * registration; the invoke path (W-1c) owns wiring the context + the effective
- * default-deny (see the INVOKE-LAYER CONTRACT below).
+ * + tests are a library export of `@stwd/policy-engine` (not a route). The
+ * capability plugin owns registration; the invoke path owns context wiring and
+ * the effective default-deny (see the INVOKE-LAYER CONTRACT below).
  *
  * FAIL-CLOSED EVERYWHERE
  * ----------------------
@@ -37,12 +36,12 @@
  *    capabilities it governs; whether an UNGOVERNED capability is allowed is the
  *    invoke layer's default-deny decision, NOT this rule's.
  *
- * INVOKE-LAYER CONTRACT (what W-1c must implement)
- * ------------------------------------------------
+ * INVOKE-LAYER CONTRACT
+ * ---------------------
  * the engine composes all rules with all-must-pass semantics, and this rule
  * passes for any capability it does not name. that means "no rule allows this
  * capability" evaluates to PASS at the engine level. therefore the EFFECTIVE
- * DEFAULT-DENY must live in the INVOKE LAYER (W-1c):
+ * DEFAULT-DENY lives in the invoke layer:
  *   1. resolve the grant fail-closed; if no grant, deny before policy runs.
  *   2. after the engine's decision, REQUIRE that at least one `capability-intent`
  *      rule MATCHED the invoked capability with `effect: "allow"` (and passed).
@@ -102,7 +101,7 @@ export function estimateXPostMicros(hasUrl: boolean): number {
 /** The effect a matching `capability-intent` rule applies. */
 export type CapabilityIntentEffect = "allow" | "deny" | "require-approval";
 
-// ─── Cumulative spend caps (#206, Privy aggregate-limit parity) ───────────────
+// ─── Cumulative spend caps ───────────────────────────────────────────────────
 //
 // A `cumulativeSpend` constraint bounds the TOTAL money an agent may move through
 // a capability over a trailing time window - the canonical agentic-wallet
@@ -219,17 +218,17 @@ export interface CapabilityIntentConstraints {
   /**
    * Max capability INVOKES per trailing hour. Evaluated against
    * `ctx.capabilityInvokeCount1h` (NOT the tx counter). If this is set but the
-   * count is absent, the rule DENIES (fail closed) — the invoke layer (W-1c)
+   * count is absent, the rule DENIES (fail closed) — the invoke layer
    * must wire the count.
    *
-   * BACKWARD COMPAT (#206): this remains the hardcoded-1h count cap and keeps
-   * working unchanged. For a configurable window use {@link maxCalls} +
+   * This is the fixed one-hour count cap. For a configurable window use
+   * {@link maxCalls} +
    * {@link callWindow}. `maxCallsPerHour` and `maxCalls` are mutually exclusive
    * (both set => config error) so there is exactly one count cap per rule.
    */
   readonly maxCallsPerHour?: number;
   /**
-   * Configurable count cap (#206): max capability invokes over the trailing
+   * Configurable count cap: max capability invokes over the trailing
    * window {@link callWindow}. Evaluated against the invoke-count the invoke
    * layer supplies for THAT window; absent count => DENY (fail closed, same as
    * `maxCallsPerHour`). Requires {@link callWindow}. Mutually exclusive with
@@ -243,7 +242,7 @@ export interface CapabilityIntentConstraints {
    */
   readonly callWindow?: string;
   /**
-   * Cumulative (aggregate) spend cap over a trailing window (#206). Evaluated
+   * Cumulative (aggregate) spend cap over a trailing window. Evaluated
    * against the trailing-window spend sum the invoke layer supplies for the
    * configured {@link CumulativeSpendConstraint.aggregateOver} scope; absent
    * aggregate => DENY (fail closed). See {@link CumulativeSpendConstraint}.
@@ -865,7 +864,7 @@ function parseConfig(rawInput: unknown): CapabilityIntentConfig | { error: strin
       }
     }
 
-    // Configurable count cap (#206): maxCalls + callWindow. Mutually exclusive
+    // Configurable count cap: maxCalls + callWindow. Mutually exclusive
     // with maxCallsPerHour so there is exactly one count cap per rule (avoid an
     // ambiguous two-window count gate). Both require the other.
     if (c.maxCalls !== undefined || c.callWindow !== undefined) {
@@ -894,7 +893,7 @@ function parseConfig(rawInput: unknown): CapabilityIntentConfig | { error: strin
       }
     }
 
-    // Cumulative spend cap (#206).
+    // Cumulative spend cap.
     if (c.cumulativeSpend !== undefined) {
       const cs = c.cumulativeSpend;
       if (!isPlainObject(cs)) {
@@ -1153,7 +1152,7 @@ function evaluateConstraints(
     }
   }
 
-  // Configurable count cap + cumulativeSpend (#206) are evaluated ONLY on the
+  // Configurable count cap + cumulativeSpend are evaluated ONLY on the
   // provider-action plane (composeProviderActionPolicyDecision), which wires the
   // windowed count + spend aggregate + operation spend declaration. The legacy
   // EvaluatorContext (tx-sign path) carries none of those signals, so a rule
@@ -1452,7 +1451,7 @@ export function composeCapabilityIntentDecision(
 
 /**
  * The `capability-intent` rule as a {@link PolicyRuleContribution}, ready for the
- * W-1a plugin to register via the plugin host with zero rework. Bound to the
+ * capability plugin to register via the plugin host. Bound to the
  * policy engine's {@link EvaluatorContext}.
  */
 export const capabilityIntentContribution: PolicyRuleContribution<EvaluatorContext> = {
@@ -1497,7 +1496,7 @@ export const PROVIDER_POLICY_REASON = {
   X_RATE_CAP_EXCEEDED: "POLICY_X_RATE_CAP_EXCEEDED",
   X_SPEND_CAP_EXCEEDED: "POLICY_X_SPEND_CAP_EXCEEDED",
   X_QUIET_HOURS: "POLICY_X_QUIET_HOURS",
-  // Cumulative-spend cap reason codes (#206). Bounded, stable set (no unbounded
+  // Cumulative-spend cap reason codes. Bounded, stable set (no unbounded
   // labels): one for the breach, one for a missing declared spend field, one for
   // a currency mismatch. Missing aggregate context reuses INPUT_UNAVAILABLE and a
   // malformed config reuses CONFIGURATION_INVALID (the house allowlist already
@@ -1525,7 +1524,7 @@ export interface ProviderPolicyContext {
    *  unavailable => fail closed (hard_deny, POLICY_INPUT_UNAVAILABLE). */
   readonly invokeCount1h?: number;
   /**
-   * Authoritative invoke counts for configurable count caps (#206), keyed by the
+   * Authoritative invoke counts for configurable count caps, keyed by the
    * per-cap bucket key ({@link windowedInvokeBucketKey}: window+max). Two
    * `maxCalls` rules with DIFFERENT windows each read their OWN count, so a daily
    * cap can never be evaluated against an hourly count (codex P2). A missing
@@ -1571,7 +1570,7 @@ export interface ProviderPolicyContext {
     readonly textCodePointLength?: number;
   };
   /**
-   * The operation's DECLARED spend field (#206). The operation - not the caller
+   * The operation's DECLARED spend field. The operation - not the caller
    * - declares which validated `policyArgs` field carries the per-invoke spend
    * amount and what currency it is denominated in. The composer reads the amount
    * ONLY from `args[spendDeclaration.field]` (validated scalars, never raw JSON).
@@ -1589,7 +1588,7 @@ export interface ProviderPolicyContext {
     readonly currency: string;
   };
   /**
-   * Authoritative trailing-window spend aggregates (#206), keyed by a stable
+   * Authoritative trailing-window spend aggregates, keyed by a stable
    * per-cap BUCKET key (see {@link cumulativeSpendBucketKey}). Each entry is the
    * ALREADY-COMMITTED (or reserved-and-committed) integer minor-unit sum over the
    * rule's trailing window for that exact cap, in the operation's currency. The
@@ -1668,7 +1667,7 @@ export interface ProviderPolicyRule {
  * default-deny. Never throws for a policy reason: an unexpected internal error
  * becomes hard_deny/POLICY_EVALUATOR_ERROR.
  *
- * NAMING / COEXISTENCE WITH THE LEGACY-PLANE FIX (#187, merged on develop):
+ * NAMING / COEXISTENCE WITH THE LEGACY PLANE:
  * `composeCapabilityIntentDecision(rules, ctx)` (above) fixes the SAME
  * allow-over-approval precedence bug for the LEGACY invoke.ts plane, reusing
  * `ContributedPolicyRule`/`EvaluatorContext` and returning a
@@ -1892,7 +1891,7 @@ function evaluateProviderConstraints(
     if (count >= constraints.maxCallsPerHour) return PROVIDER_POLICY_REASON.HARD_DENY;
   }
 
-  // Configurable count cap (#206): maxCalls over the trailing callWindow. The
+  // Configurable count cap: maxCalls over the trailing callWindow. The
   // invoke layer supplies the count for THIS EXACT cap (window+max) via
   // ctx.windowedInvokeCounts, keyed by windowedInvokeBucketKey - so two maxCalls
   // rules with DIFFERENT windows each read their own count (codex P2). Absent =>
@@ -1915,7 +1914,7 @@ function evaluateProviderConstraints(
     if (count >= constraints.maxCalls) return PROVIDER_POLICY_REASON.HARD_DENY;
   }
 
-  // Cumulative spend cap (#206).
+  // Cumulative spend cap.
   if (constraints.cumulativeSpend !== undefined) {
     const csReason = evaluateCumulativeSpend(constraints.cumulativeSpend, ctx);
     if (csReason) return csReason;

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -326,8 +326,7 @@ function capabilityMatches(config: CapabilityIntentConfig, name: string): boolea
  * Recover ONLY the capability SELECTOR (the `capabilities` patterns) from an
  * otherwise-malformed rule config, WITHOUT validating the rest of the config.
  *
- * WHY THIS EXISTS (scope isolation, master-plan §5.3 / §"malformed-input
- * precedence applies to GOVERNING rules"):
+ * SCOPE-ISOLATION CONTRACT:
  *   malformed-input precedence must apply to the rules that GOVERN the requested
  *   capability. A rule whose selector is well-formed and demonstrably scoped to a
  *   DIFFERENT capability must not brick an unrelated invoke just because some
@@ -523,7 +522,7 @@ function timeWindowAllows(
  *   count is not fixed, so a spend WINDOW over them would be ambiguous (a money
  *   gate must never rest on an ambiguous window length).
  *
- * OVER-RETENTION REJECTED (codex P1): a window longer than the aggregate store's
+ * OVER-RETENTION REJECTED: a window longer than the aggregate store's
  * retention ({@link MAX_AGGREGATE_WINDOW_SECONDS}, 30d) would SILENTLY under-
  * enforce - entries older than retention are pruned, so a `P90D` cap would
  * behave like a 30d cap and let spend from days 31-90 slip. We reject such a
@@ -816,7 +815,7 @@ function parseConfig(rawInput: unknown): CapabilityIntentConfig | { error: strin
   // `github.*.delete`, `*.delete`, `git*hub`) would be treated by
   // `patternMatches` as an exact literal that can never match, silently making
   // a deny/require-approval rule inert. Reject it at parse so the misconfig
-  // denies instead of passing (codex P2).
+  // denies instead of passing.
   const badPattern = (capabilities as string[]).find(
     (p) => p.includes("*") && !(p.endsWith(".*") && !p.slice(0, -2).includes("*")),
   );
@@ -843,7 +842,7 @@ function parseConfig(rawInput: unknown): CapabilityIntentConfig | { error: strin
     const c = raw.constraints as Record<string, unknown>;
 
     // FAIL CLOSED on unknown constraint keys: a typo like `maxCallPerHour` must
-    // deny, not silently drop the rate cap on an `allow` rule (codex P2).
+    // deny, not silently drop the rate cap on an `allow` rule.
     const unknownConstraint = Object.keys(c).filter((k) => !ALLOWED_CONSTRAINT_KEYS.has(k));
     if (unknownConstraint.length > 0) {
       return {
@@ -1288,7 +1287,7 @@ export function evaluateCapabilityIntent(
  *   4. else any matching passing `allow` => ALLOW
  *   5. else (no governing rule matched/passed) => HARD DENY / no governing allow
  *
- * MALFORMED-INPUT PRECEDENCE IS SCOPED TO GOVERNING RULES (master-plan §5.3).
+ * MALFORMED-INPUT PRECEDENCE IS SCOPED TO GOVERNING RULES.
  * A malformed rule config does NOT automatically brick every invoke: if the
  * rule's `capabilities` SELECTOR is well-formed and provably scoped to a
  * DIFFERENT capability, the rule is not governing this request and stays inert
@@ -1351,7 +1350,7 @@ export function composeCapabilityIntentDecision(
     try {
       // Parse the config. A malformed/unknown config CANNOT simply hard-deny
       // every invoke: malformed-input precedence applies to GOVERNING rules only
-      // (master-plan §5.3). A rule scoped (by a well-formed selector) to a
+      // A rule scoped (by a well-formed selector) to a
       // DIFFERENT capability is not governing this request and must stay inert
       // even if the rest of its config is broken. But if the selector itself is
       // unrecoverable, we cannot prove the rule is non-governing, so fail closed.
@@ -1527,7 +1526,7 @@ export interface ProviderPolicyContext {
    * Authoritative invoke counts for configurable count caps, keyed by the
    * per-cap bucket key ({@link windowedInvokeBucketKey}: window+max). Two
    * `maxCalls` rules with DIFFERENT windows each read their OWN count, so a daily
-   * cap can never be evaluated against an hourly count (codex P2). A missing
+   * cap can never be evaluated against an hourly count. A missing
    * entry for a rule's bucket => fail closed (POLICY_INPUT_UNAVAILABLE). Kept
    * separate from `invokeCount1h` so the hardcoded-hour cap and the configurable
    * caps never borrow each other's counter.
@@ -1597,7 +1596,7 @@ export interface ProviderPolicyContext {
    * Keying by the FULL cap identity (scope + window + max + currency), NOT just
    * the scope, lets two rules that share a scope but declare DIFFERENT windows /
    * caps each read their OWN trailing-window sum - they never share a bucket, so
-   * the same invoke is never double-counted across distinct caps (codex P2).
+   * the same invoke is never double-counted across distinct caps.
    *
    * A missing entry for a rule's bucket => the aggregate is not wired for that
    * cap => DENY (POLICY_INPUT_UNAVAILABLE). Steward never assumes a zero prior
@@ -1712,7 +1711,7 @@ export function composeProviderActionPolicyDecision(
       if ("error" in parsed) {
         // SEC-181: malformed-input precedence is scoped to GOVERNING rules,
         // matching the legacy-plane composer (composeCapabilityIntentDecision)
-        // and master-plan §5.3. A well-formed selector provably scoped to a
+        // and the legacy-plane composer. A well-formed selector provably scoped to a
         // DIFFERENT operation stays inert even though the rest of the config
         // is broken; only a malformed rule that governs THIS operation, or
         // whose selector is unrecoverable (ambiguous scope), hard-denies.
@@ -1894,7 +1893,7 @@ function evaluateProviderConstraints(
   // Configurable count cap: maxCalls over the trailing callWindow. The
   // invoke layer supplies the count for THIS EXACT cap (window+max) via
   // ctx.windowedInvokeCounts, keyed by windowedInvokeBucketKey - so two maxCalls
-  // rules with DIFFERENT windows each read their own count (codex P2). Absent =>
+  // rules with DIFFERENT windows each read their own count. Absent =>
   // fail closed (same discipline as maxCallsPerHour). A malformed callWindow is
   // rejected at store time, but re-validate at runtime so a hand-edited row
   // cannot slip an unbounded window past the gate.

--- a/packages/policy-engine/src/engine.ts
+++ b/packages/policy-engine/src/engine.ts
@@ -55,11 +55,11 @@ export interface PolicyEvaluationContext {
   priceOracle?: PriceOracle;
   /** Optional reputation score for reputation-based policies */
   reputationScore?: number;
-  /** Sprint 4: trading venue (for `venue-allowlist`). */
+  /** Trading venue for `venue-allowlist`. */
   venue?: string;
-  /** Sprint 4: requested leverage multiple (for `leverage-cap`). */
+  /** Requested leverage multiple for `leverage-cap`. */
   leverage?: number;
-  /** Sprint 4: pre-computed USD value of the action. */
+  /** Pre-computed USD value of the action. */
   valueUsd?: number;
   /**
    * Privy-style condition set items keyed by conditionSetId. Callers load these
@@ -89,7 +89,7 @@ export interface PolicyEvaluationContext {
   };
   /**
    * Capability-invoke context for `capability-intent` policies. The capability
-   * invoke route (W-1c) wires this from the resolved capability; absent on
+   * invoke route wires this from the resolved capability; absent on
    * ordinary transaction signs, so capability policies stay inert on tx signing
    * (mirrors the `typedData` seam).
    */
@@ -102,7 +102,7 @@ export interface PolicyEvaluationContext {
   };
   /**
    * Trailing-hour capability-invoke count (distinct from `recentTxCount1h`). The
-   * invoke route (W-1c) wires this so `capability-intent`'s `maxCallsPerHour`
+   * invoke route wires this so `capability-intent`'s `maxCallsPerHour`
    * constraint can be enforced; absent => that constraint fails closed (deny).
    */
   capabilityInvokeCount1h?: number;
@@ -159,7 +159,7 @@ export type AuditHook = (event: PolicyEvaluatedEvent) => void | Promise<void>;
 
 export interface PolicyEngineOptions {
   /**
-   * Sprint 4: optional sink for `policy.evaluated` audit events. Trade-
+   * Optional sink for `policy.evaluated` audit events. Trade-
    * sessions wires this to the proxy audit log so every evaluation is
    * traceable to its inputs and verdict. Failures inside the hook are
    * swallowed so they don't block the trade — but counted on

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -295,13 +295,13 @@ export interface EvaluatorContext {
   /** Optional reputation score for reputation-based policies */
   reputationScore?: number;
   /**
-   * Sprint 4: trading venue the request is destined for. Required by the
+   * Trading venue the request is destined for. Required by the
    * `venue-allowlist` evaluator. Trade-sessions sets this from the venue
    * adapter dispatch step; non-trade signing requests leave it undefined.
    */
   venue?: string;
   /**
-   * Sprint 4: requested leverage multiple (e.g. 2 = 2x). Required by the
+   * Requested leverage multiple (e.g. 2 = 2x). Required by the
    * `leverage-cap` evaluator. Undefined for non-leveraged trades and for
    * spot transfers.
    */
@@ -336,7 +336,7 @@ export interface EvaluatorContext {
   };
   /**
    * Capability-invoke context for `capability-intent` policies. Populated ONLY
-   * by the capability invoke route (W-1c); absent on ordinary signing requests,
+   * by the capability invoke route; absent on ordinary signing requests,
    * so a `capability-intent` policy is "not applicable" (passes) when this is
    * undefined. Symmetry with `typedData`: capability policies cannot interfere
    * with transaction signing, and transaction policies cannot interfere with
@@ -354,7 +354,7 @@ export interface EvaluatorContext {
   /**
    * Rolling count of capability INVOKES in the trailing hour (distinct from
    * `recentTxCount1h`, which counts transaction signs). Populated ONLY by the
-   * capability invoke route (W-1c) alongside `capability`. When a
+   * capability invoke route alongside `capability`. When a
    * `capability-intent` rule sets `constraints.maxCallsPerHour` but this count
    * is absent, the rule FAILS CLOSED (deny) rather than borrowing the tx
    * counter, so an unwired invoke path can never silently pass a rate cap.
@@ -458,7 +458,7 @@ export async function evaluatePolicy(
     default: {
       // FALLTHROUGH FOR NON-CORE RULE TYPES ONLY. Every core type is handled by a
       // `case` above; control reaches here ONLY for a rule type the core does not
-      // own. Consult the plugin policy-rule registry (Phase 2b): if a plugin
+      // own. Consult the plugin policy-rule registry: if a plugin
       // registered an evaluator for this type, run it; otherwise preserve the
       // historical "Unknown policy type" deny. Core decisions are byte-identical
       // because no core type ever reaches this arm.

--- a/packages/policy-engine/src/evaluators/leverage-cap.ts
+++ b/packages/policy-engine/src/evaluators/leverage-cap.ts
@@ -1,4 +1,4 @@
-// Sprint 4: leverage-cap policy evaluator.
+// Leverage-cap policy evaluator.
 //
 // Caps requested leverage at config.maxLeverage. A request without an
 // explicit `leverage` field (spot transfer, non-leveraged perp) ALWAYS
@@ -7,8 +7,7 @@
 // leverage from the order payload; @stwd/agent-trader and direct sign
 // requests leave it undefined.
 //
-// Per-venue refinement (e.g. 2x on Hyperliquid, 5x on Drift) is Phase 2.
-// For now a single cap per agent is sufficient for Sol's $100/day MVP.
+// The configured cap applies to the agent across venues.
 
 import type { LeverageCapConfig, PolicyResult, PolicyRule } from "@stwd/shared";
 

--- a/packages/policy-engine/src/evaluators/venue-allowlist.ts
+++ b/packages/policy-engine/src/evaluators/venue-allowlist.ts
@@ -1,4 +1,4 @@
-// Sprint 4: venue-allowlist policy evaluator.
+// Venue-allowlist policy evaluator.
 //
 // Allows trades only on the named venues. Without a venue on the context
 // (i.e. non-trade signing requests), the policy NACKs by default: this

--- a/packages/policy-engine/src/policy-rule-registry.ts
+++ b/packages/policy-engine/src/policy-rule-registry.ts
@@ -10,8 +10,8 @@
  * owns its own rule type (e.g. a venue-specific gate) cannot have that type
  * evaluated: it falls into `default:` and is denied as "Unknown policy type".
  *
- * Phase 2b of the plugin SDK lets a plugin DECLARE a rule type + evaluator
- * (`StewardPlugin.policyRules`). the plugin host registers those evaluators HERE
+ * A plugin declares a rule type and evaluator through
+ * `StewardPlugin.policyRules`. the plugin host registers those evaluators HERE
  * at composition time. `evaluatePolicy`'s `default:` consults this registry BEFORE
  * returning "Unknown policy type": if a plugin registered an evaluator for the
  * rule's type, that evaluator runs; otherwise the deny is unchanged.
@@ -19,7 +19,7 @@
  * IMPORTANT — CORE BEHAVIOR IS UNTOUCHED. the 16 core `case` arms are not changed
  * in any way; the registry is consulted ONLY in the `default:` arm, i.e. ONLY for
  * a rule type that is not a core type. a core policy decision is byte-identical
- * before and after this phase. the registry can never shadow a core rule type:
+ * with or without plugin contributions. the registry can never shadow a core rule type:
  * registration FAILS CLOSED (throws) on a `type` that is a core type or that a
  * prior plugin already registered.
  *

--- a/packages/provider-x/src/index.ts
+++ b/packages/provider-x/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @stwd/provider-x — the X (Twitter) provider-action adapter.
  *
- * Owns the three workstream-B operation argument schemas (`x.tweet.create`,
+ * Owns the three operation argument schemas (`x.tweet.create`,
  * `x.tweet.delete`, `x.user.me.read`), their canonical action construction over
  * the shared `x.provider-action.v1` profile, the non-authoritative safe summary,
  * and the validated policy-context arguments. It imports the shared X

--- a/packages/provider-x/src/operations.ts
+++ b/packages/provider-x/src/operations.ts
@@ -1,9 +1,9 @@
 /**
  * operations.ts — X provider-action operation schemas + canonical action
- * construction (issue #195 workstream B).
+ * construction.
  *
  * This adapter owns method, origin, path construction, header selection, and
- * body shape for the three workstream-B operations. It validates operation
+ * body shape for the three supported operations. It validates operation
  * ARGUMENTS strictly (fail closed with stable CANON_* codes), builds a raw
  * internal HTTP representation, and runs it through the ONE shared X
  * canonicalizer (`canonicalizeRawInternalXAction`) so the action digest matches
@@ -266,8 +266,7 @@ function buildTweetCreate(rawArgs: unknown): XActionBuild {
   const textSha256 = `sha256:${createHash("sha256").update(Buffer.from(text, "utf8")).digest("hex")}`;
 
   // Safe summary mirrors the GitHub adapter: length + sha256 only, never any
-  // slice of the text. A preview was intentionally REMOVED (codex P2, #195
-  // workstream B): for short tweets a prefix preview equals the full body, which
+  // slice of the text. A preview would equal the full body for short tweets, which
   // would leak user content the summary is contractually forbidden to contain.
   const safeSummary: Record<string, unknown> = {
     operation: "x.tweet.create",

--- a/packages/provider-x/src/operations.ts
+++ b/packages/provider-x/src/operations.ts
@@ -162,7 +162,7 @@ function textHasUrl(text: string): boolean {
   // `contentPolicy.allowUrls:false` / URL-spend / URL-approval policy be BYPASSED
   // by a real bare domain on an uncommon TLD (e.g. `example.social`, `foo.shop`).
   // A false positive only denies/escalates a borderline post, which is the safe
-  // direction (codex P2, PR review). We therefore treat ANY `label.tld` token
+  // direction. We therefore treat ANY `label.tld` token
   // (tld = 2+ ASCII letters) with a path OR a plausible domain shape as a URL,
   // and EXCLUDE only a small deny-list of common English abbreviations that
   // appear as `word.word` in ordinary prose.

--- a/packages/proxy/scripts/governed-execution-mutation-proofs.sh
+++ b/packages/proxy/scripts/governed-execution-mutation-proofs.sh
@@ -219,7 +219,7 @@ proof "M16 governed dispatch back through replay guard (P30)" "packages/proxy" "
 proof "M17 accept mismatched claim routeRevision at gate (P32)" "packages/proxy" "$GOV_TEST" "direct claim whose route revision" "$PROXY" \
   's/governedClaim.routeRevision === routeRevision/true/'
 
-# M18: treat a claim that OMITS secretVersion as verified → P33 (codex P2: a
+# M18: treat a claim that OMITS secretVersion as verified → P33 (a
 #      partial claim without secretVersion would skip the decrypt-time version
 #      recheck, so it must NOT be verified at the gate). Drop the requirement.
 proof "M18 accept claim missing secretVersion at gate (P33)" "packages/proxy" "$GOV_TEST" "governed claim omits the secret version" "$PROXY" \
@@ -241,7 +241,7 @@ proof "M19 governed dispatch re-enters legacy approval hold (P34)" "packages/pro
 # drainBody calls is therefore equivalent for that fixture, not a valid mutation
 # proof, so this runner does not claim it.
 
-# M22: drop the live route↔operation binding check → P2 (codex): a governed route
+# M22: drop the live route↔operation binding check → P2: a governed route
 #      configured for operation A must not inject its credential for a nonce minted
 #      for a DIFFERENT operation B. provider_operations.secret_route_id is not
 #      unique and the authority_revision bump only catches a reconfiguration of the

--- a/packages/proxy/src/config.ts
+++ b/packages/proxy/src/config.ts
@@ -4,7 +4,7 @@
  * Aliases let agents use short names instead of full hostnames:
  *   /openai/v1/chat/completions → api.openai.com/v1/chat/completions
  *
- * Per-tenant aliases will be configurable via DB in a future release.
+ * This registry owns the fixed aliases accepted by the proxy.
  */
 
 export const DEFAULT_ALIASES: Record<string, string> = {

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -1378,11 +1378,11 @@ async function handleProxyWithReplayCompletion(
     | undefined;
   // Set once the governed claim is verified against the selected route; the
   // single-use v2 nonce it represents is the replay guard, so a verified governed
-  // dispatch skips the header-based Idempotency-Key claim below (codex P1).
+  // dispatch skips the header-based Idempotency-Key claim below.
   let isVerifiedGovernedDispatch = false;
   if (authorityMode !== "legacy") {
     // The claim must match the SELECTED route by id AND by the exact revision +
-    // secret binding it was minted against (codex P1). A rotated route/secret
+    // secret binding it was minted against. A rotated route/secret
     // after the claim (routeId unchanged) would otherwise decrypt with the CURRENT
     // credential; requiring the claimed authorityRevision + secretId here fails
     // closed on any such drift before the decrypt. The secret VERSION is
@@ -1398,7 +1398,7 @@ async function handleProxyWithReplayCompletion(
       governedClaim.routeRevision === routeRevision &&
       governedClaim.secretId !== undefined &&
       governedClaim.secretId === routeSecretId &&
-      // secretVersion is REQUIRED for a verified governed claim (codex P2): a
+      // secretVersion is REQUIRED for a verified governed claim: a
       // partial claim that omits it must NOT be treated as verified, otherwise the
       // decrypt-time version recheck below (guarded on secretVersion !== undefined)
       // would be skipped and a rotated secret could be decrypted. The live
@@ -1474,7 +1474,7 @@ async function handleProxyWithReplayCompletion(
     return c.json({ ok: false, error: "Approved proxy route no longer matches" }, 409);
   }
   if (route.requiresApproval && !approvalReleaseId && !isVerifiedGovernedDispatch) {
-    // NOTE: a verified governed dispatch is EXCLUDED here (codex P1). A governed
+    // NOTE: a verified governed dispatch is EXCLUDED here. A governed
     // route's approval was already adjudicated by the v2 authority flow (the
     // intent is approved + the binding is execution_ready before the nonce is
     // minted); it must NOT re-enter the legacy proxy-approval hold, which would
@@ -1731,7 +1731,7 @@ async function handleProxyWithReplayCompletion(
   // consumed by the claim) and an approval-release both carry their OWN replay
   // protection, so neither goes through the header Idempotency-Key claim. Without
   // this, mutating governed actions (POST/PUT/PATCH/DELETE) would 400 for a
-  // missing Idempotency-Key AFTER the nonce was already spent (codex P1) — the
+  // missing Idempotency-Key AFTER the nonce was already spent — the
   // provider-action header allowlist does not even permit that header.
   const replayClaim =
     approvalReleaseId || isVerifiedGovernedDispatch

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to `@stwd/react` are documented here.
 
 ### Docs
 - Point example `baseUrl` values in JSDoc (`StewardProvider`, `StewardLogin`) and the README at a self-hosted instance (`http://localhost:3200`) instead of a hosted `api.steward.fi` URL. Steward is self-host-first today; there is no shared hosted API. Docs/comment only, no source behavior change.
+- Describe the Solana provider's per-mount adapter isolation as a current runtime invariant instead of retaining review-history terminology. Comment only; no runtime or API change.
 
 ### Tests
 - Added test coverage for utilities (format, theme, walletPanelRegistry), context hooks (useAuth, useSteward), data hooks (useWallet, useTransactions, useApprovals, usePolicies, useSpend), and SSR branch coverage for the component surface (auth guard, user button, tenant picker, spend dashboard, approval queue, wallet overview, policy controls, email/OAuth callbacks, passkey enrollment). Suite goes from 56 to 195 passing. No source changes.

--- a/packages/react/src/providers/SolanaProvider.tsx
+++ b/packages/react/src/providers/SolanaProvider.tsx
@@ -96,7 +96,7 @@ export function SolanaWalletProvider({
   // Build a fresh adapter list per provider mount when no wallets prop
   // was passed. Sharing a single module-level array across mounts would
   // leak connection state between providers (the previous behavior was
-  // a P2 codex finding).
+  // a cross-mount isolation defect).
   const resolvedWallets = useMemo(() => wallets ?? createDefaultSolanaWallets(), [wallets]);
 
   return (

--- a/packages/redis/src/cumulative-spend-tracker.ts
+++ b/packages/redis/src/cumulative-spend-tracker.ts
@@ -1,7 +1,7 @@
 /**
  * Cumulative (aggregate) spend tracker with CONFIGURABLE trailing windows and
  * ATOMIC single-winner reservations - backs the policy-engine `cumulativeSpend`
- * capability-intent constraint (#206, Privy aggregate-limit parity).
+ * capability-intent aggregate-limit constraint.
  *
  * WHY A NEW TRACKER (vs spend-tracker.ts / aggregation-tracker.ts)
  * ---------------------------------------------------------------
@@ -11,7 +11,7 @@
  *   - `aggregation-tracker.ts` supports rolling windows but is READ-THEN-CHECK
  *     (record AFTER settle; the evaluator reads a snapshot). Two concurrent
  *     invokes can both read the same prior sum and both pass - unacceptable for a
- *     hard money cap (#206 req 4).
+ *     hard money cap.
  * This tracker combines both: a sorted-set rolling window (any windowSeconds) +
  * a single Lua script that prunes, sums, checks EACH cap's `sum + amount <= max`
  * over its own window, and only then appends the reservation - so concurrent
@@ -67,7 +67,7 @@ import { getRedis } from "./client.js";
 
 export type CumulativeSpendScope = "operation" | "agent" | "grant";
 
-/** Reserved currency tag for the #206 windowed invoke-count stream (never a real
+/** Reserved currency tag for the windowed invoke-count stream (never a real
  *  asset), so a count stream can never collide with a spend stream. */
 const WINDOWED_INVOKE_CURRENCY = "__calls__";
 
@@ -925,7 +925,7 @@ export async function getCumulativeSpendSum(
 }
 
 /**
- * #206 configurable count cap (maxCalls + callWindow): ATOMICALLY reserve ONE
+ * Configurable count cap (maxCalls + callWindow): ATOMICALLY reserve ONE
  * invoke against EVERY count window governing the operation. The invoke is added
  * to the operation-level `__calls__` stream EXACTLY ONCE (amount=1), and each
  * cap's window is checked atomically - so combining an hourly AND a daily cap

--- a/packages/redis/src/cumulative-spend-tracker.ts
+++ b/packages/redis/src/cumulative-spend-tracker.ts
@@ -17,7 +17,7 @@
  * over its own window, and only then appends the reservation - so concurrent
  * reservers can never collectively cross any cap (TOCTOU-free).
  *
- * STREAM KEY vs CAP THRESHOLDS (codex P1 fix)
+ * STREAM KEY vs CAP THRESHOLDS
  * -------------------------------------------
  * The Redis ZSET (the "spend stream") is keyed ONLY by the spend-stream identity
  * `(agentId, scope, scopeKey, currency)` - NOT by the cap's window/max. Editing a
@@ -25,7 +25,7 @@
  * accumulated history, never a fresh empty bucket. Cap thresholds are supplied as
  * check parameters per reserve, not baked into the key.
  *
- * MULTIPLE CAPS ON ONE STREAM (codex P2 fix)
+ * MULTIPLE CAPS ON ONE STREAM
  * ------------------------------------------
  * A single invoke that is governed by several caps on the same stream (e.g. a 1h
  * AND a 24h cap, or two rules) is reserved ONCE: the atomic script checks ALL
@@ -78,7 +78,7 @@ const MAX_LEGACY_BRIDGE_ENTRIES = 10_000;
 const LEGACY_BRIDGE_VERSION = "steward.cumulative-spend-bridge.v1";
 
 /** The spend-stream identity. Editing a cap does NOT change this key, so history
- *  persists across cap edits (codex P1). */
+ *  persists across cap edits. */
 export interface CumulativeSpendStream {
   /** Tenant namespace. New governed callers MUST supply it; omitted only for
    * legacy streams that predate tenant-bound keys. */
@@ -138,7 +138,7 @@ export function __setBeforeCumulativeSpendSumImportForTests(hook?: () => Promise
 
 function streamKey(s: CumulativeSpendStream): string {
   // scopeKey/currency are operator/adapter-derived tags; encode to keep the key
-  // delimiter-safe. Deliberately NO window/max in the key (codex P1): the stream
+  // delimiter-safe. Deliberately NO window/max in the key: the stream
   // identity is the spend history, not the current cap threshold.
   const enc = (v: string) => encodeURIComponent(v);
   if (s.tenantId) {
@@ -929,7 +929,7 @@ export async function getCumulativeSpendSum(
  * invoke against EVERY count window governing the operation. The invoke is added
  * to the operation-level `__calls__` stream EXACTLY ONCE (amount=1), and each
  * cap's window is checked atomically - so combining an hourly AND a daily cap
- * never double-counts a single invoke (codex P2), and concurrent invokes cannot
+ * never double-counts a single invoke, and concurrent invokes cannot
  * collectively exceed any cap (single-winner). Returns ok=false when ANY cap is
  * at its limit, plus the per-cap prior counts (same order as `caps`). Returns
  * { ok:false } on a Redis error (fail closed).

--- a/packages/seed/src/sol-default-policy.ts
+++ b/packages/seed/src/sol-default-policy.ts
@@ -1,16 +1,16 @@
-// Sprint 4 Phase 1 Day 3: default policy for the Sol agent.
+// Default policy for the Sol agent.
 //
 // Idempotent. Safe to call on every Steward dev-mode boot. In production
 // this should be invoked once by an operator runbook and then frozen;
 // the audit trail then captures any subsequent changes.
 //
-// The Phase 1 default is intentionally tight:
+// The default is intentionally tight:
 //   - spending-limit:   $100 / day in USD (price oracle does the math)
 //   - venue-allowlist:  ["hyperliquid"]   (no Polymarket / Drift yet)
 //   - leverage-cap:     2x                (Sol blows up small)
 //
-// Worker C wires policy reads into the `/v1/trade/*` route; the policy
-// engine then evaluates these rules against every order.
+// The `/v1/trade/*` routes load these policies and the policy engine evaluates
+// them against every order.
 //
 // Usage:
 //

--- a/packages/shared/scripts/generic-http-mutation-proofs.sh
+++ b/packages/shared/scripts/generic-http-mutation-proofs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# #201 generic-http profile mutation-strength proofs. Each mutation weakens ONE
+# Generic-http profile mutation-strength proofs. Each mutation weakens ONE
 # load-bearing security predicate of the generic-http descriptor validator /
 # canonicalizer; a proof is valid iff the named test PASSES clean AND FAILS after
 # the mutation. The file is restored after each proof (no .bak residue). Run from

--- a/packages/shared/src/client.ts
+++ b/packages/shared/src/client.ts
@@ -1,8 +1,8 @@
 /**
  * client.ts: the browser/worker-safe entrypoint for `@stwd/shared`.
  *
- * WHY THIS EXISTS (issue #231)
- * ----------------------------
+ * CLIENT-SAFE BOUNDARY
+ * --------------------
  * The top-level barrel (`index.ts`) re-exports server-only modules that import
  * `node:crypto` (`provider-execution-auth.ts`, `provider-action.ts`). Any web
  * bundle that imports the barrel, even for a pure helper like

--- a/packages/shared/src/generic-http-provider-action.ts
+++ b/packages/shared/src/generic-http-provider-action.ts
@@ -6,7 +6,7 @@
  * (provider-action.ts) and `x.provider-action.v1` (x-provider-action.ts). Where
  * those two hardcode a single origin/host and a fixed set of operations, this
  * profile lets an operator DECLARE a governed HTTP operation for an arbitrary
- * public HTTPS host via config only (issue #201): allowed origin, method
+ * public HTTPS host via config only: allowed origin, method
  * allowlist, a path template with TYPED named segments, typed allowlisted query
  * params, allowlisted (never-credential) request headers, and a strict body
  * schema. The descriptor drives argument validation the same way the github

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -44,7 +44,7 @@ export type {
   PolicyRuleContribution,
   StewardPlugin,
 } from "./types/plugin.js";
-// ─── Trading venues (Sprint 4) ───
+// ─── Trading venues ───
 export * from "./types/venue.js";
 // ─── Runtime-extensible webhook event registry (core ∪ plugin-declared) ───
 export { WebhookEventRegistry } from "./webhook-event-registry.js";
@@ -569,7 +569,7 @@ export interface RawSigningChainConditionConfig {
 }
 
 /**
- * `venue-allowlist` policy config (Sprint 4).
+ * `venue-allowlist` policy config.
  *
  * Allows trades only on the named venues. Evaluator NACKs if the eval
  * context's `venue` is absent or not in the list.
@@ -579,11 +579,11 @@ export interface VenueAllowlistConfig {
 }
 
 /**
- * `leverage-cap` policy config (Sprint 4).
+ * `leverage-cap` policy config.
  *
  * Caps requested leverage at `maxLeverage`. Non-leveraged trades (no
- * `leverage` in eval context) always pass. Per-venue refinement is
- * Phase 2 work; for now this is a single cap per agent.
+ * `leverage` in eval context) always pass. The cap applies per agent rather
+ * than varying by venue.
  */
 export interface LeverageCapConfig {
   maxLeverage: number;
@@ -634,10 +634,9 @@ export interface SignTypedDataRequest {
   agentId: string;
   tenantId: string;
   /**
-   * Sprint 4: optional venue scope. When set, vault.signTypedData will
-   * look up the venue-scoped wallet under (agentId, venue) instead of
-   * the legacy NULL-venue row. Phase 1 is hyperliquid-only; the field is
-   * accepted but not yet routed through the new lookup path.
+   * Optional venue scope. When set, Vault.signTypedData resolves the signing
+   * key by (tenantId, agentId, chainFamily, venue) and enforces that scope;
+   * otherwise it resolves the unscoped wallet.
    */
   venue?: VenueId;
   domain: TypedDataDomain;

--- a/packages/shared/src/provider-profile-registry.ts
+++ b/packages/shared/src/provider-profile-registry.ts
@@ -1,9 +1,8 @@
 /**
  * provider-profile-registry.ts - the versioned canonical-profile registry.
  *
- * Replaces the closed union `"github.provider-action.v1" | "x.provider-action.v1"`
- * (issue #201) with a code-side, fail-closed registry keyed by a stable profile
- * string. Every site that CONSUMES a canonical profile (store, eval, dispatch,
+ * This code-side, fail-closed registry is keyed by a stable profile string.
+ * Every site that CONSUMES a canonical profile (store, eval, dispatch,
  * approval binding, evidence) resolves it through {@link isRegisteredProfile} /
  * {@link assertRegisteredProfile}: an UNREGISTERED profile string is REJECTED
  * everywhere, never stored, never dispatched.

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -69,9 +69,9 @@ export interface ContributedPolicyResult {
  * evaluate a rule type the plugin owns (e.g. a venue-specific gate) WITHOUT the
  * core importing the plugin.
  *
- * WIRED in Phase 2b. The plugin host registers each contribution into the policy
- * engine's runtime evaluator registry (fail-closed on a `type` that collides with
- * a core rule type or another plugin's). When `evaluatePolicy` meets a rule whose
+ * The plugin host registers each contribution into the policy engine's runtime
+ * evaluator registry, fail-closed on a `type` that collides with a core rule type
+ * or another plugin's. When `evaluatePolicy` meets a rule whose
  * `type` is not one of the core cases, it consults the registry; the contributed
  * `evaluate` runs and its result is used. Core rule evaluation is untouched.
  *
@@ -104,9 +104,9 @@ export interface PolicyRuleContribution<Ctx = unknown> {
  * created when the plugin is enabled, WITHOUT the core owning the plugin's
  * schema.
  *
- * WIRED in Phase 2c. The host applies these via `@stwd/db`'s
- * `runPluginMigrations`, which runs the plugin's drizzle migrations into a
- * SEPARATE, PER-PLUGIN bookkeeping table derived from `id`
+ * The host applies these via `@stwd/db`'s `runPluginMigrations`, which runs the
+ * plugin's drizzle migrations into a SEPARATE, PER-PLUGIN bookkeeping table
+ * derived from `id`
  * (`__drizzle_migrations_plugin_<sanitized id>` in the `drizzle` schema). The
  * isolation guarantee is total: a plugin's applied-migrations ledger is NEVER
  * written into or read from the core's `drizzle.__drizzle_migrations` journal, so
@@ -141,8 +141,8 @@ export interface PluginMigrationSource {
  * (mirrors `packages/adapters` categories) so a plugin can supply a real
  * provider integration (a concrete swap/earn/onramp/.../exchange adapter).
  *
- * WIRED in Phase 2d. The host registers each contribution into the core's
- * {@link AdapterRegistry} via its existing `register(category, provider, adapter)`
+ * The host registers each contribution into the core's {@link AdapterRegistry}
+ * via its `register(category, provider, adapter)`
  * seam, in `dependsOn` order, FAIL-CLOSED on a `(category, provider)` collision
  * with another plugin's contribution (the host never silently overwrites a real
  * money-route adapter — see the host's conflict detection). The registry's own
@@ -199,9 +199,8 @@ export interface StewardPlugin<App = unknown, Ctx = unknown, EvalCtx = unknown> 
    * for shared services and auth gates. may be async (e.g. to lazily resolve a
    * provider). called once, at the composition root, after the core is built.
    *
-   * OPTIONAL as of Phase 2: a plugin may contribute ONLY declaratively (via the
-   * contribution points below) without mounting any route/middleware. the
-   * trading plugin still uses `register` for back-compat.
+   * Optional: a plugin may contribute only declaratively through the contribution
+   * points below without mounting routes or middleware.
    */
   register?(app: App, ctx: Ctx): void | Promise<void>;
 
@@ -213,14 +212,13 @@ export interface StewardPlugin<App = unknown, Ctx = unknown, EvalCtx = unknown> 
    * webhook dispatcher/config validation accepts a plugin's event without the
    * core's closed union having to know about it ahead of time.
    *
-   * WIRED in Phase 2a — this is the keystone contribution point proven
-   * end-to-end by the trading plugin.
+   * The plugin host registers these names before route dispatch.
    */
   readonly webhookEvents?: readonly string[];
 
   /**
-   * policy rules this plugin contributes. WIRED in Phase 2b: the host registers
-   * each into the policy engine's runtime evaluator registry (fail-closed on a
+   * policy rules this plugin contributes. The host registers each into the
+   * policy engine's runtime evaluator registry (fail-closed on a
    * `type` collision with a core rule type or another plugin's). The policy
    * engine then evaluates a rule of a contributed `type` via the contribution's
    * `evaluate`. `EvalCtx` is bound by the concrete app plugin type (in
@@ -229,8 +227,8 @@ export interface StewardPlugin<App = unknown, Ctx = unknown, EvalCtx = unknown> 
   readonly policyRules?: readonly PolicyRuleContribution<EvalCtx>[];
 
   /**
-   * database migrations this plugin contributes. WIRED in Phase 2c: the host
-   * applies these via `@stwd/db`'s `runPluginMigrations` into a per-plugin
+   * database migrations this plugin contributes. The host applies these via
+   * `@stwd/db`'s `runPluginMigrations` into a per-plugin
    * namespaced bookkeeping table (`__drizzle_migrations_plugin_<id>`), totally
    * isolated from the core's `drizzle.__drizzle_migrations` journal, AFTER core
    * migrations and in `dependsOn` order, at the boot/migrate step only.
@@ -238,8 +236,8 @@ export interface StewardPlugin<App = unknown, Ctx = unknown, EvalCtx = unknown> 
   readonly migrations?: PluginMigrationSource;
 
   /**
-   * adapter integrations this plugin contributes. WIRED in Phase 2d: the host
-   * registers each into the core's adapter registry via its existing
+   * adapter integrations this plugin contributes. The host registers each into
+   * the core's adapter registry via its
    * `register(category, provider, adapter)` seam, in `dependsOn` order,
    * FAIL-CLOSED on a `(category, provider)` collision with another plugin's
    * contribution (never silently overwrites a real money-route adapter). The

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -6,7 +6,8 @@
  * core never imports a plugin; a plugin contributes routes/middleware through the
  * register seam, so the majority of installs that only want the core never pull a
  * plugin's transitive dependencies (smaller install, smaller supply-chain and
- * audit surface). trading is the first such plugin.
+ * audit surface). the deployable composition root currently knows the trading,
+ * capabilities, and wxmr first-party plugins.
  *
  * `StewardPlugin` is intentionally generic and framework-agnostic here: it carries
  * no hono (or any http-framework) types so `@stwd/shared` keeps zero runtime deps.

--- a/packages/shared/src/types/venue.ts
+++ b/packages/shared/src/types/venue.ts
@@ -15,7 +15,7 @@
 // When adding a new venue:
 //   - Append to VENUE_IDS below.
 //   - Add a row to VENUE_METADATA with chainFamily + display name.
-//   - Worker A's adapter registry will pick it up automatically.
+//   - Register the venue in every adapter that supports it.
 
 export const VENUE_IDS = ["hyperliquid", "polymarket", "drift", "aevo", "gmx"] as const;
 
@@ -74,7 +74,7 @@ export const VENUE_METADATA: Record<VenueId, VenueMetadata> = {
   },
 };
 
-// ─── Sprint 4 Day 1-2 (Worker A): trade execution types ─────────────────────
+// ─── Trade execution types ──────────────────────────────────────────────────
 // TradeAsset is the asset enum that venue-hyperliquid + trade-sessions use.
 // Keep tight: only assets Steward will actively support for perps trading.
 

--- a/packages/shared/src/webhook-event-registry.ts
+++ b/packages/shared/src/webhook-event-registry.ts
@@ -11,8 +11,8 @@
  * cannot have that event accepted: the closed union rejects it at the type
  * level, and the config validator rejects it at runtime.
  *
- * Phase 2 of the plugin SDK lets a plugin DECLARE the event-type names it emits
- * (`StewardPlugin.webhookEvents`). the plugin host registers those names here at
+ * A plugin declares the event-type names it emits through
+ * `StewardPlugin.webhookEvents`. the plugin host registers those names here at
  * composition time, so the runtime set of valid event types becomes:
  *
  *     core event types  ∪  every enabled plugin's declared event types

--- a/packages/shared/src/x-provider-action.ts
+++ b/packages/shared/src/x-provider-action.ts
@@ -2,8 +2,7 @@
  * x-provider-action.ts — the `x.provider-action.v1` canonicalization profile.
  *
  * This module is the X (Twitter) sibling of the `github.provider-action.v1`
- * profile in provider-action.ts. It defines, for the governed-provider-authority
- * plan (issue #195 workstream B):
+ * profile in provider-action.ts. It defines:
  *   - the X canonical origin (`https://api.x.com`) + host allowlist;
  *   - the X canonical action type (`XCanonicalActionV1`) and profile string;
  *   - the X origin canonicalizer + the thin body/content-type orchestration that

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -4279,7 +4279,7 @@ export class Vault {
 
   /**
    * List every wallet an agent owns, across venues and chain families.
-   * Used by the agent dashboard and by Worker A's trade-sessions package
+   * Used by the agent dashboard and the trade-sessions package
    * to enumerate available trading surfaces.
    *
    * Legacy NULL-venue rows are included. Order: legacy first, then

--- a/scripts/client-entrypoint-mutation-proofs.sh
+++ b/scripts/client-entrypoint-mutation-proofs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # client-entrypoint-mutation-proofs.sh
 #
-# Mutation proofs for the @stwd/shared/client contract test (issue #231).
+# Mutation proofs for the @stwd/shared/client contract test.
 # Each mutation weakens the client-safety guarantee, asserts the contract
 # test FAILS, then restores the original and asserts it PASSES again.
 #

--- a/scripts/custody-ack-gate-mutation-proofs.sh
+++ b/scripts/custody-ack-gate-mutation-proofs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Mutation proofs for the production local-custody acknowledgement gate (issue #213).
+# Mutation proofs for the production local-custody acknowledgement gate.
 #
 # For each mutation we WEAKEN the guard in vault-factory.ts, confirm the
 # security test suite goes RED, then RESTORE the original and confirm GREEN.

--- a/scripts/e2e-auth-test.ts
+++ b/scripts/e2e-auth-test.ts
@@ -231,7 +231,7 @@ async function testProviderDiscovery() {
       return;
     }
 
-    // /auth/providers returns ApiResponse<{...}> after #27. Some older builds
+    // /auth/providers returns ApiResponse<{...}>. Some older builds
     // returned a flat object; tolerate both for forwards compatibility.
     const providers = data?.ok && data?.data ? data.data : data;
 

--- a/scripts/e2e-integration-test.ts
+++ b/scripts/e2e-integration-test.ts
@@ -213,7 +213,7 @@ async function testCloudProvisioning() {
 
   // 1d/1e. Create test agent with wallet + policies via the platform API.
   //
-  // The #79 hardening made tenant-scoped agent create/policy writes
+  // Tenant-scoped agent create/policy writes
   // owner/admin-session-only. Platform operators provision agents (and their
   // initial policy set) through the scoped platform key instead — here via the
   // batch endpoint, which both creates the agent and applies policies in one
@@ -378,7 +378,7 @@ async function testWalletOperations() {
     } else if (status === 200 && data.ok) {
       pass("Sign tx to whitelisted address (signed)");
     } else if (status === 403) {
-      // Hardened model (#79): an agent JWT on its own cannot sign — signing
+      // An agent JWT on its own cannot sign — signing
       // requires either an owner/admin MFA session or signer-bound
       // X-Steward-Signer-Id/X-Steward-Signer-Secret headers. The
       // platform-operator e2e holds neither, so a 403 here confirms the
@@ -482,7 +482,7 @@ async function testSecretManagement() {
 
   // 3a. Create a test secret.
   //
-  // Hardened model (#79): secret management is owner/admin-session-only. The
+  // Secret management is owner/admin-session-only. The
   // platform-operator e2e authenticates with a tenant API key (not an admin
   // session), so the expected outcome here is a 403 confirming the gate is
   // enforced. If the deployment still allows API-key secret management (older

--- a/scripts/verify-evidence-bundle.mjs
+++ b/scripts/verify-evidence-bundle.mjs
@@ -679,7 +679,7 @@ function verifyManifest(manifest, events, payload) {
   // the manifest references (the case's own seqs) into `caseEvents` and derive
   // ALL role/fact reasoning from that set — never from the whole segment — so an
   // unrelated case's `exec_authorized` (or any role) can neither back a fact nor
-  // satisfy the forged-completeness guard (codex P1).
+  // satisfy the forged-completeness guard.
   const bySeq = new Map();
   for (const ev of events) bySeq.set(ev.seq, ev);
   if (!Array.isArray(manifest.events)) fail("manifest.events is not an array");


### PR DESCRIPTION
Closes #762

## Summary
- replace stale sprint, phase, workstream, issue-review, and superseded-plan narration in active source with current runtime, ownership, and trust-boundary contracts
- correct the venue-scoped typed-data signing contract and the currently composed trading, capabilities, and wxmr plugin surface
- document the Eliza action behavior and MCP credential/tenant boundary precisely
- preserve load-bearing security rationale, numbered migration SQL, and historical changelogs; add the required React docs metadata entry

This is a documentation/comment cleanup. The only executable text changes are an accurate submit-trade action description and a mutation-proof display label; execution logic is unchanged.

## Exact local evidence
- base: `201c1869d40ffca8a207a32a24eecc7eb6f24cd6` (current `develop` at push)
- head: `20538e557ad8ff310314fbca13b7e2a498660db0`
- tree: `969d6de1d4dc92076fd56db018cf321a3a3bacf9`
- full-tree targeted object scan: no stale planning/review labels in active non-test source (tests, migrations, changelogs, and history excluded)
- Biome: 770 files checked, clean
- public-package metadata: pass
- `git diff --check`: pass
- numbered migration diff: empty

Builds and runtime tests were not rerun in the sparse audit derivative because dependencies were not installed there and local disk remained constrained. Hosted checks and independent review are required before readiness.