### PR TITLE
fix(worker): isolate the runtime environment inventory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,14 @@ AGENT_TOKEN_EXPIRY=24h
 # NODE_ENV is explicitly "development" or "test" (unset is not enough).
 # STEWARD_ALLOW_DEV_SECRETS=true
 
+# Webhook destinations require HTTPS and public DNS/IP addresses. These two
+# break-glass acknowledgements disable those independent controls only for
+# webhook registration and delivery. They are resolved per request in Workers,
+# require the exact lowercase value "true", and must stay unset in production.
+# They do not authorize private SAML, provider, or ERC-8004 destinations.
+# STEWARD_ALLOW_INSECURE_WEBHOOK_URLS=true
+# STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS=true
+
 # [REQUIRED in production] HMAC key for the tamper-evident audit chain.
 # Keep this distinct from STEWARD_JWT_SECRET and STEWARD_MASTER_PASSWORD —
 # the audit chain's integrity guarantee depends on the key living in a

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,9 @@
     "packages/adapters": {
       "name": "@stwd/adapters",
       "version": "0.1.0",
+      "dependencies": {
+        "@stwd/shared": "workspace:*",
+      },
       "devDependencies": {
         "@types/bun": "1.3.14",
         "@types/node": "^25.5.0",
@@ -91,6 +94,9 @@
     "packages/attestation": {
       "name": "@stwd/attestation",
       "version": "0.1.0",
+      "dependencies": {
+        "@stwd/shared": "workspace:*",
+      },
       "devDependencies": {
         "@types/bun": "1.3.14",
         "@types/node": "^25.5.0",
@@ -374,6 +380,9 @@
     "packages/proxy-client": {
       "name": "@stwd/proxy-client",
       "version": "0.1.0",
+      "dependencies": {
+        "@stwd/shared": "workspace:*",
+      },
       "devDependencies": {
         "@stwd/auth": "workspace:*",
         "@stwd/db": "workspace:*",
@@ -571,6 +580,7 @@
       "name": "@stwd/venue-hyperliquid",
       "version": "0.1.2",
       "dependencies": {
+        "@stwd/shared": "workspace:*",
         "viem": "^2.30.0",
         "zod": "^4.3.6",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -468,6 +468,7 @@
       "name": "@stwd/redis",
       "version": "0.4.0",
       "dependencies": {
+        "@stwd/shared": "workspace:*",
         "@upstash/redis": "^1.34.3",
         "ioredis": "^5.6.1",
       },

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -14,6 +14,9 @@
     "test": "bun test src/__tests__/",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@stwd/shared": "workspace:*"
+  },
   "devDependencies": {
     "@types/bun": "1.3.14",
     "@types/node": "^25.5.0",

--- a/packages/adapters/src/__tests__/registry.test.ts
+++ b/packages/adapters/src/__tests__/registry.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { MockSwapAdapter, type SwapAdapter } from "../adapters/swap.js";
-import { AdapterRegistry, adapterRegistry } from "../registry.js";
-import { AdapterNotConfiguredError } from "../types.js";
+import { AdapterRegistry } from "../registry.js";
+import { type AdapterCategory, AdapterNotConfiguredError, type BaseAdapter } from "../types.js";
 
 const FRESH_TOKENS = {
   fromToken: { address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" },
@@ -11,18 +11,57 @@ const FRESH_TOKENS = {
   chainId: 8453,
 };
 
+const CATEGORIES = [
+  "swap",
+  "earn",
+  "onramp",
+  "offramp",
+  "kyc",
+  "tos",
+  "custodial",
+  "push",
+  "bridge",
+  "spark",
+  "exchange",
+] as const satisfies readonly AdapterCategory[];
+
+function selectionEnvironment(provider: string): Record<string, string> {
+  return Object.fromEntries(
+    CATEGORIES.map((category) => [`STEWARD_${category.toUpperCase()}_ADAPTER`, provider]),
+  );
+}
+
+function namedAdapter(category: AdapterCategory, provider: string): BaseAdapter {
+  return { category, provider, enabled: true };
+}
+
 describe("AdapterRegistry resolution", () => {
-  test("default singleton is authority-keyed across A to B to missing", () => {
-    const provider = (env: Record<string, string>) =>
+  test("invokes provider factories under the current request and never retains their adapters", () => {
+    const reg = new AdapterRegistry();
+    let generation = 0;
+    reg.registerFactory("swap", "request-swap", () => ({
+      category: "swap",
+      provider: `request-swap-${++generation}`,
+      enabled: true,
+      async getQuote() {
+        throw new Error("not implemented in test");
+      },
+      async buildSwap() {
+        throw new Error("not implemented in test");
+      },
+    }));
+
+    const resolve = () =>
       withRuntimeEnvironment(
-        { STEWARD_RUNTIME: "workers", ...env },
-        () => adapterRegistry.swap().provider,
+        {
+          STEWARD_RUNTIME: "workers",
+          NODE_ENV: "production",
+          STEWARD_SWAP_ADAPTER: "request-swap",
+        },
+        () => reg.swap(),
       );
-    expect(provider({ STEWARD_SWAP_ADAPTER: "mock", STEWARD_ALLOW_MOCK_ADAPTERS: "true" })).toBe(
-      "mock",
-    );
-    expect(provider({ STEWARD_SWAP_ADAPTER: "not-registered" })).toBe("disabled");
-    expect(provider({})).toBe("disabled");
+    expect(resolve().provider).toBe("request-swap-1");
+    expect(resolve().provider).toBe("request-swap-2");
   });
   test("DEV (no NODE_ENV): returns working mocks", async () => {
     const reg = new AdapterRegistry({ env: {} });
@@ -51,12 +90,20 @@ describe("AdapterRegistry resolution", () => {
     }
   });
 
-  test("PRODUCTION + STEWARD_ALLOW_MOCK_ADAPTERS=true: mocks allowed (staging escape hatch)", () => {
+  test("PRODUCTION mock use requires the current category selection and acknowledgement", () => {
     const reg = new AdapterRegistry({
       env: { NODE_ENV: "production", STEWARD_ALLOW_MOCK_ADAPTERS: "true" },
     });
-    expect(reg.swap().provider).toBe("mock");
-    expect(reg.swap().enabled).toBe(true);
+    expect(reg.swap()).toMatchObject({ provider: "disabled", enabled: false });
+
+    const acknowledged = new AdapterRegistry({
+      env: {
+        NODE_ENV: "production",
+        STEWARD_SWAP_ADAPTER: "mock",
+        STEWARD_ALLOW_MOCK_ADAPTERS: "true",
+      },
+    });
+    expect(acknowledged.swap()).toMatchObject({ provider: "mock", enabled: true });
   });
 
   test("PRODUCTION + env names an unknown provider: FAILS CLOSED (never silently mocks)", () => {
@@ -93,21 +140,25 @@ describe("AdapterRegistry resolution", () => {
     expect(reg.swap().enabled).toBe(true);
   });
 
-  test("a single registered provider without env disambiguation is used", () => {
+  test("production requires an explicit binding even with one durable provider", () => {
     const reg = new AdapterRegistry({ env: { NODE_ENV: "production" } });
     const real = new MockSwapAdapter() as SwapAdapter;
     reg.register("swap", "only", real);
-    expect(reg.swap()).toBe(real);
+    expect(reg.swap()).toMatchObject({ provider: "disabled", enabled: false });
   });
 
-  test("register invalidates a previously-resolved (disabled) instance", async () => {
+  test("late registration remains durable but does not replace production selection policy", () => {
     const reg = new AdapterRegistry({ env: { NODE_ENV: "production" } });
-    // Resolve once -> disabled and cached.
     expect(reg.swap().enabled).toBe(false);
-    // Now register a real provider; the cache must be invalidated.
     const real = new MockSwapAdapter() as SwapAdapter;
     reg.register("swap", "late", real);
-    expect(reg.swap()).toBe(real);
+    expect(reg.swap().enabled).toBe(false);
+
+    const selected = new AdapterRegistry({
+      env: { NODE_ENV: "production", STEWARD_SWAP_ADAPTER: "late" },
+    });
+    selected.register("swap", "late", real);
+    expect(selected.swap()).toBe(real);
   });
 
   test("describe() introspects all adapter categories", () => {
@@ -128,5 +179,129 @@ describe("AdapterRegistry resolution", () => {
         "tos",
       ].sort(),
     );
+  });
+
+  test("Worker binding removal disables every previously-allowed mock category immediately", () => {
+    const requestRegistry = new AdapterRegistry();
+    const allowed = withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        NODE_ENV: "production",
+        STEWARD_ALLOW_MOCK_ADAPTERS: "true",
+        ...selectionEnvironment("mock"),
+      },
+      () => requestRegistry.describe(),
+    );
+    for (const category of CATEGORIES) {
+      expect(allowed[category]).toEqual({ provider: "mock", enabled: true });
+    }
+
+    const removed = withRuntimeEnvironment(
+      { STEWARD_RUNTIME: "workers", NODE_ENV: "production" },
+      () => requestRegistry.describe(),
+    );
+    for (const category of CATEGORIES) {
+      expect(removed[category]).toEqual({ provider: "disabled", enabled: false });
+    }
+
+    const selectionRemovedButAckRemains = withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        NODE_ENV: "production",
+        STEWARD_ALLOW_MOCK_ADAPTERS: "true",
+      },
+      () => requestRegistry.describe(),
+    );
+    for (const category of CATEGORIES) {
+      expect(selectionRemovedButAckRemains[category]).toEqual({
+        provider: "disabled",
+        enabled: false,
+      });
+    }
+  });
+
+  test("all categories rotate durable providers A -> B and fail closed when selection disappears", () => {
+    const requestRegistry = new AdapterRegistry();
+    for (const category of CATEGORIES) {
+      requestRegistry.register(
+        category,
+        "rotation-a",
+        namedAdapter(category, `a-${category}`) as never,
+      );
+      requestRegistry.register(
+        category,
+        "rotation-b",
+        namedAdapter(category, `b-${category}`) as never,
+      );
+    }
+
+    const describeWith = (provider?: string) =>
+      withRuntimeEnvironment(
+        {
+          STEWARD_RUNTIME: "workers",
+          NODE_ENV: "production",
+          ...(provider ? selectionEnvironment(provider) : {}),
+        },
+        () => requestRegistry.describe(),
+      );
+    const selectedA = describeWith("rotation-a");
+    const selectedB = describeWith("rotation-b");
+    const missing = describeWith("removed-provider");
+    for (const category of CATEGORIES) {
+      expect(selectedA[category]).toEqual({ provider: `a-${category}`, enabled: true });
+      expect(selectedB[category]).toEqual({ provider: `b-${category}`, enabled: true });
+      expect(missing[category]).toEqual({ provider: "disabled", enabled: false });
+    }
+  });
+
+  test("hostile overlap keeps each suspended request on its immutable adapter authority", async () => {
+    const requestRegistry = new AdapterRegistry();
+    requestRegistry.register("swap", "overlap-a", namedAdapter("swap", "overlap-a") as never);
+    requestRegistry.register("swap", "overlap-b", namedAdapter("swap", "overlap-b") as never);
+    let releaseA!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    let startedA!: () => void;
+    const started = new Promise<void>((resolve) => {
+      startedA = resolve;
+    });
+
+    const requestA = withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        NODE_ENV: "production",
+        STEWARD_SWAP_ADAPTER: "overlap-a",
+      },
+      async () => {
+        expect(requestRegistry.swap().provider).toBe("overlap-a");
+        startedA();
+        await gate;
+        expect(requestRegistry.swap().provider).toBe("overlap-a");
+      },
+    );
+    await started;
+    await withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        NODE_ENV: "production",
+        STEWARD_SWAP_ADAPTER: "overlap-b",
+      },
+      async () => {
+        expect(requestRegistry.swap().provider).toBe("overlap-b");
+        releaseA();
+      },
+    );
+    await requestA;
+  });
+
+  test("Workers without NODE_ENV fail closed while Bun retains its development fallback", () => {
+    const requestRegistry = new AdapterRegistry();
+    expect(
+      withRuntimeEnvironment({ STEWARD_RUNTIME: "workers" }, () => requestRegistry.swap().enabled),
+    ).toBe(false);
+    const bunRegistry = new AdapterRegistry({ env: {} });
+    expect(bunRegistry.swap().provider).toBe("mock");
+    expect(bunRegistry.swap().enabled).toBe(true);
   });
 });

--- a/packages/adapters/src/__tests__/registry.test.ts
+++ b/packages/adapters/src/__tests__/registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { MockSwapAdapter, type SwapAdapter } from "../adapters/swap.js";
-import { AdapterRegistry } from "../registry.js";
+import { AdapterRegistry, adapterRegistry } from "../registry.js";
 import { AdapterNotConfiguredError } from "../types.js";
 
 const FRESH_TOKENS = {
@@ -11,6 +12,18 @@ const FRESH_TOKENS = {
 };
 
 describe("AdapterRegistry resolution", () => {
+  test("default singleton is authority-keyed across A to B to missing", () => {
+    const provider = (env: Record<string, string>) =>
+      withRuntimeEnvironment(
+        { STEWARD_RUNTIME: "workers", ...env },
+        () => adapterRegistry.swap().provider,
+      );
+    expect(provider({ STEWARD_SWAP_ADAPTER: "mock", STEWARD_ALLOW_MOCK_ADAPTERS: "true" })).toBe(
+      "mock",
+    );
+    expect(provider({ STEWARD_SWAP_ADAPTER: "not-registered" })).toBe("disabled");
+    expect(provider({})).toBe("disabled");
+  });
   test("DEV (no NODE_ENV): returns working mocks", async () => {
     const reg = new AdapterRegistry({ env: {} });
     expect(reg.swap().provider).toBe("mock");

--- a/packages/adapters/src/registry.ts
+++ b/packages/adapters/src/registry.ts
@@ -1,22 +1,22 @@
 /**
- * AdapterRegistry — resolves the configured adapter per category, with a
- * fail-closed default in production.
+ * AdapterRegistry — keeps durable stateless providers/factories while resolving
+ * selection policy from the current request's immutable runtime environment.
  *
  * Resolution order per category (e.g. "swap"):
- *   1. A real adapter explicitly registered via {@link AdapterRegistry.register}
- *      (this is where a real provider integration plugs in later).
- *   2. The env var STEWARD_<CATEGORY>_ADAPTER selects a registered named provider.
- *   3. Fallback:
+ *   1. The env var STEWARD_<CATEGORY>_ADAPTER selects a durable provider
+ *      registered via {@link AdapterRegistry.register}, or the built-in mock.
+ *   2. Fallback:
  *        - DEV / test (NODE_ENV !== "production"): the built-in MOCK.
  *        - PRODUCTION (NODE_ENV === "production"): a DISABLED adapter whose
  *          operations throw {@link AdapterNotConfiguredError}. This guarantees a
  *          production deploy never silently uses mocks for real money.
  *
- * The only way to use mocks in production is to opt in explicitly via
- * STEWARD_ALLOW_MOCK_ADAPTERS=true (intended for staging/load tests only).
+ * The only way to use mocks in production is to select `mock` for the current
+ * category AND opt in via STEWARD_ALLOW_MOCK_ADAPTERS=true (intended for
+ * staging/load tests only).
  */
 
-import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { type BridgeAdapter, MockBridgeAdapter } from "./adapters/bridge.js";
 import { type CustodialWalletAdapter, MockCustodialWalletAdapter } from "./adapters/custodial.js";
 import { type EarnAdapter, MockEarnAdapter } from "./adapters/earn.js";
@@ -31,7 +31,10 @@ import { MockTosAdapter, type TosAdapter } from "./adapters/tos.js";
 import { type AdapterCategory, AdapterNotConfiguredError, type BaseAdapter } from "./types.js";
 
 export interface AdapterRegistryOptions {
-  /** Explicit immutable authority. Defaults to the current request snapshot. */
+  /**
+   * Fixed environment for isolated registries. The shared singleton resolves
+   * from @stwd/shared's request snapshot and falls back to process.env on Bun.
+   */
   env?: Record<string, string | undefined>;
 }
 
@@ -48,6 +51,10 @@ type CategoryToAdapter = {
   spark: SparkAdapter;
   exchange: ExchangeEmbedAdapter;
 };
+
+type RegisteredProvider<C extends AdapterCategory = AdapterCategory> =
+  | { readonly kind: "instance"; readonly adapter: CategoryToAdapter[C] }
+  | { readonly kind: "factory"; readonly createAdapter: () => CategoryToAdapter[C] };
 
 const ALL_CATEGORIES: readonly AdapterCategory[] = [
   "swap",
@@ -110,26 +117,53 @@ function makeMockAdapter<C extends AdapterCategory>(category: C): CategoryToAdap
 }
 
 export class AdapterRegistry {
-  private readonly explicitEnv?: Record<string, string | undefined>;
-  // category -> (providerName -> adapter) for explicitly registered real adapters
-  private readonly registered = new Map<AdapterCategory, Map<string, BaseAdapter>>();
-  private readonly resolved = new Map<string, BaseAdapter>();
+  private readonly env: Readonly<Record<string, string | undefined>> | null;
+  // category -> (providerName -> stateless instance or request-authority factory)
+  private readonly registered = new Map<AdapterCategory, Map<string, RegisteredProvider>>();
+  // Configuration-free implementations may be durable; binding-dependent ones
+  // are factories. Stable mock instances preserve their in-memory development
+  // behavior without caching the authority decision that made one reachable.
+  private readonly mockAdapters = new Map<AdapterCategory, BaseAdapter>();
+  private readonly disabledAdapters = new Map<AdapterCategory, BaseAdapter>();
 
   constructor(options?: AdapterRegistryOptions) {
-    this.explicitEnv = options?.env ? Object.freeze({ ...options.env }) : undefined;
+    this.env = options?.env ? Object.freeze({ ...options.env }) : null;
   }
 
-  private environment(): Readonly<Record<string, string | undefined>> {
-    return this.explicitEnv ?? runtimeEnvironmentSnapshot();
+  private environmentValue(name: string): string | undefined {
+    return this.env ? this.env[name] : runtimeEnvironmentValue(name);
   }
 
-  private authorityKey(env: Readonly<Record<string, string | undefined>>): string {
-    return JSON.stringify([
-      env.NODE_ENV ?? "",
-      env.STEWARD_RUNTIME ?? "",
-      env.STEWARD_ALLOW_MOCK_ADAPTERS ?? "",
-      ...ALL_CATEGORIES.map((category) => env[envKey(category)] ?? ""),
-    ]);
+  private isProduction(): boolean {
+    const nodeEnvironment = this.environmentValue("NODE_ENV")?.trim();
+    if (nodeEnvironment === "production") return true;
+    // Workers are internet-facing by default. An omitted NODE_ENV binding must
+    // never activate Bun's development mocks; only explicit dev/test modes do.
+    return (
+      this.environmentValue("STEWARD_RUNTIME") === "workers" &&
+      nodeEnvironment !== "development" &&
+      nodeEnvironment !== "test"
+    );
+  }
+
+  private allowMocksInProd(): boolean {
+    return this.environmentValue("STEWARD_ALLOW_MOCK_ADAPTERS") === "true";
+  }
+
+  private mock<C extends AdapterCategory>(category: C): CategoryToAdapter[C] {
+    const existing = this.mockAdapters.get(category);
+    if (existing) return existing as CategoryToAdapter[C];
+    const created = makeMockAdapter(category);
+    this.mockAdapters.set(category, created);
+    return created;
+  }
+
+  private disabled<C extends AdapterCategory>(category: C): CategoryToAdapter[C] {
+    const existing = this.disabledAdapters.get(category);
+    if (existing) return existing as CategoryToAdapter[C];
+    const created = makeDisabledAdapter(category);
+    this.disabledAdapters.set(category, created);
+    return created;
   }
 
   /**
@@ -146,9 +180,27 @@ export class AdapterRegistry {
       byName = new Map();
       this.registered.set(category, byName);
     }
-    byName.set(providerName, adapter);
-    // Invalidate any previously-resolved instance for this category.
-    this.resolved.clear();
+    byName.set(providerName, { kind: "instance", adapter } as RegisteredProvider);
+  }
+
+  /**
+   * Register a stateless provider factory. The registry invokes it only after
+   * the current request selects this provider and never retains the returned
+   * adapter. Binding-dependent integrations MUST use this seam so a reused
+   * Worker isolate cannot carry an endpoint or credential into another binding
+   * generation.
+   */
+  registerFactory<C extends AdapterCategory>(
+    category: C,
+    providerName: string,
+    createAdapter: () => CategoryToAdapter[C],
+  ): void {
+    let byName = this.registered.get(category);
+    if (!byName) {
+      byName = new Map();
+      this.registered.set(category, byName);
+    }
+    byName.set(providerName, { kind: "factory", createAdapter } as RegisteredProvider);
   }
 
   /**
@@ -161,60 +213,50 @@ export class AdapterRegistry {
     return this.registered.get(category)?.has(providerName) ?? false;
   }
 
-  private resolve<C extends AdapterCategory>(category: C): CategoryToAdapter[C] {
-    const env = this.environment();
-    const cacheKey = `${this.authorityKey(env)}:${category}`;
-    const cached = this.resolved.get(cacheKey);
-    if (cached) return cached as CategoryToAdapter[C];
+  private instantiate<C extends AdapterCategory>(
+    provider: RegisteredProvider<C>,
+  ): CategoryToAdapter[C] {
+    return provider.kind === "factory" ? provider.createAdapter() : provider.adapter;
+  }
 
-    const configured = env[envKey(category)]?.trim();
-    const isProduction = env.NODE_ENV === "production" || env.STEWARD_RUNTIME === "workers";
-    const allowMocksInProd = env.STEWARD_ALLOW_MOCK_ADAPTERS === "true";
+  private resolve<C extends AdapterCategory>(category: C): CategoryToAdapter[C] {
+    // Never cache this authority decision: the same Worker isolate can serve a
+    // rotated binding set, and overlapping requests retain distinct ALS-backed
+    // snapshots. Provider implementations themselves remain durable above.
+    const configured = this.environmentValue(envKey(category))?.trim();
     const byName = this.registered.get(category);
 
     // 1. Explicit env selection of a registered provider.
     if (configured && configured !== "mock" && byName?.has(configured)) {
-      const adapter = byName.get(configured) as CategoryToAdapter[C];
-      this.resolved.set(cacheKey, adapter);
-      return adapter;
+      return this.instantiate(byName.get(configured) as RegisteredProvider<C>);
     }
 
     // 2. Env explicitly asks for "mock".
     if (configured === "mock") {
-      if (isProduction && !allowMocksInProd) {
-        const disabled = makeDisabledAdapter(category);
-        this.resolved.set(cacheKey, disabled);
-        return disabled;
+      if (this.isProduction() && !this.allowMocksInProd()) {
+        return this.disabled(category);
       }
-      const mock = makeMockAdapter(category);
-      this.resolved.set(cacheKey, mock);
-      return mock;
+      return this.mock(category);
     }
 
-    // 3. A single real adapter registered without env disambiguation: use it.
-    if (!configured && byName && byName.size === 1) {
-      const [adapter] = byName.values();
-      this.resolved.set(cacheKey, adapter as CategoryToAdapter[C]);
-      return adapter as CategoryToAdapter[C];
+    // 3. Bun development convenience: a sole registered provider needs no env
+    // disambiguation. Production requires a current, explicit binding.
+    if (!configured && !this.isProduction() && byName && byName.size === 1) {
+      const [provider] = byName.values();
+      return this.instantiate(provider as RegisteredProvider<C>);
     }
 
     // 4. Env names an unknown provider -> fail closed everywhere (never silently
     //    fall back to a mock when an operator asked for a specific provider).
     if (configured && configured !== "mock") {
-      const disabled = makeDisabledAdapter(category);
-      this.resolved.set(cacheKey, disabled);
-      return disabled;
+      return this.disabled(category);
     }
 
-    // 5. Nothing configured. DEV -> mock; PROD -> disabled (fail closed).
-    if (isProduction && !allowMocksInProd) {
-      const disabled = makeDisabledAdapter(category);
-      this.resolved.set(cacheKey, disabled);
-      return disabled;
-    }
-    const mock = makeMockAdapter(category);
-    this.resolved.set(cacheKey, mock);
-    return mock;
+    // 5. Nothing configured. DEV -> mock; PROD -> disabled (fail closed). The
+    // production mock acknowledgement above is valid only with an exact current
+    // `mock` selection; the allow flag alone cannot authorize every category.
+    if (this.isProduction()) return this.disabled(category);
+    return this.mock(category);
   }
 
   swap(): SwapAdapter {
@@ -263,7 +305,8 @@ export class AdapterRegistry {
 }
 
 /**
- * Default process-wide registry, resolved from process.env. Routes import this.
- * Tests construct their own {@link AdapterRegistry} with an injected env.
+ * Process-wide implementation registry. Selection is request-local under
+ * Workers and falls back to process.env under Bun. Tests can still construct an
+ * isolated registry with a fixed injected environment.
  */
 export const adapterRegistry = new AdapterRegistry();

--- a/packages/adapters/src/registry.ts
+++ b/packages/adapters/src/registry.ts
@@ -16,6 +16,7 @@
  * STEWARD_ALLOW_MOCK_ADAPTERS=true (intended for staging/load tests only).
  */
 
+import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";
 import { type BridgeAdapter, MockBridgeAdapter } from "./adapters/bridge.js";
 import { type CustodialWalletAdapter, MockCustodialWalletAdapter } from "./adapters/custodial.js";
 import { type EarnAdapter, MockEarnAdapter } from "./adapters/earn.js";
@@ -30,7 +31,7 @@ import { MockTosAdapter, type TosAdapter } from "./adapters/tos.js";
 import { type AdapterCategory, AdapterNotConfiguredError, type BaseAdapter } from "./types.js";
 
 export interface AdapterRegistryOptions {
-  /** Defaults to process.env. Injectable for tests. */
+  /** Explicit immutable authority. Defaults to the current request snapshot. */
   env?: Record<string, string | undefined>;
 }
 
@@ -109,21 +110,26 @@ function makeMockAdapter<C extends AdapterCategory>(category: C): CategoryToAdap
 }
 
 export class AdapterRegistry {
-  private readonly env: Record<string, string | undefined>;
+  private readonly explicitEnv?: Record<string, string | undefined>;
   // category -> (providerName -> adapter) for explicitly registered real adapters
   private readonly registered = new Map<AdapterCategory, Map<string, BaseAdapter>>();
-  private readonly resolved = new Map<AdapterCategory, BaseAdapter>();
+  private readonly resolved = new Map<string, BaseAdapter>();
 
   constructor(options?: AdapterRegistryOptions) {
-    this.env = options?.env ?? process.env;
+    this.explicitEnv = options?.env ? Object.freeze({ ...options.env }) : undefined;
   }
 
-  private isProduction(): boolean {
-    return this.env.NODE_ENV === "production";
+  private environment(): Readonly<Record<string, string | undefined>> {
+    return this.explicitEnv ?? runtimeEnvironmentSnapshot();
   }
 
-  private allowMocksInProd(): boolean {
-    return this.env.STEWARD_ALLOW_MOCK_ADAPTERS === "true";
+  private authorityKey(env: Readonly<Record<string, string | undefined>>): string {
+    return JSON.stringify([
+      env.NODE_ENV ?? "",
+      env.STEWARD_RUNTIME ?? "",
+      env.STEWARD_ALLOW_MOCK_ADAPTERS ?? "",
+      ...ALL_CATEGORIES.map((category) => env[envKey(category)] ?? ""),
+    ]);
   }
 
   /**
@@ -142,7 +148,7 @@ export class AdapterRegistry {
     }
     byName.set(providerName, adapter);
     // Invalidate any previously-resolved instance for this category.
-    this.resolved.delete(category);
+    this.resolved.clear();
   }
 
   /**
@@ -156,35 +162,39 @@ export class AdapterRegistry {
   }
 
   private resolve<C extends AdapterCategory>(category: C): CategoryToAdapter[C] {
-    const cached = this.resolved.get(category);
+    const env = this.environment();
+    const cacheKey = `${this.authorityKey(env)}:${category}`;
+    const cached = this.resolved.get(cacheKey);
     if (cached) return cached as CategoryToAdapter[C];
 
-    const configured = this.env[envKey(category)]?.trim();
+    const configured = env[envKey(category)]?.trim();
+    const isProduction = env.NODE_ENV === "production" || env.STEWARD_RUNTIME === "workers";
+    const allowMocksInProd = env.STEWARD_ALLOW_MOCK_ADAPTERS === "true";
     const byName = this.registered.get(category);
 
     // 1. Explicit env selection of a registered provider.
     if (configured && configured !== "mock" && byName?.has(configured)) {
       const adapter = byName.get(configured) as CategoryToAdapter[C];
-      this.resolved.set(category, adapter);
+      this.resolved.set(cacheKey, adapter);
       return adapter;
     }
 
     // 2. Env explicitly asks for "mock".
     if (configured === "mock") {
-      if (this.isProduction() && !this.allowMocksInProd()) {
+      if (isProduction && !allowMocksInProd) {
         const disabled = makeDisabledAdapter(category);
-        this.resolved.set(category, disabled);
+        this.resolved.set(cacheKey, disabled);
         return disabled;
       }
       const mock = makeMockAdapter(category);
-      this.resolved.set(category, mock);
+      this.resolved.set(cacheKey, mock);
       return mock;
     }
 
     // 3. A single real adapter registered without env disambiguation: use it.
     if (!configured && byName && byName.size === 1) {
       const [adapter] = byName.values();
-      this.resolved.set(category, adapter as CategoryToAdapter[C]);
+      this.resolved.set(cacheKey, adapter as CategoryToAdapter[C]);
       return adapter as CategoryToAdapter[C];
     }
 
@@ -192,18 +202,18 @@ export class AdapterRegistry {
     //    fall back to a mock when an operator asked for a specific provider).
     if (configured && configured !== "mock") {
       const disabled = makeDisabledAdapter(category);
-      this.resolved.set(category, disabled);
+      this.resolved.set(cacheKey, disabled);
       return disabled;
     }
 
     // 5. Nothing configured. DEV -> mock; PROD -> disabled (fail closed).
-    if (this.isProduction() && !this.allowMocksInProd()) {
+    if (isProduction && !allowMocksInProd) {
       const disabled = makeDisabledAdapter(category);
-      this.resolved.set(category, disabled);
+      this.resolved.set(cacheKey, disabled);
       return disabled;
     }
     const mock = makeMockAdapter(category);
-    this.resolved.set(category, mock);
+    this.resolved.set(cacheKey, mock);
     return mock;
   }
 

--- a/packages/api/CLOUDFLARE.md
+++ b/packages/api/CLOUDFLARE.md
@@ -99,6 +99,8 @@ rejected before any database handle is selected.
 | `STEWARD_JWT_SECRET`            | Canonical HS256 JWT signing and verification secret. Minimum 32 characters in production. |
 | `STEWARD_MASTER_PASSWORD`       | Vault keystore master password. Used by `KeyStore` (AES-256-GCM).      |
 | `STEWARD_KDF_SALT`              | Per-deployment hex salt for the KeyStore KDF. Required in production.  |
+| `STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY` | Optional dedicated webhook-secret root. Falls back to `STEWARD_MASTER_PASSWORD`. |
+| `STEWARD_WEBHOOK_SECRET_KDF_SALT` | Optional dedicated webhook KDF salt. Falls back to `STEWARD_KDF_SALT`. |
 | `STEWARD_AUDIT_HMAC_KEY`        | Separate high-entropy root for the tamper-evident audit chain. Required in production. |
 | `STEWARD_IDENTITY_JWT_PRIVATE_KEY` | Optional PKCS#8 RS256/ES256 identity-token key. Set separately in each environment that serves identity tokens. |
 | `RESEND_API_KEY`                | Magic-link email delivery.                                             |
@@ -184,6 +186,23 @@ production posture locally instead, remove the development override and set
 complete high-entropy roots, including `STEWARD_JWT_SECRET`,
 `STEWARD_MASTER_PASSWORD`, `STEWARD_KDF_SALT`, and
 `STEWARD_AUDIT_HMAC_KEY`.
+
+### Custody binding rotation
+
+Workers resolve the complete custody authority from an immutable request-local
+binding snapshot. Vault, secret, provider-token, plugin-credential, tenant
+signing-key, and webhook-secret accessors are keyed by a fingerprint of the
+effective password, KDF salt, custody provider/key/region, chain/RPC settings,
+and compatibility gates. A binding-only deployment may therefore reuse an
+existing isolate without selecting the previous deployment's custody root, and
+removing a required current binding fails closed rather than falling back to a
+captured value.
+
+Changing a password or KDF salt does not migrate existing ciphertext. Complete
+the repository's decrypt-and-re-encrypt rotation workflow before switching the
+binding set, and rotate each password/salt pair atomically. The same rule applies
+to the optional webhook-specific root and salt; omitting either dedicated value
+selects its documented global fallback for that request.
 
 Example production-like `.dev.vars` shape:
 

--- a/packages/api/CLOUDFLARE.md
+++ b/packages/api/CLOUDFLARE.md
@@ -204,6 +204,12 @@ binding set, and rotate each password/salt pair atomically. The same rule applie
 to the optional webhook-specific root and salt; omitting either dedicated value
 selects its documented global fallback for that request.
 
+AWS KMS envelope or external-custody mode in Workers also requires
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` bindings (plus
+`AWS_SESSION_TOKEN` for temporary credentials). These credentials are captured
+in the same request-local authority and passed explicitly to the AWS SDK; Worker
+custody never falls back to the isolate-global AWS credential chain.
+
 Example production-like `.dev.vars` shape:
 
 ```

--- a/packages/api/CLOUDFLARE.md
+++ b/packages/api/CLOUDFLARE.md
@@ -117,6 +117,14 @@ rejected before any database handle is selected.
 | `PASSKEY_RP_NAME`               | Display name for the WebAuthn UI.                                      |
 | `PASSKEY_ALLOWED_ORIGINS`       | Optional comma-separated additional origins for multi-tenant passkeys. |
 
+Webhook destinations require HTTPS and public DNS/IP addresses. The optional
+`STEWARD_ALLOW_INSECURE_WEBHOOK_URLS=true` and
+`STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS=true` bindings are independent,
+request-local break-glass acknowledgements for trusted local test harnesses.
+Do not configure either binding in staging or production Worker environments;
+they disable webhook transport and SSRF controls respectively and do not widen
+non-webhook URL consumers.
+
 When asymmetric identity tokens are enabled, put the private key in the
 environment-scoped secret above and configure the matching non-secret
 `STEWARD_IDENTITY_JWT_ALG`, `STEWARD_IDENTITY_JWT_KID`,

--- a/packages/api/src/__tests__/adapter-runtime-environment.test.ts
+++ b/packages/api/src/__tests__/adapter-runtime-environment.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Request-bound adapter selection evidence at the two production integration
+ * boundaries: mounted Hono routes and the Cloudflare Worker entry point.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { adapterRegistry } from "@stwd/adapters";
+import {
+  createWxmrBridgeAdapter,
+  WXMR_MONERO_CHAIN_ID,
+  WXMR_SOLANA_CHAIN_ID,
+} from "@stwd/plugin-wxmr";
+import { MONERO_ON_SOLANA } from "@stwd/shared";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { Hono } from "hono";
+import { adapterRoutes } from "../routes/adapters";
+import worker from "../worker";
+
+const CATEGORIES = [
+  "swap",
+  "earn",
+  "onramp",
+  "offramp",
+  "kyc",
+  "tos",
+  "custodial",
+  "push",
+  "bridge",
+  "spark",
+  "exchange",
+] as const;
+
+const MANAGED_KEYS = [
+  "STEWARD_RUNTIME",
+  "NODE_ENV",
+  "STEWARD_JWT_SECRET",
+  "STEWARD_ALLOW_MOCK_ADAPTERS",
+  ...CATEGORIES.map((category) => `STEWARD_${category.toUpperCase()}_ADAPTER`),
+] as const;
+
+const savedEnvironment = new Map<string, string | undefined>();
+const originalFetch = globalThis.fetch;
+
+function mockBindings(): Record<string, string> {
+  return Object.fromEntries(
+    CATEGORIES.map((category) => [`STEWARD_${category.toUpperCase()}_ADAPTER`, "mock"]),
+  );
+}
+
+function expectSelection(
+  selection: ReturnType<typeof adapterRegistry.describe>,
+  provider: "mock" | "disabled",
+  enabled: boolean,
+): void {
+  for (const category of CATEGORIES) {
+    expect(selection[category]).toEqual({ provider, enabled });
+  }
+}
+
+async function captureWorkerSelection(env: Record<string, string>) {
+  let captured: ReturnType<typeof adapterRegistry.describe> | undefined;
+  const context = Object.defineProperty({}, "waitUntil", {
+    get() {
+      captured = adapterRegistry.describe();
+      throw new Error("adapter selection captured before database selection");
+    },
+  });
+  await expect(
+    worker.fetch(new Request("https://workers.test/adapters"), env as never, context),
+  ).rejects.toThrow("adapter selection captured before database selection");
+  if (!captured) throw new Error("Worker request did not expose its adapter selection");
+  return captured;
+}
+
+describe("request-local adapter environment integration", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    for (const [key, prior] of savedEnvironment) {
+      if (prior === undefined) delete process.env[key];
+      else process.env[key] = prior;
+    }
+    savedEnvironment.clear();
+  });
+
+  function snapshotEnvironment(): void {
+    for (const key of MANAGED_KEYS) savedEnvironment.set(key, process.env[key]);
+  }
+
+  it("mounted routes stop exposing mocks on the next request after binding removal", async () => {
+    const app = new Hono().route("/adapters", adapterRoutes);
+    const allowed = await withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        NODE_ENV: "production",
+        STEWARD_ALLOW_MOCK_ADAPTERS: "true",
+        ...mockBindings(),
+      },
+      () => app.request("/adapters"),
+    );
+    expect(allowed.status).toBe(200);
+    const allowedBody = (await allowed.json()) as {
+      data: { adapters: ReturnType<typeof adapterRegistry.describe> };
+    };
+    expectSelection(allowedBody.data.adapters, "mock", true);
+
+    const removed = await withRuntimeEnvironment(
+      { STEWARD_RUNTIME: "workers", NODE_ENV: "production" },
+      () => app.request("/adapters"),
+    );
+    expect(removed.status).toBe(200);
+    const removedBody = (await removed.json()) as {
+      data: { adapters: ReturnType<typeof adapterRegistry.describe> };
+    };
+    expectSelection(removedBody.data.adapters, "disabled", false);
+  });
+
+  it("the reused Worker isolate resolves mocks, then fails closed after binding removal", async () => {
+    snapshotEnvironment();
+    const common = {
+      NODE_ENV: "production",
+      STEWARD_JWT_SECRET: "worker-adapter-runtime-secret-at-least-32-chars",
+      DATABASE_DRIVER: "bogus",
+    };
+    const allowed = await captureWorkerSelection({
+      ...common,
+      STEWARD_ALLOW_MOCK_ADAPTERS: "true",
+      ...mockBindings(),
+    });
+    expectSelection(allowed, "mock", true);
+
+    const removed = await captureWorkerSelection(common);
+    expectSelection(removed, "disabled", false);
+  });
+
+  it("the mounted Worker keeps WXMR RPC authority request-local across A -> B -> A and removal", async () => {
+    const provider = "worker-wxmr-authority-regression";
+    adapterRegistry.registerFactory("bridge", provider, createWxmrBridgeAdapter);
+    const observedUrls: string[] = [];
+    let releaseSuspendedA: (() => void) | undefined;
+    let suspendFirstA = true;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      observedUrls.push(url);
+      if (url === "https://rpc-a.example.test/" && suspendFirstA) {
+        suspendFirstA = false;
+        return new Promise<Response>((resolve) => {
+          releaseSuspendedA = () => resolve(new Response("unavailable", { status: 503 }));
+        });
+      }
+      return new Response("unavailable", { status: 503 });
+    }) as typeof fetch;
+
+    const common = {
+      NODE_ENV: "production",
+      STEWARD_JWT_SECRET: "worker-adapter-runtime-secret-at-least-32-chars",
+      DATABASE_DRIVER: "bogus",
+      STEWARD_BRIDGE_ADAPTER: provider,
+    };
+    const quoteRequest = {
+      fromChainId: WXMR_SOLANA_CHAIN_ID,
+      toChainId: WXMR_MONERO_CHAIN_ID,
+      fromToken: {
+        address: MONERO_ON_SOLANA.address,
+        symbol: "XMR",
+        decimals: 12,
+      },
+      toToken: { address: "native", symbol: "XMR", decimals: 12 },
+      amount: "1000000000000",
+      recipient:
+        "45AmZ2FRjuqZts5NGzb7ZXSNRuwS9MUqEeakpyEeSHsB5mywLwBzzq2cTsbJzTVUuLSHxtbfgKyZJVBqPffpP8fm79sjAcK",
+      slippageBps: 0,
+    } as const;
+
+    async function capture(
+      bindings: Record<string, string>,
+      configured = true,
+    ): Promise<{ providerOperation?: Promise<unknown> }> {
+      let providerOperation: Promise<unknown> | undefined;
+      const context = Object.defineProperty({}, "waitUntil", {
+        get() {
+          providerOperation = adapterRegistry.bridge().getQuote(quoteRequest);
+          // Attach a handler before control returns to Worker.fetch so an
+          // immediate upstream rejection cannot surface as an unhandled promise
+          // while the test first observes the deliberate capture exception.
+          void providerOperation.catch(() => undefined);
+          throw new Error("provider operation captured inside Worker request authority");
+        },
+      });
+      const workerRequest = worker.fetch(
+        new Request("https://workers.test/adapters"),
+        bindings as never,
+        context,
+      );
+      await expect(workerRequest).rejects.toThrow(
+        configured
+          ? "provider operation captured inside Worker request authority"
+          : "No bridge adapter is configured",
+      );
+      if (!configured) {
+        expect(providerOperation).toBeUndefined();
+        return {};
+      }
+      if (!providerOperation) throw new Error("Worker request did not invoke the provider");
+      return { providerOperation };
+    }
+
+    const suspendedA = await capture({
+      ...common,
+      WXMR_SOLANA_RPC_URL: "https://rpc-a.example.test",
+    });
+    expect(releaseSuspendedA).toBeFunction();
+
+    const overlappingB = await capture({
+      ...common,
+      WXMR_SOLANA_RPC_URL: "https://rpc-b.example.test",
+    });
+    await expect(overlappingB.providerOperation).rejects.toThrow();
+
+    releaseSuspendedA?.();
+    await expect(suspendedA.providerOperation).rejects.toThrow();
+
+    const resumedA = await capture({
+      ...common,
+      WXMR_SOLANA_RPC_URL: "https://rpc-a.example.test",
+    });
+    await expect(resumedA.providerOperation).rejects.toThrow();
+    expect(observedUrls).toEqual([
+      "https://rpc-a.example.test/",
+      "https://rpc-b.example.test/",
+      "https://rpc-a.example.test/",
+    ]);
+
+    await capture(common, false);
+    expect(observedUrls).toHaveLength(3);
+  });
+});

--- a/packages/api/src/__tests__/auth-email-config.test.ts
+++ b/packages/api/src/__tests__/auth-email-config.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { closeDb, getDb, tenantConfigs, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { KeyStore } from "@stwd/vault";
 import { eq } from "drizzle-orm";
 import {
@@ -58,6 +59,31 @@ describe("getEmailAuthForTenant", () => {
     expect(provider.constructor.name).toBe("ResendProvider");
     expect(provider.from).toBe("Global <login@example.com>");
     expect(provider.replyTo).toBeUndefined();
+  });
+
+  it("keys cached EmailAuth by code-secret authority and fails closed when missing", async () => {
+    clearEmailAuthTenantCacheForTests();
+    const common = {
+      STEWARD_RUNTIME: "workers",
+      NODE_ENV: "production",
+      STEWARD_MASTER_PASSWORD: MASTER_PASSWORD,
+      STEWARD_ACK_LOCAL_CUSTODY: "true",
+      STEWARD_KDF_SALT: "ab".repeat(32),
+      RESEND_API_KEY: "runtime-resend-key",
+      EMAIL_FROM: "Runtime <login@example.com>",
+      APP_URL: "https://runtime.example.com",
+    };
+    const resolve = (secret?: string) =>
+      withRuntimeEnvironment(
+        { ...common, ...(secret ? { STEWARD_EMAIL_CODE_SECRET: secret } : {}) },
+        () => getEmailAuthForTenant(TEST_TENANT_ID),
+      );
+    const a = await resolve("a".repeat(32));
+    const b = await resolve("b".repeat(32));
+    expect(a).not.toBe(b);
+    expect((a as any).codeVerifierSecret).toBe("a".repeat(32));
+    expect((b as any).codeVerifierSecret).toBe("b".repeat(32));
+    await expect(resolve()).rejects.toThrow("STEWARD_EMAIL_CODE_SECRET is required");
   });
 
   it("uses the tenant-specific config when emailConfig is set", async () => {

--- a/packages/api/src/__tests__/authorization-signature-middleware.test.ts
+++ b/packages/api/src/__tests__/authorization-signature-middleware.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { Hono } from "hono";
 import {
   authorizationSignature,
@@ -40,6 +41,15 @@ function makeApp(required = false) {
 function makeDefaultApp() {
   const app = new Hono<{ Variables: { requestSignatureVerified?: boolean } }>();
   app.use("*", authorizationSignature({ secrets: [SECRET] }));
+  app.post("/vault/:agentId/sign", (c) =>
+    c.json({ ok: true, verified: Boolean(c.get("requestSignatureVerified")) }),
+  );
+  return app;
+}
+
+function makeRuntimeConfiguredApp() {
+  const app = new Hono<{ Variables: { requestSignatureVerified?: boolean } }>();
+  app.use("*", authorizationSignature());
   app.post("/vault/:agentId/sign", (c) =>
     c.json({ ok: true, verified: Boolean(c.get("requestSignatureVerified")) }),
   );
@@ -496,5 +506,32 @@ describe("authorizationSignature", () => {
       if (originalAllow === undefined) delete process.env.STEWARD_ALLOW_UNSIGNED_SENSITIVE_REQUESTS;
       else process.env.STEWARD_ALLOW_UNSIGNED_SENSITIVE_REQUESTS = originalAllow;
     }
+  });
+
+  it("observes signing-authority rotations and missing bindings without rebuilding middleware", async () => {
+    const app = makeRuntimeConfiguredApp();
+    const headers = await signedHeaders();
+    const request = () =>
+      app.request("/vault/agent-1/sign", { method: "POST", headers, body: BODY });
+
+    const accepted = await withRuntimeEnvironment(
+      {
+        NODE_ENV: "production",
+        STEWARD_REQUEST_SIGNING_SECRET: SECRET,
+      },
+      request,
+    );
+    const rotated = await withRuntimeEnvironment(
+      {
+        NODE_ENV: "production",
+        STEWARD_REQUEST_SIGNING_SECRET: "rotated-request-signing-secret-with-enough-entropy",
+      },
+      request,
+    );
+    const missing = await withRuntimeEnvironment({ NODE_ENV: "production" }, request);
+
+    expect(accepted.status).toBe(200);
+    expect(rotated.status).toBe(401);
+    expect(missing.status).toBeGreaterThanOrEqual(400);
   });
 });

--- a/packages/api/src/__tests__/custody-authority.test.ts
+++ b/packages/api/src/__tests__/custody-authority.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { buildPluginContext } from "../plugin";
+import { isRuntimeVaultRpcMethodAllowed, resolveRuntimeChainId } from "../services/custody-runtime";
+import { resolveEvmReceiptRpcUrl } from "../services/transaction-receipt-poller";
 import {
   _clearConfiguredVaultsForTests,
   getConfiguredKeyStore,
@@ -138,6 +140,27 @@ describe("request-local custody authority", () => {
     expect(changed.solanaPriorityFees).toBe(false);
   });
 
+  it("fails closed on malformed request-local chain defaults", () => {
+    expect(withRuntimeEnvironment({}, () => resolveRuntimeChainId(84532))).toBe(84532);
+    expect(withRuntimeEnvironment({ CHAIN_ID: " 8453 " }, () => resolveRuntimeChainId(84532))).toBe(
+      8453,
+    );
+    for (const malformed of ["1junk", "0", "-1", "1.5", "01", "9007199254740992"]) {
+      expect(() =>
+        withRuntimeEnvironment({ CHAIN_ID: malformed }, () => resolveRuntimeChainId(84532)),
+      ).toThrow(/CHAIN_ID must be/);
+      expect(() =>
+        withRuntimeEnvironment(
+          { ...authorityEnvironment("malformed-chain", SALT_A), CHAIN_ID: malformed },
+          () => resolveCustodyAuthority(),
+        ),
+      ).toThrow(/CHAIN_ID must be/);
+    }
+    expect(() => withRuntimeEnvironment({}, () => resolveRuntimeChainId(0))).toThrow(
+      /CHAIN_ID fallback must be/,
+    );
+  });
+
   it("survives hostile A-suspends, B-runs, A-resumes overlap", async () => {
     _clearConfiguredVaultsForTests();
     let releaseA: (() => void) | undefined;
@@ -149,7 +172,22 @@ describe("request-local custody authority", () => {
       releaseA = resolve;
     });
 
-    const requestA = withRuntimeEnvironment(authorityEnvironment("overlap-a", SALT_A), async () => {
+    const authorityA = {
+      ...authorityEnvironment("overlap-a", SALT_A),
+      CHAIN_ID: "1",
+      RPC_URL: "https://rpc-a.example.invalid",
+      STEWARD_RPC_1: "https://receipt-a.example.invalid",
+      STEWARD_VAULT_RPC_ALLOWLIST: "eth_chainId,eth_aOnly",
+    };
+    const authorityB = {
+      ...authorityEnvironment("overlap-b", SALT_B),
+      CHAIN_ID: "8453",
+      RPC_URL: "https://rpc-b.example.invalid",
+      STEWARD_RPC_8453: "https://receipt-b.example.invalid",
+      STEWARD_VAULT_RPC_ALLOWLIST: "eth_chainId,eth_bOnly",
+    };
+
+    const requestA = withRuntimeEnvironment(authorityA, async () => {
       const before = resolveCustodyAuthority();
       const beforeStore = getConfiguredKeyStore("credential-lease");
       signalAStarted?.();
@@ -158,28 +196,69 @@ describe("request-local custody authority", () => {
         before,
         after: resolveCustodyAuthority(),
         sameStore: beforeStore === getConfiguredKeyStore("credential-lease"),
+        chainId: resolveRuntimeChainId(84532),
+        receiptRpc: resolveEvmReceiptRpcUrl(1),
+        allowsA: isRuntimeVaultRpcMethodAllowed("eth_aOnly"),
+        allowsB: isRuntimeVaultRpcMethodAllowed("eth_bOnly"),
       };
     });
 
     await aStarted;
-    const requestB = await withRuntimeEnvironment(
-      authorityEnvironment("overlap-b", SALT_B),
-      async () => ({
-        authority: resolveCustodyAuthority(),
-        store: getConfiguredKeyStore("credential-lease"),
-      }),
-    );
+    const requestB = await withRuntimeEnvironment(authorityB, async () => ({
+      authority: resolveCustodyAuthority(),
+      store: getConfiguredKeyStore("credential-lease"),
+      chainId: resolveRuntimeChainId(84532),
+      receiptRpc: resolveEvmReceiptRpcUrl(8453),
+      allowsA: isRuntimeVaultRpcMethodAllowed("eth_aOnly"),
+      allowsB: isRuntimeVaultRpcMethodAllowed("eth_bOnly"),
+    }));
     releaseA?.();
     const resumedA = await requestA;
 
     expect(resumedA.after.fingerprint).toBe(resumedA.before.fingerprint);
     expect(resumedA.sameStore).toBe(true);
     expect(resumedA.after.fingerprint).not.toBe(requestB.authority.fingerprint);
+    expect(resumedA.chainId).toBe(1);
+    expect(resumedA.receiptRpc).toBe("https://receipt-a.example.invalid");
+    expect(resumedA.allowsA).toBe(true);
+    expect(resumedA.allowsB).toBe(false);
+    expect(requestB.chainId).toBe(8453);
+    expect(requestB.receiptRpc).toBe("https://receipt-b.example.invalid");
+    expect(requestB.allowsA).toBe(false);
+    expect(requestB.allowsB).toBe(true);
     expect(
-      withRuntimeEnvironment(authorityEnvironment("overlap-a", SALT_A), () =>
-        getConfiguredKeyStore("credential-lease"),
-      ),
+      withRuntimeEnvironment(authorityA, () => getConfiguredKeyStore("credential-lease")),
     ).not.toBe(requestB.store);
+  });
+
+  it("keys Worker AWS custody by explicit request-local credentials and rejects omissions", () => {
+    const base = {
+      ...workerAuthorityEnvironment("aws-authority", SALT_A),
+      STEWARD_KMS_PROVIDER: "aws",
+      STEWARD_KMS_KEY_ID: "test-kms-key",
+      AWS_ACCESS_KEY_ID: "access-a",
+      AWS_SECRET_ACCESS_KEY: "secret-a",
+      AWS_SESSION_TOKEN: "session-a",
+    };
+    const authorityA = withWorkerRuntimeAuthority(base, () => resolveCustodyAuthority());
+    const authorityB = withWorkerRuntimeAuthority(
+      { ...base, AWS_SECRET_ACCESS_KEY: "secret-b", AWS_SESSION_TOKEN: "session-b" },
+      () => resolveCustodyAuthority(),
+    );
+
+    expect(authorityB.fingerprint).not.toBe(authorityA.fingerprint);
+    expect(authorityA.awsAccessKeyId).toBe("access-a");
+    expect(authorityA.awsSessionToken).toBe("session-a");
+    expect(() =>
+      withWorkerRuntimeAuthority(
+        {
+          ...workerAuthorityEnvironment("aws-authority", SALT_A),
+          STEWARD_KMS_PROVIDER: "aws",
+          STEWARD_KMS_KEY_ID: "test-kms-key",
+        },
+        () => resolveCustodyAuthority(),
+      ),
+    ).toThrow(/AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be configured together/);
   });
 
   it("keeps an isolate-cached plugin context late-bound to each request", async () => {

--- a/packages/api/src/__tests__/custody-authority.test.ts
+++ b/packages/api/src/__tests__/custody-authority.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { buildPluginContext } from "../plugin";
+import {
+  _clearConfiguredVaultsForTests,
+  getConfiguredKeyStore,
+  getConfiguredSecretVault,
+  getConfiguredVault,
+  resolveCustodyAuthority,
+} from "../services/vault-factory";
+import { type Env, withWorkerRuntimeAuthority } from "../worker";
+
+const SALT_A = "a1".repeat(16);
+const SALT_B = "b2".repeat(16);
+
+function authorityEnvironment(masterPassword: string, kdfSalt: string) {
+  return {
+    NODE_ENV: "test",
+    STEWARD_MASTER_PASSWORD: masterPassword,
+    STEWARD_KDF_SALT: kdfSalt,
+    RPC_URL: "https://rpc.example.invalid",
+    CHAIN_ID: "8453",
+  };
+}
+
+function workerAuthorityEnvironment(masterPassword: string, kdfSalt: string): Env {
+  return {
+    DATABASE_URL: "postgresql://worker.invalid/steward",
+    ...authorityEnvironment(masterPassword, kdfSalt),
+  };
+}
+
+describe("request-local custody authority", () => {
+  it("rotates every shared custody factory and fails closed when the current binding is absent", () => {
+    _clearConfiguredVaultsForTests();
+    const envA = workerAuthorityEnvironment("worker-authority-a", SALT_A);
+    const envB = workerAuthorityEnvironment("worker-authority-b", SALT_B);
+
+    const a = withWorkerRuntimeAuthority(envA, () => ({
+      authority: resolveCustodyAuthority(),
+      vault: getConfiguredVault(),
+      secrets: getConfiguredSecretVault(),
+      oauth: getConfiguredKeyStore(),
+      leases: getConfiguredKeyStore("credential-lease"),
+    }));
+    const b = withWorkerRuntimeAuthority(envB, () => ({
+      authority: resolveCustodyAuthority(),
+      vault: getConfiguredVault(),
+      secrets: getConfiguredSecretVault(),
+      oauth: getConfiguredKeyStore(),
+      leases: getConfiguredKeyStore("credential-lease"),
+    }));
+
+    expect(b.authority.fingerprint).not.toBe(a.authority.fingerprint);
+    expect(b.vault).not.toBe(a.vault);
+    expect(b.secrets).not.toBe(a.secrets);
+    expect(b.oauth).not.toBe(a.oauth);
+    expect(b.leases).not.toBe(a.leases);
+
+    const previousMasterPassword = process.env.STEWARD_MASTER_PASSWORD;
+    process.env.STEWARD_MASTER_PASSWORD = "stale-isolate-password";
+    try {
+      expect(() =>
+        withWorkerRuntimeAuthority(
+          {
+            DATABASE_URL: "postgresql://worker.invalid/steward",
+            NODE_ENV: "test",
+            STEWARD_KDF_SALT: SALT_B,
+          },
+          () =>
+            resolveCustodyAuthority({
+              fallbackPassword: "captured-import-password",
+              allowDevSecretFallback: true,
+            }),
+        ),
+      ).toThrow("STEWARD_MASTER_PASSWORD is required");
+    } finally {
+      if (previousMasterPassword === undefined) delete process.env.STEWARD_MASTER_PASSWORD;
+      else process.env.STEWARD_MASTER_PASSWORD = previousMasterPassword;
+    }
+  });
+
+  it("keys instances by KDF salt even when the password is unchanged", () => {
+    _clearConfiguredVaultsForTests();
+    const envA = authorityEnvironment("same-password", SALT_A);
+    const envB = authorityEnvironment("same-password", SALT_B);
+
+    const a = withRuntimeEnvironment(envA, () => ({
+      authority: resolveCustodyAuthority(),
+      vault: getConfiguredVault(),
+      keyStore: getConfiguredKeyStore("secret-vault"),
+    }));
+    const b = withRuntimeEnvironment(envB, () => ({
+      authority: resolveCustodyAuthority(),
+      vault: getConfiguredVault(),
+      keyStore: getConfiguredKeyStore("secret-vault"),
+    }));
+
+    expect(b.authority.fingerprint).not.toBe(a.authority.fingerprint);
+    expect(b.vault).not.toBe(a.vault);
+    expect(b.keyStore).not.toBe(a.keyStore);
+    const ciphertext = a.keyStore.encrypt("scope-a", {
+      tenantId: "tenant-a",
+      name: "authority-proof",
+      version: 1,
+    });
+    expect(() =>
+      b.keyStore.decrypt(ciphertext, {
+        tenantId: "tenant-a",
+        name: "authority-proof",
+        version: 1,
+      }),
+    ).toThrow();
+  });
+
+  it("fingerprints the full RPC, chain, and legacy-gate tuple", () => {
+    const base = authorityEnvironment("full-authority", SALT_A);
+    const first = withRuntimeEnvironment(base, () => resolveCustodyAuthority());
+    const changed = withRuntimeEnvironment(
+      {
+        ...base,
+        RPC_URL: "https://rotated-rpc.example.invalid",
+        CHAIN_ID: "84532",
+        STEWARD_SECRET_VAULT_LEGACY_ROOT_FALLBACK: "false",
+        STEWARD_ALLOW_LEGACY_KEYSTORE_DECRYPT_FALLBACK: "true",
+        STEWARD_SOLANA_PRIORITY_FEES: "0",
+        STEWARD_VAULT_RPC_ALLOWLIST: "eth_chainId,eth_getCode",
+      },
+      () => resolveCustodyAuthority(),
+    );
+
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(changed.fingerprint).not.toBe(first.fingerprint);
+    expect(changed.rpcUrl).toBe("https://rotated-rpc.example.invalid");
+    expect(changed.chainId).toBe(84532);
+    expect(changed.allowLegacySecretRootFallback).toBe(false);
+    expect(changed.allowLegacyKeystoreDecryptFallback).toBe(true);
+    expect(changed.solanaPriorityFees).toBe(false);
+  });
+
+  it("survives hostile A-suspends, B-runs, A-resumes overlap", async () => {
+    _clearConfiguredVaultsForTests();
+    let releaseA: (() => void) | undefined;
+    let signalAStarted: (() => void) | undefined;
+    const aStarted = new Promise<void>((resolve) => {
+      signalAStarted = resolve;
+    });
+    const aMayResume = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+
+    const requestA = withRuntimeEnvironment(authorityEnvironment("overlap-a", SALT_A), async () => {
+      const before = resolveCustodyAuthority();
+      const beforeStore = getConfiguredKeyStore("credential-lease");
+      signalAStarted?.();
+      await aMayResume;
+      return {
+        before,
+        after: resolveCustodyAuthority(),
+        sameStore: beforeStore === getConfiguredKeyStore("credential-lease"),
+      };
+    });
+
+    await aStarted;
+    const requestB = await withRuntimeEnvironment(
+      authorityEnvironment("overlap-b", SALT_B),
+      async () => ({
+        authority: resolveCustodyAuthority(),
+        store: getConfiguredKeyStore("credential-lease"),
+      }),
+    );
+    releaseA?.();
+    const resumedA = await requestA;
+
+    expect(resumedA.after.fingerprint).toBe(resumedA.before.fingerprint);
+    expect(resumedA.sameStore).toBe(true);
+    expect(resumedA.after.fingerprint).not.toBe(requestB.authority.fingerprint);
+    expect(
+      withRuntimeEnvironment(authorityEnvironment("overlap-a", SALT_A), () =>
+        getConfiguredKeyStore("credential-lease"),
+      ),
+    ).not.toBe(requestB.store);
+  });
+
+  it("keeps an isolate-cached plugin context late-bound to each request", async () => {
+    _clearConfiguredVaultsForTests();
+    const pluginContext = buildPluginContext();
+    const envA = authorityEnvironment("plugin-a", SALT_A);
+    const envB = authorityEnvironment("plugin-b", SALT_B);
+    const sealedA = await withRuntimeEnvironment(envA, () =>
+      pluginContext.sealCredentialLeaseToken("tenant-a", "lease-a", "token-a"),
+    );
+    const sealedB = await withRuntimeEnvironment(envB, () =>
+      pluginContext.sealCredentialLeaseToken("tenant-a", "lease-a", "token-b"),
+    );
+
+    await expect(
+      withRuntimeEnvironment(envA, () =>
+        pluginContext.exerciseCredentialLeaseToken(
+          "tenant-a",
+          "lease-a",
+          sealedA,
+          async (value) => value,
+        ),
+      ),
+    ).resolves.toBe("token-a");
+    await expect(
+      withRuntimeEnvironment(envB, () =>
+        pluginContext.exerciseCredentialLeaseToken(
+          "tenant-a",
+          "lease-a",
+          sealedA,
+          async (value) => value,
+        ),
+      ),
+    ).rejects.toThrow();
+    await expect(
+      withRuntimeEnvironment(envB, () =>
+        pluginContext.exerciseCredentialLeaseToken(
+          "tenant-a",
+          "lease-a",
+          sealedB,
+          async (value) => value,
+        ),
+      ),
+    ).resolves.toBe("token-b");
+  });
+});

--- a/packages/api/src/__tests__/custody-authority.test.ts
+++ b/packages/api/src/__tests__/custody-authority.test.ts
@@ -5,6 +5,7 @@ import { isRuntimeVaultRpcMethodAllowed, resolveRuntimeChainId } from "../servic
 import { resolveEvmReceiptRpcUrl } from "../services/transaction-receipt-poller";
 import {
   _clearConfiguredVaultsForTests,
+  _configuredCustodyInstanceCountForTests,
   getConfiguredKeyStore,
   getConfiguredSecretVault,
   getConfiguredVault,
@@ -53,7 +54,8 @@ describe("request-local custody authority", () => {
       leases: getConfiguredKeyStore("credential-lease"),
     }));
 
-    expect(b.authority.fingerprint).not.toBe(a.authority.fingerprint);
+    expect("fingerprint" in a.authority).toBe(false);
+    expect("fingerprint" in b.authority).toBe(false);
     expect(b.vault).not.toBe(a.vault);
     expect(b.secrets).not.toBe(a.secrets);
     expect(b.oauth).not.toBe(a.oauth);
@@ -98,7 +100,6 @@ describe("request-local custody authority", () => {
       keyStore: getConfiguredKeyStore("secret-vault"),
     }));
 
-    expect(b.authority.fingerprint).not.toBe(a.authority.fingerprint);
     expect(b.vault).not.toBe(a.vault);
     expect(b.keyStore).not.toBe(a.keyStore);
     const ciphertext = a.keyStore.encrypt("scope-a", {
@@ -115,7 +116,7 @@ describe("request-local custody authority", () => {
     ).toThrow();
   });
 
-  it("fingerprints the full RPC, chain, and legacy-gate tuple", () => {
+  it("resolves the full RPC, chain, and legacy-gate tuple without a secret fingerprint", () => {
     const base = authorityEnvironment("full-authority", SALT_A);
     const first = withRuntimeEnvironment(base, () => resolveCustodyAuthority());
     const changed = withRuntimeEnvironment(
@@ -132,7 +133,8 @@ describe("request-local custody authority", () => {
     );
 
     expect(Object.isFrozen(first)).toBe(true);
-    expect(changed.fingerprint).not.toBe(first.fingerprint);
+    expect("fingerprint" in first).toBe(false);
+    expect("fingerprint" in changed).toBe(false);
     expect(changed.rpcUrl).toBe("https://rotated-rpc.example.invalid");
     expect(changed.chainId).toBe(84532);
     expect(changed.allowLegacySecretRootFallback).toBe(false);
@@ -215,9 +217,9 @@ describe("request-local custody authority", () => {
     releaseA?.();
     const resumedA = await requestA;
 
-    expect(resumedA.after.fingerprint).toBe(resumedA.before.fingerprint);
     expect(resumedA.sameStore).toBe(true);
-    expect(resumedA.after.fingerprint).not.toBe(requestB.authority.fingerprint);
+    expect(resumedA.after.masterPassword).toBe(resumedA.before.masterPassword);
+    expect(resumedA.after.masterPassword).not.toBe(requestB.authority.masterPassword);
     expect(resumedA.chainId).toBe(1);
     expect(resumedA.receiptRpc).toBe("https://receipt-a.example.invalid");
     expect(resumedA.allowsA).toBe(true);
@@ -246,7 +248,7 @@ describe("request-local custody authority", () => {
       () => resolveCustodyAuthority(),
     );
 
-    expect(authorityB.fingerprint).not.toBe(authorityA.fingerprint);
+    expect(authorityB.awsSecretAccessKey).not.toBe(authorityA.awsSecretAccessKey);
     expect(authorityA.awsAccessKeyId).toBe("access-a");
     expect(authorityA.awsSessionToken).toBe("session-a");
     expect(() =>
@@ -303,5 +305,35 @@ describe("request-local custody authority", () => {
         ),
       ),
     ).resolves.toBe("token-b");
+  });
+
+  it("keeps custody instances request-local and leaves no reachable rotation generations", () => {
+    _clearConfiguredVaultsForTests();
+    const identities = new Set<object>();
+    for (let generation = 0; generation < 12; generation += 1) {
+      withRuntimeEnvironment(
+        authorityEnvironment(
+          `rotation-${generation}`,
+          generation.toString(16).padStart(2, "0").repeat(16),
+        ),
+        () => {
+          const vault = getConfiguredVault();
+          const secretVault = getConfiguredSecretVault();
+          const oauth = getConfiguredKeyStore();
+          const lease = getConfiguredKeyStore("credential-lease");
+          identities.add(vault);
+          identities.add(secretVault);
+          identities.add(oauth);
+          identities.add(lease);
+          expect(getConfiguredVault()).toBe(vault);
+          expect(getConfiguredSecretVault()).toBe(secretVault);
+          expect(getConfiguredKeyStore()).toBe(oauth);
+          expect(getConfiguredKeyStore("credential-lease")).toBe(lease);
+          expect(_configuredCustodyInstanceCountForTests()).toBe(4);
+        },
+      );
+      expect(_configuredCustodyInstanceCountForTests()).toBe(0);
+    }
+    expect(identities.size).toBe(48);
   });
 });

--- a/packages/api/src/__tests__/identity-discovery.test.ts
+++ b/packages/api/src/__tests__/identity-discovery.test.ts
@@ -10,7 +10,7 @@ import { closeDb, getDb, tenants, users, userTenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { decodeProtectedHeader, exportPKCS8, generateKeyPair, importJWK, jwtVerify } from "jose";
 import { identityDiscoveryRoutes } from "../routes/discovery";
-import { hydrateProcessEnv, withWorkerJwtAuthority } from "../worker";
+import { withWorkerJwtAuthority, withWorkerRuntimeAuthority } from "../worker";
 
 const ORIGINAL_ENV = {
   NODE_ENV: process.env.NODE_ENV,
@@ -147,18 +147,20 @@ describe("identity JWKS discovery", () => {
     const firstBarrier = new Promise<void>((resolve) => {
       releaseFirst = resolve;
     });
-    const firstRun = withWorkerJwtAuthority(firstEnv, async () => {
-      hydrateProcessEnv(firstEnv);
-      markFirstReady();
-      await firstBarrier;
-      return exerciseRoutes(firstUserId, "https://request-a.invalid");
-    });
+    const firstRun = withWorkerRuntimeAuthority(firstEnv, () =>
+      withWorkerJwtAuthority(firstEnv, async () => {
+        markFirstReady();
+        await firstBarrier;
+        return exerciseRoutes(firstUserId, "https://request-a.invalid");
+      }),
+    );
     await firstReady;
 
-    const secondRun = withWorkerJwtAuthority(secondEnv, async () => {
-      hydrateProcessEnv(secondEnv);
-      return exerciseRoutes(secondUserId, "https://request-b.invalid");
-    });
+    const secondRun = withWorkerRuntimeAuthority(secondEnv, () =>
+      withWorkerJwtAuthority(secondEnv, () =>
+        exerciseRoutes(secondUserId, "https://request-b.invalid"),
+      ),
+    );
     const [secondResult, firstResult] = await Promise.all([
       Promise.resolve(secondRun).finally(releaseFirst),
       firstRun,
@@ -276,14 +278,15 @@ describe("identity JWKS discovery", () => {
       STEWARD_IDENTITY_JWT_AUDIENCE: "explicit-worker-audience",
       APP_URL: "https://canonical.worker.test/",
     };
-    const result = await withWorkerJwtAuthority(workerEnv, async () => {
-      hydrateProcessEnv(workerEnv);
-      const token = await signIdentityJwtPayload({ sub: "explicit-base" });
-      const response = await identityDiscoveryRoutes.request(
-        "https://ignored-request-host.invalid/.well-known/openid-configuration",
-      );
-      return { token, response };
-    });
+    const result = await withWorkerRuntimeAuthority(workerEnv, () =>
+      withWorkerJwtAuthority(workerEnv, async () => {
+        const token = await signIdentityJwtPayload({ sub: "explicit-base" });
+        const response = await identityDiscoveryRoutes.request(
+          "https://ignored-request-host.invalid/.well-known/openid-configuration",
+        );
+        return { token, response };
+      }),
+    );
     expect(result.response.status).toBe(200);
     expect(await result.response.json()).toMatchObject({
       issuer: "https://canonical.worker.test",

--- a/packages/api/src/__tests__/middleware-security-hardening.test.ts
+++ b/packages/api/src/__tests__/middleware-security-hardening.test.ts
@@ -95,7 +95,7 @@ describe("middleware security hardening", () => {
   });
 
   it("mounts the shared Redis-backed global limiter on the Workers runtime (SEC-068)", () => {
-    expect(appSource).toContain("if (isWorkersRuntime) {");
+    expect(appSource).toContain("if (isWorkersRuntime()) {");
     expect(appSource).toContain('app.use("*", workersGlobalRateLimit)');
     expect(globalRateLimitSource).toContain("checkAuthRateLimit(");
     expect(globalRateLimitSource).toContain('c.req.path === "/health"');

--- a/packages/api/src/__tests__/plugin-host-adapters.test.ts
+++ b/packages/api/src/__tests__/plugin-host-adapters.test.ts
@@ -79,6 +79,22 @@ describe("PluginHost — adapter contributions (Phase 2d)", () => {
     expect(host.describe().adapterContributions.trading).toEqual(["swap::test-swap"]);
   });
 
+  it("registers request-authority factories without retaining their results", async () => {
+    const registry = new AdapterRegistry({ env: { STEWARD_SWAP_ADAPTER: "factory-swap" } });
+    let generation = 0;
+    const plugin = adapterPlugin("factory-plugin", [
+      {
+        category: "swap",
+        provider: "factory-swap",
+        createAdapter: () => fakeSwapAdapter(`factory-${++generation}`),
+      },
+    ]);
+
+    await new PluginHost<typeof registry>().register(app, ctxWith(registry), plugin);
+    expect(registry.swap().provider).toBe("factory-1");
+    expect(registry.swap().provider).toBe("factory-2");
+  });
+
   it("registers without env disambiguation when a single provider is contributed", async () => {
     // No STEWARD_SWAP_ADAPTER set; a single registered provider is used as-is.
     const registry = new AdapterRegistry({ env: {} });
@@ -183,6 +199,23 @@ describe("PluginHost — adapter contributions (Phase 2d)", () => {
 
     const host = new PluginHost<typeof ctx>();
     await expect(host.register(app, ctx, plugin)).rejects.toThrow(PluginHostError);
+  });
+
+  it("FAILS CLOSED when a contribution supplies both an instance and a factory", async () => {
+    const registry = new AdapterRegistry({ env: {} });
+    const ctx = ctxWith(registry);
+    const plugin = adapterPlugin("ambiguous", [
+      {
+        category: "swap",
+        provider: "x",
+        adapter: fakeSwapAdapter("x"),
+        createAdapter: () => fakeSwapAdapter("x"),
+      },
+    ]);
+
+    await expect(new PluginHost<typeof ctx>().register(app, ctx, plugin)).rejects.toThrow(
+      PluginHostError,
+    );
   });
 
   it("FAILS CLOSED on an empty provider name", async () => {

--- a/packages/api/src/__tests__/privy-completeness.integration.test.ts
+++ b/packages/api/src/__tests__/privy-completeness.integration.test.ts
@@ -11,6 +11,8 @@ const webhookDispatches: Array<{
 }> = [];
 
 mock.module("@stwd/webhooks", () => ({
+  currentWebhookRuntimeAuthority: () =>
+    Object.freeze({ allowInsecureHttp: false, allowPrivateNetwork: false }),
   encryptWebhookSecret: (secret: string) => `enc:${secret}`,
   decryptWebhookSecret: (secret: string) => secret.replace(/^enc:/, ""),
   isEncryptedWebhookSecret: (secret: string) => secret.startsWith("enc:"),

--- a/packages/api/src/__tests__/vault-factory.test.ts
+++ b/packages/api/src/__tests__/vault-factory.test.ts
@@ -92,13 +92,13 @@ afterEach(() => {
 });
 
 describe("vault factory", () => {
-  it("memoizes configured vaults by effective password", () => {
+  it("does not reuse process-env custody instances across rotations", () => {
     process.env.STEWARD_MASTER_PASSWORD = "factory-master-one";
     delete process.env.STEWARD_KMS_PROVIDER;
 
     const first = getConfiguredVault();
     const second = getConfiguredVault();
-    expect(second).toBe(first);
+    expect(second).not.toBe(first);
 
     process.env.STEWARD_MASTER_PASSWORD = "factory-master-two";
     expect(getConfiguredVault()).not.toBe(first);

--- a/packages/api/src/__tests__/webhook-dispatch.test.ts
+++ b/packages/api/src/__tests__/webhook-dispatch.test.ts
@@ -1,9 +1,11 @@
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { WebhookEvent } from "@stwd/shared";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 // Captured before mock.module replaces @stwd/webhooks, so these hold the REAL
 // secret-codec functions; the mock re-exports them so dispatched secrets keep
 // the real `stwd_whsec_v1:` envelope format.
 import {
+  currentWebhookRuntimeAuthority,
   decryptWebhookSecret,
   encryptWebhookSecret,
   isEncryptedWebhookSecret,
@@ -23,7 +25,12 @@ type DispatchRecord = {
   event: WebhookEvent;
   webhook: { url: string; secret: string; events?: string[] } | string;
 };
-type DispatcherOptions = { maxRetries?: number; retryDelayMs?: number };
+type DispatcherOptions = {
+  maxRetries?: number;
+  retryDelayMs?: number;
+  allowPrivateNetwork?: boolean;
+  allowInsecureHttp?: boolean;
+};
 type DispatchResult = {
   success: boolean;
   attempts: number;
@@ -112,6 +119,7 @@ mock.module("@stwd/db", () => ({
 // failures across the webhook + approvals API suites. We mock only the
 // dispatcher and pass the real secret-codec functions through.
 mock.module("@stwd/webhooks", () => ({
+  currentWebhookRuntimeAuthority,
   WebhookDispatcher: class {
     constructor(options: DispatcherOptions) {
       dispatcherOptions.push(options);
@@ -217,7 +225,12 @@ describe("dispatchWebhook", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(dispatches).toHaveLength(1);
-    expect(dispatcherOptions[0]).toEqual({ maxRetries: 0, retryDelayMs: 0 });
+    expect(dispatcherOptions[0]).toEqual({
+      maxRetries: 0,
+      retryDelayMs: 0,
+      allowPrivateNetwork: false,
+      allowInsecureHttp: false,
+    });
     expect(dispatches[0]?.event.type).toBe("tx.signed");
     expect(dispatches[0]?.event.deliveryId).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
@@ -251,6 +264,41 @@ describe("dispatchWebhook", () => {
       status: "delivered",
       attempts: 1,
       lastError: null,
+    });
+  });
+
+  it("threads one mounted request policy through destination validation and dispatch", async () => {
+    webhookRows.push({
+      tenantId: "tenant-1",
+      url: "http://127.0.0.1/signed",
+      secret: "whsec_signed",
+      events: ["tx.signed"],
+      enabled: true,
+      maxRetries: 0,
+      retryBackoffMs: 1000,
+    });
+
+    await withRuntimeEnvironment(
+      {
+        STEWARD_ALLOW_INSECURE_WEBHOOK_URLS: "true",
+        STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS: "true",
+      },
+      () =>
+        dispatchWebhookDurably(
+          "tenant-1",
+          "agent-1",
+          "tx_signed",
+          { txId: "tx-policy" },
+          "runtime-policy-enabled",
+        ),
+    );
+
+    expect(dispatches).toHaveLength(1);
+    expect(dispatcherOptions[0]).toEqual({
+      maxRetries: 0,
+      retryDelayMs: 0,
+      allowPrivateNetwork: true,
+      allowInsecureHttp: true,
     });
   });
 

--- a/packages/api/src/__tests__/webhook-policy-scope.test.ts
+++ b/packages/api/src/__tests__/webhook-policy-scope.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { validateAgentCardApiUrl } from "../services/agent-card-url";
+import { normalizeGasSponsorshipConfig } from "../services/gas-sponsorship";
+import { normalizeSamlSsoUpdate } from "../services/saml-sso-config";
+
+const enabledWebhookPolicy = {
+  STEWARD_ALLOW_INSECURE_WEBHOOK_URLS: "true",
+  STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS: "true",
+};
+
+describe("webhook policy scope", () => {
+  it("does not authorize private SAML, gas-provider, or ERC-8004 destinations", async () => {
+    await withRuntimeEnvironment(enabledWebhookPolicy, async () => {
+      const saml = normalizeSamlSsoUpdate("tenant-a", {
+        idpEntityId: "https://idp.example.test/entity",
+        idpSsoUrl: "https://10.0.0.1/sso",
+        idpCertPems: [`-----BEGIN CERTIFICATE-----\n${"A".repeat(256)}\n-----END CERTIFICATE-----`],
+      });
+      expect(saml).toBe("idpSsoUrl must be a public https URL");
+
+      const gas = normalizeGasSponsorshipConfig({
+        provider: "custom_evm_paymaster",
+        mode: "erc4337",
+        paymasterUrl: "https://10.0.0.1/paymaster",
+      });
+      expect(gas).toBe("paymasterUrl must be a public https URL (url host must be public)");
+
+      expect(await validateAgentCardApiUrl("https://10.0.0.1/agent-card")).toBe(
+        "apiUrl url host must be public",
+      );
+    });
+  });
+});

--- a/packages/api/src/__tests__/webhook-runtime-policy-mounted.test.ts
+++ b/packages/api/src/__tests__/webhook-runtime-policy-mounted.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
+
+const userId = randomUUID();
+
+let app: Hono<{ Variables: AppVariables }>;
+let priorDatabaseUrl: string | undefined;
+let priorMasterPassword: string | undefined;
+
+beforeAll(async () => {
+  priorDatabaseUrl = process.env.DATABASE_URL;
+  priorMasterPassword = process.env.STEWARD_MASTER_PASSWORD;
+  process.env.DATABASE_URL ||= "postgres://127.0.0.1:1/steward-webhook-policy-test";
+  process.env.STEWARD_MASTER_PASSWORD ||= "mounted-webhook-policy-master-password";
+  const { webhookRoutes } = await import("../routes/webhooks");
+  app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("authType", "session-jwt");
+    c.set("tenantRole", "owner");
+    // The production route skips the tenant policy lookup only for this focused
+    // boundary harness; the mounted handler and URL/event validation are real.
+    c.set("tenantId", "");
+    c.set("userId", userId);
+    c.set("sessionMfaVerifiedAt", Date.now());
+    c.set("requestId", randomUUID());
+    await next();
+  });
+  app.route("/webhooks", webhookRoutes);
+});
+
+afterAll(() => {
+  if (priorDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+  else process.env.DATABASE_URL = priorDatabaseUrl;
+  if (priorMasterPassword === undefined) delete process.env.STEWARD_MASTER_PASSWORD;
+  else process.env.STEWARD_MASTER_PASSWORD = priorMasterPassword;
+});
+
+function createWebhook(
+  url: string,
+  bindings: Record<string, string>,
+  events: string[] = ["tx.signed"],
+) {
+  return withRuntimeEnvironment(bindings, () =>
+    app.request("/webhooks", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ url, events }),
+    }),
+  );
+}
+
+describe("mounted webhook request-local policy", () => {
+  it("observes an enabled binding and then its removal without remounting the route", async () => {
+    const enabled = await createWebhook(
+      "http://127.0.0.1:38080/enabled",
+      {
+        STEWARD_ALLOW_INSECURE_WEBHOOK_URLS: "true",
+        STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS: "true",
+      },
+      ["invalid-after-url-validation"],
+    );
+    expect(enabled.status).toBe(400);
+    await expect(enabled.json()).resolves.toMatchObject({
+      error: expect.stringContaining("Invalid events"),
+    });
+
+    const insecureRemoved = await createWebhook("http://127.0.0.1:38080/insecure-removed", {});
+    expect(insecureRemoved.status).toBe(400);
+    await expect(insecureRemoved.json()).resolves.toMatchObject({ error: "url must use https" });
+
+    const privateRemoved = await createWebhook("https://127.0.0.1:38080/private-removed", {});
+    expect(privateRemoved.status).toBe(400);
+    await expect(privateRemoved.json()).resolves.toMatchObject({
+      error: "url host must be public",
+    });
+  });
+});

--- a/packages/api/src/__tests__/webhook-url-validation.test.ts
+++ b/packages/api/src/__tests__/webhook-url-validation.test.ts
@@ -1,7 +1,97 @@
 import { describe, expect, it } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { currentWebhookRuntimeAuthority } from "@stwd/webhooks";
 import { validateWebhookUrl, validateWebhookUrlResolved } from "../services/webhook-url";
 
+const enabledWebhookPolicy = {
+  STEWARD_ALLOW_INSECURE_WEBHOOK_URLS: "true",
+  STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS: "true",
+};
+
+function validateCurrentWebhookUrl(url: string) {
+  return validateWebhookUrl(url, currentWebhookRuntimeAuthority());
+}
+
+function validateCurrentWebhookUrlResolved(url: string) {
+  return validateWebhookUrlResolved(url, undefined, currentWebhookRuntimeAuthority());
+}
+
 describe("webhook URL validation", () => {
+  it("does not retain Worker escape hatches after their bindings are removed", async () => {
+    expect(
+      await withRuntimeEnvironment(enabledWebhookPolicy, () =>
+        validateCurrentWebhookUrlResolved("http://127.0.0.1/hook"),
+      ),
+    ).toBeNull();
+
+    expect(
+      await withRuntimeEnvironment({}, () =>
+        validateCurrentWebhookUrlResolved("http://127.0.0.1/hook"),
+      ),
+    ).toBe("url must use https");
+    expect(
+      await withRuntimeEnvironment({}, () =>
+        validateCurrentWebhookUrlResolved("https://127.0.0.1/hook"),
+      ),
+    ).toBe("url host must be public");
+  });
+
+  it("keeps overlapping Worker webhook policies isolated", async () => {
+    let releaseEnabled!: () => void;
+    const enabledCanFinish = new Promise<void>((resolve) => {
+      releaseEnabled = resolve;
+    });
+    let enabledStarted!: () => void;
+    const enabledDidStart = new Promise<void>((resolve) => {
+      enabledStarted = resolve;
+    });
+
+    const enabled = withRuntimeEnvironment(enabledWebhookPolicy, async () => {
+      enabledStarted();
+      await enabledCanFinish;
+      return validateCurrentWebhookUrlResolved("http://127.0.0.1/hook");
+    });
+    await enabledDidStart;
+
+    const disabled = await withRuntimeEnvironment({}, async () => {
+      const result = await validateCurrentWebhookUrlResolved("http://127.0.0.1/hook");
+      releaseEnabled();
+      return result;
+    });
+
+    expect(disabled).toBe("url must use https");
+    expect(await enabled).toBeNull();
+  });
+
+  it("requires exact lowercase Worker acknowledgements", () => {
+    for (const value of ["TRUE", "True", "1", "yes", " true "]) {
+      const result = withRuntimeEnvironment(
+        {
+          STEWARD_ALLOW_INSECURE_WEBHOOK_URLS: value,
+          STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS: value,
+        },
+        () => ({
+          authority: currentWebhookRuntimeAuthority(),
+          validation: validateCurrentWebhookUrl("http://127.0.0.1/hook"),
+        }),
+      );
+      expect(result.authority).toEqual({
+        allowInsecureHttp: false,
+        allowPrivateNetwork: false,
+      });
+      expect(result.validation).toBe("url must use https");
+    }
+  });
+
+  it("does not widen generic URL consumers when webhook acknowledgements are enabled", async () => {
+    await withRuntimeEnvironment(enabledWebhookPolicy, async () => {
+      expect(validateWebhookUrl("https://127.0.0.1/hook")).toBe("url host must be public");
+      expect(await validateWebhookUrlResolved("https://127.0.0.1/hook")).toBe(
+        "url host must be public",
+      );
+    });
+  });
+
   it("rejects IPv4-mapped IPv6 private addresses in dotted and hex forms", () => {
     for (const url of [
       "https://[::ffff:127.0.0.1]/hook",

--- a/packages/api/src/__tests__/worker-boot-validation.test.ts
+++ b/packages/api/src/__tests__/worker-boot-validation.test.ts
@@ -9,13 +9,11 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { signAgentToken, signIdentityJwtPayload } from "@stwd/auth/jwt";
 import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { decodeJwt, decodeProtectedHeader, exportPKCS8, generateKeyPair, jwtVerify } from "jose";
-import worker, { hydrateProcessEnv, withWorkerJwtAuthority } from "../worker";
+import worker, { withWorkerJwtAuthority } from "../worker";
 
 /**
- * Keys this file mutates: bindings hydrateProcessEnv copies onto the global
- * process.env, plus ambient suite values (see test-preload.ts) that some cases
- * must clear to simulate a misconfigured deployment. All restored after each
- * test.
+ * Ambient suite values (see test-preload.ts) that some cases must clear to
+ * simulate a misconfigured deployment. All are restored after each test.
  */
 const MANAGED_KEYS = [
   "STEWARD_RUNTIME",
@@ -207,22 +205,26 @@ describe("workers boot JWT env validation (SEC-134)", () => {
     snapshotEnv();
     const firstSecret = "workers-first-rotated-secret-at-least-32-chars";
     const rotatedSecret = "workers-second-rotated-secret-at-least-32-chars";
-    hydrateProcessEnv({
+    const firstEnv = {
       STEWARD_JWT_SECRET: firstSecret,
       AGENT_TOKEN_EXPIRY: "1h",
       DATABASE_URL: "unused",
-    });
-    const firstToken = await signAgentToken({ agentId: "worker-agent", tenantId: "worker-tenant" });
+    };
+    const firstToken = await withWorkerJwtAuthority(firstEnv, () =>
+      signAgentToken({ agentId: "worker-agent", tenantId: "worker-tenant" }),
+    );
     const first = decodeJwt(firstToken);
-    hydrateProcessEnv({
+    const rotatedEnv = {
       STEWARD_JWT_SECRET: rotatedSecret,
       AGENT_TOKEN_EXPIRY: "5m",
       DATABASE_URL: "unused",
-    });
-    const rotatedToken = await signAgentToken({
-      agentId: "worker-agent",
-      tenantId: "worker-tenant",
-    });
+    };
+    const rotatedToken = await withWorkerJwtAuthority(rotatedEnv, () =>
+      signAgentToken({
+        agentId: "worker-agent",
+        tenantId: "worker-tenant",
+      }),
+    );
     const rotated = decodeJwt(rotatedToken);
 
     expect((first.exp ?? 0) - (first.iat ?? 0)).toBe(3600);
@@ -260,7 +262,6 @@ describe("workers boot JWT env validation (SEC-134)", () => {
     });
 
     const firstMint = withWorkerJwtAuthority(firstEnv, async () => {
-      hydrateProcessEnv(firstEnv);
       markFirstReady();
       await firstBarrier;
       return signAgentToken({ agentId: "worker-first", tenantId: "worker-tenant" });
@@ -270,9 +271,6 @@ describe("workers boot JWT env validation (SEC-134)", () => {
     let secondToken: string;
     try {
       secondToken = await withWorkerJwtAuthority(secondEnv, async () => {
-        // This is the hostile interleaving: overwrite the isolate-wide mirror
-        // while the first invocation is suspended before it mints.
-        hydrateProcessEnv(secondEnv);
         return signAgentToken({ agentId: "worker-second", tenantId: "worker-tenant" });
       });
     } finally {
@@ -332,7 +330,6 @@ describe("workers boot JWT env validation (SEC-134)", () => {
     });
 
     const firstMint = withWorkerJwtAuthority(firstEnv, async () => {
-      hydrateProcessEnv(firstEnv);
       markFirstReady();
       await firstBarrier;
       return signIdentityJwtPayload({ sub: "worker-first" });
@@ -342,7 +339,6 @@ describe("workers boot JWT env validation (SEC-134)", () => {
     let secondToken: string;
     try {
       secondToken = await withWorkerJwtAuthority(secondEnv, async () => {
-        hydrateProcessEnv(secondEnv);
         return signIdentityJwtPayload({ sub: "worker-second" });
       });
     } finally {

--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -648,3 +648,53 @@ test("Worker X lifecycle recovery is inert when the provider is unavailable", as
   expect(calls).toBe(0);
   expect(result).toBeNull();
 });
+
+test("overlapping scheduler invocations retain their own binding generation", async () => {
+  let releaseFirst!: () => void;
+  const firstEntered = Promise.withResolvers<void>();
+  const firstRelease = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  let disabledCalls = 0;
+
+  const first = runWorkerGoogleCredentialLifecycleSweep(
+    {
+      DATABASE_URL: "postgresql://worker-a.invalid/steward",
+      GOOGLE_PROVIDER_CLIENT_ID: "provider-a",
+      GOOGLE_PROVIDER_CLIENT_SECRET: "secret-a",
+    },
+    {
+      sweep: async () => {
+        firstEntered.resolve();
+        await firstRelease;
+        return { generation: "a" };
+      },
+    },
+  );
+  await firstEntered.promise;
+  const disabled = await runWorkerGoogleCredentialLifecycleSweep(
+    {
+      DATABASE_URL: "postgresql://worker-b.invalid/steward",
+      GOOGLE_PROVIDER_CLIENT_ID: "provider-b",
+      GOOGLE_PROVIDER_CLIENT_SECRET: "secret-b",
+      STEWARD_GOOGLE_LIFECYCLE_SWEEPER: "false",
+    },
+    {
+      sweep: async () => {
+        disabledCalls += 1;
+        return { generation: "b" };
+      },
+    },
+  );
+  releaseFirst();
+
+  expect(disabled).toBeNull();
+  expect(disabledCalls).toBe(0);
+  expect(await first).toEqual({ generation: "a" });
+  expect(
+    await runWorkerGoogleCredentialLifecycleSweep(
+      { DATABASE_URL: "postgresql://worker-missing.invalid/steward" },
+      { sweep: async () => ({ generation: "missing" }) },
+    ),
+  ).toBeNull();
+});

--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -10,6 +10,9 @@ import {
 } from "@stwd/db";
 import { createPGLiteDb } from "@stwd/db/pglite";
 import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+import { isPGLiteRuntime } from "../services/context";
+import { isRuntimeVaultRpcMethodAllowed } from "../services/custody-runtime";
+import { getConfiguredVault } from "../services/vault-factory";
 import {
   __setWorkerComposedAppForTests,
   __setWorkerInitForTests,
@@ -150,7 +153,10 @@ test("mounted fetch and scheduled consumers retain hostile overlapping authoriti
     expect(scheduledProviders).toEqual(["disabled"]);
 
     const missing = await worker.fetch(new Request("https://steward.test/missing"), common, {});
-    expect(await missing.text()).toBe("disabled");
+    // Explicit NODE_ENV=test retains the documented development mock fallback;
+    // production binding-removal fail-closed behavior is covered by the mounted
+    // adapter runtime suite with a production authority.
+    expect(await missing.text()).toBe("mock");
     expect({ ...process.env }).toEqual(processEnvironmentBefore);
   } finally {
     releaseFetch();
@@ -838,4 +844,114 @@ test("overlapping scheduler invocations retain their own binding generation", as
       { sweep: async () => ({ generation: "missing" }) },
     ),
   ).toBeNull();
+});
+
+test("mounted requests isolate database, vault, and RPC authority across A -> B -> missing -> A", async () => {
+  const createDbSpy = spyOn(databaseModule, "createDbForRequest").mockImplementation(
+    (env) => ({ marker: env.DATABASE_URL }) as unknown as ReturnType<typeof databaseModule.getDb>,
+  );
+  const vaultIds = new WeakMap<object, number>();
+  let nextVaultId = 1;
+  let releaseA!: () => void;
+  const aEntered = Promise.withResolvers<void>();
+  const aRelease = new Promise<void>((resolve) => {
+    releaseA = resolve;
+  });
+  const observe = () => {
+    const requestDb = getDb() as unknown as { marker: string };
+    const requestVault = getConfiguredVault() as unknown as object;
+    let vaultId = vaultIds.get(requestVault);
+    if (!vaultId) {
+      vaultId = nextVaultId++;
+      vaultIds.set(requestVault, vaultId);
+    }
+    return {
+      database: requestDb.marker,
+      vaultId,
+      pglite: isPGLiteRuntime(),
+      allowsA: isRuntimeVaultRpcMethodAllowed("eth_aOnly"),
+      allowsB: isRuntimeVaultRpcMethodAllowed("eth_bOnly"),
+    };
+  };
+
+  __setWorkerInitForTests(Promise.resolve());
+  __setWorkerComposedAppForTests({
+    async fetch(request) {
+      const before = observe();
+      if (new URL(request.url).pathname === "/a-overlap") {
+        aEntered.resolve();
+        await aRelease;
+      }
+      return Response.json({ before, after: observe() });
+    },
+  });
+
+  const common = {
+    DATABASE_DRIVER: "neon-http",
+    NODE_ENV: "test",
+    STEWARD_JWT_SECRET: "worker-mounted-authority-secret-at-least-32-chars",
+  } as const;
+  const authorityA = {
+    ...common,
+    DATABASE_URL: "postgresql://worker-a.invalid/steward",
+    STEWARD_MASTER_PASSWORD: "mounted-authority-a",
+    STEWARD_KDF_SALT: "a1".repeat(16),
+    STEWARD_VAULT_RPC_ALLOWLIST: "eth_chainId,eth_aOnly",
+  };
+  const authorityB = {
+    ...common,
+    DATABASE_URL: "postgresql://worker-b.invalid/steward",
+    STEWARD_DB_MODE: "pglite",
+    STEWARD_MASTER_PASSWORD: "mounted-authority-b",
+    STEWARD_KDF_SALT: "b2".repeat(16),
+    STEWARD_VAULT_RPC_ALLOWLIST: "eth_chainId,eth_bOnly",
+  };
+
+  try {
+    const pendingA = worker.fetch(new Request("https://steward.test/a-overlap"), authorityA, {});
+    await aEntered.promise;
+    const b = (await (
+      await worker.fetch(new Request("https://steward.test/b"), authorityB, {})
+    ).json()) as { before: ReturnType<typeof observe>; after: ReturnType<typeof observe> };
+    await expect(
+      worker.fetch(
+        new Request("https://steward.test/missing"),
+        {
+          ...common,
+          DATABASE_URL: "postgresql://worker-missing.invalid/steward",
+          STEWARD_KDF_SALT: "c3".repeat(16),
+        },
+        {},
+      ),
+    ).rejects.toThrow("STEWARD_MASTER_PASSWORD is required");
+    releaseA();
+    const a = (await (await pendingA).json()) as {
+      before: ReturnType<typeof observe>;
+      after: ReturnType<typeof observe>;
+    };
+    const replayA = (await (
+      await worker.fetch(new Request("https://steward.test/a-replay"), authorityA, {})
+    ).json()) as { before: ReturnType<typeof observe>; after: ReturnType<typeof observe> };
+
+    expect(a.before).toEqual(a.after);
+    expect(a.before.database).toBe(authorityA.DATABASE_URL);
+    expect(a.before.pglite).toBe(false);
+    expect(a.before.allowsA).toBe(true);
+    expect(a.before.allowsB).toBe(false);
+    expect(b.before).toEqual(b.after);
+    expect(b.before.database).toBe(authorityB.DATABASE_URL);
+    expect(b.before.pglite).toBe(true);
+    expect(b.before.allowsA).toBe(false);
+    expect(b.before.allowsB).toBe(true);
+    expect(b.before.vaultId).not.toBe(a.before.vaultId);
+    expect(replayA.before.database).toBe(authorityA.DATABASE_URL);
+    expect(replayA.before.allowsA).toBe(true);
+    expect(replayA.before.allowsB).toBe(false);
+    expect(replayA.before.vaultId).not.toBe(b.before.vaultId);
+  } finally {
+    releaseA();
+    __setWorkerComposedAppForTests(null);
+    __setWorkerInitForTests(null);
+    createDbSpy.mockRestore();
+  }
 });

--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -1,4 +1,6 @@
 import { expect, spyOn, test } from "bun:test";
+import { adapterRegistry } from "@stwd/adapters";
+import { MemoryBackend } from "@stwd/auth";
 import * as databaseModule from "@stwd/db";
 import {
   __resetAuditHmacKeyCacheForTests,
@@ -8,14 +10,163 @@ import {
 } from "@stwd/db";
 import { createPGLiteDb } from "@stwd/db/pglite";
 import {
+  __resetWorkerHydrationForTests,
+  __setWorkerComposedAppForTests,
   __setWorkerInitForTests,
   hydrateProcessEnv,
   runWorkerGoogleCredentialLifecycleSweep,
   runWorkerUpstreamCredentialLeaseSweep,
   runWorkerXCredentialLifecycleSweep,
   withWorkerRequestDatabase,
+  withWorkerRuntimeAuthority,
   default as worker,
 } from "../worker";
+
+test("user-link stores remain bound to overlapping request authorities", async () => {
+  const authority = (token: string) => ({
+    DATABASE_URL: `postgresql://worker.invalid/${token}`,
+    DATABASE_DRIVER: "neon-http",
+    NODE_ENV: "test",
+    STEWARD_JWT_SECRET: `worker-${token}-jwt-secret-at-least-32-chars`,
+    REDIS_DRIVER: "upstash",
+    KV_REST_API_URL: `https://${token}.redis.invalid`,
+    KV_REST_API_TOKEN: token,
+  });
+  const a = authority("authority-a");
+  const b = authority("authority-b");
+  const [userRoutes, authRoutes] = await withWorkerRuntimeAuthority(a, () =>
+    Promise.all([import("../routes/user"), import("../routes/auth")]),
+  );
+  const {
+    __consumeUserLinkChallengeForTests,
+    __setUserLinkChallengeForTests,
+    initUserLinkChallengeStores,
+  } = userRoutes;
+  const { authStoreAuthorityKey } = authRoutes;
+  withWorkerRuntimeAuthority(a, () =>
+    initUserLinkChallengeStores(new MemoryBackend(), authStoreAuthorityKey()),
+  );
+  withWorkerRuntimeAuthority(b, () =>
+    initUserLinkChallengeStores(new MemoryBackend(), authStoreAuthorityKey()),
+  );
+  let releaseA!: () => void;
+  const aBlocked = new Promise<void>((resolve) => {
+    releaseA = resolve;
+  });
+  const pendingA = withWorkerRuntimeAuthority(a, async () => {
+    await __setUserLinkChallengeForTests("wallet", "same", "a");
+    await aBlocked;
+    return __consumeUserLinkChallengeForTests("wallet", "same");
+  });
+  expect(
+    await withWorkerRuntimeAuthority(b, async () => {
+      await __setUserLinkChallengeForTests("wallet", "same", "b");
+      return __consumeUserLinkChallengeForTests("wallet", "same");
+    }),
+  ).toBe("b");
+  releaseA();
+  expect(await pendingA).toBe("a");
+  await expect(
+    withWorkerRuntimeAuthority(authority("missing"), () =>
+      __consumeUserLinkChallengeForTests("wallet", "same"),
+    ),
+  ).rejects.toThrow("not initialized for this authority");
+});
+
+test("mounted fetch and scheduled consumers retain hostile overlapping authorities", async () => {
+  const upstreamScheduler = await import("../services/upstream-credential-lease-scheduler");
+  const googleScheduler = await import("../services/provider-google-lifecycle-scheduler");
+  const xScheduler = await import("../services/provider-x-lifecycle-scheduler");
+  const createDbSpy = spyOn(databaseModule, "createDbForRequest").mockImplementation(
+    () => ({ marker: "runtime-authority" }) as unknown as ReturnType<typeof getDb>,
+  );
+  let releaseFetch!: () => void;
+  let fetchEntered!: () => void;
+  const fetchBlocked = new Promise<void>((resolve) => {
+    releaseFetch = resolve;
+  });
+  const fetchStarted = new Promise<void>((resolve) => {
+    fetchEntered = resolve;
+  });
+  const scheduledProviders: string[] = [];
+  const upstreamSpy = spyOn(upstreamScheduler, "runUpstreamCredentialLeaseSweep").mockResolvedValue(
+    {
+      unknown: 0,
+      revoked: 0,
+      attention: 0,
+      expired: 0,
+    },
+  );
+  const googleSpy = spyOn(
+    googleScheduler,
+    "runGoogleCredentialLifecycleRecoverySweep",
+  ).mockImplementation(async () => {
+    scheduledProviders.push(adapterRegistry.swap().provider);
+    return {} as never;
+  });
+  const xSpy = spyOn(xScheduler, "runXCredentialLifecycleRecoverySweep").mockResolvedValue(
+    {} as never,
+  );
+  __setWorkerInitForTests(Promise.resolve());
+  __setWorkerComposedAppForTests({
+    async fetch() {
+      fetchEntered();
+      await fetchBlocked;
+      return new Response(adapterRegistry.swap().provider);
+    },
+  });
+  const common = {
+    DATABASE_URL: "postgresql://worker.invalid/steward",
+    DATABASE_DRIVER: "neon-http",
+    NODE_ENV: "test",
+    STEWARD_JWT_SECRET: "worker-runtime-authority-secret-at-least-32-chars",
+    GOOGLE_PROVIDER_CLIENT_ID: "runtime-google-client",
+    GOOGLE_PROVIDER_CLIENT_SECRET: "runtime-google-secret",
+  } as const;
+  const hydratedKeys = [...Object.keys(common), "STEWARD_SWAP_ADAPTER"];
+  const previousEnvironment = new Map(hydratedKeys.map((key) => [key, process.env[key]] as const));
+  try {
+    const fetchResponse = worker.fetch(
+      new Request("https://steward.test/consumer"),
+      {
+        ...common,
+        STEWARD_SWAP_ADAPTER: "mock",
+      },
+      {},
+    );
+    await fetchStarted;
+    let scheduledWork!: Promise<unknown>;
+    await worker.scheduled(
+      {},
+      { ...common, STEWARD_SWAP_ADAPTER: "not-registered" },
+      {
+        waitUntil(promise) {
+          scheduledWork = promise;
+        },
+      },
+    );
+    await scheduledWork;
+    releaseFetch();
+    expect(await (await fetchResponse).text()).toBe("mock");
+    expect(scheduledProviders).toEqual(["disabled"]);
+
+    const missing = await worker.fetch(new Request("https://steward.test/missing"), common, {});
+    expect(await missing.text()).toBe("disabled");
+  } finally {
+    releaseFetch();
+    __setWorkerComposedAppForTests(null);
+    __setWorkerInitForTests(null);
+    createDbSpy.mockRestore();
+    upstreamSpy.mockRestore();
+    googleSpy.mockRestore();
+    xSpy.mockRestore();
+    __resetWorkerHydrationForTests();
+    for (const [key, value] of previousEnvironment) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+});
 
 test("Worker hydration cannot be overridden by a STEWARD_RUNTIME binding", () => {
   const previous = process.env.STEWARD_RUNTIME;

--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -9,11 +9,10 @@ import {
   waitUntilRequestDatabaseTask,
 } from "@stwd/db";
 import { createPGLiteDb } from "@stwd/db/pglite";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
-  __resetWorkerHydrationForTests,
   __setWorkerComposedAppForTests,
   __setWorkerInitForTests,
-  hydrateProcessEnv,
   runWorkerGoogleCredentialLifecycleSweep,
   runWorkerUpstreamCredentialLeaseSweep,
   runWorkerXCredentialLifecycleSweep,
@@ -123,8 +122,7 @@ test("mounted fetch and scheduled consumers retain hostile overlapping authoriti
     GOOGLE_PROVIDER_CLIENT_ID: "runtime-google-client",
     GOOGLE_PROVIDER_CLIENT_SECRET: "runtime-google-secret",
   } as const;
-  const hydratedKeys = [...Object.keys(common), "STEWARD_SWAP_ADAPTER"];
-  const previousEnvironment = new Map(hydratedKeys.map((key) => [key, process.env[key]] as const));
+  const processEnvironmentBefore = { ...process.env };
   try {
     const fetchResponse = worker.fetch(
       new Request("https://steward.test/consumer"),
@@ -146,12 +144,14 @@ test("mounted fetch and scheduled consumers retain hostile overlapping authoriti
       },
     );
     await scheduledWork;
+    expect({ ...process.env }).toEqual(processEnvironmentBefore);
     releaseFetch();
     expect(await (await fetchResponse).text()).toBe("mock");
     expect(scheduledProviders).toEqual(["disabled"]);
 
     const missing = await worker.fetch(new Request("https://steward.test/missing"), common, {});
     expect(await missing.text()).toBe("disabled");
+    expect({ ...process.env }).toEqual(processEnvironmentBefore);
   } finally {
     releaseFetch();
     __setWorkerComposedAppForTests(null);
@@ -160,26 +160,22 @@ test("mounted fetch and scheduled consumers retain hostile overlapping authoriti
     upstreamSpy.mockRestore();
     googleSpy.mockRestore();
     xSpy.mockRestore();
-    __resetWorkerHydrationForTests();
-    for (const [key, value] of previousEnvironment) {
-      if (value === undefined) delete process.env[key];
-      else process.env[key] = value;
-    }
   }
 });
 
-test("Worker hydration cannot be overridden by a STEWARD_RUNTIME binding", () => {
-  const previous = process.env.STEWARD_RUNTIME;
-  try {
-    hydrateProcessEnv({
+test("Worker authority cannot mutate process.env or accept a runtime override", async () => {
+  const processEnvironmentBefore = { ...process.env };
+  await withWorkerRuntimeAuthority(
+    {
       DATABASE_URL: "postgresql://worker.invalid/steward",
       STEWARD_RUNTIME: "bun",
-    });
-    expect(process.env.STEWARD_RUNTIME).toBe("workers");
-  } finally {
-    if (previous === undefined) delete process.env.STEWARD_RUNTIME;
-    else process.env.STEWARD_RUNTIME = previous;
-  }
+    },
+    async () => {
+      expect(runtimeEnvironmentValue("STEWARD_RUNTIME")).toBe("workers");
+      expect({ ...process.env }).toEqual(processEnvironmentBefore);
+    },
+  );
+  expect({ ...process.env }).toEqual(processEnvironmentBefore);
 });
 
 test("Worker request database is exact, request-owned, and always closed", async () => {
@@ -323,7 +319,7 @@ test("cold Worker cron rejects a hostile database role before starting sweeps", 
     STEWARD_APP_DATABASE_ROLE: "steward_app",
     STEWARD_JWT_SECRET: "worker-hostile-role-secret-at-least-32-chars",
   };
-  const previousEnv = new Map(Object.keys(env).map((key) => [key, process.env[key]] as const));
+  const processEnvironmentBefore = { ...process.env };
   __setWorkerInitForTests(null);
   try {
     await worker.scheduled({}, env, {
@@ -333,13 +329,10 @@ test("cold Worker cron rejects a hostile database role before starting sweeps", 
     });
     await expect(scheduledWork).rejects.toThrow("RLS_DEPLOYMENT_ROLE_UNSAFE");
     expect(databases).toBe(1);
+    expect({ ...process.env }).toEqual(processEnvironmentBefore);
   } finally {
     __setWorkerInitForTests(null);
     createDbSpy.mockRestore();
-    for (const [key, value] of previousEnv) {
-      if (value === undefined) delete process.env[key];
-      else process.env[key] = value;
-    }
   }
 });
 
@@ -389,7 +382,7 @@ test("Worker cron gives every autonomous sweep its own request database", async 
     X_CLIENT_SECRET: "x-secret",
     STEWARD_MASTER_PASSWORD: "worker-cron-master-password",
   };
-  const previousEnv = new Map(Object.keys(env).map((key) => [key, process.env[key]] as const));
+  const processEnvironmentBefore = { ...process.env };
 
   try {
     __setWorkerInitForTests(Promise.resolve());
@@ -399,16 +392,13 @@ test("Worker cron gives every autonomous sweep its own request database", async 
       },
     });
     await scheduledWork;
+    expect({ ...process.env }).toEqual(processEnvironmentBefore);
   } finally {
     __setWorkerInitForTests(null);
     createDbSpy.mockRestore();
     upstreamSpy.mockRestore();
     googleSpy.mockRestore();
     xSpy.mockRestore();
-    for (const [key, value] of previousEnv) {
-      if (value === undefined) delete process.env[key];
-      else process.env[key] = value;
-    }
   }
 
   expect(databaseCount).toBe(4);

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -126,7 +126,7 @@ export function createApp(): Hono<{ Variables: AppVariables }> {
   // cross-isolate state). Mount the shared Redis-backed sliding-window limiter
   // across all routes for the Workers runtime only, so non-auth endpoints
   // there are no longer unthrottled.
-  if (isWorkersRuntime) {
+  if (isWorkersRuntime()) {
     app.use("*", workersGlobalRateLimit);
   }
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -157,11 +157,11 @@ export function createApp(): Hono<{ Variables: AppVariables }> {
   // strict mode so browser/unsigned SDK clients keep working until an operator
   // has rolled out signing clients. Mounted in pre-idempotency setup so these
   // guards always run before the idempotency middleware.
-  app.use("*", requestExpiry({ required: process.env.STEWARD_REQUIRE_REQUEST_EXPIRY === "true" }));
-  app.use(
-    "*",
-    authorizationSignature({ required: process.env.STEWARD_REQUIRE_AUTH_SIGNATURE === "true" }),
-  );
+  // Resolve the requirement and signing authority inside each middleware
+  // invocation. The Worker app is cached per isolate, while its bindings are
+  // request-scoped and may rotate without an isolate recycle.
+  app.use("*", requestExpiry());
+  app.use("*", authorizationSignature());
 
   // ─── Auth middleware per route group ────────────────────────────────────────
 

--- a/packages/api/src/compose.ts
+++ b/packages/api/src/compose.ts
@@ -1,4 +1,3 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * compose.ts — the COMPOSITION ROOT that assembles the deployable Steward
  * server: the lean core (`createApp()`) plus the opt-in plugins this repo's own

--- a/packages/api/src/compose.ts
+++ b/packages/api/src/compose.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * compose.ts — the COMPOSITION ROOT that assembles the deployable Steward
  * server: the lean core (`createApp()`) plus the opt-in plugins this repo's own
@@ -110,7 +111,7 @@ export async function composeApp(): Promise<Hono<{ Variables: AppVariables }>> {
   // unknown plugin name, so a typo'd STEWARD_PLUGINS aborts boot here rather than
   // silently shipping a wrong feature profile. composeApp reads process.env
   // directly (prod signature unchanged); the resolver itself is env-injectable
-  // for tests, which set/restore process.env.STEWARD_PLUGINS around each case.
+  // for tests, which set/restore runtimeEnvironmentValue("STEWARD_PLUGINS") around each case.
   const enabled = resolveEnabledPlugins();
 
   // 1) lean core: global mw + all core auth mw (NO idempotency, NO routes yet).

--- a/packages/api/src/embedded.ts
+++ b/packages/api/src/embedded.ts
@@ -28,7 +28,7 @@ if (!process.env.DATABASE_URL) {
   process.env.DATABASE_URL = "pglite://embedded";
 }
 
-// Ensure STEWARD_MASTER_PASSWORD is set (context.ts requires it at module level).
+// Ensure the Bun runtime custody authority has a durable master password.
 // Auto-generate one if not provided — the sidecar also generates one and passes
 // it via env, but standalone `bun run start:local` needs a fallback.
 // SEC-147: a fresh random password per boot silently makes everything sealed

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -32,8 +32,8 @@ import {
   API_VERSION,
   type ApiResponse,
   nonceCleanupTimer,
-  RATE_LIMIT_MAX_REQUESTS,
-  RATE_LIMIT_WINDOW_MS,
+  rateLimitMaxRequests,
+  rateLimitWindowMs,
 } from "./services/context";
 import { startGoogleCredentialLifecycleScheduler } from "./services/provider-google-lifecycle-scheduler";
 import { startProviderReservationReconciliationScheduler } from "./services/provider-reservation-reconciliation-scheduler";
@@ -85,8 +85,8 @@ const capabilitiesEnabled = resolveEnabledPlugins().has("capabilities");
 
 const trustedProxyHops = parseNonNegativeInt(process.env.STEWARD_TRUSTED_PROXY_HOPS, 0);
 const rateLimiter = new InMemoryRateLimiter(
-  RATE_LIMIT_MAX_REQUESTS,
-  RATE_LIMIT_WINDOW_MS,
+  rateLimitMaxRequests(),
+  rateLimitWindowMs(),
   parsePositiveInt(process.env.STEWARD_RATE_LIMIT_MAX_KEYS, 10_000),
 );
 let isShuttingDown = false;
@@ -121,7 +121,7 @@ function runtimeGate(request: Request, peerAddress: string | null): Response | n
 
 const requestLogCleanupTimer = setInterval(() => {
   rateLimiter.sweep();
-}, RATE_LIMIT_WINDOW_MS);
+}, rateLimitWindowMs());
 
 // ─── /ready — deep readiness probe ───────────────────────────────────────────
 //

--- a/packages/api/src/middleware/agent-jwt.ts
+++ b/packages/api/src/middleware/agent-jwt.ts
@@ -1,4 +1,5 @@
 import type { VerifiedAgentPrincipal } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type { Context, Next } from "hono";
 import { errors, importJWK, type JWTPayload, jwtVerify } from "jose";
 import { recordAgentTokenExp } from "../services/agent-token-status";
@@ -42,11 +43,11 @@ function invalid(c: Context, reason: string, status: 401 = 401) {
  * the STEWARD_ALLOW_DEFAULT_ELIZA_JWKS=true opt-in. Fails closed otherwise.
  */
 function resolveJwksUrl(): string {
-  const configured = process.env.ELIZA_CLOUD_JWKS_URL?.trim();
+  const configured = runtimeEnvironmentValue("ELIZA_CLOUD_JWKS_URL")?.trim();
   if (configured) return configured;
   if (
-    process.env.NODE_ENV !== "production" &&
-    process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS === "true"
+    runtimeEnvironmentValue("NODE_ENV") !== "production" &&
+    runtimeEnvironmentValue("STEWARD_ALLOW_DEFAULT_ELIZA_JWKS") === "true"
   ) {
     return DEFAULT_ELIZA_CLOUD_JWKS_URL;
   }

--- a/packages/api/src/middleware/authorization-signature.ts
+++ b/packages/api/src/middleware/authorization-signature.ts
@@ -8,12 +8,16 @@ import {
   tenantAppClients,
   tenantRequestSigningKeys,
 } from "@stwd/db";
-import { type EncryptedKey, KeyStore } from "@stwd/vault";
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+import type { EncryptedKey, KeyStore } from "@stwd/vault";
 import { and, eq } from "drizzle-orm";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import { type ApiResponse, type AppVariables, isValidTenantId } from "../services/context";
+import {
+  type CustodyAuthority,
+  getConfiguredKeyStore,
+  resolveCustodyAuthority,
+} from "../services/vault-factory";
 import { isSensitivePath } from "./sensitive-paths";
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
@@ -65,8 +69,8 @@ export type AuthorizationSignatureOptions = {
 
 function configuredSecrets(): string[] {
   const combined = [
-    runtimeEnvironmentValue("STEWARD_REQUEST_SIGNING_SECRETS"),
-    runtimeEnvironmentValue("STEWARD_REQUEST_SIGNING_SECRET"),
+    process.env.STEWARD_REQUEST_SIGNING_SECRETS,
+    process.env.STEWARD_REQUEST_SIGNING_SECRET,
   ]
     .filter(Boolean)
     .join(",");
@@ -168,8 +172,12 @@ async function tenantRequestSigningKeyCandidates(
   // reach the indexed lookup and subsequent decrypt.
   const keyId = request.headers.get("X-Steward-Signing-Key-Id");
   if (!keyId || !SIGNING_KEY_ID_PATTERN.test(keyId)) return [];
-  const masterPassword = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD");
-  if (!masterPassword) return [];
+  let authority: CustodyAuthority;
+  try {
+    authority = resolveCustodyAuthority();
+  } catch {
+    return [];
+  }
 
   const now = new Date();
   const rows = await getDb()
@@ -185,7 +193,7 @@ async function tenantRequestSigningKeyCandidates(
   // Defer KeyStore construction (itself a scrypt KDF) until a row exists, so
   // an unknown key id costs only the cheap lookup above.
   if (rows.length === 0) return [];
-  const keyStore = createKeyStore(masterPassword, undefined, "secret-vault");
+  const keyStore = createKeyStore(authority.masterPassword, authority.kdfSalt, "secret-vault");
   return rows.flatMap((row) => {
     if (row.revokedAt) return [];
     if (row.expiresAt && row.expiresAt <= now) return [];
@@ -802,24 +810,25 @@ export async function buildAuthorizationCanonicalString(
 }
 
 export function authorizationSignature(options?: AuthorizationSignatureOptions) {
+  const required =
+    options?.required ??
+    (process.env.STEWARD_REQUIRE_AUTH_SIGNATURE === "true" ||
+      process.env.NODE_ENV === "production");
+  const secrets = options?.secrets ?? configuredSecrets();
   const appSecretResolver = options?.appSecretResolver ?? appClientSecretSigningCandidates;
   const tenantKeyStoreFactory =
     options?.tenantKeyStoreFactory ??
-    ((masterPassword, masterSalt, domain) => new KeyStore(masterPassword, masterSalt, domain));
+    ((_masterPassword, _masterSalt, domain) => getConfiguredKeyStore(domain));
+  const maxClockSkewMs = parsePositiveInt(
+    process.env.STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS,
+    DEFAULT_MAX_CLOCK_SKEW_MS,
+  );
+  const timestampTtlMs = parsePositiveInt(
+    process.env.STEWARD_REQUEST_TIMESTAMP_TTL_MS,
+    DEFAULT_TIMESTAMP_TTL_MS,
+  );
+
   return createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
-    const required =
-      options?.required ??
-      (runtimeEnvironmentValue("STEWARD_REQUIRE_AUTH_SIGNATURE") === "true" ||
-        runtimeEnvironmentValue("NODE_ENV") === "production");
-    const secrets = options?.secrets ?? configuredSecrets();
-    const maxClockSkewMs = parsePositiveInt(
-      runtimeEnvironmentValue("STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS"),
-      DEFAULT_MAX_CLOCK_SKEW_MS,
-    );
-    const timestampTtlMs = parsePositiveInt(
-      runtimeEnvironmentValue("STEWARD_REQUEST_TIMESTAMP_TTL_MS"),
-      DEFAULT_TIMESTAMP_TTL_MS,
-    );
     if (!MUTATING_METHODS.has(c.req.method.toUpperCase()) || !isSensitivePath(c.req.path)) {
       return next();
     }

--- a/packages/api/src/middleware/authorization-signature.ts
+++ b/packages/api/src/middleware/authorization-signature.ts
@@ -9,6 +9,7 @@ import {
   tenantRequestSigningKeys,
 } from "@stwd/db";
 import { type EncryptedKey, KeyStore } from "@stwd/vault";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { and, eq } from "drizzle-orm";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
@@ -64,8 +65,8 @@ export type AuthorizationSignatureOptions = {
 
 function configuredSecrets(): string[] {
   const combined = [
-    process.env.STEWARD_REQUEST_SIGNING_SECRETS,
-    process.env.STEWARD_REQUEST_SIGNING_SECRET,
+    runtimeEnvironmentValue("STEWARD_REQUEST_SIGNING_SECRETS"),
+    runtimeEnvironmentValue("STEWARD_REQUEST_SIGNING_SECRET"),
   ]
     .filter(Boolean)
     .join(",");
@@ -167,7 +168,7 @@ async function tenantRequestSigningKeyCandidates(
   // reach the indexed lookup and subsequent decrypt.
   const keyId = request.headers.get("X-Steward-Signing-Key-Id");
   if (!keyId || !SIGNING_KEY_ID_PATTERN.test(keyId)) return [];
-  const masterPassword = process.env.STEWARD_MASTER_PASSWORD;
+  const masterPassword = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD");
   if (!masterPassword) return [];
 
   const now = new Date();
@@ -801,25 +802,24 @@ export async function buildAuthorizationCanonicalString(
 }
 
 export function authorizationSignature(options?: AuthorizationSignatureOptions) {
-  const required =
-    options?.required ??
-    (process.env.STEWARD_REQUIRE_AUTH_SIGNATURE === "true" ||
-      process.env.NODE_ENV === "production");
-  const secrets = options?.secrets ?? configuredSecrets();
   const appSecretResolver = options?.appSecretResolver ?? appClientSecretSigningCandidates;
   const tenantKeyStoreFactory =
     options?.tenantKeyStoreFactory ??
     ((masterPassword, masterSalt, domain) => new KeyStore(masterPassword, masterSalt, domain));
-  const maxClockSkewMs = parsePositiveInt(
-    process.env.STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS,
-    DEFAULT_MAX_CLOCK_SKEW_MS,
-  );
-  const timestampTtlMs = parsePositiveInt(
-    process.env.STEWARD_REQUEST_TIMESTAMP_TTL_MS,
-    DEFAULT_TIMESTAMP_TTL_MS,
-  );
-
   return createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
+    const required =
+      options?.required ??
+      (runtimeEnvironmentValue("STEWARD_REQUIRE_AUTH_SIGNATURE") === "true" ||
+        runtimeEnvironmentValue("NODE_ENV") === "production");
+    const secrets = options?.secrets ?? configuredSecrets();
+    const maxClockSkewMs = parsePositiveInt(
+      runtimeEnvironmentValue("STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS"),
+      DEFAULT_MAX_CLOCK_SKEW_MS,
+    );
+    const timestampTtlMs = parsePositiveInt(
+      runtimeEnvironmentValue("STEWARD_REQUEST_TIMESTAMP_TTL_MS"),
+      DEFAULT_TIMESTAMP_TTL_MS,
+    );
     if (!MUTATING_METHODS.has(c.req.method.toUpperCase()) || !isSensitivePath(c.req.path)) {
       return next();
     }

--- a/packages/api/src/middleware/authorization-signature.ts
+++ b/packages/api/src/middleware/authorization-signature.ts
@@ -8,6 +8,7 @@ import {
   tenantAppClients,
   tenantRequestSigningKeys,
 } from "@stwd/db";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type { EncryptedKey, KeyStore } from "@stwd/vault";
 import { and, eq } from "drizzle-orm";
 import type { Context } from "hono";
@@ -69,8 +70,8 @@ export type AuthorizationSignatureOptions = {
 
 function configuredSecrets(): string[] {
   const combined = [
-    process.env.STEWARD_REQUEST_SIGNING_SECRETS,
-    process.env.STEWARD_REQUEST_SIGNING_SECRET,
+    runtimeEnvironmentValue("STEWARD_REQUEST_SIGNING_SECRETS"),
+    runtimeEnvironmentValue("STEWARD_REQUEST_SIGNING_SECRET"),
   ]
     .filter(Boolean)
     .join(",");
@@ -810,25 +811,24 @@ export async function buildAuthorizationCanonicalString(
 }
 
 export function authorizationSignature(options?: AuthorizationSignatureOptions) {
-  const required =
-    options?.required ??
-    (process.env.STEWARD_REQUIRE_AUTH_SIGNATURE === "true" ||
-      process.env.NODE_ENV === "production");
-  const secrets = options?.secrets ?? configuredSecrets();
   const appSecretResolver = options?.appSecretResolver ?? appClientSecretSigningCandidates;
   const tenantKeyStoreFactory =
     options?.tenantKeyStoreFactory ??
     ((_masterPassword, _masterSalt, domain) => getConfiguredKeyStore(domain));
-  const maxClockSkewMs = parsePositiveInt(
-    process.env.STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS,
-    DEFAULT_MAX_CLOCK_SKEW_MS,
-  );
-  const timestampTtlMs = parsePositiveInt(
-    process.env.STEWARD_REQUEST_TIMESTAMP_TTL_MS,
-    DEFAULT_TIMESTAMP_TTL_MS,
-  );
-
   return createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
+    const required =
+      options?.required ??
+      (runtimeEnvironmentValue("STEWARD_REQUIRE_AUTH_SIGNATURE") === "true" ||
+        runtimeEnvironmentValue("NODE_ENV") === "production");
+    const secrets = options?.secrets ?? configuredSecrets();
+    const maxClockSkewMs = parsePositiveInt(
+      runtimeEnvironmentValue("STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS"),
+      DEFAULT_MAX_CLOCK_SKEW_MS,
+    );
+    const timestampTtlMs = parsePositiveInt(
+      runtimeEnvironmentValue("STEWARD_REQUEST_TIMESTAMP_TTL_MS"),
+      DEFAULT_TIMESTAMP_TTL_MS,
+    );
     if (!MUTATING_METHODS.has(c.req.method.toUpperCase()) || !isSensitivePath(c.req.path)) {
       return next();
     }

--- a/packages/api/src/middleware/global-rate-limit.ts
+++ b/packages/api/src/middleware/global-rate-limit.ts
@@ -14,7 +14,7 @@
 
 import type { Context, Next } from "hono";
 import { checkAuthRateLimit } from "../routes/auth";
-import { RATE_LIMIT_MAX_REQUESTS, RATE_LIMIT_WINDOW_MS } from "../services/context";
+import { rateLimitMaxRequests, rateLimitWindowMs } from "../services/context";
 
 export async function workersGlobalRateLimit(
   c: Context,
@@ -28,8 +28,8 @@ export async function workersGlobalRateLimit(
   const verdict = await checkAuthRateLimit(
     c,
     "global",
-    RATE_LIMIT_WINDOW_MS,
-    RATE_LIMIT_MAX_REQUESTS,
+    rateLimitWindowMs(),
+    rateLimitMaxRequests(),
   );
   if (!verdict.allowed) {
     return c.json(

--- a/packages/api/src/middleware/idempotency.ts
+++ b/packages/api/src/middleware/idempotency.ts
@@ -409,7 +409,10 @@ export class MemoryIdempotencyStore implements IdempotencyStore {
 
 export class RedisIdempotencyStore implements IdempotencyStore {
   private readonly fallback = new MemoryIdempotencyStore(
-    parsePositiveInt(runtimeEnvironmentValue("STEWARD_IDEMPOTENCY_MAX_ENTRIES"), DEFAULT_MAX_ENTRIES),
+    parsePositiveInt(
+      runtimeEnvironmentValue("STEWARD_IDEMPOTENCY_MAX_ENTRIES"),
+      DEFAULT_MAX_ENTRIES,
+    ),
   );
 
   private client() {
@@ -623,7 +626,8 @@ function hasReplaySafePublicContext(c: { req: { path: string } }) {
 export function idempotencyMiddleware(options?: { store?: IdempotencyStore; ttlMs?: number }) {
   const store = options?.store ?? defaultIdempotencyStore;
   const ttlMs =
-    options?.ttlMs ?? parsePositiveInt(runtimeEnvironmentValue("STEWARD_IDEMPOTENCY_TTL_MS"), DEFAULT_TTL_MS);
+    options?.ttlMs ??
+    parsePositiveInt(runtimeEnvironmentValue("STEWARD_IDEMPOTENCY_TTL_MS"), DEFAULT_TTL_MS);
 
   return createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
     if (!MUTATING_METHODS.has(c.req.method.toUpperCase())) return next();

--- a/packages/api/src/middleware/idempotency.ts
+++ b/packages/api/src/middleware/idempotency.ts
@@ -1,4 +1,5 @@
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createMiddleware } from "hono/factory";
 import type { ApiResponse, AppVariables } from "../services/context";
 import { isRecentMfaTimestamp } from "../services/recent-mfa";
@@ -120,7 +121,7 @@ function metricsRedisKey(tenantId: string): string {
 
 function metricsTtlSeconds(): number {
   const ttlMs = parsePositiveInt(
-    process.env.STEWARD_IDEMPOTENCY_METRICS_TTL_MS,
+    runtimeEnvironmentValue("STEWARD_IDEMPOTENCY_METRICS_TTL_MS"),
     DEFAULT_METRICS_TTL_MS,
   );
   return Math.max(1, Math.ceil(ttlMs / 1000));
@@ -242,7 +243,7 @@ async function snapshotFromRedis(
 
 export async function getTenantIdempotencyMetrics(
   tenantId: string,
-  ttlMs = parsePositiveInt(process.env.STEWARD_IDEMPOTENCY_TTL_MS, DEFAULT_TTL_MS),
+  ttlMs = parsePositiveInt(runtimeEnvironmentValue("STEWARD_IDEMPOTENCY_TTL_MS"), DEFAULT_TTL_MS),
 ): Promise<TenantIdempotencyMetricsSnapshot> {
   const bucket = idempotencyMetricBuckets.get(tenantId);
   const now = Date.now();
@@ -408,13 +409,13 @@ export class MemoryIdempotencyStore implements IdempotencyStore {
 
 export class RedisIdempotencyStore implements IdempotencyStore {
   private readonly fallback = new MemoryIdempotencyStore(
-    parsePositiveInt(process.env.STEWARD_IDEMPOTENCY_MAX_ENTRIES, DEFAULT_MAX_ENTRIES),
+    parsePositiveInt(runtimeEnvironmentValue("STEWARD_IDEMPOTENCY_MAX_ENTRIES"), DEFAULT_MAX_ENTRIES),
   );
 
   private client() {
     const redis = getRedisClient();
     if (redis) return redis;
-    if (process.env.NODE_ENV !== "production") return null;
+    if (runtimeEnvironmentValue("NODE_ENV") !== "production") return null;
     throw new Error("Durable idempotency store unavailable");
   }
 
@@ -622,7 +623,7 @@ function hasReplaySafePublicContext(c: { req: { path: string } }) {
 export function idempotencyMiddleware(options?: { store?: IdempotencyStore; ttlMs?: number }) {
   const store = options?.store ?? defaultIdempotencyStore;
   const ttlMs =
-    options?.ttlMs ?? parsePositiveInt(process.env.STEWARD_IDEMPOTENCY_TTL_MS, DEFAULT_TTL_MS);
+    options?.ttlMs ?? parsePositiveInt(runtimeEnvironmentValue("STEWARD_IDEMPOTENCY_TTL_MS"), DEFAULT_TTL_MS);
 
   return createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
     if (!MUTATING_METHODS.has(c.req.method.toUpperCase())) return next();

--- a/packages/api/src/middleware/redis-enforcement.ts
+++ b/packages/api/src/middleware/redis-enforcement.ts
@@ -133,7 +133,7 @@ export async function enforceRateLimit(
   const rlParams = extractRateLimitPolicy(policies);
   if (!rlParams) return { allowed: true };
   if (!isRedisAvailable()) {
-    if (!isRedisConfigured() && process.env.NODE_ENV !== "production") return { allowed: true };
+    if (!isRedisConfigured() && runtimeEnvironmentValue("NODE_ENV") !== "production") return { allowed: true };
     return {
       allowed: false,
       reason: "Rate limit enforcement is unavailable",

--- a/packages/api/src/middleware/redis-enforcement.ts
+++ b/packages/api/src/middleware/redis-enforcement.ts
@@ -133,7 +133,8 @@ export async function enforceRateLimit(
   const rlParams = extractRateLimitPolicy(policies);
   if (!rlParams) return { allowed: true };
   if (!isRedisAvailable()) {
-    if (!isRedisConfigured() && runtimeEnvironmentValue("NODE_ENV") !== "production") return { allowed: true };
+    if (!isRedisConfigured() && runtimeEnvironmentValue("NODE_ENV") !== "production")
+      return { allowed: true };
     return {
       allowed: false,
       reason: "Rate limit enforcement is unavailable",

--- a/packages/api/src/middleware/redis.ts
+++ b/packages/api/src/middleware/redis.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Redis middleware — initializes the Redis client and exposes
  * rate-limiting + spend-tracking helpers on the Hono context.
@@ -39,11 +40,11 @@ export async function initRedis(env?: Record<string, unknown>): Promise<boolean>
     }
   }
 
-  const driver = process.env.REDIS_DRIVER?.trim().toLowerCase() || "ioredis";
-  const hasIoredisUrl = Boolean(process.env.REDIS_URL);
+  const driver = runtimeEnvironmentValue("REDIS_DRIVER")?.trim().toLowerCase() || "ioredis";
+  const hasIoredisUrl = Boolean(runtimeEnvironmentValue("REDIS_URL"));
   const hasUpstashConfig = Boolean(
-    (process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL) &&
-      (process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN),
+    (runtimeEnvironmentValue("KV_REST_API_URL") || runtimeEnvironmentValue("UPSTASH_REDIS_REST_URL")) &&
+      (runtimeEnvironmentValue("KV_REST_API_TOKEN") || runtimeEnvironmentValue("UPSTASH_REDIS_REST_TOKEN")),
   );
 
   if (driver === "upstash" ? !hasUpstashConfig : !hasIoredisUrl) {
@@ -74,14 +75,14 @@ export function isRedisAvailable(): boolean {
 }
 
 export function isRedisConfigured(): boolean {
-  const driver = process.env.REDIS_DRIVER?.trim().toLowerCase() || "ioredis";
+  const driver = runtimeEnvironmentValue("REDIS_DRIVER")?.trim().toLowerCase() || "ioredis";
   if (driver === "upstash") {
     return Boolean(
-      (process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL) &&
-        (process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN),
+      (runtimeEnvironmentValue("KV_REST_API_URL") || runtimeEnvironmentValue("UPSTASH_REDIS_REST_URL")) &&
+        (runtimeEnvironmentValue("KV_REST_API_TOKEN") || runtimeEnvironmentValue("UPSTASH_REDIS_REST_TOKEN")),
     );
   }
-  return Boolean(process.env.REDIS_URL);
+  return Boolean(runtimeEnvironmentValue("REDIS_URL"));
 }
 
 /**

--- a/packages/api/src/middleware/redis.ts
+++ b/packages/api/src/middleware/redis.ts
@@ -1,4 +1,4 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+import { runtimeEnvironmentSnapshot, runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Redis middleware — initializes the Redis client and exposes
  * rate-limiting + spend-tracking helpers on the Hono context.
@@ -23,28 +23,37 @@ import { redactedThrownDiagnostics } from "@stwd/shared";
 
 // ─── Redis availability flag ─────────────────────────────────────────────────
 
-let redisAvailable = false;
-let redisClient: IoredisLike | null = null;
+const redisClients = new Map<string, IoredisLike>();
+
+function redisAuthorityFingerprint(): string {
+  const environment = runtimeEnvironmentSnapshot();
+  return JSON.stringify([
+    environment.REDIS_DRIVER ?? "ioredis",
+    environment.REDIS_URL ?? "",
+    environment.KV_REST_API_URL ?? environment.UPSTASH_REDIS_REST_URL ?? "",
+    environment.KV_REST_API_TOKEN ?? environment.UPSTASH_REDIS_REST_TOKEN ?? "",
+    environment.NODE_ENV ?? "",
+    environment.STEWARD_RUNTIME ?? "",
+    environment.STEWARD_ALLOW_INSECURE_REDIS ?? "",
+  ]);
+}
 
 /**
  * Try to connect to Redis on startup. If it fails, route-level helpers decide
  * whether to use local-development defaults or fail closed based on whether
  * Redis was configured for this deployment.
  */
-export async function initRedis(env?: Record<string, unknown>): Promise<boolean> {
-  if (redisAvailable && redisClient) return true;
-
-  if (env) {
-    for (const [key, value] of Object.entries(env)) {
-      if (typeof value === "string") process.env[key] = value;
-    }
-  }
+export async function initRedis(_env?: Record<string, unknown>): Promise<boolean> {
+  const fingerprint = redisAuthorityFingerprint();
+  if (redisClients.has(fingerprint)) return true;
 
   const driver = runtimeEnvironmentValue("REDIS_DRIVER")?.trim().toLowerCase() || "ioredis";
   const hasIoredisUrl = Boolean(runtimeEnvironmentValue("REDIS_URL"));
   const hasUpstashConfig = Boolean(
-    (runtimeEnvironmentValue("KV_REST_API_URL") || runtimeEnvironmentValue("UPSTASH_REDIS_REST_URL")) &&
-      (runtimeEnvironmentValue("KV_REST_API_TOKEN") || runtimeEnvironmentValue("UPSTASH_REDIS_REST_TOKEN")),
+    (runtimeEnvironmentValue("KV_REST_API_URL") ||
+      runtimeEnvironmentValue("UPSTASH_REDIS_REST_URL")) &&
+      (runtimeEnvironmentValue("KV_REST_API_TOKEN") ||
+        runtimeEnvironmentValue("UPSTASH_REDIS_REST_TOKEN")),
   );
 
   if (driver === "upstash" ? !hasUpstashConfig : !hasIoredisUrl) {
@@ -54,10 +63,10 @@ export async function initRedis(env?: Record<string, unknown>): Promise<boolean>
   }
 
   try {
-    redisClient = getRedis();
+    const redisClient = getRedis();
     // Ping to verify the connection
     await redisClient?.ping();
-    redisAvailable = true;
+    redisClients.set(fingerprint, redisClient);
     console.log("[steward:redis] Redis connected — rate limiting and spend tracking enabled");
     return true;
   } catch (err) {
@@ -65,21 +74,23 @@ export async function initRedis(env?: Record<string, unknown>): Promise<boolean>
       "[steward:redis] Failed to connect — Redis enforcement disabled",
       redactedThrownDiagnostics(err),
     );
-    redisAvailable = false;
+    redisClients.delete(fingerprint);
     return false;
   }
 }
 
 export function isRedisAvailable(): boolean {
-  return redisAvailable;
+  return redisClients.has(redisAuthorityFingerprint());
 }
 
 export function isRedisConfigured(): boolean {
   const driver = runtimeEnvironmentValue("REDIS_DRIVER")?.trim().toLowerCase() || "ioredis";
   if (driver === "upstash") {
     return Boolean(
-      (runtimeEnvironmentValue("KV_REST_API_URL") || runtimeEnvironmentValue("UPSTASH_REDIS_REST_URL")) &&
-        (runtimeEnvironmentValue("KV_REST_API_TOKEN") || runtimeEnvironmentValue("UPSTASH_REDIS_REST_TOKEN")),
+      (runtimeEnvironmentValue("KV_REST_API_URL") ||
+        runtimeEnvironmentValue("UPSTASH_REDIS_REST_URL")) &&
+        (runtimeEnvironmentValue("KV_REST_API_TOKEN") ||
+          runtimeEnvironmentValue("UPSTASH_REDIS_REST_TOKEN")),
     );
   }
   return Boolean(runtimeEnvironmentValue("REDIS_URL"));
@@ -90,14 +101,13 @@ export function isRedisConfigured(): boolean {
  * if Redis is not available. Call isRedisAvailable() first to check.
  */
 export function getRedisClient(): IoredisLike | null {
-  return redisAvailable ? redisClient : null;
+  return redisClients.get(redisAuthorityFingerprint()) ?? null;
 }
 
 export async function shutdownRedis(): Promise<void> {
-  if (redisAvailable) {
+  if (redisClients.size > 0) {
     await disconnectRedis();
-    redisAvailable = false;
-    redisClient = null;
+    redisClients.clear();
   }
 }
 
@@ -122,7 +132,7 @@ export async function checkAgentRateLimit(
   // Redis not available: only skip enforcement when Redis was never configured
   // (documented dev path). If Redis IS configured (production), an unavailable
   // backend must fail CLOSED — mirroring checkAgentSpendLimit (SEC-016).
-  if (!redisAvailable) {
+  if (!isRedisAvailable()) {
     if (!isRedisConfigured()) return PERMISSIVE_RATE_LIMIT;
     return { allowed: false, remaining: 0, resetMs: 60_000 };
   }
@@ -152,7 +162,7 @@ export async function checkProxyRateLimit(
 ): Promise<RateLimitResult> {
   // Same fail-closed posture as checkAgentRateLimit (SEC-016): permissive only
   // when Redis was never configured; a configured-but-down backend denies.
-  if (!redisAvailable) {
+  if (!isRedisAvailable()) {
     if (!isRedisConfigured()) return PERMISSIVE_RATE_LIMIT;
     return { allowed: false, remaining: 0, resetMs: 60_000 };
   }
@@ -182,7 +192,7 @@ export async function checkAgentSpendLimit(
   // Redis not available: only skip enforcement when Redis was never configured
   // (documented dev path). If Redis IS configured (production), an unavailable
   // backend must fail CLOSED rather than silently allow unlimited spend.
-  if (!redisAvailable) {
+  if (!isRedisAvailable()) {
     if (!isRedisConfigured()) return { allowed: true, spent: 0, remaining: limitUsd };
     return { allowed: false, spent: 0, remaining: 0 };
   }
@@ -209,7 +219,7 @@ export async function recordAgentSpend(
   host: string,
   options: SpendRecordOptions & { throwOnError?: boolean } = {},
 ): Promise<void> {
-  if (!redisAvailable) {
+  if (!isRedisAvailable()) {
     if (options.throwOnError && isRedisConfigured()) {
       throw new Error("Configured Redis spend backend is unavailable");
     }

--- a/packages/api/src/middleware/request-expiry.ts
+++ b/packages/api/src/middleware/request-expiry.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createMiddleware } from "hono/factory";
 import type { ApiResponse, AppVariables } from "../services/context";
 import { isSensitivePath } from "./sensitive-paths";
@@ -34,20 +35,26 @@ function parseHttpTime(value: string | undefined): number | null {
 }
 
 export function requestExpiry(options?: RequestExpiryOptions) {
-  const required =
-    options?.required ??
-    (process.env.STEWARD_REQUIRE_REQUEST_EXPIRY === "true" ||
-      (process.env.NODE_ENV === "production" &&
-        process.env.STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS !== "true"));
-  const maxClockSkewMs =
-    options?.maxClockSkewMs ??
-    parsePositiveInt(process.env.STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS, DEFAULT_MAX_CLOCK_SKEW_MS);
-  const timestampTtlMs =
-    options?.timestampTtlMs ??
-    parsePositiveInt(process.env.STEWARD_REQUEST_TIMESTAMP_TTL_MS, DEFAULT_TIMESTAMP_TTL_MS);
   const now = options?.now ?? (() => Date.now());
 
   return createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
+    const required =
+      options?.required ??
+      (runtimeEnvironmentValue("STEWARD_REQUIRE_REQUEST_EXPIRY") === "true" ||
+        (runtimeEnvironmentValue("NODE_ENV") === "production" &&
+          runtimeEnvironmentValue("STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS") !== "true"));
+    const maxClockSkewMs =
+      options?.maxClockSkewMs ??
+      parsePositiveInt(
+        runtimeEnvironmentValue("STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS"),
+        DEFAULT_MAX_CLOCK_SKEW_MS,
+      );
+    const timestampTtlMs =
+      options?.timestampTtlMs ??
+      parsePositiveInt(
+        runtimeEnvironmentValue("STEWARD_REQUEST_TIMESTAMP_TTL_MS"),
+        DEFAULT_TIMESTAMP_TTL_MS,
+      );
     if (!MUTATING_METHODS.has(c.req.method.toUpperCase()) || !isSensitivePath(c.req.path)) {
       return next();
     }

--- a/packages/api/src/middleware/security-headers.ts
+++ b/packages/api/src/middleware/security-headers.ts
@@ -7,6 +7,8 @@
  * private dev deploys without HTTPS.
  */
 
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
 import type { MiddlewareHandler } from "hono";
 
 const STATIC_HEADERS: Record<string, string> = {
@@ -26,7 +28,7 @@ const STATIC_HEADERS: Record<string, string> = {
 const HSTS_VALUE = "max-age=63072000; includeSubDomains; preload";
 
 export function isHstsEnabled(): boolean {
-  return process.env.STEWARD_HSTS_DISABLED !== "true";
+  return runtimeEnvironmentValue("STEWARD_HSTS_DISABLED") !== "true";
 }
 
 function hostFromRequest(req: Request): string {

--- a/packages/api/src/middleware/tenant-cors.ts
+++ b/packages/api/src/middleware/tenant-cors.ts
@@ -14,14 +14,13 @@
  *   app.use("*", tenantCors);
  */
 
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
-
 import {
   getDb,
   tenantAppClients as tenantAppClientsTable,
   tenantConfigs as tenantConfigsTable,
 } from "@stwd/db";
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { and, eq } from "drizzle-orm";
 import type { Context, Next } from "hono";
 

--- a/packages/api/src/middleware/tenant-cors.ts
+++ b/packages/api/src/middleware/tenant-cors.ts
@@ -14,6 +14,8 @@
  *   app.use("*", tenantCors);
  */
 
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
 import {
   getDb,
   tenantAppClients as tenantAppClientsTable,
@@ -147,7 +149,7 @@ const MAX_AGE = "86400";
  * environments all fail closed.
  */
 function devWildcardAllowed(): boolean {
-  const env = process.env.NODE_ENV;
+  const env = runtimeEnvironmentValue("NODE_ENV");
   return env === "development" || env === "test";
 }
 

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -7035,7 +7035,10 @@ export function isOpenApiHttpEnabled(): boolean {
   const explicit = runtimeEnvironmentValue("STEWARD_OPENAPI_ENABLED");
   if (explicit === "1" || explicit === "true") return true;
   if (explicit === "0" || explicit === "false") return false;
-  return runtimeEnvironmentValue("NODE_ENV") !== undefined && runtimeEnvironmentValue("NODE_ENV") !== "production";
+  return (
+    runtimeEnvironmentValue("NODE_ENV") !== undefined &&
+    runtimeEnvironmentValue("NODE_ENV") !== "production"
+  );
 }
 
 export const OPENAPI_DOC = getOpenApiSpec();

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { isSensitivePath, SENSITIVE_PATH_PREFIXES } from "./middleware/sensitive-paths";
 
 type JsonSchema = Record<string, unknown>;
@@ -7031,10 +7032,10 @@ export function getOpenApiSpec() {
 }
 
 export function isOpenApiHttpEnabled(): boolean {
-  const explicit = process.env.STEWARD_OPENAPI_ENABLED;
+  const explicit = runtimeEnvironmentValue("STEWARD_OPENAPI_ENABLED");
   if (explicit === "1" || explicit === "true") return true;
   if (explicit === "0" || explicit === "false") return false;
-  return process.env.NODE_ENV !== undefined && process.env.NODE_ENV !== "production";
+  return runtimeEnvironmentValue("NODE_ENV") !== undefined && runtimeEnvironmentValue("NODE_ENV") !== "production";
 }
 
 export const OPENAPI_DOC = getOpenApiSpec();

--- a/packages/api/src/plugin-config.ts
+++ b/packages/api/src/plugin-config.ts
@@ -73,12 +73,12 @@ export class UnknownPluginError extends Error {
  * throws {@link UnknownPluginError}. The legacy boolean only ever adds a KNOWN
  * name, so it cannot trip the unknown-name guard.
  *
- * @param env the environment to read. defaults to `process.env`; injectable so
+ * @param env the environment to read. Defaults to the current request snapshot;
  *   tests can drive it hermetically without mutating the real process env.
  * @returns the set of enabled plugin names (lowercased). empty in LEAN mode.
  */
 export function resolveEnabledPlugins(
-  env: Record<string, string | undefined> = process.env,
+  env: Readonly<Record<string, string | undefined>> = runtimeEnvironmentSnapshot(),
 ): Set<string> {
   const enabled = new Set<string>();
 
@@ -103,3 +103,4 @@ export function resolveEnabledPlugins(
 
   return enabled;
 }
+import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";

--- a/packages/api/src/plugin-config.ts
+++ b/packages/api/src/plugin-config.ts
@@ -103,4 +103,5 @@ export function resolveEnabledPlugins(
 
   return enabled;
 }
+
 import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -81,7 +81,6 @@ import {
 } from "@stwd/policy-engine";
 import type { PluginMigrationSource, StewardPlugin } from "@stwd/shared";
 import { WebhookEventRegistry } from "@stwd/shared";
-import { KeyStore, SecretVault } from "@stwd/vault";
 import type { Hono } from "hono";
 import {
   requireAgentJwt,
@@ -98,7 +97,6 @@ import {
   ensureAgentForTenant,
   getPolicySet,
   isValidAnyAddress,
-  MASTER_PASSWORD,
   policyEngine,
   priceOracle,
   safeJsonParse,
@@ -106,6 +104,7 @@ import {
   vault,
 } from "./services/context";
 import { createEnvEvmSimulator, type EvmSimulator } from "./services/evm-simulator";
+import { getConfiguredKeyStore, getConfiguredSecretVault } from "./services/vault-factory";
 import { CONFIGURED_WEBHOOK_EVENT_TYPES } from "./services/webhook-events";
 
 /** the steward app a plugin mounts onto: a hono app with the shared variables. */
@@ -263,8 +262,6 @@ export type StewardApiPlugin = StewardPlugin<StewardApp, StewardAppContext, Eval
  * root and passed to {@link registerPlugin}.
  */
 export function buildPluginContext(): StewardAppContext {
-  const credentialVault = new SecretVault(MASTER_PASSWORD);
-  const leaseKeyStore = new KeyStore(MASTER_PASSWORD, undefined, "credential-lease");
   return {
     db,
     vault,
@@ -291,11 +288,15 @@ export function buildPluginContext(): StewardAppContext {
     getAgentTokenStatus,
     getRedisClient,
     exerciseCredentialSecret: (tenantId, secretId, use) =>
-      credentialVault.exerciseSecret(tenantId, secretId, use),
+      getConfiguredSecretVault().exerciseSecret(tenantId, secretId, use),
     sealCredentialLeaseToken: async (tenantId, leaseId, token) =>
-      leaseKeyStore.encrypt(token, { tenantId, name: `upstream-lease:${leaseId}`, version: 1 }),
+      getConfiguredKeyStore("credential-lease").encrypt(token, {
+        tenantId,
+        name: `upstream-lease:${leaseId}`,
+        version: 1,
+      }),
     exerciseCredentialLeaseToken: async (tenantId, leaseId, sealed, use) => {
-      const token = leaseKeyStore.decrypt(sealed, {
+      const token = getConfiguredKeyStore("credential-lease").decrypt(sealed, {
         tenantId,
         name: `upstream-lease:${leaseId}`,
         version: 1,

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -640,10 +640,12 @@ export class PluginHost<Ctx> {
                 "empty provider name.",
             );
           }
-          if (contribution.adapter === undefined || contribution.adapter === null) {
+          const hasAdapter = contribution.adapter !== undefined && contribution.adapter !== null;
+          const hasFactory = typeof contribution.createAdapter === "function";
+          if (hasAdapter === hasFactory) {
             throw new PluginHostError(
               `plugin "${plugin.name}" contributes a "${category}" adapter under ` +
-                `provider "${provider}" with no adapter instance.`,
+                `provider "${provider}" with ${hasAdapter ? "both an adapter and a factory" : "neither an adapter nor a factory"}.`,
             );
           }
           const key = `${category}::${provider}`;
@@ -669,11 +671,19 @@ export class PluginHost<Ctx> {
           // the api boundary where @stwd/adapters is a legitimate dependency. The
           // cast is unavoidable (see AdapterContribution's cycle note); the
           // contribution author owns the adapter conforming to its category.
-          hostRegistry.register(
-            category,
-            provider,
-            contribution.adapter as Parameters<AdapterRegistry["register"]>[2],
-          );
+          if (hasFactory) {
+            hostRegistry.registerFactory(
+              category,
+              provider,
+              contribution.createAdapter as Parameters<AdapterRegistry["registerFactory"]>[2],
+            );
+          } else {
+            hostRegistry.register(
+              category,
+              provider,
+              contribution.adapter as Parameters<AdapterRegistry["register"]>[2],
+            );
+          }
           const list = this.adapterContributions.get(plugin.name) ?? [];
           list.push(key);
           this.adapterContributions.set(plugin.name, list);

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -17,7 +17,6 @@ import {
   userTenants,
 } from "@stwd/db";
 import { redactedThrownDiagnostics } from "@stwd/shared";
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { writeAuditEvent } from "../services/audit";
@@ -32,6 +31,7 @@ import {
   setNoStoreHeaders,
   vault,
 } from "../services/context";
+import { resolveRuntimeChainId } from "../services/custody-runtime";
 import { redactWalletMetadataSecrets } from "../services/wallet-metadata";
 
 export const accountRoutes = new Hono<{ Variables: AppVariables }>();
@@ -263,9 +263,7 @@ function accountBalanceChainId(wallet: { chainFamily: ChainFamily }, chainId?: n
   if (wallet.chainFamily === "bitcoin") {
     return chainId === 202 ? 202 : 201;
   }
-  return chainId && !isSolanaChainId(chainId)
-    ? chainId
-    : Number(runtimeEnvironmentValue("CHAIN_ID") || "84532");
+  return chainId && !isSolanaChainId(chainId) ? chainId : resolveRuntimeChainId(84532);
 }
 
 function balanceRowsForChainFilter<T extends { chainFamily: ChainFamily }>(

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -17,6 +17,7 @@ import {
   userTenants,
 } from "@stwd/db";
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { writeAuditEvent } from "../services/audit";
@@ -262,7 +263,9 @@ function accountBalanceChainId(wallet: { chainFamily: ChainFamily }, chainId?: n
   if (wallet.chainFamily === "bitcoin") {
     return chainId === 202 ? 202 : 201;
   }
-  return chainId && !isSolanaChainId(chainId) ? chainId : Number(process.env.CHAIN_ID || "84532");
+  return chainId && !isSolanaChainId(chainId)
+    ? chainId
+    : Number(runtimeEnvironmentValue("CHAIN_ID") || "84532");
 }
 
 function balanceRowsForChainFilter<T extends { chainFamily: ChainFamily }>(

--- a/packages/api/src/routes/adapters.ts
+++ b/packages/api/src/routes/adapters.ts
@@ -21,8 +21,6 @@
  * route in app.ts.
  */
 
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
-
 import {
   AdapterNotConfiguredError,
   AdapterProviderError,
@@ -41,6 +39,7 @@ import {
   perOrderCapEvaluator,
 } from "@stwd/policy-engine";
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { and, eq } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { z } from "zod";

--- a/packages/api/src/routes/adapters.ts
+++ b/packages/api/src/routes/adapters.ts
@@ -21,6 +21,8 @@
  * route in app.ts.
  */
 
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
 import {
   AdapterNotConfiguredError,
   AdapterProviderError,
@@ -375,8 +377,8 @@ async function enforceFundMovingPolicy(
 
 /** Per-request spend caps. Configurable via env; conservative defaults. */
 function spendCaps(): { perOrderCapUsd: number; dailyCapUsd: number } {
-  const perOrder = Number(process.env.STEWARD_ADAPTER_PER_OP_CAP_USD);
-  const daily = Number(process.env.STEWARD_ADAPTER_DAILY_CAP_USD);
+  const perOrder = Number(runtimeEnvironmentValue("STEWARD_ADAPTER_PER_OP_CAP_USD"));
+  const daily = Number(runtimeEnvironmentValue("STEWARD_ADAPTER_DAILY_CAP_USD"));
   return {
     perOrderCapUsd: Number.isFinite(perOrder) && perOrder > 0 ? perOrder : 10_000,
     dailyCapUsd: Number.isFinite(daily) && daily > 0 ? daily : 50_000,

--- a/packages/api/src/routes/agent-enroll.ts
+++ b/packages/api/src/routes/agent-enroll.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * agent-enroll.ts — the public keypair-only agent enrollment surface. Mounted
  * before the tenant gate: an enrolling agent holds only its
@@ -60,7 +61,7 @@ export const ENROLL_TOKEN_TTL_MAX_SECONDS = 3600;
  * surfaces as a 500 at token-mint time, and an unbounded value mints
  * long-lived tokens that defeat the minute-scale revocation story. */
 function resolveEnrollTokenTtl(): string {
-  const raw = process.env.STEWARD_AGENT_ENROLL_TOKEN_TTL?.trim();
+  const raw = runtimeEnvironmentValue("STEWARD_AGENT_ENROLL_TOKEN_TTL")?.trim();
   if (!raw) return "5m";
   const seconds = parseDurationSeconds(raw);
   if (seconds === null) {

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Agent CRUD, batch creation, token generation, and policy management routes.
  *
@@ -308,7 +309,7 @@ function requireTenantAdminOrApiKey(c: Parameters<typeof requireTenantLevel>[0])
  */
 function allowApiKeyAdminMutations(c: Parameters<typeof requireTenantLevel>[0]): boolean {
   return (
-    c.get("authType") === "api-key" && process.env.STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS === "true"
+    c.get("authType") === "api-key" && runtimeEnvironmentValue("STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS") === "true"
   );
 }
 
@@ -1799,7 +1800,7 @@ agentRoutes.put("/:agentId/policy", async (c) => {
       // Serialize the complete partial-patch read/materialize/write sequence,
       // including initial-row creation where SELECT FOR UPDATE has no row to
       // lock. PGLite runs tests on one connection and lacks this PG function.
-      if (process.env.STEWARD_PGLITE_MEMORY !== "true") {
+      if (runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true") {
         await tx.execute(
           sql`SELECT pg_advisory_xact_lock(hashtextextended(${`agent-policy:${tenantId}:${agentId}`}, 0))`,
         );

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -309,7 +309,8 @@ function requireTenantAdminOrApiKey(c: Parameters<typeof requireTenantLevel>[0])
  */
 function allowApiKeyAdminMutations(c: Parameters<typeof requireTenantLevel>[0]): boolean {
   return (
-    c.get("authType") === "api-key" && runtimeEnvironmentValue("STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS") === "true"
+    c.get("authType") === "api-key" &&
+    runtimeEnvironmentValue("STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS") === "true"
   );
 }
 

--- a/packages/api/src/routes/audit.ts
+++ b/packages/api/src/routes/audit.ts
@@ -841,7 +841,9 @@ auditRoutes.post("/verify", async (c) => {
 // applies; no HMAC key or private signing material is returned.
 auditRoutes.get("/integrity", async (c) => {
   const tenantId = c.get("tenantId");
-  const configuredLimit = Number(runtimeEnvironmentValue("STEWARD_DOCTOR_AUDIT_MAX_EVENTS") ?? "100000");
+  const configuredLimit = Number(
+    runtimeEnvironmentValue("STEWARD_DOCTOR_AUDIT_MAX_EVENTS") ?? "100000",
+  );
   const maxEvents =
     Number.isSafeInteger(configuredLimit) && configuredLimit > 0 ? configuredLimit : 100_000;
   const data = await db.transaction(async (tx) => {

--- a/packages/api/src/routes/audit.ts
+++ b/packages/api/src/routes/audit.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Audit routes — read-only endpoints for querying transaction history,
  * proxy audit logs, and approval queue data across all agents for a tenant.
@@ -455,7 +456,7 @@ auditRoutes.get("/summary", async (c) => {
       since = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
       break;
     case "all":
-      if (process.env.STEWARD_ALLOW_UNBOUNDED_AUDIT_SUMMARY !== "true") {
+      if (runtimeEnvironmentValue("STEWARD_ALLOW_UNBOUNDED_AUDIT_SUMMARY") !== "true") {
         return c.json<ApiResponse>(
           { ok: false, error: "range=all requires STEWARD_ALLOW_UNBOUNDED_AUDIT_SUMMARY=true" },
           400,
@@ -840,7 +841,7 @@ auditRoutes.post("/verify", async (c) => {
 // applies; no HMAC key or private signing material is returned.
 auditRoutes.get("/integrity", async (c) => {
   const tenantId = c.get("tenantId");
-  const configuredLimit = Number(process.env.STEWARD_DOCTOR_AUDIT_MAX_EVENTS ?? "100000");
+  const configuredLimit = Number(runtimeEnvironmentValue("STEWARD_DOCTOR_AUDIT_MAX_EVENTS") ?? "100000");
   const maxEvents =
     Number.isSafeInteger(configuredLimit) && configuredLimit > 0 ? configuredLimit : 100_000;
   const data = await db.transaction(async (tx) => {
@@ -1196,7 +1197,7 @@ auditRoutes.get("/bundle", async (c) => {
   const tenantId = c.get("tenantId");
 
   if (!isCheckpointSigningConfigured()) {
-    if (process.env.NODE_ENV === "production") {
+    if (runtimeEnvironmentValue("NODE_ENV") === "production") {
       return c.json<ApiResponse>(
         {
           ok: false,

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1395,7 +1395,7 @@ type AuthStoreBundle = {
 
 const authStoresByAuthority = new Map<string, AuthStoreBundle>();
 
-function authStoreAuthorityKey(): string | null {
+export function authStoreAuthorityKey(): string | null {
   if (runtimeEnvironmentValue("STEWARD_RUNTIME") !== "workers") return null;
   const env = runtimeEnvironmentSnapshot();
   return JSON.stringify([
@@ -1495,7 +1495,7 @@ export async function initAuthStores(usePostgres = false): Promise<void> {
   }
 
   const { initUserLinkChallengeStores } = await import("./user.js");
-  initUserLinkChallengeStores(challengeBackend);
+  initUserLinkChallengeStores(challengeBackend, authorityKey);
 
   // Reset singletons so they pick up the new stores on next use
   phoneAuthByAuthority.clear();
@@ -2151,6 +2151,8 @@ export async function getEmailAuthForTenant(tenantId: string): Promise<EmailAuth
     runtimeEnvironmentValue("EMAIL_FROM") ?? "",
     runtimeEnvironmentValue("APP_URL") ?? "",
     runtimeEnvironmentValue("NODE_ENV") ?? "",
+    runtimeEnvironmentValue("STEWARD_EMAIL_CODE_SECRET") ?? "",
+    runtimeEnvironmentValue("STEWARD_ALLOW_DEV_SECRETS") ?? "",
     authStoreAuthorityKey() ?? "bun",
   ]);
   let authorities = _emailAuthByTenant.get(tenantId);

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -74,7 +74,6 @@ import {
   IdentityJwtConfigurationError,
   InMemoryRecoveryCodeStore,
   isBuiltInProvider,
-  isDevSecretAllowed,
   isValidE164,
   type MagicLinkTemplateData,
   MockEmailInbox,
@@ -136,8 +135,7 @@ import {
   type TenantSamlSsoConfig,
   type TenantTestAccountConfig,
 } from "@stwd/shared";
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
-import { KeyStore, provisionUserWallet, Vault } from "@stwd/vault";
+import { type KeyStore, provisionUserWallet, Vault } from "@stwd/vault";
 import bs58 from "bs58";
 import { and, eq, gte, inArray, isNull, lt, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
@@ -162,7 +160,12 @@ import { socketPeerFromEnv } from "../services/runtime-gate";
 import { buildSamlServiceProviderUrls } from "../services/saml-sso-config";
 import { lockUserSession } from "../services/session-lock";
 import { testAccountOtpMatches } from "../services/test-account-credentials";
-import { getConfiguredVault } from "../services/vault-factory";
+import {
+  _clearConfiguredVaultsForTests,
+  getConfiguredKeyStore,
+  getConfiguredVault,
+  resolveCustodyAuthority,
+} from "../services/vault-factory";
 import { dispatchWebhook } from "../services/webhook-dispatch";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -180,7 +183,7 @@ async function withVerifiedAuthTenant<T>(
     userId: subject,
   });
   const driver =
-    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
+    process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true"
       ? "pglite"
       : getDatabaseDriver();
   return withTenantRlsTransaction(getDb() as never, driver, context, async (tx) =>
@@ -200,7 +203,7 @@ async function withPreAuthTenant<T>(
     subject: "public-auth-flow",
   });
   const driver =
-    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
+    process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true"
       ? "pglite"
       : getDatabaseDriver();
   return withTenantRlsTransaction(getDb() as never, driver, context, async (tx) =>
@@ -256,9 +259,9 @@ function normalizeEmailDomain(value: unknown): string | null {
  * not preserved.
  */
 function trustedProxyHops(): number {
-  const raw = runtimeEnvironmentValue("STEWARD_TRUSTED_PROXY_HOPS")?.trim();
+  const raw = process.env.STEWARD_TRUSTED_PROXY_HOPS?.trim();
   if (raw === undefined || raw === "") {
-    return runtimeEnvironmentValue("STEWARD_TRUST_PROXY_HEADERS") === "true" ? 1 : 0;
+    return process.env.STEWARD_TRUST_PROXY_HEADERS === "true" ? 1 : 0;
   }
   // Canonical non-negative integer only: "1.5" must not truncate into trust.
   if (!/^\d+$/.test(raw)) return 0;
@@ -336,7 +339,7 @@ function logNoTrustedClientIpDiag(c: Context, hops: number): void {
  * never a shared "global" bucket, never open.
  */
 export function trustedClientIp(c: Context): string | undefined {
-  const trustCloudflare = runtimeEnvironmentValue("STEWARD_TRUST_CLOUDFLARE") === "true";
+  const trustCloudflare = process.env.STEWARD_TRUST_CLOUDFLARE === "true";
   if (trustCloudflare) {
     const cf = c.req.header("cf-connecting-ip")?.trim();
     if (cf && isIP(cf)) return cf;
@@ -432,7 +435,7 @@ function authRateLimitSubject(c: Context): { subject: string; coarse: boolean } 
   const peer = socketPeerFromEnv(c.env);
   if (peer && isIP(peer)) return { subject: `ip:${clientIpBucket(peer)}`, coarse: false };
   const now = Date.now();
-  if (runtimeEnvironmentValue("NODE_ENV") === "production" && now - coarseSubjectWarnedAt >= 60_000) {
+  if (process.env.NODE_ENV === "production" && now - coarseSubjectWarnedAt >= 60_000) {
     coarseSubjectWarnedAt = now;
     console.warn(
       "[AuthRateLimit] No trusted client IP (set STEWARD_TRUSTED_PROXY_HOPS=2 on Railway); auth rate limits fall back to coarse per-host buckets instead of per-client budgets",
@@ -446,8 +449,8 @@ function authRateLimitSubject(c: Context): { subject: string; coarse: boolean } 
 
 function allowAuthRateLimitSoftFail(): boolean {
   return (
-    runtimeEnvironmentValue("NODE_ENV") !== "production" ||
-    runtimeEnvironmentValue("STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL") === "true"
+    process.env.NODE_ENV !== "production" ||
+    process.env.STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL === "true"
   );
 }
 
@@ -463,7 +466,7 @@ function allowAuthRateLimitSoftFail(): boolean {
  * isolate on Workers, which only tightens it).
  */
 function authRateLimitOutageValveMax(): number {
-  const raw = runtimeEnvironmentValue("STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX");
+  const raw = process.env.STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX;
   if (raw === undefined || raw === "") return 300;
   const parsed = Number.parseInt(raw, 10);
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : 300;
@@ -1577,7 +1580,7 @@ async function markOidcIdTokenUsedOnce(
 }
 
 function isUnsafeUnboundOAuthProviderCodeExchangeAllowed(): boolean {
-  return runtimeEnvironmentValue("STEWARD_ALLOW_UNBOUND_OAUTH_PROVIDER_CODE_EXCHANGE") === "true";
+  return process.env.STEWARD_ALLOW_UNBOUND_OAUTH_PROVIDER_CODE_EXCHANGE === "true";
 }
 
 function isValidPkceCodeVerifier(value: string): boolean {
@@ -1623,8 +1626,8 @@ export function getAuthStoreSources(): AuthStoreSources {
  */
 export function assertAuthStoresAreSafe(sources: AuthStoreSources = getAuthStoreSources()): void {
   const requiresDurableStores =
-    runtimeEnvironmentValue("NODE_ENV") === "production" || runtimeEnvironmentValue("STEWARD_RUNTIME") === "workers";
-  if (!requiresDurableStores || runtimeEnvironmentValue("STEWARD_ALLOW_MEMORY_AUTH_STORES") === "true") return;
+    process.env.NODE_ENV === "production" || process.env.STEWARD_RUNTIME === "workers";
+  if (!requiresDurableStores || process.env.STEWARD_ALLOW_MEMORY_AUTH_STORES === "true") return;
 
   const memoryStores = Object.entries(sources)
     .filter(([, source]) => source === "memory")
@@ -1652,7 +1655,8 @@ export function decryptImportSessionJson<T>(value: string): T {
   return JSON.parse(getOAuthKeyStore().decrypt(encrypted)) as T;
 }
 
-const _passkeyAuthByAuthority = new Map<string, PasskeyAuth>();
+let _passkeyAuth: PasskeyAuth | null = null;
+const _passkeyAuthByOrigin = new Map<string, PasskeyAuth>();
 
 /**
  * Get PasskeyAuth for a specific origin (multi-tenant passkey support).
@@ -1699,31 +1703,25 @@ function resolveRpID(requestHostname: string, allowedOrigins: string[], fallback
 }
 
 function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
-  const defaultRpID = runtimeEnvironmentValue("PASSKEY_RP_ID") || "steward.fi";
-  const defaultOrigin = runtimeEnvironmentValue("PASSKEY_ORIGIN") || "https://steward.fi";
-  const rpName = runtimeEnvironmentValue("PASSKEY_RP_NAME") || "Steward";
+  const defaultRpID = process.env.PASSKEY_RP_ID || "steward.fi";
+  const defaultOrigin = process.env.PASSKEY_ORIGIN || "https://steward.fi";
+  const rpName = process.env.PASSKEY_RP_NAME || "Steward";
 
-  const allowed = (runtimeEnvironmentValue("PASSKEY_ALLOWED_ORIGINS") || defaultOrigin)
-    .split(",")
-    .map((o) => o.trim())
-    .filter(Boolean);
-
-  // Cache by the complete passkey authority, never only by rpID. Binding-only
-  // rotations must not inherit the prior origin allowlist or relying-party
-  // name from an app object cached earlier in the isolate.
+  // If no origin provided, use the default singleton
   if (!requestOrigin) {
-    const acceptedOrigins = allowed.length > 1 ? allowed : [defaultOrigin];
-    const authorityKey = JSON.stringify([rpName, defaultRpID, acceptedOrigins]);
-    const cached = _passkeyAuthByAuthority.get(authorityKey);
-    if (cached) return cached;
-    const auth = new PasskeyAuth({
-      rpName,
-      rpID: defaultRpID,
-      origin: acceptedOrigins.length > 1 ? acceptedOrigins : defaultOrigin,
-      challengeStore: getChallengeStore(),
-    });
-    _passkeyAuthByAuthority.set(authorityKey, auth);
-    return auth;
+    if (!_passkeyAuth) {
+      const origins = (process.env.PASSKEY_ALLOWED_ORIGINS || defaultOrigin)
+        .split(",")
+        .map((o) => o.trim())
+        .filter(Boolean);
+      _passkeyAuth = new PasskeyAuth({
+        rpName,
+        rpID: defaultRpID,
+        origin: origins.length > 1 ? origins : defaultOrigin,
+        challengeStore: getChallengeStore(),
+      });
+    }
+    return _passkeyAuth;
   }
 
   // Parse origin to get hostname
@@ -1735,6 +1733,10 @@ function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
   }
 
   // Validate against allowed origins
+  const allowed = (process.env.PASSKEY_ALLOWED_ORIGINS || defaultOrigin)
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
   if (!allowed.includes(requestOrigin) && requestHostname !== defaultRpID) {
     return getPasskeyAuth(); // not in allowed list, use default
   }
@@ -1744,63 +1746,34 @@ function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
   // shared across apex + all subdomains.
   const rpID = resolveRpID(requestHostname, allowed, defaultRpID);
 
-  const acceptedOrigins = allowed.length > 0 ? allowed : [requestOrigin];
-  const authorityKey = JSON.stringify([rpName, rpID, acceptedOrigins]);
-  const cached = _passkeyAuthByAuthority.get(authorityKey);
+  // Cache per rpID
+  const cached = _passkeyAuthByOrigin.get(rpID);
   if (cached) return cached;
 
   // Origin list passed to PasskeyAuth covers all variants the browser may
   // present (apex + www) so SimpleWebAuthn accepts assertions from either.
+  const acceptedOrigins = allowed.length > 0 ? allowed : [requestOrigin];
+
   const auth = new PasskeyAuth({
     rpName,
     rpID,
     origin: acceptedOrigins,
     challengeStore: getChallengeStore(),
   });
-  _passkeyAuthByAuthority.set(authorityKey, auth);
+  _passkeyAuthByOrigin.set(rpID, auth);
   return auth;
 }
 
 // ─── EmailAuth cache ──────────────────────────────────────────────────────────
 
-const _emailAuthByTenant = new Map<string, Promise<EmailAuth>>();
-let _emailKeyStore: KeyStore | null = null;
-let _oauthKeyStore: KeyStore | null = null;
+const _emailAuthByTenant = new Map<string, Map<string, Promise<EmailAuth>>>();
 
 function getEmailKeyStore(): KeyStore {
-  if (_emailKeyStore) return _emailKeyStore;
-
-  const masterPassword = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD");
-  if (!masterPassword) {
-    if (!isDevSecretAllowed()) {
-      throw new Error(
-        "STEWARD_MASTER_PASSWORD is required. For local development only, set STEWARD_ALLOW_DEV_SECRETS=true to use the insecure dev key.",
-      );
-    }
-    _emailKeyStore = new KeyStore("dev-secret");
-    return _emailKeyStore;
-  }
-
-  _emailKeyStore = new KeyStore(masterPassword);
-  return _emailKeyStore;
+  return getConfiguredKeyStore(undefined, { allowDevSecretFallback: true });
 }
 
 function getOAuthKeyStore(): KeyStore {
-  if (_oauthKeyStore) return _oauthKeyStore;
-
-  const masterPassword = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD");
-  if (!masterPassword) {
-    if (!isDevSecretAllowed()) {
-      throw new Error(
-        "STEWARD_MASTER_PASSWORD is required to encrypt OAuth provider tokens. For local development only, set STEWARD_ALLOW_DEV_SECRETS=true to use the insecure dev key.",
-      );
-    }
-    _oauthKeyStore = new KeyStore("dev-secret");
-    return _oauthKeyStore;
-  }
-
-  _oauthKeyStore = new KeyStore(masterPassword);
-  return _oauthKeyStore;
+  return getConfiguredKeyStore(undefined, { allowDevSecretFallback: true });
 }
 
 type OAuthEncryptedTokenFields = Pick<
@@ -1863,16 +1836,16 @@ export function decryptOAuthProviderToken(encrypted: {
 }
 
 function isMockEmailEnabled(): boolean {
-  if (runtimeEnvironmentValue("EMAIL_PROVIDER") === "mock" && runtimeEnvironmentValue("NODE_ENV") === "production") {
+  if (process.env.EMAIL_PROVIDER === "mock" && process.env.NODE_ENV === "production") {
     throw new Error(
       "EMAIL_PROVIDER=mock is forbidden in production. Unset EMAIL_PROVIDER or set RESEND_API_KEY.",
     );
   }
-  return runtimeEnvironmentValue("EMAIL_PROVIDER") === "mock" && runtimeEnvironmentValue("NODE_ENV") !== "production";
+  return process.env.EMAIL_PROVIDER === "mock" && process.env.NODE_ENV !== "production";
 }
 
 function authTestInboxEnabled(): boolean {
-  return runtimeEnvironmentValue("NODE_ENV") === "test";
+  return process.env.NODE_ENV === "test";
 }
 
 function isEnabledTestAccount(
@@ -1965,20 +1938,20 @@ function buildGlobalEmailAuth(overrides?: {
   replyTo?: string;
   templates?: TenantEmailConfig["templates"];
 }): EmailAuth {
-  const resendKey = runtimeEnvironmentValue("RESEND_API_KEY");
+  const resendKey = process.env.RESEND_API_KEY;
   // Mock takes precedence in non-production for deterministic e2e testing.
   const provider = isMockEmailEnabled()
     ? new MockEmailProvider()
     : resendKey
       ? new ResendProvider({
           apiKey: resendKey,
-          from: runtimeEnvironmentValue("EMAIL_FROM") || "login@steward.fi",
+          from: process.env.EMAIL_FROM || "login@steward.fi",
         })
       : undefined;
 
   return new EmailAuth({
-    from: runtimeEnvironmentValue("EMAIL_FROM") || "login@steward.fi",
-    baseUrl: overrides?.baseUrl?.replace(/\/$/, "") || runtimeEnvironmentValue("APP_URL") || "https://steward.fi",
+    from: process.env.EMAIL_FROM || "login@steward.fi",
+    baseUrl: overrides?.baseUrl?.replace(/\/$/, "") || process.env.APP_URL || "https://steward.fi",
     callbackPath: overrides?.callbackPath,
     provider,
     tokenStore: getTokenStore(),
@@ -2050,7 +2023,7 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
   // We've already returned via buildGlobalEmailAuth above when apiKeyEncrypted
   // is missing, so it's safe to assume `emailConfig.from + apiKeyEncrypted`
   // are both present here.
-  const from = emailConfig.from || runtimeEnvironmentValue("EMAIL_FROM") || "login@steward.fi";
+  const from = emailConfig.from || process.env.EMAIL_FROM || "login@steward.fi";
   const provider =
     emailConfig.provider === "resend" && emailConfig.apiKeyEncrypted
       ? new ResendProvider({
@@ -2063,7 +2036,7 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
       : undefined;
 
   const baseUrl =
-    magicLinkBaseUrl?.replace(/\/$/, "") || runtimeEnvironmentValue("APP_URL") || "https://steward.fi";
+    magicLinkBaseUrl?.replace(/\/$/, "") || process.env.APP_URL || "https://steward.fi";
 
   return new EmailAuth({
     from,
@@ -2079,14 +2052,23 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
 }
 
 export async function getEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
-  const cached = _emailAuthByTenant.get(tenantId);
+  const authorityFingerprint = resolveCustodyAuthority({
+    allowDevSecretFallback: true,
+  }).fingerprint;
+  let authorities = _emailAuthByTenant.get(tenantId);
+  const cached = authorities?.get(authorityFingerprint);
   if (cached) return cached;
 
   const pending = createEmailAuthForTenant(tenantId).catch((error) => {
-    _emailAuthByTenant.delete(tenantId);
+    authorities?.delete(authorityFingerprint);
+    if (authorities?.size === 0) _emailAuthByTenant.delete(tenantId);
     throw error;
   });
-  _emailAuthByTenant.set(tenantId, pending);
+  if (!authorities) {
+    authorities = new Map();
+    _emailAuthByTenant.set(tenantId, authorities);
+  }
+  authorities.set(authorityFingerprint, pending);
   return pending;
 }
 
@@ -2099,7 +2081,7 @@ export function clearEmailAuthTenantCacheForTests(): void {
 }
 
 export function clearOAuthTokenKeyStoreForTests(): void {
-  _oauthKeyStore = null;
+  _clearConfiguredVaultsForTests();
 }
 
 /**
@@ -2498,7 +2480,7 @@ function ethereumWalletTenantId(address: string): string {
 }
 
 function getAllowedSiweDomains(): string[] {
-  const raw = runtimeEnvironmentValue("SIWE_ALLOWED_DOMAINS")?.trim();
+  const raw = process.env.SIWE_ALLOWED_DOMAINS?.trim();
   if (raw) {
     const domains = raw
       .split(",")
@@ -2507,7 +2489,7 @@ function getAllowedSiweDomains(): string[] {
     if (domains.length > 0) return domains;
   }
 
-  const appUrl = runtimeEnvironmentValue("APP_URL")?.trim() || "https://steward.fi";
+  const appUrl = process.env.APP_URL?.trim() || "https://steward.fi";
   try {
     return [new URL(appUrl).host.toLowerCase()];
   } catch {
@@ -2796,19 +2778,19 @@ export function getPhoneAuth(): PhoneAuth {
   if (_phoneAuth) return _phoneAuth;
 
   let provider: SmsProvider | undefined;
-  if (runtimeEnvironmentValue("SMS_PROVIDER") === "mock" && runtimeEnvironmentValue("NODE_ENV") !== "production") {
+  if (process.env.SMS_PROVIDER === "mock" && process.env.NODE_ENV !== "production") {
     provider = new MockSmsProvider();
   } else if (
-    runtimeEnvironmentValue("TWILIO_ACCOUNT_SID") &&
-    runtimeEnvironmentValue("TWILIO_AUTH_TOKEN") &&
-    runtimeEnvironmentValue("TWILIO_FROM")
+    process.env.TWILIO_ACCOUNT_SID &&
+    process.env.TWILIO_AUTH_TOKEN &&
+    process.env.TWILIO_FROM
   ) {
     provider = new TwilioSmsProvider({
-      accountSid: runtimeEnvironmentValue("TWILIO_ACCOUNT_SID"),
-      authToken: runtimeEnvironmentValue("TWILIO_AUTH_TOKEN"),
-      from: runtimeEnvironmentValue("TWILIO_FROM"),
+      accountSid: process.env.TWILIO_ACCOUNT_SID,
+      authToken: process.env.TWILIO_AUTH_TOKEN,
+      from: process.env.TWILIO_FROM,
     });
-  } else if (runtimeEnvironmentValue("NODE_ENV") === "production") {
+  } else if (process.env.NODE_ENV === "production") {
     throw new Error("SMS provider not configured");
   }
 
@@ -2820,11 +2802,11 @@ export function getPhoneAuth(): PhoneAuth {
 }
 
 function isWhatsAppOtpEnabled(): boolean {
-  return runtimeEnvironmentValue("WHATSAPP_OTP_ENABLED") === "true";
+  return process.env.WHATSAPP_OTP_ENABLED === "true";
 }
 
 function isFarcasterLoginEnabled(): boolean {
-  return runtimeEnvironmentValue("FARCASTER_LOGIN_ENABLED") === "true";
+  return process.env.FARCASTER_LOGIN_ENABLED === "true";
 }
 
 const TELEGRAM_LOGIN_MAX_AGE_SEC = 24 * 60 * 60;
@@ -3073,13 +3055,8 @@ class MfaRecoveryCodeStore implements RecoveryCodeStore {
   }
 }
 
-const inMemoryRecoveryCodeStore = new InMemoryRecoveryCodeStore();
-const durableRecoveryCodeStore = new MfaRecoveryCodeStore();
-function recoveryCodeStore(): RecoveryCodeStore {
-  return runtimeEnvironmentValue("NODE_ENV") === "test"
-    ? inMemoryRecoveryCodeStore
-    : durableRecoveryCodeStore;
-}
+const recoveryCodeStore: RecoveryCodeStore =
+  process.env.NODE_ENV === "test" ? new InMemoryRecoveryCodeStore() : new MfaRecoveryCodeStore();
 
 type PendingMfaAuth = {
   mfaType: "totp" | "sms";
@@ -4010,7 +3987,7 @@ function resolveSamlMappedRole(config: TenantSamlSsoConfig, groups: string[]): s
 }
 
 function getEmailAuthRedirectBaseUrl(): string {
-  return (runtimeEnvironmentValue("EMAIL_AUTH_REDIRECT_BASE_URL") || "https://www.elizacloud.ai").replace(
+  return (process.env.EMAIL_AUTH_REDIRECT_BASE_URL || "https://www.elizacloud.ai").replace(
     /\/$/,
     "",
   );
@@ -4622,7 +4599,7 @@ auth.get("/providers", async (c) => {
     discord: enabledOauth.includes("discord"),
     github: enabledOauth.includes("github"),
     twitter: enabledOauth.includes("twitter"),
-    telegram: methodEnabled("telegram") && Boolean(runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim()),
+    telegram: methodEnabled("telegram") && Boolean(process.env.TELEGRAM_BOT_TOKEN?.trim()),
     farcaster: methodEnabled("farcaster") && isFarcasterLoginEnabled(),
     linkedin: enabledOauth.includes("linkedin"),
     spotify: enabledOauth.includes("spotify"),
@@ -4651,7 +4628,7 @@ auth.post("/telegram/challenge", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
   }
 
-  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
+  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -4694,7 +4671,7 @@ auth.post("/telegram/verify", async (c) => {
   >(c);
   if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
 
-  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
+  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -5522,8 +5499,8 @@ auth.get("/test/inbox/:email", (c) => {
 
 auth.get("/test/sms-inbox/:phone", (c) => {
   if (
-    runtimeEnvironmentValue("SMS_PROVIDER") !== "mock" ||
-    runtimeEnvironmentValue("NODE_ENV") === "production" ||
+    process.env.SMS_PROVIDER !== "mock" ||
+    process.env.NODE_ENV === "production" ||
     !authTestInboxEnabled()
   ) {
     return c.json<ApiResponse>({ ok: false, error: "Not found" }, 404);
@@ -5560,8 +5537,8 @@ auth.post("/test/token", async (c) => {
   // supervised app-review / automation windows and disable it immediately
   // afterward. Never leave it enabled on an internet-reachable prod deploy.
   if (
-    runtimeEnvironmentValue("NODE_ENV") === "production" &&
-    runtimeEnvironmentValue("STEWARD_ENABLE_PROD_TEST_ACCOUNT_TOKEN") !== "true"
+    process.env.NODE_ENV === "production" &&
+    process.env.STEWARD_ENABLE_PROD_TEST_ACCOUNT_TOKEN !== "true"
   ) {
     return c.json<ApiResponse>(
       { ok: false, error: "Test account token exchange is disabled" },
@@ -6886,7 +6863,7 @@ auth.post("/mfa/totp/enroll", async (c) => {
   const secret = generateTotpSecret();
   const accountName =
     session.payload.email || session.payload.address || `user:${session.payload.userId}`;
-  const issuer = runtimeEnvironmentValue("TOTP_ISSUER") || "Steward";
+  const issuer = process.env.TOTP_ISSUER || "Steward";
 
   await writeMfaJson(
     mfaKey("totp:pending", session.payload.userId),
@@ -6964,7 +6941,7 @@ auth.post("/mfa/totp/verify", async (c) => {
     });
     await writeMfaJson(mfaKey("totp:enabled", session.payload.userId), stored);
     await getMfaBackend().delete(mfaKey("totp:pending", session.payload.userId));
-    const recoveryCodes = await generateRecoveryCodes(recoveryCodeStore(), session.payload.userId);
+    const recoveryCodes = await generateRecoveryCodes(recoveryCodeStore, session.payload.userId);
     const { issuedBefore } = await revokeUserRefreshSessions(session.payload.userId);
     await writeAuditEvent({
       tenantId: session.payload.tenantId,
@@ -7066,7 +7043,7 @@ auth.post("/mfa/totp/complete", async (c) => {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired MFA challenge" }, 401);
     }
     const verified = await verifyRecoveryCode(
-      recoveryCodeStore(),
+      recoveryCodeStore,
       challenge.userId,
       body.recoveryCode ?? "",
     );
@@ -7156,7 +7133,7 @@ auth.post("/mfa/totp/step-up", async (c) => {
   let method: "totp" | "recovery_code" = "totp";
   if (hasRecoveryCode) {
     const verified = await verifyRecoveryCode(
-      recoveryCodeStore(),
+      recoveryCodeStore,
       session.payload.userId,
       body?.recoveryCode ?? "",
     );
@@ -7187,7 +7164,7 @@ auth.get("/mfa/recovery-codes/status", async (c) => {
 
   const enabled = await hasTotpEnabled(session.payload.userId);
   const remaining = enabled
-    ? await unusedRecoveryCodeCount(recoveryCodeStore(), session.payload.userId)
+    ? await unusedRecoveryCodeCount(recoveryCodeStore, session.payload.userId)
     : 0;
   return c.json({ ok: true, enabled, remaining });
 });
@@ -7240,7 +7217,7 @@ auth.post("/mfa/recovery-codes/regenerate", async (c) => {
     ...verified.stored,
     lastAcceptedStep: verified.acceptedStep,
   });
-  const recoveryCodes = await generateRecoveryCodes(recoveryCodeStore(), session.payload.userId);
+  const recoveryCodes = await generateRecoveryCodes(recoveryCodeStore, session.payload.userId);
   await writeAuditEvent({
     tenantId: session.payload.tenantId,
     actorType: "user",
@@ -10669,9 +10646,9 @@ async function provisionOAuthUser(opts: {
  * cannot influence the provider redirect_uri.
  */
 function authCallbackBaseUrl(c: Context): string {
-  const configured = runtimeEnvironmentValue("APP_URL")?.trim();
+  const configured = process.env.APP_URL?.trim();
   if (configured) return configured.replace(/\/$/, "");
-  if (runtimeEnvironmentValue("NODE_ENV") === "production") {
+  if (process.env.NODE_ENV === "production") {
     throw new Error("APP_URL is required for OAuth/OIDC callback URLs in production");
   }
   return `${c.req.header("x-forwarded-proto") ?? "https"}://${c.req.header("host") ?? "localhost"}`;
@@ -10807,7 +10784,7 @@ async function exchangeOidcAuthorizationCode(opts: {
     if (!isAllowedOidcClientSecretEnvForTenant(provider.clientSecretEnv, tenantId)) {
       throw new Error("OIDC client secret env is outside the allowed tenant namespace");
     }
-    const secret = runtimeEnvironmentValue(provider.clientSecretEnv);
+    const secret = process.env[provider.clientSecretEnv];
     if (!secret) throw new Error(`OIDC client secret env ${provider.clientSecretEnv} is not set`);
     body.set("client_secret", secret);
   }
@@ -10865,7 +10842,7 @@ function parseOAuthRedirectAllowlistEnv(): string[] {
   const entries = new Set<string>();
 
   for (const envName of OAUTH_REDIRECT_ALLOWLIST_ENV_KEYS) {
-    const raw = runtimeEnvironmentValue(envName);
+    const raw = process.env[envName];
     if (!raw) continue;
 
     for (const entry of raw.split(",")) {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -135,7 +135,11 @@ import {
   type TenantSamlSsoConfig,
   type TenantTestAccountConfig,
 } from "@stwd/shared";
-import { runtimeEnvironmentSnapshot, runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+import {
+  runtimeEnvironmentIdentity,
+  runtimeEnvironmentSnapshot,
+  runtimeEnvironmentValue,
+} from "@stwd/shared/runtime-env";
 import { type KeyStore, provisionUserWallet, Vault } from "@stwd/vault";
 import bs58 from "bs58";
 import { and, eq, gte, inArray, isNull, lt, sql } from "drizzle-orm";
@@ -165,7 +169,6 @@ import {
   _clearConfiguredVaultsForTests,
   getConfiguredKeyStore,
   getConfiguredVault,
-  resolveCustodyAuthority,
 } from "../services/vault-factory";
 import { dispatchWebhook } from "../services/webhook-dispatch";
 
@@ -1500,7 +1503,7 @@ export async function initAuthStores(usePostgres = false): Promise<void> {
   // Reset singletons so they pick up the new stores on next use
   phoneAuthByAuthority.clear();
   _passkeyAuthByAuthority.clear();
-  _emailAuthByTenant.clear();
+  _emailAuthByRequest = new WeakMap();
 }
 
 function getChallengeStore(): ChallengeStore {
@@ -1847,7 +1850,7 @@ function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
 
 // ─── EmailAuth cache ──────────────────────────────────────────────────────────
 
-const _emailAuthByTenant = new Map<string, Map<string, Promise<EmailAuth>>>();
+let _emailAuthByRequest = new WeakMap<object, Map<string, Promise<EmailAuth>>>();
 
 function getEmailKeyStore(): KeyStore {
   return getConfiguredKeyStore(undefined, { allowDevSecretFallback: true });
@@ -2144,40 +2147,45 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
 }
 
 export async function getEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
-  const authorityFingerprint = JSON.stringify([
-    resolveCustodyAuthority({ allowDevSecretFallback: true }).fingerprint,
-    runtimeEnvironmentValue("RESEND_API_KEY") ?? "",
-    runtimeEnvironmentValue("EMAIL_PROVIDER") ?? "",
-    runtimeEnvironmentValue("EMAIL_FROM") ?? "",
-    runtimeEnvironmentValue("APP_URL") ?? "",
-    runtimeEnvironmentValue("NODE_ENV") ?? "",
-    runtimeEnvironmentValue("STEWARD_EMAIL_CODE_SECRET") ?? "",
-    runtimeEnvironmentValue("STEWARD_ALLOW_DEV_SECRETS") ?? "",
-    authStoreAuthorityKey() ?? "bun",
-  ]);
-  let authorities = _emailAuthByTenant.get(tenantId);
-  const cached = authorities?.get(authorityFingerprint);
+  const requestIdentity = runtimeEnvironmentIdentity();
+  if (!requestIdentity) return createEmailAuthForTenant(tenantId);
+
+  let tenants = _emailAuthByRequest.get(requestIdentity);
+  const cached = tenants?.get(tenantId);
   if (cached) return cached;
 
   const pending = createEmailAuthForTenant(tenantId).catch((error) => {
-    authorities?.delete(authorityFingerprint);
-    if (authorities?.size === 0) _emailAuthByTenant.delete(tenantId);
+    tenants?.delete(tenantId);
     throw error;
   });
-  if (!authorities) {
-    authorities = new Map();
-    _emailAuthByTenant.set(tenantId, authorities);
+  if (!tenants) {
+    tenants = new Map();
+    _emailAuthByRequest.set(requestIdentity, tenants);
   }
-  authorities.set(authorityFingerprint, pending);
+  tenants.set(tenantId, pending);
   return pending;
 }
 
 export function invalidateEmailAuthForTenant(tenantId: string): void {
-  _emailAuthByTenant.delete(tenantId);
+  const identity = runtimeEnvironmentIdentity();
+  if (!identity) return;
+  const tenants = _emailAuthByRequest.get(identity);
+  const cached = tenants?.get(tenantId);
+  tenants?.delete(tenantId);
+  void cached?.then(
+    (auth) => auth.disposeProvider(),
+    () => undefined,
+  );
 }
 
 export function clearEmailAuthTenantCacheForTests(): void {
-  _emailAuthByTenant.clear();
+  _emailAuthByRequest = new WeakMap();
+}
+
+/** Internal behavior hook: no cache generations outside the active request are reachable. */
+export function emailAuthRequestCacheSizeForTests(): number {
+  const identity = runtimeEnvironmentIdentity();
+  return identity ? (_emailAuthByRequest.get(identity)?.size ?? 0) : 0;
 }
 
 export function clearOAuthTokenKeyStoreForTests(): void {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -135,6 +135,7 @@ import {
   type TenantSamlSsoConfig,
   type TenantTestAccountConfig,
 } from "@stwd/shared";
+import { runtimeEnvironmentSnapshot, runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { type KeyStore, provisionUserWallet, Vault } from "@stwd/vault";
 import bs58 from "bs58";
 import { and, eq, gte, inArray, isNull, lt, sql } from "drizzle-orm";
@@ -183,7 +184,8 @@ async function withVerifiedAuthTenant<T>(
     userId: subject,
   });
   const driver =
-    process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true"
+    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" ||
+    runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
       ? "pglite"
       : getDatabaseDriver();
   return withTenantRlsTransaction(getDb() as never, driver, context, async (tx) =>
@@ -203,7 +205,8 @@ async function withPreAuthTenant<T>(
     subject: "public-auth-flow",
   });
   const driver =
-    process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true"
+    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" ||
+    runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
       ? "pglite"
       : getDatabaseDriver();
   return withTenantRlsTransaction(getDb() as never, driver, context, async (tx) =>
@@ -259,9 +262,9 @@ function normalizeEmailDomain(value: unknown): string | null {
  * not preserved.
  */
 function trustedProxyHops(): number {
-  const raw = process.env.STEWARD_TRUSTED_PROXY_HOPS?.trim();
+  const raw = runtimeEnvironmentValue("STEWARD_TRUSTED_PROXY_HOPS")?.trim();
   if (raw === undefined || raw === "") {
-    return process.env.STEWARD_TRUST_PROXY_HEADERS === "true" ? 1 : 0;
+    return runtimeEnvironmentValue("STEWARD_TRUST_PROXY_HEADERS") === "true" ? 1 : 0;
   }
   // Canonical non-negative integer only: "1.5" must not truncate into trust.
   if (!/^\d+$/.test(raw)) return 0;
@@ -339,7 +342,7 @@ function logNoTrustedClientIpDiag(c: Context, hops: number): void {
  * never a shared "global" bucket, never open.
  */
 export function trustedClientIp(c: Context): string | undefined {
-  const trustCloudflare = process.env.STEWARD_TRUST_CLOUDFLARE === "true";
+  const trustCloudflare = runtimeEnvironmentValue("STEWARD_TRUST_CLOUDFLARE") === "true";
   if (trustCloudflare) {
     const cf = c.req.header("cf-connecting-ip")?.trim();
     if (cf && isIP(cf)) return cf;
@@ -435,7 +438,10 @@ function authRateLimitSubject(c: Context): { subject: string; coarse: boolean } 
   const peer = socketPeerFromEnv(c.env);
   if (peer && isIP(peer)) return { subject: `ip:${clientIpBucket(peer)}`, coarse: false };
   const now = Date.now();
-  if (process.env.NODE_ENV === "production" && now - coarseSubjectWarnedAt >= 60_000) {
+  if (
+    runtimeEnvironmentValue("NODE_ENV") === "production" &&
+    now - coarseSubjectWarnedAt >= 60_000
+  ) {
     coarseSubjectWarnedAt = now;
     console.warn(
       "[AuthRateLimit] No trusted client IP (set STEWARD_TRUSTED_PROXY_HOPS=2 on Railway); auth rate limits fall back to coarse per-host buckets instead of per-client budgets",
@@ -449,8 +455,8 @@ function authRateLimitSubject(c: Context): { subject: string; coarse: boolean } 
 
 function allowAuthRateLimitSoftFail(): boolean {
   return (
-    process.env.NODE_ENV !== "production" ||
-    process.env.STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL === "true"
+    runtimeEnvironmentValue("NODE_ENV") !== "production" ||
+    runtimeEnvironmentValue("STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL") === "true"
   );
 }
 
@@ -466,7 +472,7 @@ function allowAuthRateLimitSoftFail(): boolean {
  * isolate on Workers, which only tightens it).
  */
 function authRateLimitOutageValveMax(): number {
-  const raw = process.env.STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX;
+  const raw = runtimeEnvironmentValue("STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX");
   if (raw === undefined || raw === "") return 300;
   const parsed = Number.parseInt(raw, 10);
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : 300;
@@ -1274,6 +1280,8 @@ type SiweNonceRecord = {
 };
 
 function getNonceBackend(): import("@stwd/auth").StoreBackend {
+  const requestBackend = currentAuthStoreBundle()?.nonceBackend;
+  if (requestBackend) return requestBackend;
   if (_nonceBackend) return _nonceBackend;
   // Lazily fall back to a fresh in-memory backend if initAuthStores() hasn't
   // been called yet (e.g. tests or Workers cold-boot before middleware runs).
@@ -1363,7 +1371,7 @@ let _authStoreSources: AuthStoreSources = {
   mfa: "memory",
   importSession: "memory",
 };
-let _phoneAuth: PhoneAuth | null = null;
+const phoneAuthByAuthority = new Map<string, PhoneAuth>();
 
 export type AuthStoreSource = "redis" | "postgres" | "memory";
 export type AuthStoreSources = {
@@ -1373,6 +1381,37 @@ export type AuthStoreSources = {
   mfa: AuthStoreSource;
   importSession: AuthStoreSource;
 };
+
+type AuthStoreBundle = {
+  challengeStore: ChallengeStore;
+  tokenStore: TokenStore;
+  oauthCodeStore: ChallengeStore;
+  emailGrantStore: ChallengeStore;
+  nonceBackend: StoreBackend;
+  mfaBackend: StoreBackend;
+  importSessionBackend: StoreBackend;
+  sources: AuthStoreSources;
+};
+
+const authStoresByAuthority = new Map<string, AuthStoreBundle>();
+
+function authStoreAuthorityKey(): string | null {
+  if (runtimeEnvironmentValue("STEWARD_RUNTIME") !== "workers") return null;
+  const env = runtimeEnvironmentSnapshot();
+  return JSON.stringify([
+    env.REDIS_DRIVER ?? "ioredis",
+    env.REDIS_URL ?? "",
+    env.KV_REST_API_URL ?? env.UPSTASH_REDIS_REST_URL ?? "",
+    env.KV_REST_API_TOKEN ?? env.UPSTASH_REDIS_REST_TOKEN ?? "",
+    env.DATABASE_URL ?? "",
+    env.STEWARD_ALLOW_MEMORY_AUTH_STORES ?? "",
+  ]);
+}
+
+function currentAuthStoreBundle(): AuthStoreBundle | undefined {
+  const key = authStoreAuthorityKey();
+  return key === null ? undefined : authStoresByAuthority.get(key);
+}
 
 /**
  * One-time OAuth nonce-exchange codes (response_type=code) live for 60s —
@@ -1413,11 +1452,7 @@ export async function initAuthStores(usePostgres = false): Promise<void> {
       `import-session store: ${importSessionSource}`,
   );
 
-  _challengeStore = new ChallengeStore({ backend: challengeBackend });
-  _tokenStore = new TokenStore({ backend: tokenBackend });
-  _nonceBackend = nonceBackend;
-  _mfaBackend = mfaBackend;
-  _authStoreSources = {
+  const sources: AuthStoreSources = {
     challenge: challengeSource,
     token: tokenSource,
     siweNonce: nonceSource,
@@ -1427,29 +1462,50 @@ export async function initAuthStores(usePostgres = false): Promise<void> {
   // Reuse the challenge backend (Redis when available) for OAuth nonce codes
   // so they survive worker restarts and round-robin between isolates. The
   // 60s TTL is enforced at write time by ChallengeStore.
-  _oauthCodeStore = new ChallengeStore({
-    backend: challengeBackend,
-    ttlMs: OAUTH_CODE_TTL_MS,
-  });
-  // Verified-email grants share the challenge backend (Redis-backed in prod)
-  // so an OTP verified on one worker can register a passkey on another.
-  _emailGrantStore = new ChallengeStore({
-    backend: challengeBackend,
-    ttlMs: EMAIL_GRANT_TTL_MS,
-  });
-  _importSessionBackend = importSessionBackend;
+  const bundle: AuthStoreBundle = {
+    challengeStore: new ChallengeStore({ backend: challengeBackend }),
+    tokenStore: new TokenStore({ backend: tokenBackend }),
+    nonceBackend,
+    mfaBackend,
+    importSessionBackend,
+    sources,
+    oauthCodeStore: new ChallengeStore({
+      backend: challengeBackend,
+      ttlMs: OAUTH_CODE_TTL_MS,
+    }),
+    // Verified-email grants share the challenge backend (Redis-backed in prod)
+    // so an OTP verified on one worker can register a passkey on another.
+    emailGrantStore: new ChallengeStore({
+      backend: challengeBackend,
+      ttlMs: EMAIL_GRANT_TTL_MS,
+    }),
+  };
+  const authorityKey = authStoreAuthorityKey();
+  if (authorityKey !== null) {
+    authStoresByAuthority.set(authorityKey, bundle);
+  } else {
+    _challengeStore = bundle.challengeStore;
+    _tokenStore = bundle.tokenStore;
+    _nonceBackend = bundle.nonceBackend;
+    _mfaBackend = bundle.mfaBackend;
+    _authStoreSources = bundle.sources;
+    _oauthCodeStore = bundle.oauthCodeStore;
+    _emailGrantStore = bundle.emailGrantStore;
+    _importSessionBackend = bundle.importSessionBackend;
+  }
 
   const { initUserLinkChallengeStores } = await import("./user.js");
   initUserLinkChallengeStores(challengeBackend);
 
   // Reset singletons so they pick up the new stores on next use
-  _passkeyAuth = null;
-  _phoneAuth = null;
-  _passkeyAuthByOrigin.clear();
+  phoneAuthByAuthority.clear();
+  _passkeyAuthByAuthority.clear();
   _emailAuthByTenant.clear();
 }
 
 function getChallengeStore(): ChallengeStore {
+  const requestStore = currentAuthStoreBundle()?.challengeStore;
+  if (requestStore) return requestStore;
   _challengeStore ??= new ChallengeStore();
   return _challengeStore;
 }
@@ -1462,6 +1518,8 @@ function getChallengeStore(): ChallengeStore {
 export { getChallengeStore as getAuthChallengeStore };
 
 function getOAuthCodeStore(): ChallengeStore {
+  const requestStore = currentAuthStoreBundle()?.oauthCodeStore;
+  if (requestStore) return requestStore;
   _oauthCodeStore ??= new ChallengeStore({ ttlMs: OAUTH_CODE_TTL_MS });
   return _oauthCodeStore;
 }
@@ -1478,6 +1536,8 @@ const EMAIL_GRANT_TTL_MS = 5 * 60 * 1000;
 let _emailGrantStore: ChallengeStore | null = null;
 
 function getEmailGrantStore(): ChallengeStore {
+  const requestStore = currentAuthStoreBundle()?.emailGrantStore;
+  if (requestStore) return requestStore;
   _emailGrantStore ??= new ChallengeStore({ ttlMs: EMAIL_GRANT_TTL_MS });
   return _emailGrantStore;
 }
@@ -1580,7 +1640,7 @@ async function markOidcIdTokenUsedOnce(
 }
 
 function isUnsafeUnboundOAuthProviderCodeExchangeAllowed(): boolean {
-  return process.env.STEWARD_ALLOW_UNBOUND_OAUTH_PROVIDER_CODE_EXCHANGE === "true";
+  return runtimeEnvironmentValue("STEWARD_ALLOW_UNBOUND_OAUTH_PROVIDER_CODE_EXCHANGE") === "true";
 }
 
 function isValidPkceCodeVerifier(value: string): boolean {
@@ -1596,11 +1656,15 @@ async function pkceChallengeForVerifier(verifier: string, method: string): Promi
 }
 
 function getTokenStore(): TokenStore {
+  const requestStore = currentAuthStoreBundle()?.tokenStore;
+  if (requestStore) return requestStore;
   _tokenStore ??= new TokenStore();
   return _tokenStore;
 }
 
 function getMfaBackend(): StoreBackend {
+  const requestBackend = currentAuthStoreBundle()?.mfaBackend;
+  if (requestBackend) return requestBackend;
   if (_mfaBackend) return _mfaBackend;
   const { MemoryBackend } = require("@stwd/auth") as typeof import("@stwd/auth");
   _mfaBackend = new MemoryBackend();
@@ -1608,6 +1672,8 @@ function getMfaBackend(): StoreBackend {
 }
 
 export function getImportSessionBackend(): StoreBackend {
+  const requestBackend = currentAuthStoreBundle()?.importSessionBackend;
+  if (requestBackend) return requestBackend;
   if (_importSessionBackend) return _importSessionBackend;
   const { MemoryBackend } = require("@stwd/auth") as typeof import("@stwd/auth");
   _importSessionBackend = new MemoryBackend();
@@ -1615,7 +1681,7 @@ export function getImportSessionBackend(): StoreBackend {
 }
 
 export function getAuthStoreSources(): AuthStoreSources {
-  return { ..._authStoreSources };
+  return { ...(currentAuthStoreBundle()?.sources ?? _authStoreSources) };
 }
 
 /**
@@ -1626,8 +1692,13 @@ export function getAuthStoreSources(): AuthStoreSources {
  */
 export function assertAuthStoresAreSafe(sources: AuthStoreSources = getAuthStoreSources()): void {
   const requiresDurableStores =
-    process.env.NODE_ENV === "production" || process.env.STEWARD_RUNTIME === "workers";
-  if (!requiresDurableStores || process.env.STEWARD_ALLOW_MEMORY_AUTH_STORES === "true") return;
+    runtimeEnvironmentValue("NODE_ENV") === "production" ||
+    runtimeEnvironmentValue("STEWARD_RUNTIME") === "workers";
+  if (
+    !requiresDurableStores ||
+    runtimeEnvironmentValue("STEWARD_ALLOW_MEMORY_AUTH_STORES") === "true"
+  )
+    return;
 
   const memoryStores = Object.entries(sources)
     .filter(([, source]) => source === "memory")
@@ -1655,8 +1726,7 @@ export function decryptImportSessionJson<T>(value: string): T {
   return JSON.parse(getOAuthKeyStore().decrypt(encrypted)) as T;
 }
 
-let _passkeyAuth: PasskeyAuth | null = null;
-const _passkeyAuthByOrigin = new Map<string, PasskeyAuth>();
+const _passkeyAuthByAuthority = new Map<string, PasskeyAuth>();
 
 /**
  * Get PasskeyAuth for a specific origin (multi-tenant passkey support).
@@ -1703,25 +1773,36 @@ function resolveRpID(requestHostname: string, allowedOrigins: string[], fallback
 }
 
 function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
-  const defaultRpID = process.env.PASSKEY_RP_ID || "steward.fi";
-  const defaultOrigin = process.env.PASSKEY_ORIGIN || "https://steward.fi";
-  const rpName = process.env.PASSKEY_RP_NAME || "Steward";
+  const defaultRpID = runtimeEnvironmentValue("PASSKEY_RP_ID") || "steward.fi";
+  const defaultOrigin = runtimeEnvironmentValue("PASSKEY_ORIGIN") || "https://steward.fi";
+  const rpName = runtimeEnvironmentValue("PASSKEY_RP_NAME") || "Steward";
 
-  // If no origin provided, use the default singleton
+  const allowed = (runtimeEnvironmentValue("PASSKEY_ALLOWED_ORIGINS") || defaultOrigin)
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+
+  // Cache by the complete passkey authority, never only by rpID. Binding-only
+  // rotations must not inherit the prior origin allowlist or relying-party
+  // name from an app object cached earlier in the isolate.
   if (!requestOrigin) {
-    if (!_passkeyAuth) {
-      const origins = (process.env.PASSKEY_ALLOWED_ORIGINS || defaultOrigin)
-        .split(",")
-        .map((o) => o.trim())
-        .filter(Boolean);
-      _passkeyAuth = new PasskeyAuth({
-        rpName,
-        rpID: defaultRpID,
-        origin: origins.length > 1 ? origins : defaultOrigin,
-        challengeStore: getChallengeStore(),
-      });
-    }
-    return _passkeyAuth;
+    const acceptedOrigins = allowed.length > 1 ? allowed : [defaultOrigin];
+    const authorityKey = JSON.stringify([
+      rpName,
+      defaultRpID,
+      acceptedOrigins,
+      authStoreAuthorityKey() ?? "bun",
+    ]);
+    const cached = _passkeyAuthByAuthority.get(authorityKey);
+    if (cached) return cached;
+    const auth = new PasskeyAuth({
+      rpName,
+      rpID: defaultRpID,
+      origin: acceptedOrigins.length > 1 ? acceptedOrigins : defaultOrigin,
+      challengeStore: getChallengeStore(),
+    });
+    _passkeyAuthByAuthority.set(authorityKey, auth);
+    return auth;
   }
 
   // Parse origin to get hostname
@@ -1733,10 +1814,6 @@ function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
   }
 
   // Validate against allowed origins
-  const allowed = (process.env.PASSKEY_ALLOWED_ORIGINS || defaultOrigin)
-    .split(",")
-    .map((o) => o.trim())
-    .filter(Boolean);
   if (!allowed.includes(requestOrigin) && requestHostname !== defaultRpID) {
     return getPasskeyAuth(); // not in allowed list, use default
   }
@@ -1746,21 +1823,25 @@ function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
   // shared across apex + all subdomains.
   const rpID = resolveRpID(requestHostname, allowed, defaultRpID);
 
-  // Cache per rpID
-  const cached = _passkeyAuthByOrigin.get(rpID);
+  const acceptedOrigins = allowed.length > 0 ? allowed : [requestOrigin];
+  const authorityKey = JSON.stringify([
+    rpName,
+    rpID,
+    acceptedOrigins,
+    authStoreAuthorityKey() ?? "bun",
+  ]);
+  const cached = _passkeyAuthByAuthority.get(authorityKey);
   if (cached) return cached;
 
   // Origin list passed to PasskeyAuth covers all variants the browser may
   // present (apex + www) so SimpleWebAuthn accepts assertions from either.
-  const acceptedOrigins = allowed.length > 0 ? allowed : [requestOrigin];
-
   const auth = new PasskeyAuth({
     rpName,
     rpID,
     origin: acceptedOrigins,
     challengeStore: getChallengeStore(),
   });
-  _passkeyAuthByOrigin.set(rpID, auth);
+  _passkeyAuthByAuthority.set(authorityKey, auth);
   return auth;
 }
 
@@ -1836,16 +1917,22 @@ export function decryptOAuthProviderToken(encrypted: {
 }
 
 function isMockEmailEnabled(): boolean {
-  if (process.env.EMAIL_PROVIDER === "mock" && process.env.NODE_ENV === "production") {
+  if (
+    runtimeEnvironmentValue("EMAIL_PROVIDER") === "mock" &&
+    runtimeEnvironmentValue("NODE_ENV") === "production"
+  ) {
     throw new Error(
       "EMAIL_PROVIDER=mock is forbidden in production. Unset EMAIL_PROVIDER or set RESEND_API_KEY.",
     );
   }
-  return process.env.EMAIL_PROVIDER === "mock" && process.env.NODE_ENV !== "production";
+  return (
+    runtimeEnvironmentValue("EMAIL_PROVIDER") === "mock" &&
+    runtimeEnvironmentValue("NODE_ENV") !== "production"
+  );
 }
 
 function authTestInboxEnabled(): boolean {
-  return process.env.NODE_ENV === "test";
+  return runtimeEnvironmentValue("NODE_ENV") === "test";
 }
 
 function isEnabledTestAccount(
@@ -1938,20 +2025,23 @@ function buildGlobalEmailAuth(overrides?: {
   replyTo?: string;
   templates?: TenantEmailConfig["templates"];
 }): EmailAuth {
-  const resendKey = process.env.RESEND_API_KEY;
+  const resendKey = runtimeEnvironmentValue("RESEND_API_KEY");
   // Mock takes precedence in non-production for deterministic e2e testing.
   const provider = isMockEmailEnabled()
     ? new MockEmailProvider()
     : resendKey
       ? new ResendProvider({
           apiKey: resendKey,
-          from: process.env.EMAIL_FROM || "login@steward.fi",
+          from: runtimeEnvironmentValue("EMAIL_FROM") || "login@steward.fi",
         })
       : undefined;
 
   return new EmailAuth({
-    from: process.env.EMAIL_FROM || "login@steward.fi",
-    baseUrl: overrides?.baseUrl?.replace(/\/$/, "") || process.env.APP_URL || "https://steward.fi",
+    from: runtimeEnvironmentValue("EMAIL_FROM") || "login@steward.fi",
+    baseUrl:
+      overrides?.baseUrl?.replace(/\/$/, "") ||
+      runtimeEnvironmentValue("APP_URL") ||
+      "https://steward.fi",
     callbackPath: overrides?.callbackPath,
     provider,
     tokenStore: getTokenStore(),
@@ -2023,7 +2113,7 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
   // We've already returned via buildGlobalEmailAuth above when apiKeyEncrypted
   // is missing, so it's safe to assume `emailConfig.from + apiKeyEncrypted`
   // are both present here.
-  const from = emailConfig.from || process.env.EMAIL_FROM || "login@steward.fi";
+  const from = emailConfig.from || runtimeEnvironmentValue("EMAIL_FROM") || "login@steward.fi";
   const provider =
     emailConfig.provider === "resend" && emailConfig.apiKeyEncrypted
       ? new ResendProvider({
@@ -2036,7 +2126,9 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
       : undefined;
 
   const baseUrl =
-    magicLinkBaseUrl?.replace(/\/$/, "") || process.env.APP_URL || "https://steward.fi";
+    magicLinkBaseUrl?.replace(/\/$/, "") ||
+    runtimeEnvironmentValue("APP_URL") ||
+    "https://steward.fi";
 
   return new EmailAuth({
     from,
@@ -2052,9 +2144,15 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
 }
 
 export async function getEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
-  const authorityFingerprint = resolveCustodyAuthority({
-    allowDevSecretFallback: true,
-  }).fingerprint;
+  const authorityFingerprint = JSON.stringify([
+    resolveCustodyAuthority({ allowDevSecretFallback: true }).fingerprint,
+    runtimeEnvironmentValue("RESEND_API_KEY") ?? "",
+    runtimeEnvironmentValue("EMAIL_PROVIDER") ?? "",
+    runtimeEnvironmentValue("EMAIL_FROM") ?? "",
+    runtimeEnvironmentValue("APP_URL") ?? "",
+    runtimeEnvironmentValue("NODE_ENV") ?? "",
+    authStoreAuthorityKey() ?? "bun",
+  ]);
   let authorities = _emailAuthByTenant.get(tenantId);
   const cached = authorities?.get(authorityFingerprint);
   if (cached) return cached;
@@ -2120,6 +2218,8 @@ export function _seedOAuthExchangeCodeForTests(
 }
 
 export function _clearOAuthCodeStoreForTests(): void {
+  for (const bundle of authStoresByAuthority.values()) bundle.oauthCodeStore.destroy();
+  authStoresByAuthority.clear();
   _oauthCodeStore?.destroy();
   _oauthCodeStore = null;
 }
@@ -2480,7 +2580,7 @@ function ethereumWalletTenantId(address: string): string {
 }
 
 function getAllowedSiweDomains(): string[] {
-  const raw = process.env.SIWE_ALLOWED_DOMAINS?.trim();
+  const raw = runtimeEnvironmentValue("SIWE_ALLOWED_DOMAINS")?.trim();
   if (raw) {
     const domains = raw
       .split(",")
@@ -2489,7 +2589,7 @@ function getAllowedSiweDomains(): string[] {
     if (domains.length > 0) return domains;
   }
 
-  const appUrl = process.env.APP_URL?.trim() || "https://steward.fi";
+  const appUrl = runtimeEnvironmentValue("APP_URL")?.trim() || "https://steward.fi";
   try {
     return [new URL(appUrl).host.toLowerCase()];
   } catch {
@@ -2775,38 +2875,50 @@ async function requireRecentFactorEnrollmentStepUp(
 }
 
 export function getPhoneAuth(): PhoneAuth {
-  if (_phoneAuth) return _phoneAuth;
+  const authorityKey = JSON.stringify([
+    runtimeEnvironmentValue("SMS_PROVIDER") ?? "",
+    runtimeEnvironmentValue("NODE_ENV") ?? "",
+    runtimeEnvironmentValue("TWILIO_ACCOUNT_SID") ?? "",
+    runtimeEnvironmentValue("TWILIO_AUTH_TOKEN") ?? "",
+    runtimeEnvironmentValue("TWILIO_FROM") ?? "",
+    authStoreAuthorityKey() ?? "bun",
+  ]);
+  const cached = phoneAuthByAuthority.get(authorityKey);
+  if (cached) return cached;
 
   let provider: SmsProvider | undefined;
-  if (process.env.SMS_PROVIDER === "mock" && process.env.NODE_ENV !== "production") {
-    provider = new MockSmsProvider();
-  } else if (
-    process.env.TWILIO_ACCOUNT_SID &&
-    process.env.TWILIO_AUTH_TOKEN &&
-    process.env.TWILIO_FROM
+  const accountSid = runtimeEnvironmentValue("TWILIO_ACCOUNT_SID");
+  const authToken = runtimeEnvironmentValue("TWILIO_AUTH_TOKEN");
+  const from = runtimeEnvironmentValue("TWILIO_FROM");
+  if (
+    runtimeEnvironmentValue("SMS_PROVIDER") === "mock" &&
+    runtimeEnvironmentValue("NODE_ENV") !== "production"
   ) {
+    provider = new MockSmsProvider();
+  } else if (accountSid && authToken && from) {
     provider = new TwilioSmsProvider({
-      accountSid: process.env.TWILIO_ACCOUNT_SID,
-      authToken: process.env.TWILIO_AUTH_TOKEN,
-      from: process.env.TWILIO_FROM,
+      accountSid,
+      authToken,
+      from,
     });
-  } else if (process.env.NODE_ENV === "production") {
+  } else if (runtimeEnvironmentValue("NODE_ENV") === "production") {
     throw new Error("SMS provider not configured");
   }
 
-  _phoneAuth = new PhoneAuth({
+  const phoneAuth = new PhoneAuth({
     provider,
     tokenStore: new TokenStore({ backend: getMfaBackend() }),
   });
-  return _phoneAuth;
+  phoneAuthByAuthority.set(authorityKey, phoneAuth);
+  return phoneAuth;
 }
 
 function isWhatsAppOtpEnabled(): boolean {
-  return process.env.WHATSAPP_OTP_ENABLED === "true";
+  return runtimeEnvironmentValue("WHATSAPP_OTP_ENABLED") === "true";
 }
 
 function isFarcasterLoginEnabled(): boolean {
-  return process.env.FARCASTER_LOGIN_ENABLED === "true";
+  return runtimeEnvironmentValue("FARCASTER_LOGIN_ENABLED") === "true";
 }
 
 const TELEGRAM_LOGIN_MAX_AGE_SEC = 24 * 60 * 60;
@@ -3055,8 +3167,13 @@ class MfaRecoveryCodeStore implements RecoveryCodeStore {
   }
 }
 
-const recoveryCodeStore: RecoveryCodeStore =
-  process.env.NODE_ENV === "test" ? new InMemoryRecoveryCodeStore() : new MfaRecoveryCodeStore();
+const inMemoryRecoveryCodeStore = new InMemoryRecoveryCodeStore();
+const durableRecoveryCodeStore = new MfaRecoveryCodeStore();
+function recoveryCodeStore(): RecoveryCodeStore {
+  return runtimeEnvironmentValue("NODE_ENV") === "test"
+    ? inMemoryRecoveryCodeStore
+    : durableRecoveryCodeStore;
+}
 
 type PendingMfaAuth = {
   mfaType: "totp" | "sms";
@@ -3987,10 +4104,9 @@ function resolveSamlMappedRole(config: TenantSamlSsoConfig, groups: string[]): s
 }
 
 function getEmailAuthRedirectBaseUrl(): string {
-  return (process.env.EMAIL_AUTH_REDIRECT_BASE_URL || "https://www.elizacloud.ai").replace(
-    /\/$/,
-    "",
-  );
+  return (
+    runtimeEnvironmentValue("EMAIL_AUTH_REDIRECT_BASE_URL") || "https://www.elizacloud.ai"
+  ).replace(/\/$/, "");
 }
 
 function buildEmailAuthRedirectUrl(params?: Record<string, string | undefined>): string {
@@ -4599,7 +4715,8 @@ auth.get("/providers", async (c) => {
     discord: enabledOauth.includes("discord"),
     github: enabledOauth.includes("github"),
     twitter: enabledOauth.includes("twitter"),
-    telegram: methodEnabled("telegram") && Boolean(process.env.TELEGRAM_BOT_TOKEN?.trim()),
+    telegram:
+      methodEnabled("telegram") && Boolean(runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim()),
     farcaster: methodEnabled("farcaster") && isFarcasterLoginEnabled(),
     linkedin: enabledOauth.includes("linkedin"),
     spotify: enabledOauth.includes("spotify"),
@@ -4628,7 +4745,7 @@ auth.post("/telegram/challenge", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
   }
 
-  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -4671,7 +4788,7 @@ auth.post("/telegram/verify", async (c) => {
   >(c);
   if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
 
-  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -5499,8 +5616,8 @@ auth.get("/test/inbox/:email", (c) => {
 
 auth.get("/test/sms-inbox/:phone", (c) => {
   if (
-    process.env.SMS_PROVIDER !== "mock" ||
-    process.env.NODE_ENV === "production" ||
+    runtimeEnvironmentValue("SMS_PROVIDER") !== "mock" ||
+    runtimeEnvironmentValue("NODE_ENV") === "production" ||
     !authTestInboxEnabled()
   ) {
     return c.json<ApiResponse>({ ok: false, error: "Not found" }, 404);
@@ -5537,8 +5654,8 @@ auth.post("/test/token", async (c) => {
   // supervised app-review / automation windows and disable it immediately
   // afterward. Never leave it enabled on an internet-reachable prod deploy.
   if (
-    process.env.NODE_ENV === "production" &&
-    process.env.STEWARD_ENABLE_PROD_TEST_ACCOUNT_TOKEN !== "true"
+    runtimeEnvironmentValue("NODE_ENV") === "production" &&
+    runtimeEnvironmentValue("STEWARD_ENABLE_PROD_TEST_ACCOUNT_TOKEN") !== "true"
   ) {
     return c.json<ApiResponse>(
       { ok: false, error: "Test account token exchange is disabled" },
@@ -6863,7 +6980,7 @@ auth.post("/mfa/totp/enroll", async (c) => {
   const secret = generateTotpSecret();
   const accountName =
     session.payload.email || session.payload.address || `user:${session.payload.userId}`;
-  const issuer = process.env.TOTP_ISSUER || "Steward";
+  const issuer = runtimeEnvironmentValue("TOTP_ISSUER") || "Steward";
 
   await writeMfaJson(
     mfaKey("totp:pending", session.payload.userId),
@@ -6941,7 +7058,7 @@ auth.post("/mfa/totp/verify", async (c) => {
     });
     await writeMfaJson(mfaKey("totp:enabled", session.payload.userId), stored);
     await getMfaBackend().delete(mfaKey("totp:pending", session.payload.userId));
-    const recoveryCodes = await generateRecoveryCodes(recoveryCodeStore, session.payload.userId);
+    const recoveryCodes = await generateRecoveryCodes(recoveryCodeStore(), session.payload.userId);
     const { issuedBefore } = await revokeUserRefreshSessions(session.payload.userId);
     await writeAuditEvent({
       tenantId: session.payload.tenantId,
@@ -7043,7 +7160,7 @@ auth.post("/mfa/totp/complete", async (c) => {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired MFA challenge" }, 401);
     }
     const verified = await verifyRecoveryCode(
-      recoveryCodeStore,
+      recoveryCodeStore(),
       challenge.userId,
       body.recoveryCode ?? "",
     );
@@ -7133,7 +7250,7 @@ auth.post("/mfa/totp/step-up", async (c) => {
   let method: "totp" | "recovery_code" = "totp";
   if (hasRecoveryCode) {
     const verified = await verifyRecoveryCode(
-      recoveryCodeStore,
+      recoveryCodeStore(),
       session.payload.userId,
       body?.recoveryCode ?? "",
     );
@@ -7164,7 +7281,7 @@ auth.get("/mfa/recovery-codes/status", async (c) => {
 
   const enabled = await hasTotpEnabled(session.payload.userId);
   const remaining = enabled
-    ? await unusedRecoveryCodeCount(recoveryCodeStore, session.payload.userId)
+    ? await unusedRecoveryCodeCount(recoveryCodeStore(), session.payload.userId)
     : 0;
   return c.json({ ok: true, enabled, remaining });
 });
@@ -7217,7 +7334,7 @@ auth.post("/mfa/recovery-codes/regenerate", async (c) => {
     ...verified.stored,
     lastAcceptedStep: verified.acceptedStep,
   });
-  const recoveryCodes = await generateRecoveryCodes(recoveryCodeStore, session.payload.userId);
+  const recoveryCodes = await generateRecoveryCodes(recoveryCodeStore(), session.payload.userId);
   await writeAuditEvent({
     tenantId: session.payload.tenantId,
     actorType: "user",
@@ -10646,9 +10763,9 @@ async function provisionOAuthUser(opts: {
  * cannot influence the provider redirect_uri.
  */
 function authCallbackBaseUrl(c: Context): string {
-  const configured = process.env.APP_URL?.trim();
+  const configured = runtimeEnvironmentValue("APP_URL")?.trim();
   if (configured) return configured.replace(/\/$/, "");
-  if (process.env.NODE_ENV === "production") {
+  if (runtimeEnvironmentValue("NODE_ENV") === "production") {
     throw new Error("APP_URL is required for OAuth/OIDC callback URLs in production");
   }
   return `${c.req.header("x-forwarded-proto") ?? "https"}://${c.req.header("host") ?? "localhost"}`;
@@ -10784,7 +10901,7 @@ async function exchangeOidcAuthorizationCode(opts: {
     if (!isAllowedOidcClientSecretEnvForTenant(provider.clientSecretEnv, tenantId)) {
       throw new Error("OIDC client secret env is outside the allowed tenant namespace");
     }
-    const secret = process.env[provider.clientSecretEnv];
+    const secret = runtimeEnvironmentValue(provider.clientSecretEnv);
     if (!secret) throw new Error(`OIDC client secret env ${provider.clientSecretEnv} is not set`);
     body.set("client_secret", secret);
   }
@@ -10842,7 +10959,7 @@ function parseOAuthRedirectAllowlistEnv(): string[] {
   const entries = new Set<string>();
 
   for (const envName of OAUTH_REDIRECT_ALLOWLIST_ENV_KEYS) {
-    const raw = process.env[envName];
+    const raw = runtimeEnvironmentValue(envName);
     if (!raw) continue;
 
     for (const entry of raw.split(",")) {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -136,6 +136,7 @@ import {
   type TenantSamlSsoConfig,
   type TenantTestAccountConfig,
 } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { KeyStore, provisionUserWallet, Vault } from "@stwd/vault";
 import bs58 from "bs58";
 import { and, eq, gte, inArray, isNull, lt, sql } from "drizzle-orm";
@@ -179,7 +180,7 @@ async function withVerifiedAuthTenant<T>(
     userId: subject,
   });
   const driver =
-    process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true"
+    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
       ? "pglite"
       : getDatabaseDriver();
   return withTenantRlsTransaction(getDb() as never, driver, context, async (tx) =>
@@ -199,7 +200,7 @@ async function withPreAuthTenant<T>(
     subject: "public-auth-flow",
   });
   const driver =
-    process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true"
+    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
       ? "pglite"
       : getDatabaseDriver();
   return withTenantRlsTransaction(getDb() as never, driver, context, async (tx) =>
@@ -255,9 +256,9 @@ function normalizeEmailDomain(value: unknown): string | null {
  * not preserved.
  */
 function trustedProxyHops(): number {
-  const raw = process.env.STEWARD_TRUSTED_PROXY_HOPS?.trim();
+  const raw = runtimeEnvironmentValue("STEWARD_TRUSTED_PROXY_HOPS")?.trim();
   if (raw === undefined || raw === "") {
-    return process.env.STEWARD_TRUST_PROXY_HEADERS === "true" ? 1 : 0;
+    return runtimeEnvironmentValue("STEWARD_TRUST_PROXY_HEADERS") === "true" ? 1 : 0;
   }
   // Canonical non-negative integer only: "1.5" must not truncate into trust.
   if (!/^\d+$/.test(raw)) return 0;
@@ -335,7 +336,7 @@ function logNoTrustedClientIpDiag(c: Context, hops: number): void {
  * never a shared "global" bucket, never open.
  */
 export function trustedClientIp(c: Context): string | undefined {
-  const trustCloudflare = process.env.STEWARD_TRUST_CLOUDFLARE === "true";
+  const trustCloudflare = runtimeEnvironmentValue("STEWARD_TRUST_CLOUDFLARE") === "true";
   if (trustCloudflare) {
     const cf = c.req.header("cf-connecting-ip")?.trim();
     if (cf && isIP(cf)) return cf;
@@ -431,7 +432,7 @@ function authRateLimitSubject(c: Context): { subject: string; coarse: boolean } 
   const peer = socketPeerFromEnv(c.env);
   if (peer && isIP(peer)) return { subject: `ip:${clientIpBucket(peer)}`, coarse: false };
   const now = Date.now();
-  if (process.env.NODE_ENV === "production" && now - coarseSubjectWarnedAt >= 60_000) {
+  if (runtimeEnvironmentValue("NODE_ENV") === "production" && now - coarseSubjectWarnedAt >= 60_000) {
     coarseSubjectWarnedAt = now;
     console.warn(
       "[AuthRateLimit] No trusted client IP (set STEWARD_TRUSTED_PROXY_HOPS=2 on Railway); auth rate limits fall back to coarse per-host buckets instead of per-client budgets",
@@ -445,8 +446,8 @@ function authRateLimitSubject(c: Context): { subject: string; coarse: boolean } 
 
 function allowAuthRateLimitSoftFail(): boolean {
   return (
-    process.env.NODE_ENV !== "production" ||
-    process.env.STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL === "true"
+    runtimeEnvironmentValue("NODE_ENV") !== "production" ||
+    runtimeEnvironmentValue("STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL") === "true"
   );
 }
 
@@ -462,7 +463,7 @@ function allowAuthRateLimitSoftFail(): boolean {
  * isolate on Workers, which only tightens it).
  */
 function authRateLimitOutageValveMax(): number {
-  const raw = process.env.STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX;
+  const raw = runtimeEnvironmentValue("STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX");
   if (raw === undefined || raw === "") return 300;
   const parsed = Number.parseInt(raw, 10);
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : 300;
@@ -1576,7 +1577,7 @@ async function markOidcIdTokenUsedOnce(
 }
 
 function isUnsafeUnboundOAuthProviderCodeExchangeAllowed(): boolean {
-  return process.env.STEWARD_ALLOW_UNBOUND_OAUTH_PROVIDER_CODE_EXCHANGE === "true";
+  return runtimeEnvironmentValue("STEWARD_ALLOW_UNBOUND_OAUTH_PROVIDER_CODE_EXCHANGE") === "true";
 }
 
 function isValidPkceCodeVerifier(value: string): boolean {
@@ -1622,8 +1623,8 @@ export function getAuthStoreSources(): AuthStoreSources {
  */
 export function assertAuthStoresAreSafe(sources: AuthStoreSources = getAuthStoreSources()): void {
   const requiresDurableStores =
-    process.env.NODE_ENV === "production" || process.env.STEWARD_RUNTIME === "workers";
-  if (!requiresDurableStores || process.env.STEWARD_ALLOW_MEMORY_AUTH_STORES === "true") return;
+    runtimeEnvironmentValue("NODE_ENV") === "production" || runtimeEnvironmentValue("STEWARD_RUNTIME") === "workers";
+  if (!requiresDurableStores || runtimeEnvironmentValue("STEWARD_ALLOW_MEMORY_AUTH_STORES") === "true") return;
 
   const memoryStores = Object.entries(sources)
     .filter(([, source]) => source === "memory")
@@ -1651,8 +1652,7 @@ export function decryptImportSessionJson<T>(value: string): T {
   return JSON.parse(getOAuthKeyStore().decrypt(encrypted)) as T;
 }
 
-let _passkeyAuth: PasskeyAuth | null = null;
-const _passkeyAuthByOrigin = new Map<string, PasskeyAuth>();
+const _passkeyAuthByAuthority = new Map<string, PasskeyAuth>();
 
 /**
  * Get PasskeyAuth for a specific origin (multi-tenant passkey support).
@@ -1699,25 +1699,31 @@ function resolveRpID(requestHostname: string, allowedOrigins: string[], fallback
 }
 
 function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
-  const defaultRpID = process.env.PASSKEY_RP_ID || "steward.fi";
-  const defaultOrigin = process.env.PASSKEY_ORIGIN || "https://steward.fi";
-  const rpName = process.env.PASSKEY_RP_NAME || "Steward";
+  const defaultRpID = runtimeEnvironmentValue("PASSKEY_RP_ID") || "steward.fi";
+  const defaultOrigin = runtimeEnvironmentValue("PASSKEY_ORIGIN") || "https://steward.fi";
+  const rpName = runtimeEnvironmentValue("PASSKEY_RP_NAME") || "Steward";
 
-  // If no origin provided, use the default singleton
+  const allowed = (runtimeEnvironmentValue("PASSKEY_ALLOWED_ORIGINS") || defaultOrigin)
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+
+  // Cache by the complete passkey authority, never only by rpID. Binding-only
+  // rotations must not inherit the prior origin allowlist or relying-party
+  // name from an app object cached earlier in the isolate.
   if (!requestOrigin) {
-    if (!_passkeyAuth) {
-      const origins = (process.env.PASSKEY_ALLOWED_ORIGINS || defaultOrigin)
-        .split(",")
-        .map((o) => o.trim())
-        .filter(Boolean);
-      _passkeyAuth = new PasskeyAuth({
-        rpName,
-        rpID: defaultRpID,
-        origin: origins.length > 1 ? origins : defaultOrigin,
-        challengeStore: getChallengeStore(),
-      });
-    }
-    return _passkeyAuth;
+    const acceptedOrigins = allowed.length > 1 ? allowed : [defaultOrigin];
+    const authorityKey = JSON.stringify([rpName, defaultRpID, acceptedOrigins]);
+    const cached = _passkeyAuthByAuthority.get(authorityKey);
+    if (cached) return cached;
+    const auth = new PasskeyAuth({
+      rpName,
+      rpID: defaultRpID,
+      origin: acceptedOrigins.length > 1 ? acceptedOrigins : defaultOrigin,
+      challengeStore: getChallengeStore(),
+    });
+    _passkeyAuthByAuthority.set(authorityKey, auth);
+    return auth;
   }
 
   // Parse origin to get hostname
@@ -1729,10 +1735,6 @@ function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
   }
 
   // Validate against allowed origins
-  const allowed = (process.env.PASSKEY_ALLOWED_ORIGINS || defaultOrigin)
-    .split(",")
-    .map((o) => o.trim())
-    .filter(Boolean);
   if (!allowed.includes(requestOrigin) && requestHostname !== defaultRpID) {
     return getPasskeyAuth(); // not in allowed list, use default
   }
@@ -1742,21 +1744,20 @@ function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
   // shared across apex + all subdomains.
   const rpID = resolveRpID(requestHostname, allowed, defaultRpID);
 
-  // Cache per rpID
-  const cached = _passkeyAuthByOrigin.get(rpID);
+  const acceptedOrigins = allowed.length > 0 ? allowed : [requestOrigin];
+  const authorityKey = JSON.stringify([rpName, rpID, acceptedOrigins]);
+  const cached = _passkeyAuthByAuthority.get(authorityKey);
   if (cached) return cached;
 
   // Origin list passed to PasskeyAuth covers all variants the browser may
   // present (apex + www) so SimpleWebAuthn accepts assertions from either.
-  const acceptedOrigins = allowed.length > 0 ? allowed : [requestOrigin];
-
   const auth = new PasskeyAuth({
     rpName,
     rpID,
     origin: acceptedOrigins,
     challengeStore: getChallengeStore(),
   });
-  _passkeyAuthByOrigin.set(rpID, auth);
+  _passkeyAuthByAuthority.set(authorityKey, auth);
   return auth;
 }
 
@@ -1769,7 +1770,7 @@ let _oauthKeyStore: KeyStore | null = null;
 function getEmailKeyStore(): KeyStore {
   if (_emailKeyStore) return _emailKeyStore;
 
-  const masterPassword = process.env.STEWARD_MASTER_PASSWORD;
+  const masterPassword = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD");
   if (!masterPassword) {
     if (!isDevSecretAllowed()) {
       throw new Error(
@@ -1787,7 +1788,7 @@ function getEmailKeyStore(): KeyStore {
 function getOAuthKeyStore(): KeyStore {
   if (_oauthKeyStore) return _oauthKeyStore;
 
-  const masterPassword = process.env.STEWARD_MASTER_PASSWORD;
+  const masterPassword = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD");
   if (!masterPassword) {
     if (!isDevSecretAllowed()) {
       throw new Error(
@@ -1862,16 +1863,16 @@ export function decryptOAuthProviderToken(encrypted: {
 }
 
 function isMockEmailEnabled(): boolean {
-  if (process.env.EMAIL_PROVIDER === "mock" && process.env.NODE_ENV === "production") {
+  if (runtimeEnvironmentValue("EMAIL_PROVIDER") === "mock" && runtimeEnvironmentValue("NODE_ENV") === "production") {
     throw new Error(
       "EMAIL_PROVIDER=mock is forbidden in production. Unset EMAIL_PROVIDER or set RESEND_API_KEY.",
     );
   }
-  return process.env.EMAIL_PROVIDER === "mock" && process.env.NODE_ENV !== "production";
+  return runtimeEnvironmentValue("EMAIL_PROVIDER") === "mock" && runtimeEnvironmentValue("NODE_ENV") !== "production";
 }
 
 function authTestInboxEnabled(): boolean {
-  return process.env.NODE_ENV === "test";
+  return runtimeEnvironmentValue("NODE_ENV") === "test";
 }
 
 function isEnabledTestAccount(
@@ -1964,20 +1965,20 @@ function buildGlobalEmailAuth(overrides?: {
   replyTo?: string;
   templates?: TenantEmailConfig["templates"];
 }): EmailAuth {
-  const resendKey = process.env.RESEND_API_KEY;
+  const resendKey = runtimeEnvironmentValue("RESEND_API_KEY");
   // Mock takes precedence in non-production for deterministic e2e testing.
   const provider = isMockEmailEnabled()
     ? new MockEmailProvider()
     : resendKey
       ? new ResendProvider({
           apiKey: resendKey,
-          from: process.env.EMAIL_FROM || "login@steward.fi",
+          from: runtimeEnvironmentValue("EMAIL_FROM") || "login@steward.fi",
         })
       : undefined;
 
   return new EmailAuth({
-    from: process.env.EMAIL_FROM || "login@steward.fi",
-    baseUrl: overrides?.baseUrl?.replace(/\/$/, "") || process.env.APP_URL || "https://steward.fi",
+    from: runtimeEnvironmentValue("EMAIL_FROM") || "login@steward.fi",
+    baseUrl: overrides?.baseUrl?.replace(/\/$/, "") || runtimeEnvironmentValue("APP_URL") || "https://steward.fi",
     callbackPath: overrides?.callbackPath,
     provider,
     tokenStore: getTokenStore(),
@@ -2049,7 +2050,7 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
   // We've already returned via buildGlobalEmailAuth above when apiKeyEncrypted
   // is missing, so it's safe to assume `emailConfig.from + apiKeyEncrypted`
   // are both present here.
-  const from = emailConfig.from || process.env.EMAIL_FROM || "login@steward.fi";
+  const from = emailConfig.from || runtimeEnvironmentValue("EMAIL_FROM") || "login@steward.fi";
   const provider =
     emailConfig.provider === "resend" && emailConfig.apiKeyEncrypted
       ? new ResendProvider({
@@ -2062,7 +2063,7 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
       : undefined;
 
   const baseUrl =
-    magicLinkBaseUrl?.replace(/\/$/, "") || process.env.APP_URL || "https://steward.fi";
+    magicLinkBaseUrl?.replace(/\/$/, "") || runtimeEnvironmentValue("APP_URL") || "https://steward.fi";
 
   return new EmailAuth({
     from,
@@ -2497,7 +2498,7 @@ function ethereumWalletTenantId(address: string): string {
 }
 
 function getAllowedSiweDomains(): string[] {
-  const raw = process.env.SIWE_ALLOWED_DOMAINS?.trim();
+  const raw = runtimeEnvironmentValue("SIWE_ALLOWED_DOMAINS")?.trim();
   if (raw) {
     const domains = raw
       .split(",")
@@ -2506,7 +2507,7 @@ function getAllowedSiweDomains(): string[] {
     if (domains.length > 0) return domains;
   }
 
-  const appUrl = process.env.APP_URL?.trim() || "https://steward.fi";
+  const appUrl = runtimeEnvironmentValue("APP_URL")?.trim() || "https://steward.fi";
   try {
     return [new URL(appUrl).host.toLowerCase()];
   } catch {
@@ -2795,19 +2796,19 @@ export function getPhoneAuth(): PhoneAuth {
   if (_phoneAuth) return _phoneAuth;
 
   let provider: SmsProvider | undefined;
-  if (process.env.SMS_PROVIDER === "mock" && process.env.NODE_ENV !== "production") {
+  if (runtimeEnvironmentValue("SMS_PROVIDER") === "mock" && runtimeEnvironmentValue("NODE_ENV") !== "production") {
     provider = new MockSmsProvider();
   } else if (
-    process.env.TWILIO_ACCOUNT_SID &&
-    process.env.TWILIO_AUTH_TOKEN &&
-    process.env.TWILIO_FROM
+    runtimeEnvironmentValue("TWILIO_ACCOUNT_SID") &&
+    runtimeEnvironmentValue("TWILIO_AUTH_TOKEN") &&
+    runtimeEnvironmentValue("TWILIO_FROM")
   ) {
     provider = new TwilioSmsProvider({
-      accountSid: process.env.TWILIO_ACCOUNT_SID,
-      authToken: process.env.TWILIO_AUTH_TOKEN,
-      from: process.env.TWILIO_FROM,
+      accountSid: runtimeEnvironmentValue("TWILIO_ACCOUNT_SID"),
+      authToken: runtimeEnvironmentValue("TWILIO_AUTH_TOKEN"),
+      from: runtimeEnvironmentValue("TWILIO_FROM"),
     });
-  } else if (process.env.NODE_ENV === "production") {
+  } else if (runtimeEnvironmentValue("NODE_ENV") === "production") {
     throw new Error("SMS provider not configured");
   }
 
@@ -2819,11 +2820,11 @@ export function getPhoneAuth(): PhoneAuth {
 }
 
 function isWhatsAppOtpEnabled(): boolean {
-  return process.env.WHATSAPP_OTP_ENABLED === "true";
+  return runtimeEnvironmentValue("WHATSAPP_OTP_ENABLED") === "true";
 }
 
 function isFarcasterLoginEnabled(): boolean {
-  return process.env.FARCASTER_LOGIN_ENABLED === "true";
+  return runtimeEnvironmentValue("FARCASTER_LOGIN_ENABLED") === "true";
 }
 
 const TELEGRAM_LOGIN_MAX_AGE_SEC = 24 * 60 * 60;
@@ -3072,8 +3073,13 @@ class MfaRecoveryCodeStore implements RecoveryCodeStore {
   }
 }
 
-const recoveryCodeStore: RecoveryCodeStore =
-  process.env.NODE_ENV === "test" ? new InMemoryRecoveryCodeStore() : new MfaRecoveryCodeStore();
+const inMemoryRecoveryCodeStore = new InMemoryRecoveryCodeStore();
+const durableRecoveryCodeStore = new MfaRecoveryCodeStore();
+function recoveryCodeStore(): RecoveryCodeStore {
+  return runtimeEnvironmentValue("NODE_ENV") === "test"
+    ? inMemoryRecoveryCodeStore
+    : durableRecoveryCodeStore;
+}
 
 type PendingMfaAuth = {
   mfaType: "totp" | "sms";
@@ -4004,7 +4010,7 @@ function resolveSamlMappedRole(config: TenantSamlSsoConfig, groups: string[]): s
 }
 
 function getEmailAuthRedirectBaseUrl(): string {
-  return (process.env.EMAIL_AUTH_REDIRECT_BASE_URL || "https://www.elizacloud.ai").replace(
+  return (runtimeEnvironmentValue("EMAIL_AUTH_REDIRECT_BASE_URL") || "https://www.elizacloud.ai").replace(
     /\/$/,
     "",
   );
@@ -4616,7 +4622,7 @@ auth.get("/providers", async (c) => {
     discord: enabledOauth.includes("discord"),
     github: enabledOauth.includes("github"),
     twitter: enabledOauth.includes("twitter"),
-    telegram: methodEnabled("telegram") && Boolean(process.env.TELEGRAM_BOT_TOKEN?.trim()),
+    telegram: methodEnabled("telegram") && Boolean(runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim()),
     farcaster: methodEnabled("farcaster") && isFarcasterLoginEnabled(),
     linkedin: enabledOauth.includes("linkedin"),
     spotify: enabledOauth.includes("spotify"),
@@ -4645,7 +4651,7 @@ auth.post("/telegram/challenge", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
   }
 
-  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -4688,7 +4694,7 @@ auth.post("/telegram/verify", async (c) => {
   >(c);
   if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
 
-  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -5516,8 +5522,8 @@ auth.get("/test/inbox/:email", (c) => {
 
 auth.get("/test/sms-inbox/:phone", (c) => {
   if (
-    process.env.SMS_PROVIDER !== "mock" ||
-    process.env.NODE_ENV === "production" ||
+    runtimeEnvironmentValue("SMS_PROVIDER") !== "mock" ||
+    runtimeEnvironmentValue("NODE_ENV") === "production" ||
     !authTestInboxEnabled()
   ) {
     return c.json<ApiResponse>({ ok: false, error: "Not found" }, 404);
@@ -5554,8 +5560,8 @@ auth.post("/test/token", async (c) => {
   // supervised app-review / automation windows and disable it immediately
   // afterward. Never leave it enabled on an internet-reachable prod deploy.
   if (
-    process.env.NODE_ENV === "production" &&
-    process.env.STEWARD_ENABLE_PROD_TEST_ACCOUNT_TOKEN !== "true"
+    runtimeEnvironmentValue("NODE_ENV") === "production" &&
+    runtimeEnvironmentValue("STEWARD_ENABLE_PROD_TEST_ACCOUNT_TOKEN") !== "true"
   ) {
     return c.json<ApiResponse>(
       { ok: false, error: "Test account token exchange is disabled" },
@@ -6880,7 +6886,7 @@ auth.post("/mfa/totp/enroll", async (c) => {
   const secret = generateTotpSecret();
   const accountName =
     session.payload.email || session.payload.address || `user:${session.payload.userId}`;
-  const issuer = process.env.TOTP_ISSUER || "Steward";
+  const issuer = runtimeEnvironmentValue("TOTP_ISSUER") || "Steward";
 
   await writeMfaJson(
     mfaKey("totp:pending", session.payload.userId),
@@ -6958,7 +6964,7 @@ auth.post("/mfa/totp/verify", async (c) => {
     });
     await writeMfaJson(mfaKey("totp:enabled", session.payload.userId), stored);
     await getMfaBackend().delete(mfaKey("totp:pending", session.payload.userId));
-    const recoveryCodes = await generateRecoveryCodes(recoveryCodeStore, session.payload.userId);
+    const recoveryCodes = await generateRecoveryCodes(recoveryCodeStore(), session.payload.userId);
     const { issuedBefore } = await revokeUserRefreshSessions(session.payload.userId);
     await writeAuditEvent({
       tenantId: session.payload.tenantId,
@@ -7060,7 +7066,7 @@ auth.post("/mfa/totp/complete", async (c) => {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired MFA challenge" }, 401);
     }
     const verified = await verifyRecoveryCode(
-      recoveryCodeStore,
+      recoveryCodeStore(),
       challenge.userId,
       body.recoveryCode ?? "",
     );
@@ -7150,7 +7156,7 @@ auth.post("/mfa/totp/step-up", async (c) => {
   let method: "totp" | "recovery_code" = "totp";
   if (hasRecoveryCode) {
     const verified = await verifyRecoveryCode(
-      recoveryCodeStore,
+      recoveryCodeStore(),
       session.payload.userId,
       body?.recoveryCode ?? "",
     );
@@ -7181,7 +7187,7 @@ auth.get("/mfa/recovery-codes/status", async (c) => {
 
   const enabled = await hasTotpEnabled(session.payload.userId);
   const remaining = enabled
-    ? await unusedRecoveryCodeCount(recoveryCodeStore, session.payload.userId)
+    ? await unusedRecoveryCodeCount(recoveryCodeStore(), session.payload.userId)
     : 0;
   return c.json({ ok: true, enabled, remaining });
 });
@@ -7234,7 +7240,7 @@ auth.post("/mfa/recovery-codes/regenerate", async (c) => {
     ...verified.stored,
     lastAcceptedStep: verified.acceptedStep,
   });
-  const recoveryCodes = await generateRecoveryCodes(recoveryCodeStore, session.payload.userId);
+  const recoveryCodes = await generateRecoveryCodes(recoveryCodeStore(), session.payload.userId);
   await writeAuditEvent({
     tenantId: session.payload.tenantId,
     actorType: "user",
@@ -10663,9 +10669,9 @@ async function provisionOAuthUser(opts: {
  * cannot influence the provider redirect_uri.
  */
 function authCallbackBaseUrl(c: Context): string {
-  const configured = process.env.APP_URL?.trim();
+  const configured = runtimeEnvironmentValue("APP_URL")?.trim();
   if (configured) return configured.replace(/\/$/, "");
-  if (process.env.NODE_ENV === "production") {
+  if (runtimeEnvironmentValue("NODE_ENV") === "production") {
     throw new Error("APP_URL is required for OAuth/OIDC callback URLs in production");
   }
   return `${c.req.header("x-forwarded-proto") ?? "https"}://${c.req.header("host") ?? "localhost"}`;
@@ -10801,7 +10807,7 @@ async function exchangeOidcAuthorizationCode(opts: {
     if (!isAllowedOidcClientSecretEnvForTenant(provider.clientSecretEnv, tenantId)) {
       throw new Error("OIDC client secret env is outside the allowed tenant namespace");
     }
-    const secret = process.env[provider.clientSecretEnv];
+    const secret = runtimeEnvironmentValue(provider.clientSecretEnv);
     if (!secret) throw new Error(`OIDC client secret env ${provider.clientSecretEnv} is not set`);
     body.set("client_secret", secret);
   }
@@ -10859,7 +10865,7 @@ function parseOAuthRedirectAllowlistEnv(): string[] {
   const entries = new Set<string>();
 
   for (const envName of OAUTH_REDIRECT_ALLOWLIST_ENV_KEYS) {
-    const raw = process.env[envName];
+    const raw = runtimeEnvironmentValue(envName);
     if (!raw) continue;
 
     for (const entry of raw.split(",")) {

--- a/packages/api/src/routes/condition-sets.ts
+++ b/packages/api/src/routes/condition-sets.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Privy-style condition set CRUD.
  *
@@ -265,7 +266,7 @@ const MAX_CONDITION_SET_ITEM_LABEL_LENGTH = 255;
 const MAX_ITEM_METADATA_BYTES = 4_096;
 
 function shouldUsePostgresAdvisoryLocks(): boolean {
-  return process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true";
+  return runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" && runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true";
 }
 
 function parsePaginationParam(

--- a/packages/api/src/routes/condition-sets.ts
+++ b/packages/api/src/routes/condition-sets.ts
@@ -266,7 +266,10 @@ const MAX_CONDITION_SET_ITEM_LABEL_LENGTH = 255;
 const MAX_ITEM_METADATA_BYTES = 4_096;
 
 function shouldUsePostgresAdvisoryLocks(): boolean {
-  return runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" && runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true";
+  return (
+    runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" &&
+    runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true"
+  );
 }
 
 function parsePaginationParam(

--- a/packages/api/src/routes/erc8004.ts
+++ b/packages/api/src/routes/erc8004.ts
@@ -14,6 +14,7 @@ import { redactedThrownDiagnostics } from "@stwd/shared";
 import { and, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
+import { validateAgentCardApiUrl } from "../services/agent-card-url";
 import { writeAuditEvent } from "../services/audit";
 import {
   type ApiResponse,
@@ -24,7 +25,6 @@ import {
   requireTenantLevel,
 } from "../services/context";
 import { isRecentMfaTimestamp } from "../services/recent-mfa";
-import { validateWebhookUrlResolved } from "../services/webhook-url";
 
 export const erc8004Routes = new Hono<{ Variables: AppVariables }>();
 type AgentRegistrationRow = typeof agentRegistrations.$inferSelect;
@@ -80,14 +80,6 @@ function requireRecentAdminMfa(c: Parameters<typeof requireTenantLevel>[0], reas
 
 function signedFeedbackWritesEnabled(): boolean {
   return false;
-}
-
-async function validateAgentCardApiUrl(apiUrl: string): Promise<string | null> {
-  if (!apiUrl) return null;
-  const destinationError = await validateWebhookUrlResolved(apiUrl);
-  if (destinationError) return `apiUrl ${destinationError}`;
-  if (new URL(apiUrl).protocol !== "https:") return "apiUrl must use https";
-  return null;
 }
 
 function publicDiscoveryAgentRow(row: Record<string, unknown>) {

--- a/packages/api/src/routes/erc8004.ts
+++ b/packages/api/src/routes/erc8004.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * ERC-8004 on-chain identity, reputation, and discovery routes.
  *
@@ -355,8 +356,8 @@ erc8004Routes.post("/:id/feedback", async (c) => {
   try {
     const duplicate = await db.transaction(async (tx) => {
       if (
-        process.env.STEWARD_DB_MODE !== "pglite" &&
-        process.env.STEWARD_PGLITE_MEMORY !== "true"
+        runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" &&
+        runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true"
       ) {
         await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${feedbackReplayKey}))`);
       }

--- a/packages/api/src/routes/global-wallet.ts
+++ b/packages/api/src/routes/global-wallet.ts
@@ -8,6 +8,7 @@ import {
   userWalletAppConsents,
 } from "@stwd/db";
 import type { ApiResponse, SignTypedDataRequest } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { Vault } from "@stwd/vault";
 import { and, eq, sql } from "drizzle-orm";
 import type { Context, Next } from "hono";
@@ -1000,7 +1001,10 @@ globalWalletRoutes.post("/rpc/confirm", async (c) => {
     walletIndex,
   });
   const confirmation = await getDb().transaction(async (tx) => {
-    if (process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true") {
+    if (
+      runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" &&
+      runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true"
+    ) {
       await tx.execute(
         sql`select pg_advisory_xact_lock(hashtext(${`global-wallet-confirmation:${consent.id}:${method}:${requestHash}`}))`,
       );

--- a/packages/api/src/routes/global-wallet.ts
+++ b/packages/api/src/routes/global-wallet.ts
@@ -1,4 +1,3 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createHash } from "node:crypto";
 import {
   agents,
@@ -21,6 +20,7 @@ import {
   setNoStoreHeaders,
   verifySessionToken,
 } from "../services/context";
+import { resolveRuntimeChainId } from "../services/custody-runtime";
 import { globalWalletFeatureFlags } from "../services/global-wallet-runtime";
 import { isRecentMfaTimestamp } from "../services/recent-mfa";
 import { getConfiguredVault } from "../services/vault-factory";
@@ -383,7 +383,7 @@ function parseRpcQuantity(value: unknown): bigint | string {
 
 function parseRpcChainId(value: unknown): number | string {
   if (value === undefined || value === null || value === "") {
-    return Number(runtimeEnvironmentValue("CHAIN_ID") || "84532");
+    return resolveRuntimeChainId(84532);
   }
   const parsed = parseRpcQuantity(value);
   if (typeof parsed === "string")
@@ -1000,7 +1000,7 @@ globalWalletRoutes.post("/rpc/confirm", async (c) => {
     walletIndex,
   });
   const confirmation = await getDb().transaction(async (tx) => {
-    if (runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" && runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true") {
+    if (process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true") {
       await tx.execute(
         sql`select pg_advisory_xact_lock(hashtext(${`global-wallet-confirmation:${consent.id}:${method}:${requestHash}`}))`,
       );
@@ -1635,7 +1635,7 @@ globalWalletRoutes.post("/rpc", async (c) => {
   const result =
     method === "eth_accounts"
       ? [wallet.walletAddress]
-      : `0x${Number(runtimeEnvironmentValue("CHAIN_ID") || "84532").toString(16)}`;
+      : `0x${resolveRuntimeChainId(84532).toString(16)}`;
   return c.json<ApiResponse>({
     ok: true,
     data: { jsonrpc: body.jsonrpc ?? "2.0", id: body.id ?? null, result },

--- a/packages/api/src/routes/global-wallet.ts
+++ b/packages/api/src/routes/global-wallet.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createHash } from "node:crypto";
 import {
   agents,
@@ -382,7 +383,7 @@ function parseRpcQuantity(value: unknown): bigint | string {
 
 function parseRpcChainId(value: unknown): number | string {
   if (value === undefined || value === null || value === "") {
-    return Number(process.env.CHAIN_ID || "84532");
+    return Number(runtimeEnvironmentValue("CHAIN_ID") || "84532");
   }
   const parsed = parseRpcQuantity(value);
   if (typeof parsed === "string")
@@ -999,7 +1000,7 @@ globalWalletRoutes.post("/rpc/confirm", async (c) => {
     walletIndex,
   });
   const confirmation = await getDb().transaction(async (tx) => {
-    if (process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true") {
+    if (runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" && runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true") {
       await tx.execute(
         sql`select pg_advisory_xact_lock(hashtext(${`global-wallet-confirmation:${consent.id}:${method}:${requestHash}`}))`,
       );
@@ -1634,7 +1635,7 @@ globalWalletRoutes.post("/rpc", async (c) => {
   const result =
     method === "eth_accounts"
       ? [wallet.walletAddress]
-      : `0x${Number(process.env.CHAIN_ID || "84532").toString(16)}`;
+      : `0x${Number(runtimeEnvironmentValue("CHAIN_ID") || "84532").toString(16)}`;
   return c.json<ApiResponse>({
     ok: true,
     data: { jsonrpc: body.jsonrpc ?? "2.0", id: body.id ?? null, result },

--- a/packages/api/src/routes/intents.ts
+++ b/packages/api/src/routes/intents.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Privy-style generic intent routes.
  *
@@ -78,7 +79,8 @@ const DEFAULT_INTENT_TTL_SECONDS = 24 * 60 * 60;
 const MAX_INTENT_TTL_SECONDS = 7 * 24 * 60 * 60;
 const AGENT_KEY_QUORUM_STATUSES = new Set(["active", "paused", "revoked"]);
 const VAULT_RPC_ALLOWLIST = new Set(
-  (process.env.STEWARD_VAULT_RPC_ALLOWLIST ?? "eth_chainId,eth_blockNumber,eth_getBalance")
+  (runtimeEnvironmentValue("STEWARD_VAULT_RPC_ALLOWLIST") ??
+    "eth_chainId,eth_blockNumber,eth_getBalance")
     .split(",")
     .map((method) => method.trim())
     .filter(Boolean),
@@ -1126,7 +1128,7 @@ class IntentExecutionError extends Error {
 }
 
 async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
-  if (process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true") {
+  if (runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true") {
     return fn();
   }
   return db.transaction(async (tx) => {

--- a/packages/api/src/routes/intents.ts
+++ b/packages/api/src/routes/intents.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Privy-style generic intent routes.
  *
@@ -1121,7 +1122,10 @@ class IntentExecutionError extends Error {
 }
 
 async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
-  if (process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true") {
+  if (
+    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" ||
+    runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
+  ) {
     return fn();
   }
   return db.transaction(async (tx) => {

--- a/packages/api/src/routes/intents.ts
+++ b/packages/api/src/routes/intents.ts
@@ -1,4 +1,3 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Privy-style generic intent routes.
  *
@@ -33,6 +32,7 @@ import {
   transactions,
   vault,
 } from "../services/context";
+import { isRuntimeVaultRpcMethodAllowed } from "../services/custody-runtime";
 import { redactSignedTransactions, toIntentResponse } from "../services/intent-response";
 import { getPolicyRulesValidationError } from "../services/policy-validation";
 import { isRecentMfaTimestamp } from "../services/recent-mfa";
@@ -78,13 +78,6 @@ const MAX_AGENT_SIGNER_METADATA_BYTES = 8_192;
 const DEFAULT_INTENT_TTL_SECONDS = 24 * 60 * 60;
 const MAX_INTENT_TTL_SECONDS = 7 * 24 * 60 * 60;
 const AGENT_KEY_QUORUM_STATUSES = new Set(["active", "paused", "revoked"]);
-const VAULT_RPC_ALLOWLIST = new Set(
-  (runtimeEnvironmentValue("STEWARD_VAULT_RPC_ALLOWLIST") ??
-    "eth_chainId,eth_blockNumber,eth_getBalance")
-    .split(",")
-    .map((method) => method.trim())
-    .filter(Boolean),
-);
 const MAX_UINT256_DECIMAL =
   "115792089237316195423570985008687907853269984665640564039457584007913129639935";
 const MAX_UINT256_DECIMAL_DIGITS = 78;
@@ -795,7 +788,7 @@ async function executeSendCallsIntent(row: typeof intents.$inferSelect) {
 
 async function executeRpcIntent(row: typeof intents.$inferSelect) {
   const method = normalizeRequiredText(row.payload.method, "method", 128);
-  if (!VAULT_RPC_ALLOWLIST.has(method)) {
+  if (!isRuntimeVaultRpcMethodAllowed(method)) {
     throw new IntentExecutionError("RPC method is not allowlisted", 403);
   }
   const request = {
@@ -1128,7 +1121,7 @@ class IntentExecutionError extends Error {
 }
 
 async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
-  if (runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true") {
+  if (process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true") {
     return fn();
   }
   return db.transaction(async (tx) => {

--- a/packages/api/src/routes/kms.ts
+++ b/packages/api/src/routes/kms.ts
@@ -59,7 +59,7 @@ import {
   timingSafeEqual,
 } from "node:crypto";
 import { getDb, type Secret, secrets as secretRows } from "@stwd/db";
-import { SecretVault } from "@stwd/vault";
+import type { SecretVault } from "@stwd/vault";
 import { and, asc, eq } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { type AuditEventInput, writeAuditEvent } from "../services/audit";
@@ -68,10 +68,10 @@ import {
   type ApiResponse,
   type AppVariables,
   hasAgentTokenScope,
-  MASTER_PASSWORD,
   safeJsonParse,
   setNoStoreHeaders,
 } from "../services/context";
+import { getConfiguredSecretVault } from "../services/vault-factory";
 
 export const kmsRoutes = new Hono<{ Variables: AppVariables }>();
 
@@ -88,12 +88,8 @@ const B64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
 // rather than pretending — the adapter surfaces the error loudly.
 const SUPPORTED_ALGORITHM = "ed25519";
 
-// Lazily initialised so context.ts can set MASTER_PASSWORD first (same pattern
-// as routes/secrets.ts — the SAME SecretVault custody plane, not a fork).
-let _secretVault: SecretVault | undefined;
 function getSecretVault(): SecretVault {
-  _secretVault ??= new SecretVault(MASTER_PASSWORD);
-  return _secretVault;
+  return getConfiguredSecretVault();
 }
 
 kmsRoutes.use("*", async (c, next) => {

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Platform-level management routes.
  *
@@ -381,7 +382,7 @@ function auditCtx(c: {
 }
 
 function platformIdentityMigrationAllowed(): boolean {
-  return process.env.STEWARD_ALLOW_PLATFORM_IDENTITY_MIGRATION === "true";
+  return runtimeEnvironmentValue("STEWARD_ALLOW_PLATFORM_IDENTITY_MIGRATION") === "true";
 }
 
 function platformIdentityMigrationDisabledResponse(c: Context) {

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -1,4 +1,3 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Platform-level management routes.
  *
@@ -17,7 +16,6 @@ import {
   generateApiKey,
   hashSha256Hex,
   hasPlatformScope,
-  isDevSecretAllowed,
   isValidE164,
   platformAuthMiddleware,
   revocationStore,
@@ -61,7 +59,7 @@ import {
   type TenantOidcProviderConfig,
   type TenantTestAccountConfig,
 } from "@stwd/shared";
-import { KeyStore, Vault } from "@stwd/vault";
+import { type KeyStore, Vault } from "@stwd/vault";
 import {
   and,
   count,
@@ -100,7 +98,7 @@ import {
   publicTestAccount,
   redactedTestAccount,
 } from "../services/test-account-credentials";
-import { getConfiguredVault } from "../services/vault-factory";
+import { getConfiguredKeyStore, getConfiguredVault } from "../services/vault-factory";
 import { dispatchWebhook } from "../services/webhook-dispatch";
 import { getEmailAuthForTenant, invalidateEmailAuthForTenant } from "./auth";
 
@@ -383,7 +381,7 @@ function auditCtx(c: {
 }
 
 function platformIdentityMigrationAllowed(): boolean {
-  return runtimeEnvironmentValue("STEWARD_ALLOW_PLATFORM_IDENTITY_MIGRATION") === "true";
+  return process.env.STEWARD_ALLOW_PLATFORM_IDENTITY_MIGRATION === "true";
 }
 
 function platformIdentityMigrationDisabledResponse(c: Context) {
@@ -408,25 +406,8 @@ function vault(): Vault {
   return getVault();
 }
 
-let _platformKeyStore: KeyStore | undefined;
 function platformKeyStore(): KeyStore {
-  if (_platformKeyStore) return _platformKeyStore;
-
-  const masterPassword = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD");
-  if (!masterPassword) {
-    if (!isDevSecretAllowed()) {
-      throw new Error(
-        "⛔ STEWARD_MASTER_PASSWORD must be set. For local development only, opt in to the " +
-          "insecure dev fallback with STEWARD_ALLOW_DEV_SECRETS=true.",
-      );
-    }
-    console.warn(
-      "⚠️  [DEV ONLY] Using insecure 'dev-secret' as vault master password. Set STEWARD_MASTER_PASSWORD before going to production!",
-    );
-  }
-
-  _platformKeyStore = new KeyStore(masterPassword || "dev-secret");
-  return _platformKeyStore;
+  return getConfiguredKeyStore(undefined, { allowDevSecretFallback: true });
 }
 
 // ─── Validation helpers ───────────────────────────────────────────────────────

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Platform-level management routes.
  *
@@ -382,7 +383,7 @@ function auditCtx(c: {
 }
 
 function platformIdentityMigrationAllowed(): boolean {
-  return process.env.STEWARD_ALLOW_PLATFORM_IDENTITY_MIGRATION === "true";
+  return runtimeEnvironmentValue("STEWARD_ALLOW_PLATFORM_IDENTITY_MIGRATION") === "true";
 }
 
 function platformIdentityMigrationDisabledResponse(c: Context) {
@@ -411,7 +412,7 @@ let _platformKeyStore: KeyStore | undefined;
 function platformKeyStore(): KeyStore {
   if (_platformKeyStore) return _platformKeyStore;
 
-  const masterPassword = process.env.STEWARD_MASTER_PASSWORD;
+  const masterPassword = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD");
   if (!masterPassword) {
     if (!isDevSecretAllowed()) {
       throw new Error(

--- a/packages/api/src/routes/policies-standalone.ts
+++ b/packages/api/src/routes/policies-standalone.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Standalone Policy Template CRUD, assignment, and simulation routes.
  *
@@ -180,7 +181,7 @@ async function insertTemplateWithQuota(
   id: string,
 ): Promise<PolicyTemplate> {
   return db.transaction(async (tx) => {
-    if (process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true") {
+    if (runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" && runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true") {
       await tx.execute(
         sql`select pg_advisory_xact_lock(hashtext(${`policy_templates:${tenantId}`}))`,
       );

--- a/packages/api/src/routes/policies-standalone.ts
+++ b/packages/api/src/routes/policies-standalone.ts
@@ -181,7 +181,10 @@ async function insertTemplateWithQuota(
   id: string,
 ): Promise<PolicyTemplate> {
   return db.transaction(async (tx) => {
-    if (runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" && runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true") {
+    if (
+      runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" &&
+      runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true"
+    ) {
       await tx.execute(
         sql`select pg_advisory_xact_lock(hashtext(${`policy_templates:${tenantId}`}))`,
       );

--- a/packages/api/src/routes/provider-google-connect.ts
+++ b/packages/api/src/routes/provider-google-connect.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Google Workspace provider-account OAuth connect routes (#203).
  *
@@ -56,7 +57,7 @@ async function getConnectStore(): Promise<PendingConnectStore> {
   if (_connectStore) return _connectStore;
   const { getRedisClient } = await import("../middleware/redis.js");
   const redisClient = getRedisClient();
-  const usePostgres = process.env.STEWARD_AUTH_STORE_BACKEND === "postgres";
+  const usePostgres = runtimeEnvironmentValue("STEWARD_AUTH_STORE_BACKEND") === "postgres";
   const { backend, source } = await buildBackend("challenge", redisClient, usePostgres);
   assertGoogleConnectStoreIsSafe(source);
   // TTL is fixed at construction; the store's set() ignores a per-call ttl.

--- a/packages/api/src/routes/provider-google-connect.ts
+++ b/packages/api/src/routes/provider-google-connect.ts
@@ -22,11 +22,10 @@ import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 
 import { buildBackend, ChallengeStore } from "@stwd/auth";
 import type { AppVariables } from "@stwd/shared";
-import { SecretVault } from "@stwd/vault";
+import type { SecretVault } from "@stwd/vault";
 import type { Context, Hono } from "hono";
 import {
   type ApiResponse,
-  MASTER_PASSWORD,
   safeJsonParse,
   setNoStoreHeaders,
   tenantAuth,
@@ -44,6 +43,7 @@ import {
   resolveGoogleConnectConfig,
 } from "../services/provider-google-connect";
 import { hasRecentGoogleConnectMfa } from "../services/provider-google-connect-mfa";
+import { getConfiguredSecretVault } from "../services/vault-factory";
 import { assertAllowedOAuthRedirectUri } from "./auth";
 
 type RouteContext = Context<{ Variables: AppVariables }>;
@@ -75,10 +75,8 @@ export function __setProviderGoogleConnectStoreForTests(store: PendingConnectSto
   _connectStore = store;
 }
 
-let _vault: SecretVault | null = null;
 function getVault(): SecretVault {
-  _vault ??= new SecretVault(MASTER_PASSWORD);
-  return _vault;
+  return getConfiguredSecretVault();
 }
 
 function fail(c: RouteContext, error: unknown): Response {

--- a/packages/api/src/routes/provider-x-connect.ts
+++ b/packages/api/src/routes/provider-x-connect.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Provider-account X (Twitter) OAuth connect routes (issue #195 workstream A).
  *
@@ -53,7 +54,7 @@ async function getConnectStore(): Promise<PendingConnectStore> {
   if (_connectStore) return _connectStore;
   const { getRedisClient } = await import("../middleware/redis.js");
   const redisClient = getRedisClient();
-  const usePostgres = process.env.STEWARD_AUTH_STORE_BACKEND === "postgres";
+  const usePostgres = runtimeEnvironmentValue("STEWARD_AUTH_STORE_BACKEND") === "postgres";
   const { backend } = await buildBackend("challenge", redisClient, usePostgres);
   // TTL is fixed at construction; the store's set() ignores a per-call ttl.
   const store = new ChallengeStore({ backend, ttlMs: X_CONNECT_STATE_TTL_MS });

--- a/packages/api/src/routes/provider-x-connect.ts
+++ b/packages/api/src/routes/provider-x-connect.ts
@@ -21,11 +21,10 @@ import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 
 import { buildBackend, ChallengeStore } from "@stwd/auth";
 import type { AppVariables } from "@stwd/shared";
-import { SecretVault } from "@stwd/vault";
+import type { SecretVault } from "@stwd/vault";
 import type { Context, Hono } from "hono";
 import {
   type ApiResponse,
-  MASTER_PASSWORD,
   safeJsonParse,
   setNoStoreHeaders,
   tenantAuth,
@@ -41,6 +40,7 @@ import {
   X_CONNECT_STATE_TTL_MS,
   XConnectError,
 } from "../services/provider-x-connect";
+import { getConfiguredSecretVault } from "../services/vault-factory";
 import { assertAllowedOAuthRedirectUri } from "./auth";
 
 type RouteContext = Context<{ Variables: AppVariables }>;
@@ -71,10 +71,8 @@ export function __setProviderXConnectStoreForTests(store: PendingConnectStore | 
   _connectStore = store;
 }
 
-let _vault: SecretVault | null = null;
 function getVault(): SecretVault {
-  _vault ??= new SecretVault(MASTER_PASSWORD);
-  return _vault;
+  return getConfiguredSecretVault();
 }
 
 function fail(c: RouteContext, error: unknown): Response {

--- a/packages/api/src/routes/quote.ts
+++ b/packages/api/src/routes/quote.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   type AttestationProvider,
   createDstackTdxProvider,
@@ -76,7 +77,7 @@ quoteRoutes.get("/", async (c) => {
 });
 
 export function createConfiguredAttestationProvider(): AttestationProvider {
-  const provider = process.env.STEWARD_ATTESTATION_PROVIDER ?? "noop-dev";
+  const provider = runtimeEnvironmentValue("STEWARD_ATTESTATION_PROVIDER") ?? "noop-dev";
   switch (provider) {
     case "dstack-tdx":
       return createDstackTdxProvider();

--- a/packages/api/src/routes/quote.ts
+++ b/packages/api/src/routes/quote.ts
@@ -1,10 +1,10 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   type AttestationProvider,
   createDstackTdxProvider,
   createNoopDevProvider,
 } from "@stwd/attestation";
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
 import { checkAuthRateLimit } from "./auth";

--- a/packages/api/src/routes/secrets.ts
+++ b/packages/api/src/routes/secrets.ts
@@ -17,7 +17,7 @@ import {
   secrets as secretRows,
   tenantConfigs as tenantConfigsTable,
 } from "@stwd/db";
-import { SecretVault, validateSecretRouteConfig } from "@stwd/vault";
+import { type SecretVault, validateSecretRouteConfig } from "@stwd/vault";
 import { and, eq, inArray } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import {
@@ -30,7 +30,6 @@ import {
   type AppVariables,
   ensureAgentForTenant,
   isNonEmptyString,
-  MASTER_PASSWORD,
   safeJsonParse,
   sanitizeErrorMessage,
   setNoStoreHeaders,
@@ -42,6 +41,7 @@ import {
   lockSecretRouteNamespaces,
   SecretRouteAuthorityConflict,
 } from "../services/secret-route-authority";
+import { getConfiguredSecretVault } from "../services/vault-factory";
 
 export const secretsRoutes = new Hono<{ Variables: AppVariables }>();
 
@@ -300,11 +300,8 @@ function parseSecretRouteCreate(
   };
 }
 
-// Lazily initialised so context.ts can set MASTER_PASSWORD first
-let _secretVault: SecretVault | undefined;
 function getSecretVault(): SecretVault {
-  _secretVault ??= new SecretVault(MASTER_PASSWORD);
-  return _secretVault;
+  return getConfiguredSecretVault();
 }
 
 function requireTenantAdminSession(c: Context<{ Variables: AppVariables }>): boolean {

--- a/packages/api/src/routes/tenant-config.ts
+++ b/packages/api/src/routes/tenant-config.ts
@@ -39,7 +39,7 @@ import type {
   TenantTestAccountConfig,
   TenantTheme,
 } from "@stwd/shared";
-import { type EncryptedKey, KeyStore } from "@stwd/vault";
+import type { EncryptedKey, KeyStore } from "@stwd/vault";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { DEFAULT_TENANT_CONFIGS } from "../defaults/tenant-configs";
@@ -57,7 +57,6 @@ import {
   db,
   ensureAgentForTenant,
   getConditionSetReferenceValidationError,
-  MASTER_PASSWORD,
   requireTenantLevel,
   safeJsonParse,
   setNoStoreHeaders,
@@ -71,6 +70,7 @@ import {
   createTenantTestAccountConfig,
   publicTestAccount,
 } from "../services/test-account-credentials";
+import { getConfiguredKeyStore } from "../services/vault-factory";
 import { requireTenantId } from "./tenants";
 
 export const tenantConfigRoutes = new Hono<{ Variables: AppVariables }>();
@@ -886,7 +886,7 @@ function serializeTenantAppClientSecret(
 }
 
 function requestSigningKeyStore(): KeyStore {
-  return new KeyStore(MASTER_PASSWORD, undefined, "secret-vault");
+  return getConfiguredKeyStore("secret-vault");
 }
 
 function generateRequestSigningSecret(): { secret: string; prefix: string } {

--- a/packages/api/src/routes/tenant-config.ts
+++ b/packages/api/src/routes/tenant-config.ts
@@ -6,6 +6,7 @@
  */
 
 import { randomBytes, randomUUID } from "node:crypto";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { resolveTxt } from "node:dns/promises";
 import { hashSha256Hex } from "@stwd/auth";
 import {
@@ -448,8 +449,8 @@ function hasLocalhostUrl(value: string): boolean {
 
 function configuredRequestSigningSecrets(): string[] {
   return [
-    ...(process.env.STEWARD_REQUEST_SIGNING_SECRETS ?? "").split(","),
-    process.env.STEWARD_REQUEST_SIGNING_SECRET ?? "",
+    ...(runtimeEnvironmentValue("STEWARD_REQUEST_SIGNING_SECRETS") ?? "").split(","),
+    runtimeEnvironmentValue("STEWARD_REQUEST_SIGNING_SECRET") ?? "",
   ]
     .map((secret) => secret.trim())
     .filter(Boolean);
@@ -480,13 +481,13 @@ function buildTenantSecurityChecklist(
   appClientSecrets: TenantAppClientSecret[],
   requestSigningKeys: TenantRequestSigningKey[],
 ): TenantSecurityChecklist {
-  const production = process.env.NODE_ENV === "production";
+  const production = runtimeEnvironmentValue("NODE_ENV") === "production";
   // SEC-010: these mirror the ACTUAL enforcement posture of the mounted
   // guards (app.ts). Freshness/signature headers are always verified when
   // present; they are REQUIRED only via the explicit env opt-ins, so the
   // checklist must not claim production enforcement that does not exist.
-  const requestExpiryRequired = process.env.STEWARD_REQUIRE_REQUEST_EXPIRY === "true";
-  const authSignatureRequired = process.env.STEWARD_REQUIRE_AUTH_SIGNATURE === "true";
+  const requestExpiryRequired = runtimeEnvironmentValue("STEWARD_REQUIRE_REQUEST_EXPIRY") === "true";
+  const authSignatureRequired = runtimeEnvironmentValue("STEWARD_REQUIRE_AUTH_SIGNATURE") === "true";
   const signingSecrets = configuredRequestSigningSecrets();
   const appClientSigningSecrets = appClientSecrets.filter(
     (secret) =>

--- a/packages/api/src/routes/tenant-config.ts
+++ b/packages/api/src/routes/tenant-config.ts
@@ -6,7 +6,6 @@
  */
 
 import { randomBytes, randomUUID } from "node:crypto";
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { resolveTxt } from "node:dns/promises";
 import { hashSha256Hex } from "@stwd/auth";
 import {
@@ -39,6 +38,7 @@ import type {
   TenantTestAccountConfig,
   TenantTheme,
 } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type { EncryptedKey, KeyStore } from "@stwd/vault";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
@@ -486,8 +486,10 @@ function buildTenantSecurityChecklist(
   // guards (app.ts). Freshness/signature headers are always verified when
   // present; they are REQUIRED only via the explicit env opt-ins, so the
   // checklist must not claim production enforcement that does not exist.
-  const requestExpiryRequired = runtimeEnvironmentValue("STEWARD_REQUIRE_REQUEST_EXPIRY") === "true";
-  const authSignatureRequired = runtimeEnvironmentValue("STEWARD_REQUIRE_AUTH_SIGNATURE") === "true";
+  const requestExpiryRequired =
+    runtimeEnvironmentValue("STEWARD_REQUIRE_REQUEST_EXPIRY") === "true";
+  const authSignatureRequired =
+    runtimeEnvironmentValue("STEWARD_REQUIRE_AUTH_SIGNATURE") === "true";
   const signingSecrets = configuredRequestSigningSecrets();
   const appClientSigningSecrets = appClientSecrets.filter(
     (secret) =>

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -78,6 +78,7 @@ import {
   type SignRequest,
   type TenantAuthAbuseConfig,
 } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   applyUserWalletDefaults,
   generateMnemonic,
@@ -931,7 +932,7 @@ function slugifyTenantId(value: string): string {
 }
 
 function userTenantCreationAllowed(): boolean {
-  return process.env.ALLOW_USER_TENANT_CREATION === "true";
+  return runtimeEnvironmentValue("ALLOW_USER_TENANT_CREATION") === "true";
 }
 
 async function writeUserAudit(
@@ -1558,7 +1559,10 @@ function userWalletRowsToAccountWallets(
 }
 
 async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
-  if (process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true") {
+  if (
+    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" ||
+    runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
+  ) {
     return fn();
   }
   const db = getDb();
@@ -1745,18 +1749,18 @@ export async function userSessionAuth(
 
 const user = new Hono<{ Variables: UserVariables }>();
 const allowPrivateKeyExport = (): boolean =>
-  process.env.STEWARD_ALLOW_KEY_EXPORT !== "false" &&
-  process.env.STEWARD_ALLOW_PRIVATE_KEY_EXPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_KEY_EXPORT") !== "false" &&
+  runtimeEnvironmentValue("STEWARD_ALLOW_PRIVATE_KEY_EXPORT") === "true";
 const allowPrivateKeyImport = (): boolean =>
-  process.env.STEWARD_ALLOW_PRIVATE_KEY_IMPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_PRIVATE_KEY_IMPORT") === "true";
 const allowUnsafeMessageSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING") === "true";
 const allowUserPrivateKeyExport = (): boolean =>
-  process.env.STEWARD_ALLOW_USER_PRIVATE_KEY_EXPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_USER_PRIVATE_KEY_EXPORT") === "true";
 const allowUserPrivateKeyImport = (): boolean =>
-  process.env.STEWARD_ALLOW_USER_PRIVATE_KEY_IMPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_USER_PRIVATE_KEY_IMPORT") === "true";
 const allowUserUnsafeMessageSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_USER_UNSAFE_MESSAGE_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_USER_UNSAFE_MESSAGE_SIGNING") === "true";
 
 // Apply session auth to all routes in this group
 user.use("*", userSessionAuth);
@@ -2038,7 +2042,7 @@ function farcasterProviderAccountId(address: string): string {
 }
 
 function userFarcasterAllowedDomains(): string[] | undefined {
-  const raw = process.env.SIWE_ALLOWED_DOMAINS?.trim();
+  const raw = runtimeEnvironmentValue("SIWE_ALLOWED_DOMAINS")?.trim();
   if (!raw) return undefined;
   const domains = raw
     .split(",")
@@ -3105,7 +3109,7 @@ for (const channel of ["sms", "whatsapp"] as const) {
   user.post(`/me/accounts/phone/${channel}/send`, async (c) => {
     const personalSessionResponse = requirePersonalUserSession(c);
     if (personalSessionResponse) return personalSessionResponse;
-    if (channel === "whatsapp" && process.env.WHATSAPP_OTP_ENABLED !== "true") {
+    if (channel === "whatsapp" && runtimeEnvironmentValue("WHATSAPP_OTP_ENABLED") !== "true") {
       return c.json<ApiResponse>({ ok: false, error: "WhatsApp OTP is not configured" }, 503);
     }
     const session = c.get("userSession");
@@ -3150,7 +3154,7 @@ for (const channel of ["sms", "whatsapp"] as const) {
   user.post(`/me/accounts/phone/${channel}/verify`, async (c) => {
     const personalSessionResponse = requirePersonalUserSession(c);
     if (personalSessionResponse) return personalSessionResponse;
-    if (channel === "whatsapp" && process.env.WHATSAPP_OTP_ENABLED !== "true") {
+    if (channel === "whatsapp" && runtimeEnvironmentValue("WHATSAPP_OTP_ENABLED") !== "true") {
       return c.json<ApiResponse>({ ok: false, error: "WhatsApp OTP is not configured" }, 503);
     }
     const session = c.get("userSession");
@@ -3276,7 +3280,7 @@ user.post("/me/accounts/telegram/challenge", async (c) => {
     );
   }
 
-  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -3303,7 +3307,7 @@ user.post("/me/accounts/telegram", async (c) => {
     );
   }
 
-  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -3401,7 +3405,7 @@ user.post("/me/accounts/farcaster/nonce", async (c) => {
       403,
     );
   }
-  if (process.env.FARCASTER_LOGIN_ENABLED !== "true") {
+  if (runtimeEnvironmentValue("FARCASTER_LOGIN_ENABLED") !== "true") {
     return c.json<ApiResponse>({ ok: false, error: "Farcaster login is not configured" }, 503);
   }
 
@@ -3430,7 +3434,7 @@ user.post("/me/accounts/farcaster", async (c) => {
     );
   }
 
-  if (process.env.FARCASTER_LOGIN_ENABLED !== "true") {
+  if (runtimeEnvironmentValue("FARCASTER_LOGIN_ENABLED") !== "true") {
     return c.json<ApiResponse>({ ok: false, error: "Farcaster login is not configured" }, 503);
   }
   const body = await safeJsonParse<Parameters<typeof verifyFarcasterLogin>[0]>(c);

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -117,6 +117,7 @@ import { redactWalletMetadataSecrets } from "../services/wallet-metadata";
 import { dispatchWebhook } from "../services/webhook-dispatch";
 import {
   assertAllowedOAuthRedirectUri,
+  authStoreAuthorityKey,
   claimSmsVerifyAttempt,
   clearSmsVerifyFailures,
   createSessionToken,
@@ -207,23 +208,77 @@ let currentUserLinkBackend: StoreBackend | null = null;
 let walletLinkChallenges: ChallengeStore;
 let socialLinkChallenges: ChallengeStore;
 let oauthLinkChallenges: ChallengeStore;
+type UserLinkStores = {
+  wallet: ChallengeStore;
+  social: ChallengeStore;
+  oauth: ChallengeStore;
+};
+const userLinkStoresByAuthority = new Map<string, UserLinkStores>();
+
+function createUserLinkStores(backend: StoreBackend): UserLinkStores {
+  return {
+    wallet: new ChallengeStore({
+      backend: new NamespacedStoreBackend(backend, "user-link-wallet"),
+      ttlMs: WALLET_LINK_CHALLENGE_TTL_MS,
+    }),
+    social: new ChallengeStore({
+      backend: new NamespacedStoreBackend(backend, "user-link-social"),
+      ttlMs: SOCIAL_LINK_CHALLENGE_TTL_MS,
+    }),
+    oauth: new ChallengeStore({
+      backend: new NamespacedStoreBackend(backend, "user-link-oauth"),
+      ttlMs: OAUTH_LINK_CHALLENGE_TTL_MS,
+    }),
+  };
+}
+
+function currentUserLinkStores(): UserLinkStores {
+  const authority = authStoreAuthorityKey();
+  if (authority !== null) {
+    const stores = userLinkStoresByAuthority.get(authority);
+    if (!stores)
+      throw new Error("User-link challenge stores are not initialized for this authority");
+    return stores;
+  }
+  return {
+    wallet: walletLinkChallenges,
+    social: socialLinkChallenges,
+    oauth: oauthLinkChallenges,
+  };
+}
+
+/** @internal request-authority regression seams. */
+export async function __setUserLinkChallengeForTests(
+  kind: keyof UserLinkStores,
+  key: string,
+  value: string,
+): Promise<boolean> {
+  return currentUserLinkStores()[kind].setIfNotExists(key, value);
+}
+
+/** @internal request-authority regression seams. */
+export async function __consumeUserLinkChallengeForTests(
+  kind: keyof UserLinkStores,
+  key: string,
+): Promise<string | null> {
+  return currentUserLinkStores()[kind].consume(key);
+}
 
 /** Bind account-link challenges to auth startup's selected durable backend. */
-export function initUserLinkChallengeStores(backend: StoreBackend): void {
+export function initUserLinkChallengeStores(
+  backend: StoreBackend,
+  authority?: string | null,
+): void {
+  if (authority !== undefined && authority !== null) {
+    userLinkStoresByAuthority.set(authority, createUserLinkStores(backend));
+    return;
+  }
   const supersededBackend = currentUserLinkBackend;
   currentUserLinkBackend = backend;
-  walletLinkChallenges = new ChallengeStore({
-    backend: new NamespacedStoreBackend(backend, "user-link-wallet"),
-    ttlMs: WALLET_LINK_CHALLENGE_TTL_MS,
-  });
-  socialLinkChallenges = new ChallengeStore({
-    backend: new NamespacedStoreBackend(backend, "user-link-social"),
-    ttlMs: SOCIAL_LINK_CHALLENGE_TTL_MS,
-  });
-  oauthLinkChallenges = new ChallengeStore({
-    backend: new NamespacedStoreBackend(backend, "user-link-oauth"),
-    ttlMs: OAUTH_LINK_CHALLENGE_TTL_MS,
-  });
+  const stores = createUserLinkStores(backend);
+  walletLinkChallenges = stores.wallet;
+  socialLinkChallenges = stores.social;
+  oauthLinkChallenges = stores.oauth;
   if (supersededBackend instanceof MemoryBackend && supersededBackend !== backend) {
     supersededBackend.destroy();
   }
@@ -2072,7 +2127,7 @@ function telegramLinkHashKey(hash: string): string {
 async function consumeTelegramLinkHashOnce(hash: string, authDate: number): Promise<boolean> {
   const expiresAtMs = (authDate + TELEGRAM_LINK_MAX_AGE_SEC) * 1000;
   const ttlMs = Math.max(1_000, expiresAtMs - Date.now());
-  return socialLinkChallenges.setIfNotExists(telegramLinkHashKey(hash), "1", ttlMs);
+  return currentUserLinkStores().social.setIfNotExists(telegramLinkHashKey(hash), "1", ttlMs);
 }
 
 type UserLinkedAccount = {
@@ -2494,7 +2549,7 @@ user.post("/me/accounts/wallet/ethereum/nonce", async (c) => {
     issuedAt,
     ...(requestedAddress ? { account: requestedAddress } : {}),
   });
-  await walletLinkChallenges.setIfNotExists(
+  await currentUserLinkStores().wallet.setIfNotExists(
     walletLinkChallengeKey("ethereum", userId, nonce),
     JSON.stringify({ userId, address: requestedAddress, issuedAt }),
   );
@@ -2544,7 +2599,7 @@ user.post("/me/accounts/wallet/ethereum", async (c) => {
   }
 
   const challengeKey = walletLinkChallengeKey("ethereum", userId, parsed.nonce);
-  const rawChallenge = await walletLinkChallenges.get(challengeKey);
+  const rawChallenge = await currentUserLinkStores().wallet.get(challengeKey);
   if (!rawChallenge) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired wallet link nonce" }, 401);
   }
@@ -2561,19 +2616,25 @@ user.post("/me/accounts/wallet/ethereum", async (c) => {
   if (!verified) return c.json<ApiResponse>({ ok: false, error: "Invalid wallet signature" }, 401);
 
   const lockKey = walletLinkRedeemLockKey("ethereum", userId, parsed.nonce);
-  if (!(await walletLinkChallenges.setIfNotExists(lockKey, "1", WALLET_LINK_REDEEM_LOCK_TTL_MS))) {
+  if (
+    !(await currentUserLinkStores().wallet.setIfNotExists(
+      lockKey,
+      "1",
+      WALLET_LINK_REDEEM_LOCK_TTL_MS,
+    ))
+  ) {
     return c.json<ApiResponse>(
       { ok: false, error: "Wallet link nonce is already being redeemed" },
       409,
     );
   }
   try {
-    const consumed = await walletLinkChallenges.consume(challengeKey);
+    const consumed = await currentUserLinkStores().wallet.consume(challengeKey);
     if (!consumed || consumed !== rawChallenge) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired wallet link nonce" }, 401);
     }
   } finally {
-    await walletLinkChallenges.delete(lockKey);
+    await currentUserLinkStores().wallet.delete(lockKey);
   }
 
   const normalized = address.toLowerCase();
@@ -2680,7 +2741,7 @@ user.post("/me/accounts/wallet/solana/nonce", async (c) => {
     issuedAt,
     ...(requestedPublicKey ? { account: requestedPublicKey } : {}),
   });
-  await walletLinkChallenges.setIfNotExists(
+  await currentUserLinkStores().wallet.setIfNotExists(
     walletLinkChallengeKey("solana", userId, nonce),
     JSON.stringify({ userId, publicKey: requestedPublicKey, issuedAt }),
   );
@@ -2736,7 +2797,7 @@ user.post("/me/accounts/wallet/solana", async (c) => {
   }
 
   const challengeKey = walletLinkChallengeKey("solana", userId, parsed.nonce);
-  const rawChallenge = await walletLinkChallenges.get(challengeKey);
+  const rawChallenge = await currentUserLinkStores().wallet.get(challengeKey);
   if (!rawChallenge) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired wallet link nonce" }, 401);
   }
@@ -2750,19 +2811,25 @@ user.post("/me/accounts/wallet/solana", async (c) => {
   }
 
   const lockKey = walletLinkRedeemLockKey("solana", userId, parsed.nonce);
-  if (!(await walletLinkChallenges.setIfNotExists(lockKey, "1", WALLET_LINK_REDEEM_LOCK_TTL_MS))) {
+  if (
+    !(await currentUserLinkStores().wallet.setIfNotExists(
+      lockKey,
+      "1",
+      WALLET_LINK_REDEEM_LOCK_TTL_MS,
+    ))
+  ) {
     return c.json<ApiResponse>(
       { ok: false, error: "Wallet link nonce is already being redeemed" },
       409,
     );
   }
   try {
-    const consumed = await walletLinkChallenges.consume(challengeKey);
+    const consumed = await currentUserLinkStores().wallet.consume(challengeKey);
     if (!consumed || consumed !== rawChallenge) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired wallet link nonce" }, 401);
     }
   } finally {
-    await walletLinkChallenges.delete(lockKey);
+    await currentUserLinkStores().wallet.delete(lockKey);
   }
 
   const [userRow] = await getDb()
@@ -2885,7 +2952,7 @@ user.post("/me/accounts/oauth/:provider/challenge", async (c) => {
 
   const userId = c.get("userId");
   const state = randomOAuthLinkState();
-  await oauthLinkChallenges.setIfNotExists(
+  await currentUserLinkStores().oauth.setIfNotExists(
     oauthLinkChallengeKey(userId, state),
     JSON.stringify({
       userId,
@@ -2948,7 +3015,9 @@ user.post("/me/accounts/oauth/:provider/token", async (c) => {
   }
 
   const userId = c.get("userId");
-  const challenge = await oauthLinkChallenges.consume(oauthLinkChallengeKey(userId, state));
+  const challenge = await currentUserLinkStores().oauth.consume(
+    oauthLinkChallengeKey(userId, state),
+  );
   if (!challenge) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired OAuth link state" }, 401);
   }
@@ -3286,7 +3355,7 @@ user.post("/me/accounts/telegram/challenge", async (c) => {
   }
   const userId = c.get("userId");
   const challengeId = crypto.randomUUID();
-  await socialLinkChallenges.setIfNotExists(
+  await currentUserLinkStores().social.setIfNotExists(
     socialLinkChallengeKey("telegram", userId, challengeId),
     JSON.stringify({ userId, issuedAt: new Date().toISOString() }),
   );
@@ -3319,7 +3388,7 @@ user.post("/me/accounts/telegram", async (c) => {
   }
   const userId = c.get("userId");
   const challengeKey = socialLinkChallengeKey("telegram", userId, challengeId);
-  const challenge = await socialLinkChallenges.consume(challengeKey);
+  const challenge = await currentUserLinkStores().social.consume(challengeKey);
   if (!challenge) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired Telegram challenge" }, 401);
   }
@@ -3413,7 +3482,7 @@ user.post("/me/accounts/farcaster/nonce", async (c) => {
   const nonce = Array.from(crypto.getRandomValues(new Uint8Array(16)))
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("");
-  await socialLinkChallenges.setIfNotExists(
+  await currentUserLinkStores().social.setIfNotExists(
     socialLinkChallengeKey("farcaster", userId, nonce),
     JSON.stringify({ userId, issuedAt: new Date().toISOString() }),
   );
@@ -3455,7 +3524,7 @@ user.post("/me/accounts/farcaster", async (c) => {
 
   const userId = c.get("userId");
   const nonceKey = socialLinkChallengeKey("farcaster", userId, farcasterUser.message.nonce);
-  const nonceRecord = await socialLinkChallenges.consume(nonceKey);
+  const nonceRecord = await currentUserLinkStores().social.consume(nonceKey);
   if (!nonceRecord) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired Farcaster nonce" }, 401);
   }

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -17,6 +17,8 @@
  *       This file exports a Hono route group ready for mounting.
  */
 
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
 import {
   createDecipheriv,
   createPrivateKey,
@@ -930,7 +932,7 @@ function slugifyTenantId(value: string): string {
 }
 
 function userTenantCreationAllowed(): boolean {
-  return process.env.ALLOW_USER_TENANT_CREATION === "true";
+  return runtimeEnvironmentValue("ALLOW_USER_TENANT_CREATION") === "true";
 }
 
 async function writeUserAudit(
@@ -1557,7 +1559,7 @@ function userWalletRowsToAccountWallets(
 }
 
 async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
-  if (process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true") {
+  if (runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true") {
     return fn();
   }
   const db = getDb();
@@ -1744,18 +1746,18 @@ export async function userSessionAuth(
 
 const user = new Hono<{ Variables: UserVariables }>();
 const allowPrivateKeyExport = (): boolean =>
-  process.env.STEWARD_ALLOW_KEY_EXPORT !== "false" &&
-  process.env.STEWARD_ALLOW_PRIVATE_KEY_EXPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_KEY_EXPORT") !== "false" &&
+  runtimeEnvironmentValue("STEWARD_ALLOW_PRIVATE_KEY_EXPORT") === "true";
 const allowPrivateKeyImport = (): boolean =>
-  process.env.STEWARD_ALLOW_PRIVATE_KEY_IMPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_PRIVATE_KEY_IMPORT") === "true";
 const allowUnsafeMessageSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING") === "true";
 const allowUserPrivateKeyExport = (): boolean =>
-  process.env.STEWARD_ALLOW_USER_PRIVATE_KEY_EXPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_USER_PRIVATE_KEY_EXPORT") === "true";
 const allowUserPrivateKeyImport = (): boolean =>
-  process.env.STEWARD_ALLOW_USER_PRIVATE_KEY_IMPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_USER_PRIVATE_KEY_IMPORT") === "true";
 const allowUserUnsafeMessageSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_USER_UNSAFE_MESSAGE_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_USER_UNSAFE_MESSAGE_SIGNING") === "true";
 
 // Apply session auth to all routes in this group
 user.use("*", userSessionAuth);
@@ -2037,7 +2039,7 @@ function farcasterProviderAccountId(address: string): string {
 }
 
 function userFarcasterAllowedDomains(): string[] | undefined {
-  const raw = process.env.SIWE_ALLOWED_DOMAINS?.trim();
+  const raw = runtimeEnvironmentValue("SIWE_ALLOWED_DOMAINS")?.trim();
   if (!raw) return undefined;
   const domains = raw
     .split(",")
@@ -3104,7 +3106,7 @@ for (const channel of ["sms", "whatsapp"] as const) {
   user.post(`/me/accounts/phone/${channel}/send`, async (c) => {
     const personalSessionResponse = requirePersonalUserSession(c);
     if (personalSessionResponse) return personalSessionResponse;
-    if (channel === "whatsapp" && process.env.WHATSAPP_OTP_ENABLED !== "true") {
+    if (channel === "whatsapp" && runtimeEnvironmentValue("WHATSAPP_OTP_ENABLED") !== "true") {
       return c.json<ApiResponse>({ ok: false, error: "WhatsApp OTP is not configured" }, 503);
     }
     const session = c.get("userSession");
@@ -3149,7 +3151,7 @@ for (const channel of ["sms", "whatsapp"] as const) {
   user.post(`/me/accounts/phone/${channel}/verify`, async (c) => {
     const personalSessionResponse = requirePersonalUserSession(c);
     if (personalSessionResponse) return personalSessionResponse;
-    if (channel === "whatsapp" && process.env.WHATSAPP_OTP_ENABLED !== "true") {
+    if (channel === "whatsapp" && runtimeEnvironmentValue("WHATSAPP_OTP_ENABLED") !== "true") {
       return c.json<ApiResponse>({ ok: false, error: "WhatsApp OTP is not configured" }, 503);
     }
     const session = c.get("userSession");
@@ -3275,7 +3277,7 @@ user.post("/me/accounts/telegram/challenge", async (c) => {
     );
   }
 
-  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -3302,7 +3304,7 @@ user.post("/me/accounts/telegram", async (c) => {
     );
   }
 
-  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -3400,7 +3402,7 @@ user.post("/me/accounts/farcaster/nonce", async (c) => {
       403,
     );
   }
-  if (process.env.FARCASTER_LOGIN_ENABLED !== "true") {
+  if (runtimeEnvironmentValue("FARCASTER_LOGIN_ENABLED") !== "true") {
     return c.json<ApiResponse>({ ok: false, error: "Farcaster login is not configured" }, 503);
   }
 
@@ -3429,7 +3431,7 @@ user.post("/me/accounts/farcaster", async (c) => {
     );
   }
 
-  if (process.env.FARCASTER_LOGIN_ENABLED !== "true") {
+  if (runtimeEnvironmentValue("FARCASTER_LOGIN_ENABLED") !== "true") {
     return c.json<ApiResponse>({ ok: false, error: "Farcaster login is not configured" }, 503);
   }
   const body = await safeJsonParse<Parameters<typeof verifyFarcasterLogin>[0]>(c);
@@ -5102,7 +5104,8 @@ user.post("/me/wallet/sign", async (c) => {
 
   const tenantId = `personal-${userId}`;
   const agentId = wallet.id;
-  const chainId = signBody.chainId ?? parseInt(process.env.CHAIN_ID || "84532", 10);
+  const chainId =
+    signBody.chainId ?? parseInt(runtimeEnvironmentValue("CHAIN_ID") || "84532", 10);
   let codeResponse: Awaited<ReturnType<Vault["rpcPassthrough"]>>;
   try {
     codeResponse = await vault.rpcPassthrough({

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -17,8 +17,6 @@
  *       This file exports a Hono route group ready for mounting.
  */
 
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
-
 import {
   createDecipheriv,
   createPrivateKey,
@@ -104,6 +102,7 @@ import {
   setNoStoreHeaders,
   verifySessionToken,
 } from "../services/context";
+import { resolveRuntimeChainId } from "../services/custody-runtime";
 import {
   publicGasSponsorshipState,
   readTenantGasSponsorshipConfig,
@@ -932,7 +931,7 @@ function slugifyTenantId(value: string): string {
 }
 
 function userTenantCreationAllowed(): boolean {
-  return runtimeEnvironmentValue("ALLOW_USER_TENANT_CREATION") === "true";
+  return process.env.ALLOW_USER_TENANT_CREATION === "true";
 }
 
 async function writeUserAudit(
@@ -1559,7 +1558,7 @@ function userWalletRowsToAccountWallets(
 }
 
 async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
-  if (runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true") {
+  if (process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true") {
     return fn();
   }
   const db = getDb();
@@ -1746,18 +1745,18 @@ export async function userSessionAuth(
 
 const user = new Hono<{ Variables: UserVariables }>();
 const allowPrivateKeyExport = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_KEY_EXPORT") !== "false" &&
-  runtimeEnvironmentValue("STEWARD_ALLOW_PRIVATE_KEY_EXPORT") === "true";
+  process.env.STEWARD_ALLOW_KEY_EXPORT !== "false" &&
+  process.env.STEWARD_ALLOW_PRIVATE_KEY_EXPORT === "true";
 const allowPrivateKeyImport = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_PRIVATE_KEY_IMPORT") === "true";
+  process.env.STEWARD_ALLOW_PRIVATE_KEY_IMPORT === "true";
 const allowUnsafeMessageSigning = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING") === "true";
+  process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING === "true";
 const allowUserPrivateKeyExport = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_USER_PRIVATE_KEY_EXPORT") === "true";
+  process.env.STEWARD_ALLOW_USER_PRIVATE_KEY_EXPORT === "true";
 const allowUserPrivateKeyImport = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_USER_PRIVATE_KEY_IMPORT") === "true";
+  process.env.STEWARD_ALLOW_USER_PRIVATE_KEY_IMPORT === "true";
 const allowUserUnsafeMessageSigning = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_USER_UNSAFE_MESSAGE_SIGNING") === "true";
+  process.env.STEWARD_ALLOW_USER_UNSAFE_MESSAGE_SIGNING === "true";
 
 // Apply session auth to all routes in this group
 user.use("*", userSessionAuth);
@@ -2039,7 +2038,7 @@ function farcasterProviderAccountId(address: string): string {
 }
 
 function userFarcasterAllowedDomains(): string[] | undefined {
-  const raw = runtimeEnvironmentValue("SIWE_ALLOWED_DOMAINS")?.trim();
+  const raw = process.env.SIWE_ALLOWED_DOMAINS?.trim();
   if (!raw) return undefined;
   const domains = raw
     .split(",")
@@ -3106,7 +3105,7 @@ for (const channel of ["sms", "whatsapp"] as const) {
   user.post(`/me/accounts/phone/${channel}/send`, async (c) => {
     const personalSessionResponse = requirePersonalUserSession(c);
     if (personalSessionResponse) return personalSessionResponse;
-    if (channel === "whatsapp" && runtimeEnvironmentValue("WHATSAPP_OTP_ENABLED") !== "true") {
+    if (channel === "whatsapp" && process.env.WHATSAPP_OTP_ENABLED !== "true") {
       return c.json<ApiResponse>({ ok: false, error: "WhatsApp OTP is not configured" }, 503);
     }
     const session = c.get("userSession");
@@ -3151,7 +3150,7 @@ for (const channel of ["sms", "whatsapp"] as const) {
   user.post(`/me/accounts/phone/${channel}/verify`, async (c) => {
     const personalSessionResponse = requirePersonalUserSession(c);
     if (personalSessionResponse) return personalSessionResponse;
-    if (channel === "whatsapp" && runtimeEnvironmentValue("WHATSAPP_OTP_ENABLED") !== "true") {
+    if (channel === "whatsapp" && process.env.WHATSAPP_OTP_ENABLED !== "true") {
       return c.json<ApiResponse>({ ok: false, error: "WhatsApp OTP is not configured" }, 503);
     }
     const session = c.get("userSession");
@@ -3277,7 +3276,7 @@ user.post("/me/accounts/telegram/challenge", async (c) => {
     );
   }
 
-  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
+  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -3304,7 +3303,7 @@ user.post("/me/accounts/telegram", async (c) => {
     );
   }
 
-  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
+  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -3402,7 +3401,7 @@ user.post("/me/accounts/farcaster/nonce", async (c) => {
       403,
     );
   }
-  if (runtimeEnvironmentValue("FARCASTER_LOGIN_ENABLED") !== "true") {
+  if (process.env.FARCASTER_LOGIN_ENABLED !== "true") {
     return c.json<ApiResponse>({ ok: false, error: "Farcaster login is not configured" }, 503);
   }
 
@@ -3431,7 +3430,7 @@ user.post("/me/accounts/farcaster", async (c) => {
     );
   }
 
-  if (runtimeEnvironmentValue("FARCASTER_LOGIN_ENABLED") !== "true") {
+  if (process.env.FARCASTER_LOGIN_ENABLED !== "true") {
     return c.json<ApiResponse>({ ok: false, error: "Farcaster login is not configured" }, 503);
   }
   const body = await safeJsonParse<Parameters<typeof verifyFarcasterLogin>[0]>(c);
@@ -5104,8 +5103,7 @@ user.post("/me/wallet/sign", async (c) => {
 
   const tenantId = `personal-${userId}`;
   const agentId = wallet.id;
-  const chainId =
-    signBody.chainId ?? parseInt(runtimeEnvironmentValue("CHAIN_ID") || "84532", 10);
+  const chainId = signBody.chainId ?? resolveRuntimeChainId(84532);
   let codeResponse: Awaited<ReturnType<Vault["rpcPassthrough"]>>;
   try {
     codeResponse = await vault.rpcPassthrough({

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -33,6 +33,7 @@ import {
   type TenantAuthAbuseConfig,
   toCaip2,
 } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   assertMoneroAddress,
   assertSolanaPriorityFeeWithinCap,
@@ -190,32 +191,32 @@ async function writeOutcomeUnknownAudit(
 // Fail-closed by construction: anything other than the exact string "true"
 // (unset, "false", "1", etc.) yields false, i.e. signing disabled.
 const allowPrivateKeyExport = (): boolean =>
-  process.env.STEWARD_ALLOW_KEY_EXPORT !== "false" &&
-  process.env.STEWARD_ALLOW_PRIVATE_KEY_EXPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_KEY_EXPORT") !== "false" &&
+  runtimeEnvironmentValue("STEWARD_ALLOW_PRIVATE_KEY_EXPORT") === "true";
 const allowVaultPrivateKeyExport = (): boolean =>
-  process.env.STEWARD_ALLOW_VAULT_PRIVATE_KEY_EXPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_PRIVATE_KEY_EXPORT") === "true";
 const allowUnsafeMessageSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING") === "true";
 const allowVaultUnsafeMessageSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_VAULT_UNSAFE_MESSAGE_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_UNSAFE_MESSAGE_SIGNING") === "true";
 // Audited opt-in for UNCONSTRAINED EIP-712 typed-data signing (no `typed-data`
 // policy required). Both flags must be set. Normally typed-data signing is
 // authorized per-agent by a `typed-data` policy instead; this is the
 // break-glass equivalent of the message-signing flags.
 const allowUnsafeTypedDataSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_TYPED_DATA_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_TYPED_DATA_SIGNING") === "true";
 const allowVaultUnsafeTypedDataSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_VAULT_UNSAFE_TYPED_DATA_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_UNSAFE_TYPED_DATA_SIGNING") === "true";
 const allowUnsafeRawSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_RAW_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_RAW_SIGNING") === "true";
 const allowVaultUnsafeRawSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_VAULT_UNSAFE_RAW_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_UNSAFE_RAW_SIGNING") === "true";
 const allowUnsafeContractCallSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_CONTRACT_CALL_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_CONTRACT_CALL_SIGNING") === "true";
 const allowUnsafeUserOperationSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_USER_OPERATION_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_USER_OPERATION_SIGNING") === "true";
 const allowUnsafeAuthorizationSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_AUTHORIZATION_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_AUTHORIZATION_SIGNING") === "true";
 /**
  * Blind-signing opt-in for Solana. When false (default), the sign-solana route
  * refuses any transaction whose instructions cannot all be confidently decoded
@@ -224,11 +225,11 @@ const allowUnsafeAuthorizationSigning = (): boolean =>
  * that policy controls cannot be enforced against the transaction's real effects.
  */
 const allowUnsafeSolanaBlindSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING") === "true";
 const allowPrivateKeyImport = (): boolean =>
-  process.env.STEWARD_ALLOW_PRIVATE_KEY_IMPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_PRIVATE_KEY_IMPORT") === "true";
 const allowVaultPrivateKeyImport = (): boolean =>
-  process.env.STEWARD_ALLOW_VAULT_PRIVATE_KEY_IMPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_PRIVATE_KEY_IMPORT") === "true";
 const MAX_VAULT_HISTORY_LIMIT = 200;
 const MAX_UINT256_DECIMAL =
   "115792089237316195423570985008687907853269984665640564039457584007913129639935";
@@ -1433,7 +1434,7 @@ function isBitcoinPsbtBase64(value: unknown): value is string {
 }
 
 function maxBitcoinPsbtFeeSats(): bigint {
-  const configured = process.env.STEWARD_MAX_BITCOIN_PSBT_FEE_SATS;
+  const configured = runtimeEnvironmentValue("STEWARD_MAX_BITCOIN_PSBT_FEE_SATS");
   if (configured && /^\d+$/.test(configured)) return BigInt(configured);
   return DEFAULT_MAX_BITCOIN_PSBT_FEE_SATS;
 }
@@ -1442,7 +1443,7 @@ function maxBitcoinPsbtFeeSats(): bigint {
 const DEFAULT_MAX_MONERO_FEE_PICONERO = 100_000_000_000n;
 
 function maxMoneroFeePiconero(): bigint {
-  const configured = process.env.STEWARD_MAX_MONERO_FEE_PICONERO;
+  const configured = runtimeEnvironmentValue("STEWARD_MAX_MONERO_FEE_PICONERO");
   if (configured && /^\d+$/.test(configured)) return BigInt(configured);
   return DEFAULT_MAX_MONERO_FEE_PICONERO;
 }
@@ -1962,7 +1963,10 @@ async function requireSignerPermission(
 }
 
 async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
-  if (process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true") {
+  if (
+    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" ||
+    runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
+  ) {
     return fn();
   }
   return db.transaction(async (tx) => {

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -5,8 +5,6 @@
  * Mount: app.route("/vault", vaultRoutes)
  */
 
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
-
 import {
   createDecipheriv,
   createHash,
@@ -98,6 +96,7 @@ import {
   transactions,
   vault,
 } from "../services/context";
+import { isRuntimeVaultRpcMethodAllowed, resolveRuntimeChainId } from "../services/custody-runtime";
 import {
   consumeExecutionAuthorization,
   executionPayloadDigestForEvmSign,
@@ -191,32 +190,32 @@ async function writeOutcomeUnknownAudit(
 // Fail-closed by construction: anything other than the exact string "true"
 // (unset, "false", "1", etc.) yields false, i.e. signing disabled.
 const allowPrivateKeyExport = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_KEY_EXPORT") !== "false" &&
-  runtimeEnvironmentValue("STEWARD_ALLOW_PRIVATE_KEY_EXPORT") === "true";
+  process.env.STEWARD_ALLOW_KEY_EXPORT !== "false" &&
+  process.env.STEWARD_ALLOW_PRIVATE_KEY_EXPORT === "true";
 const allowVaultPrivateKeyExport = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_PRIVATE_KEY_EXPORT") === "true";
+  process.env.STEWARD_ALLOW_VAULT_PRIVATE_KEY_EXPORT === "true";
 const allowUnsafeMessageSigning = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING") === "true";
+  process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING === "true";
 const allowVaultUnsafeMessageSigning = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_UNSAFE_MESSAGE_SIGNING") === "true";
+  process.env.STEWARD_ALLOW_VAULT_UNSAFE_MESSAGE_SIGNING === "true";
 // Audited opt-in for UNCONSTRAINED EIP-712 typed-data signing (no `typed-data`
 // policy required). Both flags must be set. Normally typed-data signing is
 // authorized per-agent by a `typed-data` policy instead; this is the
 // break-glass equivalent of the message-signing flags.
 const allowUnsafeTypedDataSigning = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_TYPED_DATA_SIGNING") === "true";
+  process.env.STEWARD_ALLOW_UNSAFE_TYPED_DATA_SIGNING === "true";
 const allowVaultUnsafeTypedDataSigning = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_UNSAFE_TYPED_DATA_SIGNING") === "true";
+  process.env.STEWARD_ALLOW_VAULT_UNSAFE_TYPED_DATA_SIGNING === "true";
 const allowUnsafeRawSigning = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_RAW_SIGNING") === "true";
+  process.env.STEWARD_ALLOW_UNSAFE_RAW_SIGNING === "true";
 const allowVaultUnsafeRawSigning = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_UNSAFE_RAW_SIGNING") === "true";
+  process.env.STEWARD_ALLOW_VAULT_UNSAFE_RAW_SIGNING === "true";
 const allowUnsafeContractCallSigning = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_CONTRACT_CALL_SIGNING") === "true";
+  process.env.STEWARD_ALLOW_UNSAFE_CONTRACT_CALL_SIGNING === "true";
 const allowUnsafeUserOperationSigning = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_USER_OPERATION_SIGNING") === "true";
+  process.env.STEWARD_ALLOW_UNSAFE_USER_OPERATION_SIGNING === "true";
 const allowUnsafeAuthorizationSigning = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_AUTHORIZATION_SIGNING") === "true";
+  process.env.STEWARD_ALLOW_UNSAFE_AUTHORIZATION_SIGNING === "true";
 /**
  * Blind-signing opt-in for Solana. When false (default), the sign-solana route
  * refuses any transaction whose instructions cannot all be confidently decoded
@@ -225,18 +224,11 @@ const allowUnsafeAuthorizationSigning = (): boolean =>
  * that policy controls cannot be enforced against the transaction's real effects.
  */
 const allowUnsafeSolanaBlindSigning = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING") === "true";
+  process.env.STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING === "true";
 const allowPrivateKeyImport = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_PRIVATE_KEY_IMPORT") === "true";
+  process.env.STEWARD_ALLOW_PRIVATE_KEY_IMPORT === "true";
 const allowVaultPrivateKeyImport = (): boolean =>
-  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_PRIVATE_KEY_IMPORT") === "true";
-const VAULT_RPC_ALLOWLIST = new Set(
-  (runtimeEnvironmentValue("STEWARD_VAULT_RPC_ALLOWLIST") ??
-    "eth_chainId,eth_blockNumber,eth_getBalance")
-    .split(",")
-    .map((method) => method.trim())
-    .filter(Boolean),
-);
+  process.env.STEWARD_ALLOW_VAULT_PRIVATE_KEY_IMPORT === "true";
 const MAX_VAULT_HISTORY_LIMIT = 200;
 const MAX_UINT256_DECIMAL =
   "115792089237316195423570985008687907853269984665640564039457584007913129639935";
@@ -555,7 +547,7 @@ function parseTransferActionInput(body: TransferActionInput): {
   const chainId =
     typeof body.chainId === "number" && Number.isInteger(body.chainId)
       ? body.chainId
-      : parseInt(runtimeEnvironmentValue("CHAIN_ID") || "8453", 10);
+      : resolveRuntimeChainId(8453);
   const referenceId = parseReferenceId(body.referenceId);
   const isSolanaTransfer = isSolanaActionChain(chainId);
 
@@ -608,7 +600,7 @@ function parseSendCallsActionInput(body: SendCallsActionInput):
   const chainId =
     typeof body.chainId === "number" && Number.isInteger(body.chainId)
       ? body.chainId
-      : parseInt(runtimeEnvironmentValue("CHAIN_ID") || "8453", 10);
+      : resolveRuntimeChainId(8453);
   if (!Number.isSafeInteger(chainId) || chainId <= 0) return "chainId must be a positive integer";
   const referenceId = parseReferenceId(body.referenceId);
   if (referenceId === null) return "referenceId must be a non-empty string up to 128 characters";
@@ -1441,7 +1433,7 @@ function isBitcoinPsbtBase64(value: unknown): value is string {
 }
 
 function maxBitcoinPsbtFeeSats(): bigint {
-  const configured = runtimeEnvironmentValue("STEWARD_MAX_BITCOIN_PSBT_FEE_SATS");
+  const configured = process.env.STEWARD_MAX_BITCOIN_PSBT_FEE_SATS;
   if (configured && /^\d+$/.test(configured)) return BigInt(configured);
   return DEFAULT_MAX_BITCOIN_PSBT_FEE_SATS;
 }
@@ -1450,7 +1442,7 @@ function maxBitcoinPsbtFeeSats(): bigint {
 const DEFAULT_MAX_MONERO_FEE_PICONERO = 100_000_000_000n;
 
 function maxMoneroFeePiconero(): bigint {
-  const configured = runtimeEnvironmentValue("STEWARD_MAX_MONERO_FEE_PICONERO");
+  const configured = process.env.STEWARD_MAX_MONERO_FEE_PICONERO;
   if (configured && /^\d+$/.test(configured)) return BigInt(configured);
   return DEFAULT_MAX_MONERO_FEE_PICONERO;
 }
@@ -1970,7 +1962,7 @@ async function requireSignerPermission(
 }
 
 async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
-  if (runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true") {
+  if (process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true") {
     return fn();
   }
   return db.transaction(async (tx) => {
@@ -2099,8 +2091,7 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
     );
   }
 
-  const resolvedChainId =
-    request.chainId || parseInt(runtimeEnvironmentValue("CHAIN_ID") || "8453", 10);
+  const resolvedChainId = request.chainId || resolveRuntimeChainId(8453);
   if (!hasCalldata(request.data)) {
     const gasGuard = await nativeTransferGasAccountingGuard(
       c,
@@ -7256,7 +7247,7 @@ vaultRoutes.post("/:agentId/sign-typed-data", async (c) => {
 
   const resolvedChainId =
     (typeof body.domain.chainId === "number" ? body.domain.chainId : 0) ||
-    parseInt(runtimeEnvironmentValue("CHAIN_ID") || "8453", 10);
+    resolveRuntimeChainId(8453);
   // Use the EIP-712 domain's verifyingContract as the request `to` so that
   // destination-based policies (approved-addresses, condition-set, contract
   // allowlist) meaningfully gate the contract the typed data authorizes. Falls
@@ -10176,7 +10167,7 @@ vaultRoutes.post("/:agentId/rpc", async (c) => {
   if (!isNonEmptyString(body.method)) {
     return c.json<ApiResponse>({ ok: false, error: "'method' is required" }, 400);
   }
-  if (!VAULT_RPC_ALLOWLIST.has(body.method)) {
+  if (!isRuntimeVaultRpcMethodAllowed(body.method)) {
     return c.json<ApiResponse>({ ok: false, error: "RPC method is not allowlisted" }, 403);
   }
 

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -5,6 +5,8 @@
  * Mount: app.route("/vault", vaultRoutes)
  */
 
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
 import {
   createDecipheriv,
   createHash,
@@ -189,32 +191,32 @@ async function writeOutcomeUnknownAudit(
 // Fail-closed by construction: anything other than the exact string "true"
 // (unset, "false", "1", etc.) yields false, i.e. signing disabled.
 const allowPrivateKeyExport = (): boolean =>
-  process.env.STEWARD_ALLOW_KEY_EXPORT !== "false" &&
-  process.env.STEWARD_ALLOW_PRIVATE_KEY_EXPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_KEY_EXPORT") !== "false" &&
+  runtimeEnvironmentValue("STEWARD_ALLOW_PRIVATE_KEY_EXPORT") === "true";
 const allowVaultPrivateKeyExport = (): boolean =>
-  process.env.STEWARD_ALLOW_VAULT_PRIVATE_KEY_EXPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_PRIVATE_KEY_EXPORT") === "true";
 const allowUnsafeMessageSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING") === "true";
 const allowVaultUnsafeMessageSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_VAULT_UNSAFE_MESSAGE_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_UNSAFE_MESSAGE_SIGNING") === "true";
 // Audited opt-in for UNCONSTRAINED EIP-712 typed-data signing (no `typed-data`
 // policy required). Both flags must be set. Normally typed-data signing is
 // authorized per-agent by a `typed-data` policy instead; this is the
 // break-glass equivalent of the message-signing flags.
 const allowUnsafeTypedDataSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_TYPED_DATA_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_TYPED_DATA_SIGNING") === "true";
 const allowVaultUnsafeTypedDataSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_VAULT_UNSAFE_TYPED_DATA_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_UNSAFE_TYPED_DATA_SIGNING") === "true";
 const allowUnsafeRawSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_RAW_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_RAW_SIGNING") === "true";
 const allowVaultUnsafeRawSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_VAULT_UNSAFE_RAW_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_UNSAFE_RAW_SIGNING") === "true";
 const allowUnsafeContractCallSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_CONTRACT_CALL_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_CONTRACT_CALL_SIGNING") === "true";
 const allowUnsafeUserOperationSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_USER_OPERATION_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_USER_OPERATION_SIGNING") === "true";
 const allowUnsafeAuthorizationSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_AUTHORIZATION_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_AUTHORIZATION_SIGNING") === "true";
 /**
  * Blind-signing opt-in for Solana. When false (default), the sign-solana route
  * refuses any transaction whose instructions cannot all be confidently decoded
@@ -223,13 +225,14 @@ const allowUnsafeAuthorizationSigning = (): boolean =>
  * that policy controls cannot be enforced against the transaction's real effects.
  */
 const allowUnsafeSolanaBlindSigning = (): boolean =>
-  process.env.STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING") === "true";
 const allowPrivateKeyImport = (): boolean =>
-  process.env.STEWARD_ALLOW_PRIVATE_KEY_IMPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_PRIVATE_KEY_IMPORT") === "true";
 const allowVaultPrivateKeyImport = (): boolean =>
-  process.env.STEWARD_ALLOW_VAULT_PRIVATE_KEY_IMPORT === "true";
+  runtimeEnvironmentValue("STEWARD_ALLOW_VAULT_PRIVATE_KEY_IMPORT") === "true";
 const VAULT_RPC_ALLOWLIST = new Set(
-  (process.env.STEWARD_VAULT_RPC_ALLOWLIST ?? "eth_chainId,eth_blockNumber,eth_getBalance")
+  (runtimeEnvironmentValue("STEWARD_VAULT_RPC_ALLOWLIST") ??
+    "eth_chainId,eth_blockNumber,eth_getBalance")
     .split(",")
     .map((method) => method.trim())
     .filter(Boolean),
@@ -552,7 +555,7 @@ function parseTransferActionInput(body: TransferActionInput): {
   const chainId =
     typeof body.chainId === "number" && Number.isInteger(body.chainId)
       ? body.chainId
-      : parseInt(process.env.CHAIN_ID || "8453", 10);
+      : parseInt(runtimeEnvironmentValue("CHAIN_ID") || "8453", 10);
   const referenceId = parseReferenceId(body.referenceId);
   const isSolanaTransfer = isSolanaActionChain(chainId);
 
@@ -605,7 +608,7 @@ function parseSendCallsActionInput(body: SendCallsActionInput):
   const chainId =
     typeof body.chainId === "number" && Number.isInteger(body.chainId)
       ? body.chainId
-      : parseInt(process.env.CHAIN_ID || "8453", 10);
+      : parseInt(runtimeEnvironmentValue("CHAIN_ID") || "8453", 10);
   if (!Number.isSafeInteger(chainId) || chainId <= 0) return "chainId must be a positive integer";
   const referenceId = parseReferenceId(body.referenceId);
   if (referenceId === null) return "referenceId must be a non-empty string up to 128 characters";
@@ -1438,7 +1441,7 @@ function isBitcoinPsbtBase64(value: unknown): value is string {
 }
 
 function maxBitcoinPsbtFeeSats(): bigint {
-  const configured = process.env.STEWARD_MAX_BITCOIN_PSBT_FEE_SATS;
+  const configured = runtimeEnvironmentValue("STEWARD_MAX_BITCOIN_PSBT_FEE_SATS");
   if (configured && /^\d+$/.test(configured)) return BigInt(configured);
   return DEFAULT_MAX_BITCOIN_PSBT_FEE_SATS;
 }
@@ -1447,7 +1450,7 @@ function maxBitcoinPsbtFeeSats(): bigint {
 const DEFAULT_MAX_MONERO_FEE_PICONERO = 100_000_000_000n;
 
 function maxMoneroFeePiconero(): bigint {
-  const configured = process.env.STEWARD_MAX_MONERO_FEE_PICONERO;
+  const configured = runtimeEnvironmentValue("STEWARD_MAX_MONERO_FEE_PICONERO");
   if (configured && /^\d+$/.test(configured)) return BigInt(configured);
   return DEFAULT_MAX_MONERO_FEE_PICONERO;
 }
@@ -1967,7 +1970,7 @@ async function requireSignerPermission(
 }
 
 async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
-  if (process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true") {
+  if (runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true") {
     return fn();
   }
   return db.transaction(async (tx) => {
@@ -2096,7 +2099,8 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
     );
   }
 
-  const resolvedChainId = request.chainId || parseInt(process.env.CHAIN_ID || "8453", 10);
+  const resolvedChainId =
+    request.chainId || parseInt(runtimeEnvironmentValue("CHAIN_ID") || "8453", 10);
   if (!hasCalldata(request.data)) {
     const gasGuard = await nativeTransferGasAccountingGuard(
       c,
@@ -7252,7 +7256,7 @@ vaultRoutes.post("/:agentId/sign-typed-data", async (c) => {
 
   const resolvedChainId =
     (typeof body.domain.chainId === "number" ? body.domain.chainId : 0) ||
-    parseInt(process.env.CHAIN_ID || "8453", 10);
+    parseInt(runtimeEnvironmentValue("CHAIN_ID") || "8453", 10);
   // Use the EIP-712 domain's verifyingContract as the request `to` so that
   // destination-based policies (approved-addresses, condition-set, contract
   // allowlist) meaningfully gate the contract the typed data authorizes. Falls

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -7,7 +7,7 @@
 import { randomBytes } from "node:crypto";
 import { tenantConfigs as tenantConfigsTable } from "@stwd/db";
 import { redactedThrownDiagnostics, type TenantAuthAbuseConfig } from "@stwd/shared";
-import { encryptWebhookSecret } from "@stwd/webhooks";
+import { currentWebhookRuntimeAuthority, encryptWebhookSecret } from "@stwd/webhooks";
 import { and, count, desc, eq, or, type SQL, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { writeAuditEvent } from "../services/audit";
@@ -340,8 +340,9 @@ webhookRoutes.post("/", async (c) => {
 
   // SEC-017: resolve DNS and reject non-public answers (string checks alone
   // miss public-hostname-to-private-IP and rebinding).
+  const webhookAuthority = currentWebhookRuntimeAuthority();
   const urlError = isNonEmptyString(body.url)
-    ? await validateWebhookUrlResolved(body.url)
+    ? await validateWebhookUrlResolved(body.url, undefined, webhookAuthority)
     : "url is required";
   if (urlError) {
     return c.json<ApiResponse>({ ok: false, error: urlError }, 400);
@@ -532,8 +533,9 @@ webhookRoutes.put("/:id", async (c) => {
   }
 
   if (body.url !== undefined) {
+    const webhookAuthority = currentWebhookRuntimeAuthority();
     const urlError = isNonEmptyString(body.url)
-      ? await validateWebhookUrlResolved(body.url)
+      ? await validateWebhookUrlResolved(body.url, undefined, webhookAuthority)
       : "url is required";
     if (urlError) {
       return c.json<ApiResponse>({ ok: false, error: urlError }, 400);

--- a/packages/api/src/services/agent-card-url.ts
+++ b/packages/api/src/services/agent-card-url.ts
@@ -1,0 +1,10 @@
+import { validateWebhookUrlResolved } from "./webhook-url";
+
+/** Validate the public HTTPS destination published in an ERC-8004 agent card. */
+export async function validateAgentCardApiUrl(apiUrl: string): Promise<string | null> {
+  if (!apiUrl) return null;
+  const destinationError = await validateWebhookUrlResolved(apiUrl);
+  if (destinationError) return `apiUrl ${destinationError}`;
+  if (new URL(apiUrl).protocol !== "https:") return "apiUrl must use https";
+  return null;
+}

--- a/packages/api/src/services/audit-archive.ts
+++ b/packages/api/src/services/audit-archive.ts
@@ -274,7 +274,10 @@ async function lockTenantAuditWriter(
   tx: { execute(query: ReturnType<typeof sql>): Promise<unknown> },
   tenantId: string,
 ) {
-  if (runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" && runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true") {
+  if (
+    runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" &&
+    runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true"
+  ) {
     await tx.execute(
       sql`SELECT pg_advisory_xact_lock(hashtextextended(${`steward_audit_${tenantId}`}, 0))`,
     );

--- a/packages/api/src/services/audit-archive.ts
+++ b/packages/api/src/services/audit-archive.ts
@@ -2,6 +2,7 @@
 
 import { createHash, createPublicKey, type KeyObject, randomUUID, sign, verify } from "node:crypto";
 import { getDb } from "@stwd/db";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { sql } from "drizzle-orm";
 import { type AuditReadExecutor, verifyAuditChain, withTenantAuditedTransaction } from "./audit";
 import { parseSigningKey, publicKeyPem } from "./audit-checkpoint";
@@ -90,7 +91,7 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3
 const DURABILITY_URI_PATTERN = /^(?:s3|gs|azure|https):\/\/[^\s]{1,1900}$/;
 
 function parseTrustedKeyRegistry(envName: string): Readonly<Record<string, string>> {
-  const raw = process.env[envName]?.trim();
+  const raw = runtimeEnvironmentValue(envName)?.trim();
   if (!raw) return Object.freeze({});
   let parsed: unknown;
   try {
@@ -120,11 +121,11 @@ function currentArchiveSigningIdentity(): {
   privateKey: KeyObject;
   publicKey: string;
 } {
-  const keyId = process.env.STEWARD_AUDIT_SIGNING_KEY_ID?.trim() ?? "";
+  const keyId = runtimeEnvironmentValue("STEWARD_AUDIT_SIGNING_KEY_ID")?.trim() ?? "";
   if (!KEY_ID_PATTERN.test(keyId)) {
     throw new Error("STEWARD_AUDIT_SIGNING_KEY_ID is required for audit archives");
   }
-  const privateKey = parseSigningKey(process.env.STEWARD_AUDIT_SIGNING_KEY ?? "");
+  const privateKey = parseSigningKey(runtimeEnvironmentValue("STEWARD_AUDIT_SIGNING_KEY") ?? "");
   const publicKey = publicKeyPem(privateKey);
   const trusted = parseTrustedKeyRegistry("STEWARD_AUDIT_ARCHIVE_TRUSTED_SIGNING_KEYS");
   const configured = trusted[keyId];
@@ -273,7 +274,7 @@ async function lockTenantAuditWriter(
   tx: { execute(query: ReturnType<typeof sql>): Promise<unknown> },
   tenantId: string,
 ) {
-  if (process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true") {
+  if (runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" && runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true") {
     await tx.execute(
       sql`SELECT pg_advisory_xact_lock(hashtextextended(${`steward_audit_${tenantId}`}, 0))`,
     );

--- a/packages/api/src/services/audit-checkpoint-anchor.ts
+++ b/packages/api/src/services/audit-checkpoint-anchor.ts
@@ -7,6 +7,8 @@
  * assembly.
  */
 
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
 import { spawnSync } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -449,7 +451,7 @@ function validateTimestampUrl(raw: string): URL {
   if (url.username || url.password) {
     throw new AuditCheckpointAnchorError("RFC 3161 URL must not contain credentials");
   }
-  if (url.protocol !== "https:" && process.env.NODE_ENV === "production") {
+  if (url.protocol !== "https:" && runtimeEnvironmentValue("NODE_ENV") === "production") {
     throw new AuditCheckpointAnchorError("RFC 3161 URL must use HTTPS in production");
   }
   if (url.protocol !== "https:" && url.protocol !== "http:") {
@@ -567,7 +569,7 @@ export class Rfc3161TimestampSink implements AuditCheckpointAnchorSink {
 }
 
 function configuredMode(): AuditCheckpointAnchorMode {
-  const value = process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE?.trim() || "off";
+  const value = runtimeEnvironmentValue("STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE")?.trim() || "off";
   if (value === "off" || value === "best-effort" || value === "required") return value;
   throw new AuditCheckpointAnchorError(
     "STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE must be off, best-effort, or required",
@@ -582,7 +584,7 @@ export function configuredAuditCheckpointAnchor(): {
 } {
   const mode = configuredMode();
   if (mode === "off") return { mode };
-  const provider = process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER?.trim() || "rfc3161";
+  const provider = runtimeEnvironmentValue("STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER")?.trim() || "rfc3161";
   if (provider !== "rfc3161") {
     const registration = registeredSinkProviders.get(provider);
     if (!registration) {
@@ -597,22 +599,22 @@ export function configuredAuditCheckpointAnchor(): {
       verify: registration.verify,
     };
   }
-  const url = process.env.STEWARD_AUDIT_RFC3161_URL?.trim();
+  const url = runtimeEnvironmentValue("STEWARD_AUDIT_RFC3161_URL")?.trim();
   if (!url) {
     throw new AuditCheckpointAnchorError(
       "STEWARD_AUDIT_RFC3161_URL is required when checkpoint anchoring is enabled",
     );
   }
-  const rawTimeout = process.env.STEWARD_AUDIT_RFC3161_TIMEOUT_MS?.trim();
+  const rawTimeout = runtimeEnvironmentValue("STEWARD_AUDIT_RFC3161_TIMEOUT_MS")?.trim();
   const timeoutMs = rawTimeout ? Number(rawTimeout) : undefined;
-  const caFile = process.env.STEWARD_AUDIT_RFC3161_CA_FILE?.trim();
+  const caFile = runtimeEnvironmentValue("STEWARD_AUDIT_RFC3161_CA_FILE")?.trim();
   if (!caFile) {
     throw new AuditCheckpointAnchorError(
       "STEWARD_AUDIT_RFC3161_CA_FILE is required when RFC 3161 anchoring is enabled",
     );
   }
   const seconds = (name: string, fallback: number) => {
-    const raw = process.env[name]?.trim();
+    const raw = runtimeEnvironmentValue(name)?.trim();
     const value = raw ? Number(raw) : fallback;
     if (!Number.isSafeInteger(value) || value < 0 || value > 3600) {
       throw new AuditCheckpointAnchorError(`${name} must be an integer from 0 to 3600 seconds`);
@@ -626,8 +628,8 @@ export function configuredAuditCheckpointAnchor(): {
       url,
       timeoutMs,
       caFile,
-      untrustedFile: process.env.STEWARD_AUDIT_RFC3161_UNTRUSTED_FILE?.trim(),
-      expectedPolicyOid: process.env.STEWARD_AUDIT_RFC3161_POLICY_OID?.trim(),
+      untrustedFile: runtimeEnvironmentValue("STEWARD_AUDIT_RFC3161_UNTRUSTED_FILE")?.trim(),
+      expectedPolicyOid: runtimeEnvironmentValue("STEWARD_AUDIT_RFC3161_POLICY_OID")?.trim(),
       maxPastAgeMs: seconds("STEWARD_AUDIT_RFC3161_MAX_AGE_SECONDS", 300),
       maxFutureSkewMs: seconds("STEWARD_AUDIT_RFC3161_MAX_FUTURE_SKEW_SECONDS", 300),
     }),

--- a/packages/api/src/services/audit-checkpoint-anchor.ts
+++ b/packages/api/src/services/audit-checkpoint-anchor.ts
@@ -7,13 +7,12 @@
  * assembly.
  */
 
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
-
 import { spawnSync } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { canonicalCheckpointBytes, type SignedCheckpoint } from "./audit-checkpoint";
 
 export type AuditCheckpointAnchorMode = "off" | "best-effort" | "required";
@@ -584,7 +583,8 @@ export function configuredAuditCheckpointAnchor(): {
 } {
   const mode = configuredMode();
   if (mode === "off") return { mode };
-  const provider = runtimeEnvironmentValue("STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER")?.trim() || "rfc3161";
+  const provider =
+    runtimeEnvironmentValue("STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER")?.trim() || "rfc3161";
   if (provider !== "rfc3161") {
     const registration = registeredSinkProviders.get(provider);
     if (!registration) {

--- a/packages/api/src/services/audit-checkpoint.ts
+++ b/packages/api/src/services/audit-checkpoint.ts
@@ -31,8 +31,6 @@
  * Zero new dependencies: uses node:crypto Ed25519 primitives.
  */
 
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
-
 import {
   createHash,
   createPrivateKey,
@@ -41,6 +39,7 @@ import {
   sign,
   verify,
 } from "node:crypto";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 
 // This package is typechecked with @cloudflare/workers-types in scope, whose
 // `Buffer` shadows Node's and lacks `concat` / "base64". We therefore avoid

--- a/packages/api/src/services/audit-checkpoint.ts
+++ b/packages/api/src/services/audit-checkpoint.ts
@@ -31,6 +31,8 @@
  * Zero new dependencies: uses node:crypto Ed25519 primitives.
  */
 
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
 import {
   createHash,
   createPrivateKey,
@@ -365,7 +367,7 @@ let cachedSignerKeySource: string | null = null;
  * to decide between hard-fail (production) and disabled-with-warning (dev).
  */
 export function isCheckpointSigningConfigured(): boolean {
-  const env = process.env.STEWARD_AUDIT_SIGNING_KEY;
+  const env = runtimeEnvironmentValue("STEWARD_AUDIT_SIGNING_KEY");
   return typeof env === "string" && env.trim().length > 0;
 }
 
@@ -376,7 +378,7 @@ export function isCheckpointSigningConfigured(): boolean {
  * gracefully.
  */
 export function getCheckpointSigner(): AuditCheckpointSigner {
-  const env = process.env.STEWARD_AUDIT_SIGNING_KEY ?? "";
+  const env = runtimeEnvironmentValue("STEWARD_AUDIT_SIGNING_KEY") ?? "";
   if (env.trim().length === 0) {
     throw new AuditSigningKeyError(
       "STEWARD_AUDIT_SIGNING_KEY is not configured. Generate one with: " +

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Tamper-evident audit log writer & verifier.
  *
@@ -125,7 +126,7 @@ let warnedDevFallback = false;
 let cachedKey: Uint8Array | null = null;
 function getHmacKey(): Uint8Array {
   if (cachedKey) return cachedKey;
-  const env = process.env.STEWARD_AUDIT_HMAC_KEY;
+  const env = runtimeEnvironmentValue("STEWARD_AUDIT_HMAC_KEY");
   if (env && env.length > 0) {
     const isHex = /^[0-9a-fA-F]+$/.test(env) && env.length % 2 === 0;
     // Hex keys decode to env.length/2 bytes; raw keys count chars directly.
@@ -141,14 +142,14 @@ function getHmacKey(): Uint8Array {
       isHex && env.length >= MIN_HMAC_RAW_BYTES * 2 ? toU8(env) : new TextEncoder().encode(env);
     return cachedKey;
   }
-  if (process.env.NODE_ENV === "production") {
+  if (runtimeEnvironmentValue("NODE_ENV") === "production") {
     throw new Error(
       "STEWARD_AUDIT_HMAC_KEY is required in production. Generate with `openssl rand -hex 32`.",
     );
   }
   // Default-deny: the dev fallback is only allowed with an explicit opt-in
   // consistent with the rest of the repo (STEWARD_ALLOW_DEV_SECRETS).
-  if (process.env.STEWARD_ALLOW_DEV_SECRETS !== "true") {
+  if (runtimeEnvironmentValue("STEWARD_ALLOW_DEV_SECRETS") !== "true") {
     throw new Error(
       "STEWARD_AUDIT_HMAC_KEY is required. For local development only, set " +
         "STEWARD_ALLOW_DEV_SECRETS=true to use the insecure dev key.",

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -123,10 +123,16 @@ function u8Equals(a: Uint8Array, b: Uint8Array): boolean {
 const MIN_HMAC_RAW_BYTES = 32;
 
 let warnedDevFallback = false;
-let cachedKey: Uint8Array | null = null;
+const cachedKeys = new Map<string, Uint8Array>();
 function getHmacKey(): Uint8Array {
-  if (cachedKey) return cachedKey;
   const env = runtimeEnvironmentValue("STEWARD_AUDIT_HMAC_KEY");
+  const authority = JSON.stringify([
+    env ?? "",
+    runtimeEnvironmentValue("NODE_ENV") ?? "",
+    runtimeEnvironmentValue("STEWARD_ALLOW_DEV_SECRETS") ?? "",
+  ]);
+  const cachedKey = cachedKeys.get(authority);
+  if (cachedKey) return cachedKey;
   if (env && env.length > 0) {
     const isHex = /^[0-9a-fA-F]+$/.test(env) && env.length % 2 === 0;
     // Hex keys decode to env.length/2 bytes; raw keys count chars directly.
@@ -138,9 +144,10 @@ function getHmacKey(): Uint8Array {
           "Generate with `openssl rand -hex 32`.",
       );
     }
-    cachedKey =
+    const key =
       isHex && env.length >= MIN_HMAC_RAW_BYTES * 2 ? toU8(env) : new TextEncoder().encode(env);
-    return cachedKey;
+    cachedKeys.set(authority, key);
+    return key;
   }
   if (runtimeEnvironmentValue("NODE_ENV") === "production") {
     throw new Error(
@@ -162,10 +169,11 @@ function getHmacKey(): Uint8Array {
         "(STEWARD_ALLOW_DEV_SECRETS=true). Audit chain is NOT tamper-evident. Never use in production.",
     );
   }
-  cachedKey = new TextEncoder().encode(
+  const key = new TextEncoder().encode(
     "dev-audit-hmac-key-do-not-use-in-production-aaaaaaaaaaaaaaaaaaaaaaaa",
   );
-  return cachedKey;
+  cachedKeys.set(authority, key);
+  return key;
 }
 
 /**

--- a/packages/api/src/services/auth-abuse.ts
+++ b/packages/api/src/services/auth-abuse.ts
@@ -1,9 +1,9 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type {
   TenantAuthAbuseConfig,
   TenantCaptchaAction,
   TenantCaptchaProvider,
 } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 
 const CAPTCHA_PROVIDERS = new Set<TenantCaptchaProvider>(["turnstile", "hcaptcha"]);
 const CAPTCHA_ACTIONS = new Set<TenantCaptchaAction>(["email_otp", "sms_otp"]);

--- a/packages/api/src/services/auth-abuse.ts
+++ b/packages/api/src/services/auth-abuse.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type {
   TenantAuthAbuseConfig,
   TenantCaptchaAction,
@@ -442,7 +443,7 @@ export function validateEmailAbusePolicy(
   }
   if (emailConfig.blockDisposable) {
     const envDomains = new Set(
-      (process.env.STEWARD_DISPOSABLE_EMAIL_DOMAINS ?? "")
+      (runtimeEnvironmentValue("STEWARD_DISPOSABLE_EMAIL_DOMAINS") ?? "")
         .split(",")
         .map((entry) => entry.trim().toLowerCase())
         .filter(Boolean),
@@ -502,7 +503,7 @@ export function validatePhoneAbusePolicy(
     return "phone country code is blocked";
   }
   if (phoneConfig.blockVoip) {
-    const blockedPrefixes = (process.env.STEWARD_VOIP_PHONE_PREFIXES ?? "")
+    const blockedPrefixes = (runtimeEnvironmentValue("STEWARD_VOIP_PHONE_PREFIXES") ?? "")
       .split(",")
       .map((entry) => entry.trim())
       .filter(Boolean);
@@ -535,7 +536,7 @@ export async function verifyCaptchaToken(
   if (typeof safeSecretEnv === "string" && safeSecretEnv.startsWith("captcha.")) {
     return { ok: false, status: 503, error: "CAPTCHA provider is not configured" };
   }
-  const secret = process.env[secretEnv]?.trim();
+  const secret = runtimeEnvironmentValue(secretEnv)?.trim();
   if (!secret) {
     return { ok: false, status: 503, error: "CAPTCHA provider is not configured" };
   }

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -322,10 +322,6 @@ export const DATABASE_URL =
   runtimeEnvironmentValue("DATABASE_URL")?.trim() ||
   (isPGLiteRuntime ? "" : requireEnv("DATABASE_URL"));
 
-if (runtimeEnvironmentValue("DATABASE_URL")) {
-  process.env.DATABASE_URL = DATABASE_URL;
-}
-
 // ─── Singletons ───────────────────────────────────────────────────────────────
 
 // `db` is a late-bound Proxy over getDb() rather than a captured handle.

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -86,9 +86,11 @@ function positiveIntEnv(name: string, fallback: number): number {
 // than any real client — can raise the ceiling without changing the production
 // default (100 requests / 60s per client IP). A missing or invalid override
 // falls back to that default, so this can never weaken the guard unintentionally.
-export const RATE_LIMIT_WINDOW_MS = positiveIntEnv("STEWARD_RATE_LIMIT_WINDOW_MS", 60_000);
-export const RATE_LIMIT_MAX_REQUESTS = positiveIntEnv("STEWARD_RATE_LIMIT_MAX_REQUESTS", 100);
-export const isWorkersRuntime =
+export const rateLimitWindowMs = (): number =>
+  positiveIntEnv("STEWARD_RATE_LIMIT_WINDOW_MS", 60_000);
+export const rateLimitMaxRequests = (): number =>
+  positiveIntEnv("STEWARD_RATE_LIMIT_MAX_REQUESTS", 100);
+export const isWorkersRuntime = (): boolean =>
   runtimeEnvironmentValue("STEWARD_RUNTIME") === "workers" ||
   (typeof navigator !== "undefined" && navigator.userAgent === "Cloudflare-Workers");
 
@@ -249,7 +251,7 @@ export async function verifySessionToken(token: string) {
 
 export const nonceStore = new Map<string, { nonce: string; expiresAt: number }>();
 
-export const nonceCleanupTimer = isWorkersRuntime
+export const nonceCleanupTimer = isWorkersRuntime()
   ? undefined
   : setInterval(
       () => {
@@ -308,19 +310,9 @@ export { extractRpcErrorMessage, isRpcError } from "./rpc-error";
 
 // ─── Environment ──────────────────────────────────────────────────────────────
 
-function requireEnv(name: string): string {
-  const value = runtimeEnvironmentValue(name)?.trim();
-  if (!value) throw new Error(`${name} is required`);
-  return value;
-}
-
-const isPGLiteRuntime =
+export const isPGLiteRuntime = (): boolean =>
   runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" ||
   runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true";
-
-export const DATABASE_URL =
-  runtimeEnvironmentValue("DATABASE_URL")?.trim() ||
-  (isPGLiteRuntime ? "" : requireEnv("DATABASE_URL"));
 
 // ─── Singletons ───────────────────────────────────────────────────────────────
 
@@ -392,9 +384,11 @@ export const tenantConfigs = new Map<string, TenantConfig>([
   [defaultTenantConfig.id, defaultTenantConfig],
 ]);
 
-export const defaultTenantReady = db.execute(sql`
-  SELECT steward_bootstrap.ensure_default_tenant(${runtimeEnvironmentValue("STEWARD_DEFAULT_TENANT_KEY") || ""})
-`);
+async function ensureDefaultTenantReady(): Promise<void> {
+  await db.execute(sql`
+    SELECT steward_bootstrap.ensure_default_tenant(${runtimeEnvironmentValue("STEWARD_DEFAULT_TENANT_KEY") || ""})
+  `);
+}
 
 // ─── App variable types ───────────────────────────────────────────────────────
 
@@ -747,7 +741,7 @@ export async function withAuthenticatedTenantDatabase<T>(
 ): Promise<T> {
   if (hasTenantTransactionDatabase({ tenantId, userId, ...characteristics })) return callback();
   const context = tenantContextFromAuthenticatedPrincipal({ tenantId, method, subject, userId });
-  const driver = isPGLiteRuntime ? "pglite" : getDatabaseDriver();
+  const driver = isPGLiteRuntime() ? "pglite" : getDatabaseDriver();
   return withTenantRlsTransaction(
     getDb() as never,
     driver,
@@ -773,7 +767,7 @@ export async function tenantAuth(
   next: Next,
   options?: { requireTenantMatch?: string; bindTenantDatabase?: boolean },
 ) {
-  await defaultTenantReady;
+  await ensureDefaultTenantReady();
 
   const authHeader = c.req.header("Authorization");
   if (authHeader?.startsWith("Bearer ")) {

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -53,6 +53,7 @@ import {
   type Tenant,
   type TenantConfig,
 } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type { Vault } from "@stwd/vault";
 import { WebhookDispatcher } from "@stwd/webhooks";
 import { and, eq, gte, sql } from "drizzle-orm";
@@ -73,7 +74,7 @@ export const DEFAULT_TENANT_ID = "default";
  * value can never silently disable a guard — it just reverts to the default.
  */
 function positiveIntEnv(name: string, fallback: number): number {
-  const raw = process.env[name]?.trim();
+  const raw = runtimeEnvironmentValue(name)?.trim();
   if (!raw) return fallback;
   const parsed = Number(raw);
   if (!Number.isInteger(parsed) || parsed <= 0) return fallback;
@@ -88,7 +89,7 @@ function positiveIntEnv(name: string, fallback: number): number {
 export const RATE_LIMIT_WINDOW_MS = positiveIntEnv("STEWARD_RATE_LIMIT_WINDOW_MS", 60_000);
 export const RATE_LIMIT_MAX_REQUESTS = positiveIntEnv("STEWARD_RATE_LIMIT_MAX_REQUESTS", 100);
 export const isWorkersRuntime =
-  process.env.STEWARD_RUNTIME === "workers" ||
+  runtimeEnvironmentValue("STEWARD_RUNTIME") === "workers" ||
   (typeof navigator !== "undefined" && navigator.userAgent === "Cloudflare-Workers");
 
 // ─── JWT helpers ──────────────────────────────────────────────────────────────
@@ -308,18 +309,20 @@ export { extractRpcErrorMessage, isRpcError } from "./rpc-error";
 // ─── Environment ──────────────────────────────────────────────────────────────
 
 function requireEnv(name: string): string {
-  const value = process.env[name]?.trim();
+  const value = runtimeEnvironmentValue(name)?.trim();
   if (!value) throw new Error(`${name} is required`);
   return value;
 }
 
 const isPGLiteRuntime =
-  process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true";
+  runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" ||
+  runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true";
 
 export const DATABASE_URL =
-  process.env.DATABASE_URL?.trim() || (isPGLiteRuntime ? "" : requireEnv("DATABASE_URL"));
+  runtimeEnvironmentValue("DATABASE_URL")?.trim() ||
+  (isPGLiteRuntime ? "" : requireEnv("DATABASE_URL"));
 
-if (process.env.DATABASE_URL) {
+if (runtimeEnvironmentValue("DATABASE_URL")) {
   process.env.DATABASE_URL = DATABASE_URL;
 }
 
@@ -394,7 +397,7 @@ export const tenantConfigs = new Map<string, TenantConfig>([
 ]);
 
 export const defaultTenantReady = db.execute(sql`
-  SELECT steward_bootstrap.ensure_default_tenant(${process.env.STEWARD_DEFAULT_TENANT_KEY || ""})
+  SELECT steward_bootstrap.ensure_default_tenant(${runtimeEnvironmentValue("STEWARD_DEFAULT_TENANT_KEY") || ""})
 `);
 
 // ─── App variable types ───────────────────────────────────────────────────────

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -318,7 +318,6 @@ const isPGLiteRuntime =
 
 export const DATABASE_URL =
   process.env.DATABASE_URL?.trim() || (isPGLiteRuntime ? "" : requireEnv("DATABASE_URL"));
-export const MASTER_PASSWORD = requireEnv("STEWARD_MASTER_PASSWORD");
 
 if (process.env.DATABASE_URL) {
   process.env.DATABASE_URL = DATABASE_URL;
@@ -351,22 +350,11 @@ export const db: DbHandle = new Proxy({} as DbHandle, {
   },
 });
 
-// `vault` is a late-bound Proxy resolving the Vault for the CURRENT master
-// password, memoized per password. In production STEWARD_MASTER_PASSWORD is
-// fixed before this module loads, so exactly one Vault is ever built and every
-// access returns it — behaviorally identical to `const vault = new Vault(...)`.
-//
-// In the single-process api test suite, individual files set their own
-// STEWARD_MASTER_PASSWORD in beforeAll, and a few construct their OWN Vault with
-// that password to seal keys directly into their per-file PGLite db. A captured
-// singleton would have frozen the first (preload) password, so the route-level
-// vault could not decrypt keys those files sealed under a different password —
-// surfacing as AES-GCM "Unsupported state or unable to authenticate data". A
-// per-password memo keeps the route vault in lockstep with whatever password
-// sealed each key. MASTER_PASSWORD (captured at import) is the fallback when the
-// env var is transiently unset (e.g. another file's afterAll deleted it).
+// `vault` is a late-bound Proxy resolving the Vault for the current immutable
+// custody authority. Worker requests therefore cannot retain or borrow another
+// request's password/KDF/provider tuple; Bun resolves the same tuple from env.
 function activeVault(): Vault {
-  return getConfiguredVault({ fallbackPassword: MASTER_PASSWORD });
+  return getConfiguredVault();
 }
 export const vault: Vault = new Proxy({} as Vault, {
   get(_target, property) {

--- a/packages/api/src/services/custody-runtime.ts
+++ b/packages/api/src/services/custody-runtime.ts
@@ -1,0 +1,36 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
+const DEFAULT_VAULT_RPC_ALLOWLIST = "eth_chainId,eth_blockNumber,eth_getBalance";
+
+/** Resolve a chain default from the active request snapshot, falling back to Bun's env. */
+export function resolveRuntimeChainId(fallback: number): number {
+  if (!Number.isSafeInteger(fallback) || fallback <= 0) {
+    throw new Error("CHAIN_ID fallback must be a positive safe integer");
+  }
+  const configured = runtimeEnvironmentValue("CHAIN_ID")?.trim();
+  if (!configured) return fallback;
+  if (!/^[1-9]\d*$/.test(configured)) {
+    throw new Error("CHAIN_ID must be a canonical positive integer");
+  }
+  const chainId = Number(configured);
+  if (!Number.isSafeInteger(chainId)) {
+    throw new Error("CHAIN_ID must be a positive safe integer");
+  }
+  return chainId;
+}
+
+/** Check the RPC gate from the active request snapshot rather than isolate-global state. */
+export function isRuntimeVaultRpcMethodAllowed(method: string): boolean {
+  const configured =
+    runtimeEnvironmentValue("STEWARD_VAULT_RPC_ALLOWLIST") ?? DEFAULT_VAULT_RPC_ALLOWLIST;
+  return configured
+    .split(",")
+    .map((candidate) => candidate.trim())
+    .filter(Boolean)
+    .includes(method);
+}
+
+/** Resolve an arbitrary custody-adjacent binding from the active request snapshot. */
+export function runtimeCustodyValue(name: string): string | undefined {
+  return runtimeEnvironmentValue(name);
+}

--- a/packages/api/src/services/eip1271.ts
+++ b/packages/api/src/services/eip1271.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * EIP-1271 verification helper.
  *
@@ -73,11 +74,11 @@ const DEFAULT_PUBLIC_RPCS: Record<number, string> = {
  * Returns null if no RPC is available for this chain.
  */
 export function resolveRpcUrl(chainId: number): string | null {
-  const envOverride = process.env[`SIWE_RPC_${chainId}`];
+  const envOverride = runtimeEnvironmentValue(`SIWE_RPC_${chainId}`);
   if (envOverride && envOverride.trim().length > 0) {
     return envOverride.trim();
   }
-  if (process.env.NODE_ENV === "production") return null;
+  if (runtimeEnvironmentValue("NODE_ENV") === "production") return null;
   return DEFAULT_PUBLIC_RPCS[chainId] ?? null;
 }
 

--- a/packages/api/src/services/evm-simulator.ts
+++ b/packages/api/src/services/evm-simulator.ts
@@ -1,7 +1,4 @@
-import {
-  runtimeEnvironmentSnapshot,
-  runtimeEnvironmentValue,
-} from "@stwd/shared/runtime-env";
+import { runtimeEnvironmentSnapshot, runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 export interface EvmSimulationRequest {
   chainId: number;
   from: string;
@@ -63,8 +60,9 @@ function hexWei(decimal: string): `0x${string}` {
 
 export class JsonRpcEvmSimulator implements EvmSimulator {
   constructor(
-    private readonly env: Readonly<Record<string, string | undefined>> =
-      runtimeEnvironmentSnapshot(),
+    private readonly env: Readonly<
+      Record<string, string | undefined>
+    > = runtimeEnvironmentSnapshot(),
   ) {}
 
   async simulate(request: EvmSimulationRequest): Promise<EvmSimulationResult> {

--- a/packages/api/src/services/evm-simulator.ts
+++ b/packages/api/src/services/evm-simulator.ts
@@ -1,3 +1,7 @@
+import {
+  runtimeEnvironmentSnapshot,
+  runtimeEnvironmentValue,
+} from "@stwd/shared/runtime-env";
 export interface EvmSimulationRequest {
   chainId: number;
   from: string;
@@ -58,7 +62,10 @@ function hexWei(decimal: string): `0x${string}` {
 }
 
 export class JsonRpcEvmSimulator implements EvmSimulator {
-  constructor(private readonly env: Record<string, string | undefined> = process.env) {}
+  constructor(
+    private readonly env: Readonly<Record<string, string | undefined>> =
+      runtimeEnvironmentSnapshot(),
+  ) {}
 
   async simulate(request: EvmSimulationRequest): Promise<EvmSimulationResult> {
     const url = rpcUrlForChain(request.chainId, this.env);
@@ -86,7 +93,7 @@ export class JsonRpcEvmSimulator implements EvmSimulator {
 
 export function createEnvEvmSimulator(): EvmSimulator | null {
   const hasJson =
-    Object.keys(parseRpcUrls(process.env.STEWARD_EVM_RPC_URLS_JSON)).length > 0 ||
-    Object.keys(process.env).some((key) => /^STEWARD_EVM_RPC_URL_\d+$/.test(key));
+    Object.keys(parseRpcUrls(runtimeEnvironmentValue("STEWARD_EVM_RPC_URLS_JSON"))).length > 0 ||
+    Object.keys(runtimeEnvironmentSnapshot()).some((key) => /^STEWARD_EVM_RPC_URL_\d+$/.test(key));
   return hasJson ? new JsonRpcEvmSimulator() : null;
 }

--- a/packages/api/src/services/gas-sponsorship.ts
+++ b/packages/api/src/services/gas-sponsorship.ts
@@ -1,4 +1,5 @@
 import { getDb, sponsoredGasEvents, tenantConfigs as tenantConfigsTable } from "@stwd/db";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type {
   GasSponsorshipMode,
   GasSponsorshipProvider,
@@ -46,9 +47,9 @@ function normalizeHttpsUrl(value: unknown, field: string): string | undefined | 
     return `${field} must be a valid URL`;
   }
   const localProviderUrlsAllowed =
-    process.env.STEWARD_ALLOW_LOCAL_PROVIDER_URLS === "true" ||
-    process.env.NODE_ENV === "test" ||
-    process.env.NODE_ENV === "development";
+    runtimeEnvironmentValue("STEWARD_ALLOW_LOCAL_PROVIDER_URLS") === "true" ||
+    runtimeEnvironmentValue("NODE_ENV") === "test" ||
+    runtimeEnvironmentValue("NODE_ENV") === "development";
   if (url.protocol !== "https:" && url.hostname !== "localhost" && url.hostname !== "127.0.0.1") {
     return `${field} must use https`;
   }

--- a/packages/api/src/services/gas-sponsorship.ts
+++ b/packages/api/src/services/gas-sponsorship.ts
@@ -1,5 +1,4 @@
 import { getDb, sponsoredGasEvents, tenantConfigs as tenantConfigsTable } from "@stwd/db";
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type {
   GasSponsorshipMode,
   GasSponsorshipProvider,
@@ -7,6 +6,7 @@ import type {
   SponsoredGasSpendSummary,
   TenantGasSponsorshipConfig,
 } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { and, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import { validateWebhookUrl } from "./webhook-url";
 

--- a/packages/api/src/services/key-export-plaintext-gate.ts
+++ b/packages/api/src/services/key-export-plaintext-gate.ts
@@ -32,4 +32,5 @@ export function plaintextKeyExportResponseGateError(
 
   return null;
 }
+
 import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";

--- a/packages/api/src/services/key-export-plaintext-gate.ts
+++ b/packages/api/src/services/key-export-plaintext-gate.ts
@@ -15,7 +15,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 export function plaintextKeyExportResponseGateError(
   body: unknown,
-  env: EnvLike = process.env,
+  env: EnvLike = runtimeEnvironmentSnapshot(),
 ): string | null {
   if (!isProductionLike(env)) return null;
 
@@ -32,3 +32,4 @@ export function plaintextKeyExportResponseGateError(
 
   return null;
 }
+import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * provider-action-service.ts — the provider-action authority pipeline.
  *
@@ -1041,7 +1042,7 @@ class ProviderActionService {
         const verification = verifyXSummonAttestation(
           input.summonAttestation,
           {
-            audience: process.env.STEWARD_X_SUMMON_ATTESTATION_AUDIENCE ?? "",
+            audience: runtimeEnvironmentValue("STEWARD_X_SUMMON_ATTESTATION_AUDIENCE") ?? "",
             tenantId,
             workspaceId: input.workspaceId,
             actorAgentId,
@@ -1049,7 +1050,7 @@ class ProviderActionService {
             sourcePostId,
             idempotencyKeyHash: input.idempotencyKeyHash,
           },
-          process.env.STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS,
+          runtimeEnvironmentValue("STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS"),
           providerPolicyClockForTests?.() ?? new Date(),
         );
         if (verification.ok) {
@@ -1161,7 +1162,7 @@ class ProviderActionService {
         // PGLite is a single-connection test harness and has no advisory-lock
         // function. Production Postgres must serialize this identity before the
         // locked replay check below.
-        if (process.env.STEWARD_PGLITE_MEMORY !== "true") {
+        if (runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true") {
           await tx.execute(
             sql`SELECT pg_advisory_xact_lock(hashtextextended(${`provider-action-create:${createIdentity}`}, 0))`,
           );
@@ -2803,7 +2804,7 @@ class ProviderActionService {
         const verification = verifyXSummonAttestation(
           persistedAttestation,
           {
-            audience: process.env.STEWARD_X_SUMMON_ATTESTATION_AUDIENCE ?? "",
+            audience: runtimeEnvironmentValue("STEWARD_X_SUMMON_ATTESTATION_AUDIENCE") ?? "",
             tenantId: args.tenantId,
             workspaceId: args.workspaceId,
             actorAgentId: args.actorAgentId,
@@ -2811,7 +2812,7 @@ class ProviderActionService {
             sourcePostId,
             idempotencyKeyHash: args.idempotencyKeyHash,
           },
-          process.env.STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS,
+          runtimeEnvironmentValue("STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS"),
           providerPolicyClockForTests?.() ?? new Date(),
         );
         if (!verification.ok) {

--- a/packages/api/src/services/provider-case.ts
+++ b/packages/api/src/services/provider-case.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * provider-case.ts — correlated provider-case evidence assembler (pure read).
  *
@@ -91,7 +92,7 @@ export class CaseRangeTooLargeError extends Error {
  * escalate to REPEATABLE READ READ ONLY for a true snapshot.
  */
 function isPGLiteRuntime(): boolean {
-  return process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true";
+  return runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true";
 }
 
 /** Sensitive-key set for the safe-summary re-validation (spec §3.3). Mirrors the

--- a/packages/api/src/services/provider-case.ts
+++ b/packages/api/src/services/provider-case.ts
@@ -92,7 +92,10 @@ export class CaseRangeTooLargeError extends Error {
  * escalate to REPEATABLE READ READ ONLY for a true snapshot.
  */
 function isPGLiteRuntime(): boolean {
-  return runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true";
+  return (
+    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" ||
+    runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
+  );
 }
 
 /** Sensitive-key set for the safe-summary re-validation (spec §3.3). Mirrors the

--- a/packages/api/src/services/provider-google-connect.ts
+++ b/packages/api/src/services/provider-google-connect.ts
@@ -48,6 +48,7 @@ import {
   withTenantAuditedTransaction,
 } from "@stwd/db";
 import { isValidOAuthBearerToken, isValidOAuthOpaqueToken } from "@stwd/shared";
+import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";
 import type { SecretVault } from "@stwd/vault";
 
 type DbBase = ReturnType<typeof getDb>;
@@ -81,7 +82,7 @@ export const GOOGLE_CONNECT_STATE_TTL_MS = 10 * 60 * 1000;
 
 export function assertGoogleConnectStoreIsSafe(
   source: "redis" | "postgres" | "memory",
-  env: NodeJS.ProcessEnv = process.env,
+  env: Readonly<Record<string, string | undefined>> = runtimeEnvironmentSnapshot(),
 ): void {
   const requiresDurableStore = env.NODE_ENV === "production" || env.STEWARD_RUNTIME === "workers";
   if (
@@ -329,7 +330,7 @@ export interface GoogleConnectConfig {
  * .env.example for the separation rationale.
  */
 export function resolveGoogleConnectConfig(
-  env: NodeJS.ProcessEnv = process.env,
+  env: Readonly<Record<string, string | undefined>> = runtimeEnvironmentSnapshot(),
 ): GoogleConnectConfig {
   const clientId = env.GOOGLE_PROVIDER_CLIENT_ID?.trim();
   const clientSecret = env.GOOGLE_PROVIDER_CLIENT_SECRET?.trim();

--- a/packages/api/src/services/provider-google-lifecycle-scheduler.ts
+++ b/packages/api/src/services/provider-google-lifecycle-scheduler.ts
@@ -1,18 +1,17 @@
 import { redactedThrownDiagnostics } from "@stwd/shared";
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
-import { SecretVault } from "@stwd/vault";
 import {
   type GoogleCredentialLifecycleSweepResult,
   resolveGoogleConnectConfig,
   runGoogleCredentialLifecycleSweep,
 } from "./provider-google-connect";
 import { runInternalJobForEachTenant } from "./tenant-job";
+import { getConfiguredSecretVault } from "./vault-factory";
 
 const DEFAULT_INTERVAL_MS = 60_000;
 const MIN_INTERVAL_MS = 5_000;
 const MAX_INTERVAL_MS = 5 * 60_000;
 function configuredInterval(): number {
-  const raw = runtimeEnvironmentValue("STEWARD_GOOGLE_LIFECYCLE_SWEEP_INTERVAL_MS");
+  const raw = process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEP_INTERVAL_MS;
   if (raw === undefined) return DEFAULT_INTERVAL_MS;
   const parsed = Number(raw);
   if (!Number.isSafeInteger(parsed) || parsed < MIN_INTERVAL_MS || parsed > MAX_INTERVAL_MS) {
@@ -24,11 +23,9 @@ function configuredInterval(): number {
 }
 
 export async function runGoogleCredentialLifecycleRecoverySweep(): Promise<GoogleCredentialLifecycleSweepResult> {
-  const password = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD")?.trim();
-  if (!password) throw new Error("STEWARD_MASTER_PASSWORD is required for Google OAuth recovery");
   const results = await runInternalJobForEachTenant("google-credential-lifecycle-sweep", () =>
     runGoogleCredentialLifecycleSweep({
-      vault: new SecretVault(password),
+      vault: getConfiguredSecretVault(),
       config: resolveGoogleConnectConfig(),
     }),
   );
@@ -48,7 +45,7 @@ export function startGoogleCredentialLifecycleScheduler(options?: {
   intervalMs?: number;
   sweep?: () => Promise<GoogleCredentialLifecycleSweepResult>;
 }): () => Promise<void> {
-  if (runtimeEnvironmentValue("STEWARD_GOOGLE_LIFECYCLE_SWEEPER") === "false") return async () => {};
+  if (process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEPER === "false") return async () => {};
   const sweep = options?.sweep ?? runGoogleCredentialLifecycleRecoverySweep;
   let active: Promise<void> | undefined;
   let stopped = false;

--- a/packages/api/src/services/provider-google-lifecycle-scheduler.ts
+++ b/packages/api/src/services/provider-google-lifecycle-scheduler.ts
@@ -1,4 +1,5 @@
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { SecretVault } from "@stwd/vault";
 import {
   type GoogleCredentialLifecycleSweepResult,
@@ -11,7 +12,7 @@ const DEFAULT_INTERVAL_MS = 60_000;
 const MIN_INTERVAL_MS = 5_000;
 const MAX_INTERVAL_MS = 5 * 60_000;
 function configuredInterval(): number {
-  const raw = process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEP_INTERVAL_MS;
+  const raw = runtimeEnvironmentValue("STEWARD_GOOGLE_LIFECYCLE_SWEEP_INTERVAL_MS");
   if (raw === undefined) return DEFAULT_INTERVAL_MS;
   const parsed = Number(raw);
   if (!Number.isSafeInteger(parsed) || parsed < MIN_INTERVAL_MS || parsed > MAX_INTERVAL_MS) {
@@ -23,7 +24,7 @@ function configuredInterval(): number {
 }
 
 export async function runGoogleCredentialLifecycleRecoverySweep(): Promise<GoogleCredentialLifecycleSweepResult> {
-  const password = process.env.STEWARD_MASTER_PASSWORD?.trim();
+  const password = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD")?.trim();
   if (!password) throw new Error("STEWARD_MASTER_PASSWORD is required for Google OAuth recovery");
   const results = await runInternalJobForEachTenant("google-credential-lifecycle-sweep", () =>
     runGoogleCredentialLifecycleSweep({
@@ -47,7 +48,7 @@ export function startGoogleCredentialLifecycleScheduler(options?: {
   intervalMs?: number;
   sweep?: () => Promise<GoogleCredentialLifecycleSweepResult>;
 }): () => Promise<void> {
-  if (process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEPER === "false") return async () => {};
+  if (runtimeEnvironmentValue("STEWARD_GOOGLE_LIFECYCLE_SWEEPER") === "false") return async () => {};
   const sweep = options?.sweep ?? runGoogleCredentialLifecycleRecoverySweep;
   let active: Promise<void> | undefined;
   let stopped = false;

--- a/packages/api/src/services/provider-google-lifecycle-scheduler.ts
+++ b/packages/api/src/services/provider-google-lifecycle-scheduler.ts
@@ -1,4 +1,5 @@
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   type GoogleCredentialLifecycleSweepResult,
   resolveGoogleConnectConfig,
@@ -11,7 +12,7 @@ const DEFAULT_INTERVAL_MS = 60_000;
 const MIN_INTERVAL_MS = 5_000;
 const MAX_INTERVAL_MS = 5 * 60_000;
 function configuredInterval(): number {
-  const raw = process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEP_INTERVAL_MS;
+  const raw = runtimeEnvironmentValue("STEWARD_GOOGLE_LIFECYCLE_SWEEP_INTERVAL_MS");
   if (raw === undefined) return DEFAULT_INTERVAL_MS;
   const parsed = Number(raw);
   if (!Number.isSafeInteger(parsed) || parsed < MIN_INTERVAL_MS || parsed > MAX_INTERVAL_MS) {
@@ -45,7 +46,8 @@ export function startGoogleCredentialLifecycleScheduler(options?: {
   intervalMs?: number;
   sweep?: () => Promise<GoogleCredentialLifecycleSweepResult>;
 }): () => Promise<void> {
-  if (process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEPER === "false") return async () => {};
+  if (runtimeEnvironmentValue("STEWARD_GOOGLE_LIFECYCLE_SWEEPER") === "false")
+    return async () => {};
   const sweep = options?.sweep ?? runGoogleCredentialLifecycleRecoverySweep;
   let active: Promise<void> | undefined;
   let stopped = false;

--- a/packages/api/src/services/provider-reservation-reconciliation-scheduler.ts
+++ b/packages/api/src/services/provider-reservation-reconciliation-scheduler.ts
@@ -1,11 +1,12 @@
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { providerActionService } from "./provider-action-service";
 import { runInternalJobForEachTenant } from "./tenant-job";
 
 const DEFAULT_INTERVAL_MS = 15_000;
 
 function configuredInterval(): number {
-  const parsed = Number(process.env.STEWARD_PROVIDER_RESERVATION_SWEEP_INTERVAL_MS);
+  const parsed = Number(runtimeEnvironmentValue("STEWARD_PROVIDER_RESERVATION_SWEEP_INTERVAL_MS"));
   return Number.isSafeInteger(parsed) && parsed >= 1_000 ? parsed : DEFAULT_INTERVAL_MS;
 }
 
@@ -17,7 +18,7 @@ function configuredInterval(): number {
  * into an unobservable catch.
  */
 export function startProviderReservationReconciliationScheduler(): () => void {
-  if (process.env.STEWARD_PROVIDER_RESERVATION_SWEEPER === "false") return () => {};
+  if (runtimeEnvironmentValue("STEWARD_PROVIDER_RESERVATION_SWEEPER") === "false") return () => {};
   let running = false;
   const tick = () => {
     if (running) return;

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -287,7 +287,9 @@ export interface XConnectConfig {
  * user-auth `TWITTER_CLIENT_ID` / `TWITTER_CLIENT_SECRET` (login plane). See
  * .env.example for the separation rationale.
  */
-export function resolveXConnectConfig(env: NodeJS.ProcessEnv = process.env): XConnectConfig {
+export function resolveXConnectConfig(
+  env: Readonly<Record<string, string | undefined>> = runtimeEnvironmentSnapshot(),
+): XConnectConfig {
   const clientId = env.X_CLIENT_ID?.trim();
   const clientSecret = env.X_CLIENT_SECRET?.trim();
   if (!clientId || !clientSecret) {
@@ -3127,3 +3129,4 @@ async function revokeUpstreamBestEffort(
 
 // re-export sql for callers/tests that need raw predicates
 export { sql };
+import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -3129,4 +3129,5 @@ async function revokeUpstreamBestEffort(
 
 // re-export sql for callers/tests that need raw predicates
 export { sql };
+
 import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";

--- a/packages/api/src/services/provider-x-lifecycle-scheduler.ts
+++ b/packages/api/src/services/provider-x-lifecycle-scheduler.ts
@@ -1,4 +1,5 @@
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { SecretVault } from "@stwd/vault";
 import {
   resolveXConnectConfig,
@@ -12,7 +13,7 @@ const MIN_INTERVAL_MS = 5_000;
 const MAX_INTERVAL_MS = 5 * 60_000;
 
 function configuredInterval(): number {
-  const raw = process.env.STEWARD_X_LIFECYCLE_SWEEP_INTERVAL_MS;
+  const raw = runtimeEnvironmentValue("STEWARD_X_LIFECYCLE_SWEEP_INTERVAL_MS");
   if (raw === undefined) return DEFAULT_INTERVAL_MS;
   const parsed = Number(raw);
   if (!Number.isSafeInteger(parsed) || parsed < MIN_INTERVAL_MS || parsed > MAX_INTERVAL_MS) {
@@ -24,7 +25,7 @@ function configuredInterval(): number {
 }
 
 export async function runXCredentialLifecycleRecoverySweep(): Promise<XCredentialLifecycleSweepResult> {
-  const password = process.env.STEWARD_MASTER_PASSWORD?.trim();
+  const password = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD")?.trim();
   if (!password) throw new Error("STEWARD_MASTER_PASSWORD is required for X OAuth recovery");
   const results = await runInternalJobForEachTenant("x-credential-lifecycle-sweep", () =>
     runXCredentialLifecycleSweep({

--- a/packages/api/src/services/provider-x-lifecycle-scheduler.ts
+++ b/packages/api/src/services/provider-x-lifecycle-scheduler.ts
@@ -1,4 +1,5 @@
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   resolveXConnectConfig,
   runXCredentialLifecycleSweep,
@@ -12,7 +13,7 @@ const MIN_INTERVAL_MS = 5_000;
 const MAX_INTERVAL_MS = 5 * 60_000;
 
 function configuredInterval(): number {
-  const raw = process.env.STEWARD_X_LIFECYCLE_SWEEP_INTERVAL_MS;
+  const raw = runtimeEnvironmentValue("STEWARD_X_LIFECYCLE_SWEEP_INTERVAL_MS");
   if (raw === undefined) return DEFAULT_INTERVAL_MS;
   const parsed = Number(raw);
   if (!Number.isSafeInteger(parsed) || parsed < MIN_INTERVAL_MS || parsed > MAX_INTERVAL_MS) {

--- a/packages/api/src/services/provider-x-lifecycle-scheduler.ts
+++ b/packages/api/src/services/provider-x-lifecycle-scheduler.ts
@@ -1,19 +1,18 @@
 import { redactedThrownDiagnostics } from "@stwd/shared";
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
-import { SecretVault } from "@stwd/vault";
 import {
   resolveXConnectConfig,
   runXCredentialLifecycleSweep,
   type XCredentialLifecycleSweepResult,
 } from "./provider-x-connect";
 import { runInternalJobForEachTenant } from "./tenant-job";
+import { getConfiguredSecretVault } from "./vault-factory";
 
 const DEFAULT_INTERVAL_MS = 60_000;
 const MIN_INTERVAL_MS = 5_000;
 const MAX_INTERVAL_MS = 5 * 60_000;
 
 function configuredInterval(): number {
-  const raw = runtimeEnvironmentValue("STEWARD_X_LIFECYCLE_SWEEP_INTERVAL_MS");
+  const raw = process.env.STEWARD_X_LIFECYCLE_SWEEP_INTERVAL_MS;
   if (raw === undefined) return DEFAULT_INTERVAL_MS;
   const parsed = Number(raw);
   if (!Number.isSafeInteger(parsed) || parsed < MIN_INTERVAL_MS || parsed > MAX_INTERVAL_MS) {
@@ -25,11 +24,9 @@ function configuredInterval(): number {
 }
 
 export async function runXCredentialLifecycleRecoverySweep(): Promise<XCredentialLifecycleSweepResult> {
-  const password = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD")?.trim();
-  if (!password) throw new Error("STEWARD_MASTER_PASSWORD is required for X OAuth recovery");
   const results = await runInternalJobForEachTenant("x-credential-lifecycle-sweep", () =>
     runXCredentialLifecycleSweep({
-      vault: new SecretVault(password),
+      vault: getConfiguredSecretVault(),
       config: resolveXConnectConfig(),
     }),
   );

--- a/packages/api/src/services/retention.ts
+++ b/packages/api/src/services/retention.ts
@@ -12,6 +12,8 @@
  * untrusted env values can never be interpolated into SQL text.
  */
 
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
 import { getDb } from "@stwd/db";
 import { redactedThrownDiagnostics } from "@stwd/shared";
 import { sql } from "drizzle-orm";
@@ -67,7 +69,7 @@ class RetentionAuthorizationAuditError extends Error {
 }
 
 function readPositiveInt(envName: string): number | undefined {
-  const raw = process.env[envName];
+  const raw = runtimeEnvironmentValue(envName);
   if (raw === undefined || raw === "") return undefined;
   const n = Number(raw);
   if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
@@ -211,7 +213,7 @@ async function sweepDeactivatedUsers(ctx: RetentionSweepContext): Promise<SweepR
         `${MIN_DEACTIVATED_USERS_DAYS}-day floor; refusing to hard-delete users.`,
     );
   }
-  if (process.env.STEWARD_RETENTION_DEACTIVATED_USERS_DELETE_CONFIRMED !== "true") {
+  if (runtimeEnvironmentValue("STEWARD_RETENTION_DEACTIVATED_USERS_DELETE_CONFIRMED") !== "true") {
     throw new Error(
       "[retention] Deactivated-user cleanup performs global hard deletes. Set " +
         "STEWARD_RETENTION_DEACTIVATED_USERS_DELETE_CONFIRMED=true only after account " +
@@ -366,7 +368,7 @@ async function runRetentionSweeper(
  * Returns a cancel function.
  */
 export function startRetentionScheduler(): () => void {
-  if (process.env.STEWARD_RETENTION_DISABLED === "true") {
+  if (runtimeEnvironmentValue("STEWARD_RETENTION_DISABLED") === "true") {
     console.log("[retention] STEWARD_RETENTION_DISABLED=true; scheduler not started");
     return () => {};
   }

--- a/packages/api/src/services/retention.ts
+++ b/packages/api/src/services/retention.ts
@@ -12,10 +12,9 @@
  * untrusted env values can never be interpolated into SQL text.
  */
 
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
-
 import { getDb } from "@stwd/db";
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { sql } from "drizzle-orm";
 import { writeAuditEvent } from "./audit";
 import { runTenantAuditRetention } from "./audit-archive";

--- a/packages/api/src/services/saml-sso-config.ts
+++ b/packages/api/src/services/saml-sso-config.ts
@@ -1,5 +1,5 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type { TenantSamlSsoConfig, TenantSamlSsoUpdate } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { validateWebhookUrl } from "./webhook-url";
 
 const MAX_CERTS = 5;
@@ -80,7 +80,10 @@ export function buildSamlServiceProviderUrls(tenantId: string): {
   acsUrl: string;
   metadataUrl: string;
 } {
-  const appUrl = (runtimeEnvironmentValue("APP_URL")?.trim() || "https://steward.fi").replace(/\/$/, "");
+  const appUrl = (runtimeEnvironmentValue("APP_URL")?.trim() || "https://steward.fi").replace(
+    /\/$/,
+    "",
+  );
   const encodedTenant = encodeURIComponent(tenantId);
   const metadataUrl = `${appUrl}/auth/saml/${encodedTenant}/metadata`;
   return {

--- a/packages/api/src/services/saml-sso-config.ts
+++ b/packages/api/src/services/saml-sso-config.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type { TenantSamlSsoConfig, TenantSamlSsoUpdate } from "@stwd/shared";
 import { validateWebhookUrl } from "./webhook-url";
 
@@ -79,7 +80,7 @@ export function buildSamlServiceProviderUrls(tenantId: string): {
   acsUrl: string;
   metadataUrl: string;
 } {
-  const appUrl = (process.env.APP_URL?.trim() || "https://steward.fi").replace(/\/$/, "");
+  const appUrl = (runtimeEnvironmentValue("APP_URL")?.trim() || "https://steward.fi").replace(/\/$/, "");
   const encodedTenant = encodeURIComponent(tenantId);
   const metadataUrl = `${appUrl}/auth/saml/${encodedTenant}/metadata`;
   return {

--- a/packages/api/src/services/signer-credentials.ts
+++ b/packages/api/src/services/signer-credentials.ts
@@ -1,5 +1,5 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 
 const SIGNER_CREDENTIAL_VERSION = "stwd_scrypt_v1";
 const SCRYPT_COST = 16_384;

--- a/packages/api/src/services/signer-credentials.ts
+++ b/packages/api/src/services/signer-credentials.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
 
 const SIGNER_CREDENTIAL_VERSION = "stwd_scrypt_v1";
@@ -7,7 +8,7 @@ const SCRYPT_PARALLELIZATION = 1;
 const SCRYPT_KEY_LENGTH = 32;
 
 function signerCredentialPepper(): string {
-  const pepper = process.env.STEWARD_SIGNER_CREDENTIAL_PEPPER;
+  const pepper = runtimeEnvironmentValue("STEWARD_SIGNER_CREDENTIAL_PEPPER");
   if (pepper && pepper.trim().length >= 32) return pepper;
   if (pepper) {
     throw new Error(
@@ -20,13 +21,13 @@ function signerCredentialPepper(): string {
   // defense-in-depth against a DB-only attacker (scrypt+salt still applies),
   // but losing it must be loud, not silent. Production fails closed; outside
   // production the pepperless path requires the explicit dev opt-in.
-  if (process.env.NODE_ENV === "production") {
+  if (runtimeEnvironmentValue("NODE_ENV") === "production") {
     throw new Error(
       "STEWARD_SIGNER_CREDENTIAL_PEPPER is required in production. " +
         "Generate with `openssl rand -hex 32`.",
     );
   }
-  if (process.env.STEWARD_ALLOW_DEV_SECRETS !== "true") {
+  if (runtimeEnvironmentValue("STEWARD_ALLOW_DEV_SECRETS") !== "true") {
     throw new Error(
       "STEWARD_SIGNER_CREDENTIAL_PEPPER is required. For local development only, set " +
         "STEWARD_ALLOW_DEV_SECRETS=true to run without a pepper.",

--- a/packages/api/src/services/tenant-job.ts
+++ b/packages/api/src/services/tenant-job.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   getDatabaseDriver,
   getDb,
@@ -46,7 +47,7 @@ export async function runInternalJobForTenant<T>(
   const context = tenantContextForInternalJob({ tenantId, job });
   return withTenantRlsTransaction(
     getDb() as never,
-    process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true"
+    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
       ? "pglite"
       : getDatabaseDriver(),
     context,

--- a/packages/api/src/services/tenant-job.ts
+++ b/packages/api/src/services/tenant-job.ts
@@ -1,4 +1,3 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   getDatabaseDriver,
   getDb,
@@ -6,6 +5,7 @@ import {
   withTenantRlsTransaction,
   withTenantTransactionDatabase,
 } from "@stwd/db";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { sql } from "drizzle-orm";
 
 function rowsOf<T>(result: unknown): T[] {
@@ -47,7 +47,8 @@ export async function runInternalJobForTenant<T>(
   const context = tenantContextForInternalJob({ tenantId, job });
   return withTenantRlsTransaction(
     getDb() as never,
-    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
+    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" ||
+      runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
       ? "pglite"
       : getDatabaseDriver(),
     context,

--- a/packages/api/src/services/transaction-receipt-poller.ts
+++ b/packages/api/src/services/transaction-receipt-poller.ts
@@ -1,4 +1,5 @@
 import { redactedThrownDiagnostics, toCaip2 } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { createPublicClient, http, type TransactionReceipt } from "viem";
 import { withTenantAuditedTransaction, writeAuditEvent } from "./audit";
@@ -586,22 +587,24 @@ export async function pollBroadcastTransactionReceiptsForAllTenants(
 }
 
 export function startTransactionReceiptPollingScheduler(): () => void {
-  if (process.env.STEWARD_TRANSACTION_RECEIPT_POLLER === "false") {
+  if (runtimeEnvironmentValue("STEWARD_TRANSACTION_RECEIPT_POLLER") === "false") {
     console.log("[tx-poller] Disabled by STEWARD_TRANSACTION_RECEIPT_POLLER=false");
     return () => {};
   }
 
   const intervalMs = parsePositiveInt(
-    process.env.STEWARD_TRANSACTION_RECEIPT_POLL_INTERVAL_MS,
+    runtimeEnvironmentValue("STEWARD_TRANSACTION_RECEIPT_POLL_INTERVAL_MS"),
     DEFAULT_RECEIPT_POLL_INTERVAL_MS,
   );
   const batchSize = parsePositiveInt(
-    process.env.STEWARD_TRANSACTION_RECEIPT_POLL_BATCH_SIZE,
+    runtimeEnvironmentValue("STEWARD_TRANSACTION_RECEIPT_POLL_BATCH_SIZE"),
     DEFAULT_RECEIPT_POLL_BATCH_SIZE,
   );
   // SEC-152: when unset (or invalid), leave undefined so each chain's default
   // applies (e.g. 12 for Ethereum L1 mainnet) instead of forcing 1 everywhere.
-  const confirmationsEnv = process.env.STEWARD_TRANSACTION_RECEIPT_CONFIRMATIONS?.trim();
+  const confirmationsEnv = runtimeEnvironmentValue(
+    "STEWARD_TRANSACTION_RECEIPT_CONFIRMATIONS",
+  )?.trim();
   const parsedConfirmations = confirmationsEnv ? Number(confirmationsEnv) : undefined;
   const minConfirmations =
     parsedConfirmations !== undefined &&
@@ -610,11 +613,11 @@ export function startTransactionReceiptPollingScheduler(): () => void {
       ? parsedConfirmations
       : undefined;
   const stillPendingAfterMs = parsePositiveInt(
-    process.env.STEWARD_TRANSACTION_STILL_PENDING_AFTER_MS,
+    runtimeEnvironmentValue("STEWARD_TRANSACTION_STILL_PENDING_AFTER_MS"),
     DEFAULT_STILL_PENDING_AFTER_MS,
   );
   const stillPendingIntervalMs = parsePositiveInt(
-    process.env.STEWARD_TRANSACTION_STILL_PENDING_INTERVAL_MS,
+    runtimeEnvironmentValue("STEWARD_TRANSACTION_STILL_PENDING_INTERVAL_MS"),
     DEFAULT_STILL_PENDING_INTERVAL_MS,
   );
   let running = false;

--- a/packages/api/src/services/transaction-receipt-poller.ts
+++ b/packages/api/src/services/transaction-receipt-poller.ts
@@ -1,4 +1,5 @@
 import { redactedThrownDiagnostics, toCaip2 } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { createPublicClient, http, type TransactionReceipt } from "viem";
 import { withTenantAuditedTransaction, writeAuditEvent } from "./audit";
@@ -74,11 +75,11 @@ function rpcEnvKey(chainId: number): string {
 }
 
 export function resolveEvmReceiptRpcUrl(chainId: number): string | null {
-  const chainSpecific = process.env[rpcEnvKey(chainId)]?.trim();
+  const chainSpecific = runtimeEnvironmentValue(rpcEnvKey(chainId))?.trim();
   if (chainSpecific) return chainSpecific;
 
-  const activeChainId = parsePositiveInt(process.env.CHAIN_ID, 84532);
-  const defaultRpc = process.env.RPC_URL?.trim();
+  const activeChainId = parsePositiveInt(runtimeEnvironmentValue("CHAIN_ID"), 84532);
+  const defaultRpc = runtimeEnvironmentValue("RPC_URL")?.trim();
   if (defaultRpc && activeChainId === chainId) return defaultRpc;
 
   return EVM_CHAIN_RPCS[chainId] ?? null;
@@ -585,22 +586,22 @@ export async function pollBroadcastTransactionReceiptsForAllTenants(
 }
 
 export function startTransactionReceiptPollingScheduler(): () => void {
-  if (process.env.STEWARD_TRANSACTION_RECEIPT_POLLER === "false") {
+  if (runtimeEnvironmentValue("STEWARD_TRANSACTION_RECEIPT_POLLER") === "false") {
     console.log("[tx-poller] Disabled by STEWARD_TRANSACTION_RECEIPT_POLLER=false");
     return () => {};
   }
 
   const intervalMs = parsePositiveInt(
-    process.env.STEWARD_TRANSACTION_RECEIPT_POLL_INTERVAL_MS,
+    runtimeEnvironmentValue("STEWARD_TRANSACTION_RECEIPT_POLL_INTERVAL_MS"),
     DEFAULT_RECEIPT_POLL_INTERVAL_MS,
   );
   const batchSize = parsePositiveInt(
-    process.env.STEWARD_TRANSACTION_RECEIPT_POLL_BATCH_SIZE,
+    runtimeEnvironmentValue("STEWARD_TRANSACTION_RECEIPT_POLL_BATCH_SIZE"),
     DEFAULT_RECEIPT_POLL_BATCH_SIZE,
   );
   // SEC-152: when unset (or invalid), leave undefined so each chain's default
   // applies (e.g. 12 for Ethereum L1 mainnet) instead of forcing 1 everywhere.
-  const confirmationsEnv = process.env.STEWARD_TRANSACTION_RECEIPT_CONFIRMATIONS?.trim();
+  const confirmationsEnv = runtimeEnvironmentValue("STEWARD_TRANSACTION_RECEIPT_CONFIRMATIONS")?.trim();
   const parsedConfirmations = confirmationsEnv ? Number(confirmationsEnv) : undefined;
   const minConfirmations =
     parsedConfirmations !== undefined &&
@@ -609,11 +610,11 @@ export function startTransactionReceiptPollingScheduler(): () => void {
       ? parsedConfirmations
       : undefined;
   const stillPendingAfterMs = parsePositiveInt(
-    process.env.STEWARD_TRANSACTION_STILL_PENDING_AFTER_MS,
+    runtimeEnvironmentValue("STEWARD_TRANSACTION_STILL_PENDING_AFTER_MS"),
     DEFAULT_STILL_PENDING_AFTER_MS,
   );
   const stillPendingIntervalMs = parsePositiveInt(
-    process.env.STEWARD_TRANSACTION_STILL_PENDING_INTERVAL_MS,
+    runtimeEnvironmentValue("STEWARD_TRANSACTION_STILL_PENDING_INTERVAL_MS"),
     DEFAULT_STILL_PENDING_INTERVAL_MS,
   );
   let running = false;

--- a/packages/api/src/services/transaction-receipt-poller.ts
+++ b/packages/api/src/services/transaction-receipt-poller.ts
@@ -1,9 +1,9 @@
 import { redactedThrownDiagnostics, toCaip2 } from "@stwd/shared";
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { createPublicClient, http, type TransactionReceipt } from "viem";
 import { withTenantAuditedTransaction, writeAuditEvent } from "./audit";
 import { agents, db, transactions } from "./context";
+import { resolveRuntimeChainId, runtimeCustodyValue } from "./custody-runtime";
 import { runInternalJobForEachTenant } from "./tenant-job";
 import { dispatchWebhook } from "./webhook-dispatch";
 
@@ -75,11 +75,11 @@ function rpcEnvKey(chainId: number): string {
 }
 
 export function resolveEvmReceiptRpcUrl(chainId: number): string | null {
-  const chainSpecific = runtimeEnvironmentValue(rpcEnvKey(chainId))?.trim();
+  const chainSpecific = runtimeCustodyValue(rpcEnvKey(chainId))?.trim();
   if (chainSpecific) return chainSpecific;
 
-  const activeChainId = parsePositiveInt(runtimeEnvironmentValue("CHAIN_ID"), 84532);
-  const defaultRpc = runtimeEnvironmentValue("RPC_URL")?.trim();
+  const activeChainId = parsePositiveInt(String(resolveRuntimeChainId(84532)), 84532);
+  const defaultRpc = runtimeCustodyValue("RPC_URL")?.trim();
   if (defaultRpc && activeChainId === chainId) return defaultRpc;
 
   return EVM_CHAIN_RPCS[chainId] ?? null;
@@ -586,22 +586,22 @@ export async function pollBroadcastTransactionReceiptsForAllTenants(
 }
 
 export function startTransactionReceiptPollingScheduler(): () => void {
-  if (runtimeEnvironmentValue("STEWARD_TRANSACTION_RECEIPT_POLLER") === "false") {
+  if (process.env.STEWARD_TRANSACTION_RECEIPT_POLLER === "false") {
     console.log("[tx-poller] Disabled by STEWARD_TRANSACTION_RECEIPT_POLLER=false");
     return () => {};
   }
 
   const intervalMs = parsePositiveInt(
-    runtimeEnvironmentValue("STEWARD_TRANSACTION_RECEIPT_POLL_INTERVAL_MS"),
+    process.env.STEWARD_TRANSACTION_RECEIPT_POLL_INTERVAL_MS,
     DEFAULT_RECEIPT_POLL_INTERVAL_MS,
   );
   const batchSize = parsePositiveInt(
-    runtimeEnvironmentValue("STEWARD_TRANSACTION_RECEIPT_POLL_BATCH_SIZE"),
+    process.env.STEWARD_TRANSACTION_RECEIPT_POLL_BATCH_SIZE,
     DEFAULT_RECEIPT_POLL_BATCH_SIZE,
   );
   // SEC-152: when unset (or invalid), leave undefined so each chain's default
   // applies (e.g. 12 for Ethereum L1 mainnet) instead of forcing 1 everywhere.
-  const confirmationsEnv = runtimeEnvironmentValue("STEWARD_TRANSACTION_RECEIPT_CONFIRMATIONS")?.trim();
+  const confirmationsEnv = process.env.STEWARD_TRANSACTION_RECEIPT_CONFIRMATIONS?.trim();
   const parsedConfirmations = confirmationsEnv ? Number(confirmationsEnv) : undefined;
   const minConfirmations =
     parsedConfirmations !== undefined &&
@@ -610,11 +610,11 @@ export function startTransactionReceiptPollingScheduler(): () => void {
       ? parsedConfirmations
       : undefined;
   const stillPendingAfterMs = parsePositiveInt(
-    runtimeEnvironmentValue("STEWARD_TRANSACTION_STILL_PENDING_AFTER_MS"),
+    process.env.STEWARD_TRANSACTION_STILL_PENDING_AFTER_MS,
     DEFAULT_STILL_PENDING_AFTER_MS,
   );
   const stillPendingIntervalMs = parsePositiveInt(
-    runtimeEnvironmentValue("STEWARD_TRANSACTION_STILL_PENDING_INTERVAL_MS"),
+    process.env.STEWARD_TRANSACTION_STILL_PENDING_INTERVAL_MS,
     DEFAULT_STILL_PENDING_INTERVAL_MS,
   );
   let running = false;

--- a/packages/api/src/services/upstream-credential-lease-scheduler.ts
+++ b/packages/api/src/services/upstream-credential-lease-scheduler.ts
@@ -1,4 +1,5 @@
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { runInternalJobForEachTenant } from "./tenant-job";
 
 const DEFAULT_INTERVAL_MS = 15_000;
@@ -74,10 +75,10 @@ export async function runUpstreamCredentialLeaseSweep() {
 }
 
 function configuredInterval(): number {
-  if (process.env.STEWARD_UPSTREAM_LEASE_SWEEP_INTERVAL_MS === undefined) {
+  if (runtimeEnvironmentValue("STEWARD_UPSTREAM_LEASE_SWEEP_INTERVAL_MS") === undefined) {
     return DEFAULT_INTERVAL_MS;
   }
-  const parsed = Number(process.env.STEWARD_UPSTREAM_LEASE_SWEEP_INTERVAL_MS);
+  const parsed = Number(runtimeEnvironmentValue("STEWARD_UPSTREAM_LEASE_SWEEP_INTERVAL_MS"));
   if (!Number.isSafeInteger(parsed) || parsed < 1_000 || parsed > MAX_INTERVAL_MS) {
     throw new Error(
       `STEWARD_UPSTREAM_LEASE_SWEEP_INTERVAL_MS must be between 1000 and ${MAX_INTERVAL_MS}`,
@@ -102,7 +103,7 @@ export async function startUpstreamCredentialLeaseScheduler(options?: {
     remaining?: boolean;
   }>;
 }): Promise<() => Promise<void>> {
-  if (process.env.STEWARD_UPSTREAM_LEASE_SWEEPER === "false") {
+  if (runtimeEnvironmentValue("STEWARD_UPSTREAM_LEASE_SWEEPER") === "false") {
     Object.assign(schedulerHealth, {
       enabled: false,
       inFlight: false,

--- a/packages/api/src/services/vault-factory.ts
+++ b/packages/api/src/services/vault-factory.ts
@@ -1,6 +1,5 @@
-import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+import { runtimeEnvironmentIdentity, runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   AwsKmsExternalKeyCustodyProvider,
   createMoneroBackendFromEnv,
@@ -80,7 +79,6 @@ export interface ConfiguredVaultOptions {
 }
 
 export interface CustodyAuthority {
-  readonly fingerprint: string;
   readonly workerRuntime: boolean;
   readonly nodeEnvironment?: string;
   readonly masterPassword: string;
@@ -114,19 +112,24 @@ export interface CustodyAuthority {
   readonly allowLegacySecretRootFallback: boolean;
 }
 
-const vaultsByKey = new Map<string, Vault>();
-const secretVaultsByKey = new Map<string, SecretVault>();
-const keyStoresByKey = new Map<string, KeyStore>();
-const MAX_CACHED_CUSTODY_INSTANCES = 24;
+interface RequestCustodyInstances {
+  vault?: Vault;
+  secretVault?: SecretVault;
+  readonly keyStores: Map<KeyStoreDomain | undefined, KeyStore>;
+}
+
+let custodyInstancesByRequest = new WeakMap<object, RequestCustodyInstances>();
 let warnedDevSecretFallback = false;
 
-function cacheCustodyInstance<T>(cache: Map<string, T>, key: string, value: T): T {
-  if (cache.size >= MAX_CACHED_CUSTODY_INSTANCES) {
-    const oldest = cache.keys().next().value as string | undefined;
-    if (oldest) cache.delete(oldest);
+function requestCustodyInstances(): RequestCustodyInstances | undefined {
+  const identity = runtimeEnvironmentIdentity();
+  if (!identity) return undefined;
+  let instances = custodyInstancesByRequest.get(identity);
+  if (!instances) {
+    instances = { keyStores: new Map() };
+    custodyInstancesByRequest.set(identity, instances);
   }
-  cache.set(key, value);
-  return value;
+  return instances;
 }
 
 function runtimeValue(name: string): string | undefined {
@@ -324,10 +327,6 @@ function resolveMasterPassword(options: ConfiguredVaultOptions): string {
   throw new Error("STEWARD_MASTER_PASSWORD is required");
 }
 
-function authorityFingerprint(authority: Omit<CustodyAuthority, "fingerprint">): string {
-  return createHash("sha256").update(JSON.stringify(authority)).digest("hex");
-}
-
 /** Resolve and freeze the complete custody root from this request's authority. */
 export function resolveCustodyAuthority(options: ConfiguredVaultOptions = {}): CustodyAuthority {
   const mode = configuredMode();
@@ -377,7 +376,7 @@ export function resolveCustodyAuthority(options: ConfiguredVaultOptions = {}): C
     allowLegacySecretRootFallback:
       legacySecretRoot === "true" ||
       (legacySecretRoot !== "false" && nodeEnvironment !== "production"),
-  } satisfies Omit<CustodyAuthority, "fingerprint">;
+  } satisfies CustodyAuthority;
   const usesAws = mode === "kms-envelope:aws" || resolved.externalCustodyProvider === "aws-kms";
   const hasAwsCredentialPart = Boolean(
     resolved.awsAccessKeyId || resolved.awsSecretAccessKey || resolved.awsSessionToken,
@@ -388,7 +387,7 @@ export function resolveCustodyAuthority(options: ConfiguredVaultOptions = {}): C
       "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be configured together for AWS custody",
     );
   }
-  return Object.freeze({ ...resolved, fingerprint: authorityFingerprint(resolved) });
+  return Object.freeze(resolved);
 }
 
 function createVaultForAuthority(authority: CustodyAuthority): Vault {
@@ -436,45 +435,53 @@ export function createConfiguredVault(options: ConfiguredVaultOptions = {}): Vau
 }
 
 export function getConfiguredVault(options: ConfiguredVaultOptions = {}): Vault {
-  const authority = resolveCustodyAuthority(options);
-  let vault = vaultsByKey.get(authority.fingerprint);
-  if (!vault) {
-    vault = cacheCustodyInstance(
-      vaultsByKey,
-      authority.fingerprint,
-      createVaultForAuthority(authority),
-    );
-  }
-  return vault;
+  const instances = requestCustodyInstances();
+  if (!instances) return createConfiguredVault(options);
+  instances.vault ??= createVaultForAuthority(resolveCustodyAuthority(options));
+  return instances.vault;
 }
 
 export function getConfiguredSecretVault(options: ConfiguredVaultOptions = {}): SecretVault {
-  const authority = resolveCustodyAuthority(options);
-  let vault = secretVaultsByKey.get(authority.fingerprint);
-  if (!vault) {
-    vault = new SecretVault(authority.masterPassword, authority.kdfSalt, {
+  const instances = requestCustodyInstances();
+  if (!instances) {
+    const authority = resolveCustodyAuthority(options);
+    return new SecretVault(authority.masterPassword, authority.kdfSalt, {
       nodeEnvironment: authority.nodeEnvironment,
       allowLegacyDecryptFallback: authority.allowLegacyKeystoreDecryptFallback,
       allowLegacySecretRootFallback: authority.allowLegacySecretRootFallback,
     });
-    cacheCustodyInstance(secretVaultsByKey, authority.fingerprint, vault);
   }
-  return vault;
+  if (!instances.secretVault) {
+    const authority = resolveCustodyAuthority(options);
+    instances.secretVault = new SecretVault(authority.masterPassword, authority.kdfSalt, {
+      nodeEnvironment: authority.nodeEnvironment,
+      allowLegacyDecryptFallback: authority.allowLegacyKeystoreDecryptFallback,
+      allowLegacySecretRootFallback: authority.allowLegacySecretRootFallback,
+    });
+  }
+  return instances.secretVault;
 }
 
 export function getConfiguredKeyStore(
   domain?: KeyStoreDomain,
   options: ConfiguredVaultOptions = {},
 ): KeyStore {
-  const authority = resolveCustodyAuthority(options);
-  const key = `${authority.fingerprint}:${domain ?? "legacy"}`;
-  let keyStore = keyStoresByKey.get(key);
+  const instances = requestCustodyInstances();
+  if (!instances) {
+    const authority = resolveCustodyAuthority(options);
+    return new KeyStore(authority.masterPassword, authority.kdfSalt, domain, {
+      nodeEnvironment: authority.nodeEnvironment,
+      allowLegacyDecryptFallback: authority.allowLegacyKeystoreDecryptFallback,
+    });
+  }
+  let keyStore = instances.keyStores.get(domain);
   if (!keyStore) {
+    const authority = resolveCustodyAuthority(options);
     keyStore = new KeyStore(authority.masterPassword, authority.kdfSalt, domain, {
       nodeEnvironment: authority.nodeEnvironment,
       allowLegacyDecryptFallback: authority.allowLegacyKeystoreDecryptFallback,
     });
-    cacheCustodyInstance(keyStoresByKey, key, keyStore);
+    instances.keyStores.set(domain, keyStore);
   }
   return keyStore;
 }
@@ -500,8 +507,19 @@ export function configuredVaultStartupLogLine(): string {
 }
 
 export function _clearConfiguredVaultsForTests(): void {
-  vaultsByKey.clear();
-  secretVaultsByKey.clear();
-  keyStoresByKey.clear();
+  custodyInstancesByRequest = new WeakMap();
   warnedDevSecretFallback = false;
+}
+
+/** Internal behavior hook: only the active request's instances are observable. */
+export function _configuredCustodyInstanceCountForTests(): number {
+  const identity = runtimeEnvironmentIdentity();
+  if (!identity) return 0;
+  const instances = custodyInstancesByRequest.get(identity);
+  if (!instances) return 0;
+  return (
+    Number(Boolean(instances.vault)) +
+    Number(Boolean(instances.secretVault)) +
+    instances.keyStores.size
+  );
 }

--- a/packages/api/src/services/vault-factory.ts
+++ b/packages/api/src/services/vault-factory.ts
@@ -1,7 +1,15 @@
+import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
-import { isDevSecretAllowed } from "@stwd/auth";
 import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
-import { AwsKmsExternalKeyCustodyProvider, KmsEnvelopeKeystore, Vault } from "@stwd/vault";
+import {
+  AwsKmsExternalKeyCustodyProvider,
+  createMoneroBackendFromEnv,
+  KeyStore,
+  type KeyStoreDomain,
+  KmsEnvelopeKeystore,
+  SecretVault,
+  Vault,
+} from "@stwd/vault";
 
 const require = createRequire(import.meta.url);
 
@@ -70,25 +78,90 @@ export interface ConfiguredVaultOptions {
   fallbackPassword?: string;
 }
 
+export interface CustodyAuthority {
+  readonly fingerprint: string;
+  readonly nodeEnvironment?: string;
+  readonly masterPassword: string;
+  readonly kdfSalt?: string;
+  readonly mode: VaultMode;
+  readonly kmsKeyId?: string;
+  readonly awsRegion?: string;
+  readonly pkcs11Module?: string;
+  readonly pkcs11Pin?: string;
+  readonly pkcs11KeyLabel?: string;
+  readonly externalCustodyProvider?: ExternalCustodyProviderName;
+  readonly externalCustodyAwsRegion?: string;
+  readonly externalCustodyAwsMaxGasLimit?: string;
+  readonly externalCustodyAwsMaxGasPriceWei?: string;
+  readonly externalCustodyAwsMaxTotalFeeWei?: string;
+  readonly localCustodyAcknowledged: boolean;
+  readonly rpcUrl: string;
+  readonly chainId: number;
+  readonly solanaPriorityFees: boolean;
+  readonly vaultRpcAllowlist?: string;
+  readonly moneroWalletRpcUrl?: string;
+  readonly moneroWalletRpcLogin?: string;
+  readonly moneroDaemonUrl?: string;
+  readonly moneroNetwork?: string;
+  readonly webhookSecretEncryptionKey?: string;
+  readonly webhookSecretKdfSalt?: string;
+  readonly allowLegacyKeystoreDecryptFallback: boolean;
+  readonly allowLegacySecretRootFallback: boolean;
+}
+
 const vaultsByKey = new Map<string, Vault>();
+const secretVaultsByKey = new Map<string, SecretVault>();
+const keyStoresByKey = new Map<string, KeyStore>();
+const MAX_CACHED_CUSTODY_INSTANCES = 24;
 let warnedDevSecretFallback = false;
 
+function cacheCustodyInstance<T>(cache: Map<string, T>, key: string, value: T): T {
+  if (cache.size >= MAX_CACHED_CUSTODY_INSTANCES) {
+    const oldest = cache.keys().next().value as string | undefined;
+    if (oldest) cache.delete(oldest);
+  }
+  cache.set(key, value);
+  return value;
+}
+
+function runtimeValue(name: string): string | undefined {
+  return runtimeEnvironmentValue(name)?.trim() || undefined;
+}
+
+function runtimeRaw(name: string): string | undefined {
+  return runtimeEnvironmentValue(name) || undefined;
+}
+
+function runtimeNodeEnvironment(): string | undefined {
+  return (
+    runtimeRaw("NODE_ENV") ??
+    (runtimeRaw("STEWARD_RUNTIME") === "workers" ? "production" : undefined)
+  );
+}
+
 function configuredKmsProvider(): "aws" | "pkcs11" | undefined {
-  const value = runtimeEnvironmentValue("STEWARD_KMS_PROVIDER")?.trim();
+  const value = runtimeValue("STEWARD_KMS_PROVIDER");
   if (!value) return undefined;
   if (value === "aws" || value === "pkcs11") return value;
   throw new Error(`Unsupported STEWARD_KMS_PROVIDER: ${value}`);
 }
 
 function configuredExternalCustodyProvider(): ExternalCustodyProviderName | undefined {
-  const value = runtimeEnvironmentValue("STEWARD_EXTERNAL_CUSTODY_PROVIDER")?.trim();
+  const value = runtimeValue("STEWARD_EXTERNAL_CUSTODY_PROVIDER");
   if (!value) return undefined;
   if (value === "aws-kms") return value;
   throw new Error(`Unsupported STEWARD_EXTERNAL_CUSTODY_PROVIDER: ${value}`);
 }
 
-function createExternalCustodyProvider() {
-  const provider = configuredExternalCustodyProvider();
+function positiveBigInt(value: string | undefined, name: string): bigint {
+  if (!value || !/^\d+$/.test(value) || BigInt(value) <= 0n) {
+    throw new Error(`${name} is required and must be a positive integer`);
+  }
+  return BigInt(value);
+}
+
+function createExternalCustodyProvider(authority: CustodyAuthority) {
+  const provider = authority.externalCustodyProvider;
   if (!provider) return undefined;
   // External signing uses the same optional AWS SDK package as envelope mode,
   // but it is deliberately selected by a separate configuration key and never
@@ -100,24 +173,35 @@ function createExternalCustodyProvider() {
       "@aws-sdk/client-kms is required when STEWARD_EXTERNAL_CUSTODY_PROVIDER=aws-kms",
     );
   }
-  return AwsKmsExternalKeyCustodyProvider.fromEnv();
+  return new AwsKmsExternalKeyCustodyProvider({
+    region: authority.externalCustodyAwsRegion,
+    maxGasLimit: positiveBigInt(
+      authority.externalCustodyAwsMaxGasLimit,
+      "STEWARD_EXTERNAL_CUSTODY_AWS_MAX_GAS_LIMIT",
+    ),
+    maxGasPriceWei: positiveBigInt(
+      authority.externalCustodyAwsMaxGasPriceWei,
+      "STEWARD_EXTERNAL_CUSTODY_AWS_MAX_GAS_PRICE_WEI",
+    ),
+    maxTotalFeeWei: positiveBigInt(
+      authority.externalCustodyAwsMaxTotalFeeWei,
+      "STEWARD_EXTERNAL_CUSTODY_AWS_MAX_TOTAL_FEE_WEI",
+    ),
+  });
 }
 
 function requireKmsConfiguration(provider: "aws" | "pkcs11"): void {
   if (provider === "aws") {
-    if (
-      !runtimeEnvironmentValue("STEWARD_KMS_KEY_ID")?.trim() &&
-      !runtimeEnvironmentValue("STEWARD_AWS_KMS_KEY_ARN")?.trim()
-    ) {
+    if (!runtimeValue("STEWARD_KMS_KEY_ID") && !runtimeValue("STEWARD_AWS_KMS_KEY_ARN")) {
       throw new Error("STEWARD_KMS_KEY_ID or STEWARD_AWS_KMS_KEY_ARN is required for AWS KMS");
     }
     return;
   }
 
   const missing = [
-    ["STEWARD_PKCS11_MODULE", runtimeEnvironmentValue("STEWARD_PKCS11_MODULE")],
-    ["STEWARD_PKCS11_PIN", runtimeEnvironmentValue("STEWARD_PKCS11_PIN")],
-    ["STEWARD_PKCS11_KEY_LABEL", runtimeEnvironmentValue("STEWARD_PKCS11_KEY_LABEL")],
+    ["STEWARD_PKCS11_MODULE", runtimeValue("STEWARD_PKCS11_MODULE")],
+    ["STEWARD_PKCS11_PIN", runtimeValue("STEWARD_PKCS11_PIN")],
+    ["STEWARD_PKCS11_KEY_LABEL", runtimeValue("STEWARD_PKCS11_KEY_LABEL")],
   ]
     .filter(([, value]) => !value?.trim())
     .map(([name]) => name);
@@ -157,7 +241,7 @@ export function modeExposesPlaintextAtSignTime(mode: VaultMode): boolean {
 }
 
 function localCustodyAcknowledged(): boolean {
-  return runtimeEnvironmentValue(LOCAL_CUSTODY_ACK_ENV) === "true";
+  return runtimeRaw(LOCAL_CUSTODY_ACK_ENV) === "true";
 }
 
 /**
@@ -170,7 +254,7 @@ function localCustodyAcknowledged(): boolean {
  * ack because selecting them is already an explicit configuration decision.
  */
 export function assertProductionCustodyAcknowledged(mode: VaultMode): void {
-  if (runtimeEnvironmentValue("NODE_ENV") !== "production") return;
+  if (runtimeNodeEnvironment() !== "production") return;
   if (mode !== "local") return;
   if (localCustodyAcknowledged()) return;
   throw new LocalCustodyAcknowledgementRequiredError();
@@ -193,12 +277,22 @@ function configuredMode(): VaultMode {
 }
 
 function resolveMasterPassword(options: ConfiguredVaultOptions): string {
-  const configured = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD")?.trim();
+  const configured = runtimeValue("STEWARD_MASTER_PASSWORD");
   if (configured) return configured;
-  if (options.fallbackPassword?.trim()) return options.fallbackPassword.trim();
+  const requestLocalAuthority = runtimeRaw("STEWARD_RUNTIME") === "workers";
 
-  if (options.allowDevSecretFallback) {
-    if (!isDevSecretAllowed()) {
+  // An active runtime snapshot is authoritative. Never fall back to a password
+  // captured by an older isolate/request when the current binding is absent.
+  if (!requestLocalAuthority && options.fallbackPassword?.trim()) {
+    return options.fallbackPassword.trim();
+  }
+
+  if (options.allowDevSecretFallback && !requestLocalAuthority) {
+    const devSecretAllowed =
+      runtimeNodeEnvironment() !== "production" &&
+      (runtimeRaw("STEWARD_ALLOW_DEV_SECRETS") === "true" ||
+        runtimeRaw("STEWARD_ALLOW_DEV_SECRET") === "true");
+    if (!devSecretAllowed) {
       throw new Error(
         "STEWARD_MASTER_PASSWORD must be set. For local development only, opt in to the insecure dev fallback with STEWARD_ALLOW_DEV_SECRETS=true.",
       );
@@ -215,47 +309,160 @@ function resolveMasterPassword(options: ConfiguredVaultOptions): string {
   throw new Error("STEWARD_MASTER_PASSWORD is required");
 }
 
-export function createConfiguredVault(options: ConfiguredVaultOptions = {}): Vault {
+function authorityFingerprint(authority: Omit<CustodyAuthority, "fingerprint">): string {
+  return createHash("sha256").update(JSON.stringify(authority)).digest("hex");
+}
+
+/** Resolve and freeze the complete custody root from this request's authority. */
+export function resolveCustodyAuthority(options: ConfiguredVaultOptions = {}): CustodyAuthority {
   const mode = configuredMode();
-  // Root-of-trust gate: never silently boot local plaintext custody in prod.
   assertProductionCustodyAcknowledged(mode);
   const masterPassword = resolveMasterPassword(options);
-  return new Vault({
+  const nodeEnvironment = runtimeNodeEnvironment();
+  const legacySecretRoot = runtimeRaw("STEWARD_SECRET_VAULT_LEGACY_ROOT_FALLBACK");
+  const chainId = Number.parseInt(runtimeRaw("CHAIN_ID") ?? "84532", 10);
+  if (!Number.isSafeInteger(chainId) || chainId <= 0) {
+    throw new Error("CHAIN_ID must be a positive safe integer");
+  }
+  const resolved = {
+    nodeEnvironment,
     masterPassword,
-    rpcUrl: runtimeEnvironmentValue("RPC_URL") || "https://sepolia.base.org",
-    chainId: parseInt(runtimeEnvironmentValue("CHAIN_ID") || "84532", 10),
-    ...(mode === "local" ? {} : { keystoreBackend: KmsEnvelopeKeystore.fromEnv() }),
-    ...(configuredExternalCustodyProvider()
-      ? { externalKeyCustodyProvider: createExternalCustodyProvider() }
+    kdfSalt: runtimeRaw("STEWARD_KDF_SALT"),
+    mode,
+    kmsKeyId: runtimeRaw("STEWARD_KMS_KEY_ID") ?? runtimeRaw("STEWARD_AWS_KMS_KEY_ARN"),
+    awsRegion: runtimeRaw("STEWARD_AWS_REGION") ?? runtimeRaw("AWS_REGION"),
+    pkcs11Module: runtimeRaw("STEWARD_PKCS11_MODULE"),
+    pkcs11Pin: runtimeRaw("STEWARD_PKCS11_PIN"),
+    pkcs11KeyLabel: runtimeRaw("STEWARD_PKCS11_KEY_LABEL"),
+    externalCustodyProvider: configuredExternalCustodyProvider(),
+    externalCustodyAwsRegion: runtimeRaw("STEWARD_EXTERNAL_CUSTODY_AWS_REGION"),
+    externalCustodyAwsMaxGasLimit: runtimeValue("STEWARD_EXTERNAL_CUSTODY_AWS_MAX_GAS_LIMIT"),
+    externalCustodyAwsMaxGasPriceWei: runtimeValue(
+      "STEWARD_EXTERNAL_CUSTODY_AWS_MAX_GAS_PRICE_WEI",
+    ),
+    externalCustodyAwsMaxTotalFeeWei: runtimeValue(
+      "STEWARD_EXTERNAL_CUSTODY_AWS_MAX_TOTAL_FEE_WEI",
+    ),
+    localCustodyAcknowledged: localCustodyAcknowledged(),
+    rpcUrl: runtimeRaw("RPC_URL") ?? "https://sepolia.base.org",
+    chainId,
+    solanaPriorityFees: runtimeRaw("STEWARD_SOLANA_PRIORITY_FEES") !== "0",
+    vaultRpcAllowlist: runtimeRaw("STEWARD_VAULT_RPC_ALLOWLIST"),
+    moneroWalletRpcUrl: runtimeRaw("STEWARD_MONERO_WALLET_RPC_URL"),
+    moneroWalletRpcLogin: runtimeRaw("STEWARD_MONERO_WALLET_RPC_LOGIN"),
+    moneroDaemonUrl: runtimeRaw("STEWARD_MONERO_DAEMON_URL"),
+    moneroNetwork: runtimeRaw("STEWARD_MONERO_NETWORK"),
+    webhookSecretEncryptionKey: runtimeEnvironmentValue("STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY"),
+    webhookSecretKdfSalt: runtimeEnvironmentValue("STEWARD_WEBHOOK_SECRET_KDF_SALT"),
+    allowLegacyKeystoreDecryptFallback:
+      nodeEnvironment !== "production" &&
+      runtimeRaw("STEWARD_ALLOW_LEGACY_KEYSTORE_DECRYPT_FALLBACK") === "true",
+    allowLegacySecretRootFallback:
+      legacySecretRoot === "true" ||
+      (legacySecretRoot !== "false" && nodeEnvironment !== "production"),
+  } satisfies Omit<CustodyAuthority, "fingerprint">;
+  return Object.freeze({ ...resolved, fingerprint: authorityFingerprint(resolved) });
+}
+
+function createVaultForAuthority(authority: CustodyAuthority): Vault {
+  const kmsEnvelope =
+    authority.mode === "kms-envelope:aws"
+      ? new KmsEnvelopeKeystore({
+          provider: "aws",
+          keyId: authority.kmsKeyId,
+          region: authority.awsRegion,
+        })
+      : authority.mode === "kms-envelope:pkcs11"
+        ? new KmsEnvelopeKeystore({
+            provider: "pkcs11",
+            modulePath: authority.pkcs11Module,
+            pin: authority.pkcs11Pin,
+            keyLabel: authority.pkcs11KeyLabel,
+          })
+        : undefined;
+  const moneroBackend = createMoneroBackendFromEnv({
+    STEWARD_MONERO_WALLET_RPC_URL: authority.moneroWalletRpcUrl,
+    STEWARD_MONERO_WALLET_RPC_LOGIN: authority.moneroWalletRpcLogin,
+    STEWARD_MONERO_DAEMON_URL: authority.moneroDaemonUrl,
+    STEWARD_MONERO_NETWORK: authority.moneroNetwork,
+  });
+  return new Vault({
+    masterPassword: authority.masterPassword,
+    masterSalt: authority.kdfSalt,
+    nodeEnvironment: authority.nodeEnvironment,
+    allowLegacyKeystoreDecryptFallback: authority.allowLegacyKeystoreDecryptFallback,
+    rpcUrl: authority.rpcUrl,
+    chainId: authority.chainId,
+    solanaPriorityFees: authority.solanaPriorityFees,
+    rpcPassthroughAllowlist: authority.vaultRpcAllowlist ?? null,
+    ...(moneroBackend ? { moneroBackend } : {}),
+    ...(kmsEnvelope ? { keystoreBackend: kmsEnvelope } : {}),
+    ...(authority.externalCustodyProvider
+      ? { externalKeyCustodyProvider: createExternalCustodyProvider(authority) }
       : {}),
   });
 }
 
+export function createConfiguredVault(options: ConfiguredVaultOptions = {}): Vault {
+  return createVaultForAuthority(resolveCustodyAuthority(options));
+}
+
 export function getConfiguredVault(options: ConfiguredVaultOptions = {}): Vault {
-  const mode = configuredMode();
-  const externalCustody = configuredExternalCustodyProvider() ?? "none";
-  const masterPassword = resolveMasterPassword(options);
-  const key = `${mode}:${externalCustody}:${masterPassword}`;
-  let vault = vaultsByKey.get(key);
+  const authority = resolveCustodyAuthority(options);
+  let vault = vaultsByKey.get(authority.fingerprint);
   if (!vault) {
-    vault = createConfiguredVault({ ...options, fallbackPassword: masterPassword });
-    vaultsByKey.set(key, vault);
+    vault = cacheCustodyInstance(
+      vaultsByKey,
+      authority.fingerprint,
+      createVaultForAuthority(authority),
+    );
   }
   return vault;
 }
 
+export function getConfiguredSecretVault(options: ConfiguredVaultOptions = {}): SecretVault {
+  const authority = resolveCustodyAuthority(options);
+  let vault = secretVaultsByKey.get(authority.fingerprint);
+  if (!vault) {
+    vault = new SecretVault(authority.masterPassword, authority.kdfSalt, {
+      nodeEnvironment: authority.nodeEnvironment,
+      allowLegacyDecryptFallback: authority.allowLegacyKeystoreDecryptFallback,
+      allowLegacySecretRootFallback: authority.allowLegacySecretRootFallback,
+    });
+    cacheCustodyInstance(secretVaultsByKey, authority.fingerprint, vault);
+  }
+  return vault;
+}
+
+export function getConfiguredKeyStore(
+  domain?: KeyStoreDomain,
+  options: ConfiguredVaultOptions = {},
+): KeyStore {
+  const authority = resolveCustodyAuthority(options);
+  const key = `${authority.fingerprint}:${domain ?? "legacy"}`;
+  let keyStore = keyStoresByKey.get(key);
+  if (!keyStore) {
+    keyStore = new KeyStore(authority.masterPassword, authority.kdfSalt, domain, {
+      nodeEnvironment: authority.nodeEnvironment,
+      allowLegacyDecryptFallback: authority.allowLegacyKeystoreDecryptFallback,
+    });
+    cacheCustodyInstance(keyStoresByKey, key, keyStore);
+  }
+  return keyStore;
+}
+
 export function configuredVaultStartupLogLine(): string {
-  const provider = configuredKmsProvider();
-  const mode: VaultMode = provider ? `kms-envelope:${provider}` : "local";
+  const authority = resolveCustodyAuthority();
+  const mode = authority.mode;
   const plaintextAtSignTime = modeExposesPlaintextAtSignTime(mode);
-  const externalCustody = configuredExternalCustodyProvider() ?? "none";
+  const externalCustody = authority.externalCustodyProvider ?? "none";
   // In production, local mode only reaches this point when the operator has
   // explicitly acknowledged the weak posture (see assertProductionCustodyAcknowledged).
   // Surface that acknowledgement in the boot log so it is auditable. Never emit
   // key material, KMS key ids, or the master password here.
   const ack =
-    mode === "local" && runtimeEnvironmentValue("NODE_ENV") === "production"
-      ? ` local_custody_acknowledged=${localCustodyAcknowledged()}`
+    mode === "local" && authority.nodeEnvironment === "production"
+      ? ` local_custody_acknowledged=${authority.localCustodyAcknowledged}`
       : "";
   return (
     `[steward] vault mode=${mode} external_custody=${externalCustody} ` +
@@ -266,5 +473,7 @@ export function configuredVaultStartupLogLine(): string {
 
 export function _clearConfiguredVaultsForTests(): void {
   vaultsByKey.clear();
+  secretVaultsByKey.clear();
+  keyStoresByKey.clear();
   warnedDevSecretFallback = false;
 }

--- a/packages/api/src/services/vault-factory.ts
+++ b/packages/api/src/services/vault-factory.ts
@@ -10,6 +10,7 @@ import {
   SecretVault,
   Vault,
 } from "@stwd/vault";
+import { resolveRuntimeChainId } from "./custody-runtime";
 
 const require = createRequire(import.meta.url);
 
@@ -80,12 +81,16 @@ export interface ConfiguredVaultOptions {
 
 export interface CustodyAuthority {
   readonly fingerprint: string;
+  readonly workerRuntime: boolean;
   readonly nodeEnvironment?: string;
   readonly masterPassword: string;
   readonly kdfSalt?: string;
   readonly mode: VaultMode;
   readonly kmsKeyId?: string;
   readonly awsRegion?: string;
+  readonly awsAccessKeyId?: string;
+  readonly awsSecretAccessKey?: string;
+  readonly awsSessionToken?: string;
   readonly pkcs11Module?: string;
   readonly pkcs11Pin?: string;
   readonly pkcs11KeyLabel?: string;
@@ -160,6 +165,15 @@ function positiveBigInt(value: string | undefined, name: string): bigint {
   return BigInt(value);
 }
 
+function awsCredentials(authority: CustodyAuthority) {
+  if (!authority.awsAccessKeyId || !authority.awsSecretAccessKey) return undefined;
+  return {
+    accessKeyId: authority.awsAccessKeyId,
+    secretAccessKey: authority.awsSecretAccessKey,
+    sessionToken: authority.awsSessionToken,
+  };
+}
+
 function createExternalCustodyProvider(authority: CustodyAuthority) {
   const provider = authority.externalCustodyProvider;
   if (!provider) return undefined;
@@ -175,6 +189,7 @@ function createExternalCustodyProvider(authority: CustodyAuthority) {
   }
   return new AwsKmsExternalKeyCustodyProvider({
     region: authority.externalCustodyAwsRegion,
+    credentials: awsCredentials(authority),
     maxGasLimit: positiveBigInt(
       authority.externalCustodyAwsMaxGasLimit,
       "STEWARD_EXTERNAL_CUSTODY_AWS_MAX_GAS_LIMIT",
@@ -319,18 +334,20 @@ export function resolveCustodyAuthority(options: ConfiguredVaultOptions = {}): C
   assertProductionCustodyAcknowledged(mode);
   const masterPassword = resolveMasterPassword(options);
   const nodeEnvironment = runtimeNodeEnvironment();
+  const workerRuntime = runtimeRaw("STEWARD_RUNTIME") === "workers";
   const legacySecretRoot = runtimeRaw("STEWARD_SECRET_VAULT_LEGACY_ROOT_FALLBACK");
-  const chainId = Number.parseInt(runtimeRaw("CHAIN_ID") ?? "84532", 10);
-  if (!Number.isSafeInteger(chainId) || chainId <= 0) {
-    throw new Error("CHAIN_ID must be a positive safe integer");
-  }
+  const chainId = resolveRuntimeChainId(84532);
   const resolved = {
+    workerRuntime,
     nodeEnvironment,
     masterPassword,
     kdfSalt: runtimeRaw("STEWARD_KDF_SALT"),
     mode,
     kmsKeyId: runtimeRaw("STEWARD_KMS_KEY_ID") ?? runtimeRaw("STEWARD_AWS_KMS_KEY_ARN"),
     awsRegion: runtimeRaw("STEWARD_AWS_REGION") ?? runtimeRaw("AWS_REGION"),
+    awsAccessKeyId: runtimeRaw("AWS_ACCESS_KEY_ID"),
+    awsSecretAccessKey: runtimeRaw("AWS_SECRET_ACCESS_KEY"),
+    awsSessionToken: runtimeRaw("AWS_SESSION_TOKEN"),
     pkcs11Module: runtimeRaw("STEWARD_PKCS11_MODULE"),
     pkcs11Pin: runtimeRaw("STEWARD_PKCS11_PIN"),
     pkcs11KeyLabel: runtimeRaw("STEWARD_PKCS11_KEY_LABEL"),
@@ -361,6 +378,16 @@ export function resolveCustodyAuthority(options: ConfiguredVaultOptions = {}): C
       legacySecretRoot === "true" ||
       (legacySecretRoot !== "false" && nodeEnvironment !== "production"),
   } satisfies Omit<CustodyAuthority, "fingerprint">;
+  const usesAws = mode === "kms-envelope:aws" || resolved.externalCustodyProvider === "aws-kms";
+  const hasAwsCredentialPart = Boolean(
+    resolved.awsAccessKeyId || resolved.awsSecretAccessKey || resolved.awsSessionToken,
+  );
+  const hasAwsCredentials = Boolean(resolved.awsAccessKeyId && resolved.awsSecretAccessKey);
+  if (usesAws && !hasAwsCredentials && (workerRuntime || hasAwsCredentialPart)) {
+    throw new Error(
+      "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be configured together for AWS custody",
+    );
+  }
   return Object.freeze({ ...resolved, fingerprint: authorityFingerprint(resolved) });
 }
 
@@ -371,6 +398,7 @@ function createVaultForAuthority(authority: CustodyAuthority): Vault {
           provider: "aws",
           keyId: authority.kmsKeyId,
           region: authority.awsRegion,
+          credentials: awsCredentials(authority),
         })
       : authority.mode === "kms-envelope:pkcs11"
         ? new KmsEnvelopeKeystore({

--- a/packages/api/src/services/vault-factory.ts
+++ b/packages/api/src/services/vault-factory.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 import { isDevSecretAllowed } from "@stwd/auth";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { AwsKmsExternalKeyCustodyProvider, KmsEnvelopeKeystore, Vault } from "@stwd/vault";
 
 const require = createRequire(import.meta.url);
@@ -73,14 +74,14 @@ const vaultsByKey = new Map<string, Vault>();
 let warnedDevSecretFallback = false;
 
 function configuredKmsProvider(): "aws" | "pkcs11" | undefined {
-  const value = process.env.STEWARD_KMS_PROVIDER?.trim();
+  const value = runtimeEnvironmentValue("STEWARD_KMS_PROVIDER")?.trim();
   if (!value) return undefined;
   if (value === "aws" || value === "pkcs11") return value;
   throw new Error(`Unsupported STEWARD_KMS_PROVIDER: ${value}`);
 }
 
 function configuredExternalCustodyProvider(): ExternalCustodyProviderName | undefined {
-  const value = process.env.STEWARD_EXTERNAL_CUSTODY_PROVIDER?.trim();
+  const value = runtimeEnvironmentValue("STEWARD_EXTERNAL_CUSTODY_PROVIDER")?.trim();
   if (!value) return undefined;
   if (value === "aws-kms") return value;
   throw new Error(`Unsupported STEWARD_EXTERNAL_CUSTODY_PROVIDER: ${value}`);
@@ -104,16 +105,19 @@ function createExternalCustodyProvider() {
 
 function requireKmsConfiguration(provider: "aws" | "pkcs11"): void {
   if (provider === "aws") {
-    if (!process.env.STEWARD_KMS_KEY_ID?.trim() && !process.env.STEWARD_AWS_KMS_KEY_ARN?.trim()) {
+    if (
+      !runtimeEnvironmentValue("STEWARD_KMS_KEY_ID")?.trim() &&
+      !runtimeEnvironmentValue("STEWARD_AWS_KMS_KEY_ARN")?.trim()
+    ) {
       throw new Error("STEWARD_KMS_KEY_ID or STEWARD_AWS_KMS_KEY_ARN is required for AWS KMS");
     }
     return;
   }
 
   const missing = [
-    ["STEWARD_PKCS11_MODULE", process.env.STEWARD_PKCS11_MODULE],
-    ["STEWARD_PKCS11_PIN", process.env.STEWARD_PKCS11_PIN],
-    ["STEWARD_PKCS11_KEY_LABEL", process.env.STEWARD_PKCS11_KEY_LABEL],
+    ["STEWARD_PKCS11_MODULE", runtimeEnvironmentValue("STEWARD_PKCS11_MODULE")],
+    ["STEWARD_PKCS11_PIN", runtimeEnvironmentValue("STEWARD_PKCS11_PIN")],
+    ["STEWARD_PKCS11_KEY_LABEL", runtimeEnvironmentValue("STEWARD_PKCS11_KEY_LABEL")],
   ]
     .filter(([, value]) => !value?.trim())
     .map(([name]) => name);
@@ -153,7 +157,7 @@ export function modeExposesPlaintextAtSignTime(mode: VaultMode): boolean {
 }
 
 function localCustodyAcknowledged(): boolean {
-  return process.env[LOCAL_CUSTODY_ACK_ENV] === "true";
+  return runtimeEnvironmentValue(LOCAL_CUSTODY_ACK_ENV) === "true";
 }
 
 /**
@@ -166,7 +170,7 @@ function localCustodyAcknowledged(): boolean {
  * ack because selecting them is already an explicit configuration decision.
  */
 export function assertProductionCustodyAcknowledged(mode: VaultMode): void {
-  if (process.env.NODE_ENV !== "production") return;
+  if (runtimeEnvironmentValue("NODE_ENV") !== "production") return;
   if (mode !== "local") return;
   if (localCustodyAcknowledged()) return;
   throw new LocalCustodyAcknowledgementRequiredError();
@@ -189,7 +193,7 @@ function configuredMode(): VaultMode {
 }
 
 function resolveMasterPassword(options: ConfiguredVaultOptions): string {
-  const configured = process.env.STEWARD_MASTER_PASSWORD?.trim();
+  const configured = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD")?.trim();
   if (configured) return configured;
   if (options.fallbackPassword?.trim()) return options.fallbackPassword.trim();
 
@@ -218,8 +222,8 @@ export function createConfiguredVault(options: ConfiguredVaultOptions = {}): Vau
   const masterPassword = resolveMasterPassword(options);
   return new Vault({
     masterPassword,
-    rpcUrl: process.env.RPC_URL || "https://sepolia.base.org",
-    chainId: parseInt(process.env.CHAIN_ID || "84532", 10),
+    rpcUrl: runtimeEnvironmentValue("RPC_URL") || "https://sepolia.base.org",
+    chainId: parseInt(runtimeEnvironmentValue("CHAIN_ID") || "84532", 10),
     ...(mode === "local" ? {} : { keystoreBackend: KmsEnvelopeKeystore.fromEnv() }),
     ...(configuredExternalCustodyProvider()
       ? { externalKeyCustodyProvider: createExternalCustodyProvider() }
@@ -250,7 +254,7 @@ export function configuredVaultStartupLogLine(): string {
   // Surface that acknowledgement in the boot log so it is auditable. Never emit
   // key material, KMS key ids, or the master password here.
   const ack =
-    mode === "local" && process.env.NODE_ENV === "production"
+    mode === "local" && runtimeEnvironmentValue("NODE_ENV") === "production"
       ? ` local_custody_acknowledged=${localCustodyAcknowledged()}`
       : "";
   return (

--- a/packages/api/src/services/webhook-dispatch.ts
+++ b/packages/api/src/services/webhook-dispatch.ts
@@ -2,10 +2,12 @@ import { createHash, randomUUID } from "node:crypto";
 import { and, eq, waitUntilRequestDatabaseTask, webhookConfigs, webhookDeliveries } from "@stwd/db";
 import { redactedThrownDiagnostics, type WebhookEvent } from "@stwd/shared";
 import {
+  currentWebhookRuntimeAuthority,
   decryptWebhookSecret,
   encryptWebhookSecret,
   isEncryptedWebhookSecret,
   WebhookDispatcher,
+  type WebhookRuntimeAuthority,
 } from "@stwd/webhooks";
 import { db } from "./context";
 import {
@@ -28,6 +30,7 @@ export function dispatchWebhook(
   type: DispatchableWebhookEventType,
   data: Record<string, unknown>,
 ): void {
+  const webhookAuthority = currentWebhookRuntimeAuthority();
   const configuredType = toConfiguredWebhookEventType(type);
   // EMISSION-PATH WIDENING (Phase 2b): a plugin-declared event is one that is NOT
   // a core configured/alias type but IS present in the runtime
@@ -57,14 +60,18 @@ export function dispatchWebhook(
   // existing process-owned fire-and-forget behavior when no request lease is
   // active.
   void waitUntilRequestDatabaseTask(() =>
-    dispatchConfiguredWebhooks(event, configuredType, isPluginEvent ? type : null).catch(
-      (error) => {
-        console.error(
-          "[webhooks] Failed to dispatch configured webhooks",
-          redactedThrownDiagnostics(error),
-        );
-      },
-    ),
+    dispatchConfiguredWebhooks(
+      event,
+      configuredType,
+      isPluginEvent ? type : null,
+      undefined,
+      webhookAuthority,
+    ).catch((error) => {
+      console.error(
+        "[webhooks] Failed to dispatch configured webhooks",
+        redactedThrownDiagnostics(error),
+      );
+    }),
   );
 
   // SEC-101: the unverifiable tenant-route webhookUrl field is retired. The
@@ -81,6 +88,7 @@ export async function dispatchWebhookDurably(
   data: Record<string, unknown>,
   idempotencyKey: string,
 ): Promise<void> {
+  const webhookAuthority = currentWebhookRuntimeAuthority();
   const configuredType = toConfiguredWebhookEventType(type);
   const isPluginEvent = configuredType === null && webhookEventRegistry.has(type);
   await dispatchConfiguredWebhooks(
@@ -94,6 +102,7 @@ export async function dispatchWebhookDurably(
     configuredType,
     isPluginEvent ? type : null,
     idempotencyKey,
+    webhookAuthority,
   );
 }
 
@@ -105,6 +114,7 @@ export async function dispatchTestWebhook(config: {
   events: string[];
   actorId?: string | null;
 }): Promise<typeof webhookDeliveries.$inferSelect> {
+  const webhookAuthority = currentWebhookRuntimeAuthority();
   const event: WebhookEvent = {
     type: "webhook.test",
     tenantId: config.tenantId,
@@ -117,12 +127,16 @@ export async function dispatchTestWebhook(config: {
     timestamp: new Date(),
   };
 
-  return dispatchConfiguredWebhook(event, {
-    ...config,
-    maxRetries: 0,
-    retryBackoffMs: 0,
-    visibilityTimeoutMs: 0,
-  });
+  return dispatchConfiguredWebhook(
+    event,
+    {
+      ...config,
+      maxRetries: 0,
+      retryBackoffMs: 0,
+      visibilityTimeoutMs: 0,
+    },
+    webhookAuthority,
+  );
 }
 
 export async function dispatchReplayWebhook(config: {
@@ -139,6 +153,7 @@ export async function dispatchReplayWebhook(config: {
   originalAgentId?: string | null;
   originalCreatedAt: Date | string;
 }): Promise<typeof webhookDeliveries.$inferSelect> {
+  const webhookAuthority = currentWebhookRuntimeAuthority();
   const originalTimestamp =
     typeof config.originalPayload.timestamp === "string" ||
     config.originalPayload.timestamp instanceof Date
@@ -160,10 +175,14 @@ export async function dispatchReplayWebhook(config: {
       : originalTimestamp,
   };
 
-  return dispatchConfiguredWebhook(event, {
-    ...config,
-    replayedFromDeliveryId: config.replayedFromDeliveryId,
-  });
+  return dispatchConfiguredWebhook(
+    event,
+    {
+      ...config,
+      replayedFromDeliveryId: config.replayedFromDeliveryId,
+    },
+    webhookAuthority,
+  );
 }
 
 async function dispatchConfiguredWebhooks(
@@ -171,6 +190,7 @@ async function dispatchConfiguredWebhooks(
   configuredType: ConfiguredWebhookEventType | null,
   pluginEventType: string | null = null,
   idempotencyKey?: string,
+  webhookAuthority: WebhookRuntimeAuthority = currentWebhookRuntimeAuthority(),
 ): Promise<void> {
   const configs = await db
     .select()
@@ -191,15 +211,19 @@ async function dispatchConfiguredWebhooks(
           : config.events.length === 0;
       })
       .map((config) =>
-        dispatchConfiguredWebhook(event, {
-          id: config.id,
-          url: config.url,
-          secret: config.secret,
-          events: config.events,
-          maxRetries: config.maxRetries,
-          retryBackoffMs: config.retryBackoffMs,
-          idempotencyKey,
-        }),
+        dispatchConfiguredWebhook(
+          event,
+          {
+            id: config.id,
+            url: config.url,
+            secret: config.secret,
+            events: config.events,
+            maxRetries: config.maxRetries,
+            retryBackoffMs: config.retryBackoffMs,
+            idempotencyKey,
+          },
+          webhookAuthority,
+        ),
       ),
   );
 }
@@ -217,6 +241,7 @@ async function dispatchConfiguredWebhook(
     replayedFromDeliveryId?: string | null;
     idempotencyKey?: string;
   },
+  webhookAuthority: WebhookRuntimeAuthority = currentWebhookRuntimeAuthority(),
 ): Promise<typeof webhookDeliveries.$inferSelect> {
   const signingSecret = decryptWebhookSecret(config.secret);
   // Plaintext compatibility rows are upgraded lazily with a compare-and-set.
@@ -287,7 +312,11 @@ async function dispatchConfiguredWebhook(
   // SEC-017: re-validate the destination at delivery time with FRESH DNS
   // answers — registration-time validation cannot see DNS rebinding (public A
   // record at config time, private at fetch time). Fail closed: no fetch.
-  const deliveryUrlError = await validateWebhookUrlResolved(config.url);
+  const deliveryUrlError = await validateWebhookUrlResolved(
+    config.url,
+    undefined,
+    webhookAuthority,
+  );
   if (deliveryUrlError) {
     const [rejected] = await db
       .update(webhookDeliveries)
@@ -305,6 +334,8 @@ async function dispatchConfiguredWebhook(
   const dispatcher = new WebhookDispatcher({
     maxRetries: 0,
     retryDelayMs: 0,
+    allowPrivateNetwork: webhookAuthority.allowPrivateNetwork,
+    allowInsecureHttp: webhookAuthority.allowInsecureHttp,
   });
   const result = await dispatcher.dispatch(eventWithDelivery, { ...config, secret: signingSecret });
   const retryable = !result.success && config.maxRetries > 0;

--- a/packages/api/src/services/webhook-retry-scheduler.ts
+++ b/packages/api/src/services/webhook-retry-scheduler.ts
@@ -1,4 +1,5 @@
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { PersistentQueue } from "@stwd/webhooks";
 import { runInternalJobForEachTenant } from "./tenant-job";
 
@@ -12,17 +13,17 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
 }
 
 export function startWebhookRetryScheduler(): () => void {
-  if (process.env.STEWARD_WEBHOOK_RETRY_WORKER === "false") {
+  if (runtimeEnvironmentValue("STEWARD_WEBHOOK_RETRY_WORKER") === "false") {
     console.log("[webhooks] Retry scheduler disabled by STEWARD_WEBHOOK_RETRY_WORKER=false");
     return () => {};
   }
 
   const intervalMs = parsePositiveInt(
-    process.env.STEWARD_WEBHOOK_RETRY_INTERVAL_MS,
+    runtimeEnvironmentValue("STEWARD_WEBHOOK_RETRY_INTERVAL_MS"),
     DEFAULT_WEBHOOK_RETRY_INTERVAL_MS,
   );
   const batchSize = parsePositiveInt(
-    process.env.STEWARD_WEBHOOK_RETRY_BATCH_SIZE,
+    runtimeEnvironmentValue("STEWARD_WEBHOOK_RETRY_BATCH_SIZE"),
     DEFAULT_WEBHOOK_RETRY_BATCH_SIZE,
   );
   const queue = new PersistentQueue(undefined, { batchSize });

--- a/packages/api/src/services/webhook-url.ts
+++ b/packages/api/src/services/webhook-url.ts
@@ -1,7 +1,11 @@
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
+import type { WebhookRuntimeAuthority } from "@stwd/webhooks";
 
-const ALLOW_INSECURE_WEBHOOK_URLS = process.env.STEWARD_ALLOW_INSECURE_WEBHOOK_URLS === "true";
+const FAIL_CLOSED_WEBHOOK_AUTHORITY: WebhookRuntimeAuthority = Object.freeze({
+  allowInsecureHttp: false,
+  allowPrivateNetwork: false,
+});
 
 function isNonPublicIpv4(hostname: string): boolean {
   const octets = hostname.split(".").map((part) => Number(part));
@@ -149,13 +153,16 @@ function isNonPublicIpv6(hostname: string): boolean {
   );
 }
 
-export function validateWebhookUrl(url: string): string | null {
+export function validateWebhookUrl(
+  url: string,
+  authority: WebhookRuntimeAuthority = FAIL_CLOSED_WEBHOOK_AUTHORITY,
+): string | null {
   try {
     const parsed = new URL(url);
     if (parsed.username || parsed.password) return "url must not include credentials";
 
     if (parsed.protocol !== "https:") {
-      if (!ALLOW_INSECURE_WEBHOOK_URLS || parsed.protocol !== "http:") {
+      if (!authority.allowInsecureHttp || parsed.protocol !== "http:") {
         return "url must use https";
       }
     }
@@ -165,6 +172,7 @@ export function validateWebhookUrl(url: string): string | null {
       .replace(/\.+$/g, "")
       .toLowerCase();
     if (!hostname) return "url must include a host";
+    if (authority.allowPrivateNetwork) return null;
     if (hostname === "localhost" || hostname.endsWith(".localhost")) {
       return "url host must be public";
     }
@@ -211,9 +219,11 @@ function isNonPublicAddress(address: string, family?: number): boolean {
 export async function validateWebhookUrlResolved(
   url: string,
   resolver: DnsResolver = defaultResolver,
+  authority: WebhookRuntimeAuthority = FAIL_CLOSED_WEBHOOK_AUTHORITY,
 ): Promise<string | null> {
-  const stringError = validateWebhookUrl(url);
+  const stringError = validateWebhookUrl(url, authority);
   if (stringError) return stringError;
+  if (authority.allowPrivateNetwork) return null;
 
   let hostname: string;
   try {

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -43,8 +43,8 @@
  */
 
 // Import the dependency-light JWT module directly. Importing the auth barrel
-// here would evaluate Worker-sensitive auth modules before bindings are
-// hydrated into process.env.
+// here would evaluate Worker-sensitive auth modules before request authority is
+// bound.
 import {
   createJwtRuntimeAuthority,
   type JwtRuntimeEnvironment,
@@ -320,53 +320,6 @@ export async function runWorkerXCredentialLifecycleSweep(
   });
 }
 
-/**
- * Pull Worker `env` bindings into `globalThis.process.env` so any code that
- * reads `runtimeEnvironmentValue("X")` at request time (e.g. JWT secret, RPC URL) can find it.
- *
- * Workers expose `nodejs_compat`'s `process.env` as an empty object on cold
- * boot — bindings come in via the `fetch` handler's `env` argument instead.
- * This runs on EVERY request (SEC-148): Workers may reuse isolates across
- * different deployments (and therefore different binding sets), and rotated
- * bindings/secrets must take effect without waiting for an isolate recycle.
- * Keys we hydrated that disappear from a later binding set are deleted again
- * so stale values cannot linger. Module-init-time readers still see only the
- * first binding set an isolate ever served (imports are cached per isolate) —
- * that is inherent to the module registry and unchanged by this.
- *
- * Known trade-off (accepted, SEC-148): string bindings — including secrets —
- * are copied onto the global `process.env` only for audited compatibility
- * callers. Security and routing decisions resolve the immutable request
- * snapshot and must not depend on this bridge.
- */
-const hydratedEnvKeys = new Set<string>();
-
-export function hydrateProcessEnv(env: Env): void {
-  const target = (globalThis as any).process?.env;
-  if (!target) return;
-
-  const present = new Set<string>();
-  for (const key of Object.keys(env)) {
-    if (key === "STEWARD_RUNTIME") continue;
-    const value = env[key];
-    if (typeof value === "string") {
-      target[key] = value;
-      present.add(key);
-    }
-  }
-  for (const key of hydratedEnvKeys) {
-    if (!present.has(key)) delete target[key];
-  }
-  hydratedEnvKeys.clear();
-  for (const key of present) hydratedEnvKeys.add(key);
-  target.STEWARD_RUNTIME = "workers";
-}
-
-/** @internal prevent mounted Worker tests from changing later Bun test authority. */
-export function __resetWorkerHydrationForTests(): void {
-  hydratedEnvKeys.clear();
-}
-
 const workerInitByAuthority = new Map<string, Promise<void>>();
 let workerInitOverride: Promise<void> | null = null;
 
@@ -404,7 +357,7 @@ function workerJwtEnvironment(env: Env): Readonly<JwtRuntimeEnvironment> {
 /**
  * Bind authentication-critical Worker configuration before any request code
  * can yield. Downstream JWT signing and verification resolve this immutable
- * authority rather than the isolate-wide process.env compatibility mirror.
+ * authority rather than isolate-wide state.
  */
 export function withWorkerJwtAuthority<T>(env: Env, callback: () => T): T {
   const authority = createJwtRuntimeAuthority(workerJwtEnvironment(env));
@@ -418,8 +371,7 @@ export function withWorkerRuntimeAuthority<T>(env: Env, callback: () => T): T {
 
 function validateWorkerSecurityEnv(): void {
   // The request authority was resolved synchronously from this invocation's
-  // bindings. This validation never consults the process.env compatibility
-  // mirror, even after another request hydrates a different binding set.
+  // bindings and never consults another invocation's authority.
   validateJwtSecretEnv();
 }
 
@@ -429,9 +381,6 @@ async function ensureWorkerInit(env: Env): Promise<void> {
   const existing = workerInitByAuthority.get(authorityKey);
   if (existing) return existing;
   const pending = (async () => {
-    // Workers bindings are only available inside fetch(). Hydrate process.env
-    // before importing app modules that read required env at module init.
-    hydrateProcessEnv(env);
     // SEC-134: the Bun entry (index.ts) runs validateJwtSecretEnv() at startup;
     // run the same validation on the Workers boot path so a bad/missing JWT
     // secret or malformed AGENT_TOKEN_EXPIRY fails closed at cold start instead
@@ -532,11 +481,7 @@ async function getComposedApp() {
 export default {
   async fetch(request: Request, env: Env, ctx: unknown): Promise<Response> {
     return withWorkerRuntimeAuthority(env, async () => {
-      // Keep the legacy bridge for modules not yet migrated to request-local
-      // configuration. Security-sensitive OIDC settings use the immutable
-      // snapshot above and cannot be replaced by an overlapping request.
       return withWorkerJwtAuthority(env, async () => {
-        hydrateProcessEnv(env);
         validateWorkerSecurityEnv();
         const executionCtx = ctx as { waitUntil?: (promise: Promise<unknown>) => void };
         const waitUntil =
@@ -562,7 +507,6 @@ export default {
   ) {
     withWorkerRuntimeAuthority(env, () => {
       return withWorkerJwtAuthority(env, () => {
-        hydrateProcessEnv(env);
         validateWorkerSecurityEnv();
         const scheduledWork = withWorkerRequestDatabase(env, () => ensureWorkerInit(env)).then(() =>
           Promise.all([

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -59,7 +59,7 @@ import {
   type NeonTransactionDbHandle,
   withRequestDatabase,
 } from "@stwd/db";
-import { runtimeEnvironmentValue, withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { initRedis } from "./middleware/redis";
 
 export interface Env {
@@ -79,6 +79,33 @@ export interface Env {
   /** Deprecated compatibility fallback for existing Worker deployments. */
   STEWARD_SESSION_SECRET?: string;
   STEWARD_MASTER_PASSWORD?: string;
+  STEWARD_KDF_SALT?: string;
+  STEWARD_KMS_PROVIDER?: string;
+  STEWARD_KMS_KEY_ID?: string;
+  STEWARD_AWS_KMS_KEY_ARN?: string;
+  STEWARD_AWS_REGION?: string;
+  AWS_REGION?: string;
+  STEWARD_PKCS11_MODULE?: string;
+  STEWARD_PKCS11_PIN?: string;
+  STEWARD_PKCS11_KEY_LABEL?: string;
+  STEWARD_EXTERNAL_CUSTODY_PROVIDER?: string;
+  STEWARD_EXTERNAL_CUSTODY_AWS_REGION?: string;
+  STEWARD_EXTERNAL_CUSTODY_AWS_MAX_GAS_LIMIT?: string;
+  STEWARD_EXTERNAL_CUSTODY_AWS_MAX_GAS_PRICE_WEI?: string;
+  STEWARD_EXTERNAL_CUSTODY_AWS_MAX_TOTAL_FEE_WEI?: string;
+  STEWARD_ACK_LOCAL_CUSTODY?: string;
+  RPC_URL?: string;
+  CHAIN_ID?: string;
+  STEWARD_SOLANA_PRIORITY_FEES?: string;
+  STEWARD_VAULT_RPC_ALLOWLIST?: string;
+  STEWARD_ALLOW_LEGACY_KEYSTORE_DECRYPT_FALLBACK?: string;
+  STEWARD_SECRET_VAULT_LEGACY_ROOT_FALLBACK?: string;
+  STEWARD_MONERO_WALLET_RPC_URL?: string;
+  STEWARD_MONERO_WALLET_RPC_LOGIN?: string;
+  STEWARD_MONERO_DAEMON_URL?: string;
+  STEWARD_MONERO_NETWORK?: string;
+  STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY?: string;
+  STEWARD_WEBHOOK_SECRET_KDF_SALT?: string;
   STEWARD_EMBEDDED?: string;
   STEWARD_EMBEDDED_MODE?: string;
   STEWARD_DB_MODE?: string;
@@ -232,7 +259,7 @@ export async function runWorkerUpstreamCredentialLeaseSweep(
   const capabilitiesEnabled =
     options?.capabilitiesEnabled ??
     (await import("./plugin-config")).resolveEnabledPlugins().has("capabilities");
-  if (!capabilitiesEnabled || runtimeEnvironmentValue("STEWARD_UPSTREAM_LEASE_SWEEPER") === "false") return null;
+  if (!capabilitiesEnabled || process.env.STEWARD_UPSTREAM_LEASE_SWEEPER === "false") return null;
   const sweep =
     options?.sweep ??
     (await import("./services/upstream-credential-lease-scheduler"))
@@ -246,9 +273,9 @@ export async function runWorkerGoogleCredentialLifecycleSweep(
 ): Promise<unknown | null> {
   hydrateProcessEnv(env);
   if (
-    runtimeEnvironmentValue("STEWARD_GOOGLE_LIFECYCLE_SWEEPER") === "false" ||
-    !runtimeEnvironmentValue("GOOGLE_PROVIDER_CLIENT_ID") ||
-    !runtimeEnvironmentValue("GOOGLE_PROVIDER_CLIENT_SECRET")
+    process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEPER === "false" ||
+    !env.GOOGLE_PROVIDER_CLIENT_ID ||
+    !env.GOOGLE_PROVIDER_CLIENT_SECRET
   ) {
     return null;
   }
@@ -265,10 +292,10 @@ export async function runWorkerXCredentialLifecycleSweep(
 ): Promise<unknown | null> {
   hydrateProcessEnv(env);
   if (
-    runtimeEnvironmentValue("STEWARD_X_LIFECYCLE_SWEEPER") === "false" ||
-    !runtimeEnvironmentValue("X_CLIENT_ID") ||
-    !runtimeEnvironmentValue("X_CLIENT_SECRET") ||
-    !runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD")
+    process.env.STEWARD_X_LIFECYCLE_SWEEPER === "false" ||
+    !env.X_CLIENT_ID ||
+    !env.X_CLIENT_SECRET ||
+    !env.STEWARD_MASTER_PASSWORD
   ) {
     return null;
   }
@@ -281,7 +308,7 @@ export async function runWorkerXCredentialLifecycleSweep(
 
 /**
  * Pull Worker `env` bindings into `globalThis.process.env` so any code that
- * reads `runtimeEnvironmentValue("X")` at request time (e.g. JWT secret, RPC URL) can find it.
+ * reads `process.env.X` at request time (e.g. JWT secret, RPC URL) can find it.
  *
  * Workers expose `nodejs_compat`'s `process.env` as an empty object on cold
  * boot — bindings come in via the `fetch` handler's `env` argument instead.
@@ -359,6 +386,11 @@ export function withWorkerJwtAuthority<T>(env: Env, callback: () => T): T {
   return withJwtRuntimeAuthority(authority, callback);
 }
 
+/** Bind the complete immutable Worker environment before custody resolution. */
+export function withWorkerRuntimeAuthority<T>(env: Env, callback: () => T): T {
+  return withRuntimeEnvironment({ ...env, STEWARD_RUNTIME: "workers" }, callback);
+}
+
 function validateWorkerSecurityEnv(): void {
   // The request authority was resolved synchronously from this invocation's
   // bindings. This validation never consults the process.env compatibility
@@ -407,7 +439,7 @@ async function ensureWorkerInit(env: Env): Promise<void> {
           dbUrl.includes("sslmode=verify-ca") ||
           dbUrl.includes("sslmode=verify-full"),
         hstsEnabled: isHstsEnabled(),
-        insecureDbAllowed: runtimeEnvironmentValue("STEWARD_ALLOW_INSECURE_DB") === "true",
+        insecureDbAllowed: process.env.STEWARD_ALLOW_INSECURE_DB === "true",
         runtime: "workers",
       },
     });
@@ -452,7 +484,7 @@ async function getComposedApp() {
 
 export default {
   async fetch(request: Request, env: Env, ctx: unknown): Promise<Response> {
-    return withRuntimeEnvironment({ ...env, STEWARD_RUNTIME: "workers" }, async () => {
+    return withWorkerRuntimeAuthority(env, async () => {
       // Keep the legacy bridge for modules not yet migrated to request-local
       // configuration. Security-sensitive OIDC settings use the immutable
       // snapshot above and cannot be replaced by an overlapping request.
@@ -481,7 +513,7 @@ export default {
     env: Env,
     ctx: { waitUntil(promise: Promise<unknown>): void },
   ) {
-    withRuntimeEnvironment({ ...env, STEWARD_RUNTIME: "workers" }, () => {
+    withWorkerRuntimeAuthority(env, () => {
       return withWorkerJwtAuthority(env, () => {
         hydrateProcessEnv(env);
         validateWorkerSecurityEnv();

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -59,7 +59,11 @@ import {
   type NeonTransactionDbHandle,
   withRequestDatabase,
 } from "@stwd/db";
-import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import {
+  runtimeEnvironmentSnapshot,
+  runtimeEnvironmentValue,
+  withRuntimeEnvironment,
+} from "@stwd/shared/runtime-env";
 import { initRedis } from "./middleware/redis";
 
 export interface Env {
@@ -258,60 +262,67 @@ export async function runWorkerUpstreamCredentialLeaseSweep(
     sweep?: () => Promise<WorkerLeaseSweepResult>;
   },
 ): Promise<WorkerLeaseSweepResult | null> {
-  hydrateProcessEnv(env);
-  const capabilitiesEnabled =
-    options?.capabilitiesEnabled ??
-    (await import("./plugin-config")).resolveEnabledPlugins().has("capabilities");
-  if (!capabilitiesEnabled || process.env.STEWARD_UPSTREAM_LEASE_SWEEPER === "false") return null;
-  const sweep =
-    options?.sweep ??
-    (await import("./services/upstream-credential-lease-scheduler"))
-      .runUpstreamCredentialLeaseSweep;
-  return sweep();
+  return withWorkerRuntimeAuthority(env, async () => {
+    const capabilitiesEnabled =
+      options?.capabilitiesEnabled ??
+      (await import("./plugin-config")).resolveEnabledPlugins().has("capabilities");
+    if (
+      !capabilitiesEnabled ||
+      runtimeEnvironmentValue("STEWARD_UPSTREAM_LEASE_SWEEPER") === "false"
+    )
+      return null;
+    const sweep =
+      options?.sweep ??
+      (await import("./services/upstream-credential-lease-scheduler"))
+        .runUpstreamCredentialLeaseSweep;
+    return sweep();
+  });
 }
 
 export async function runWorkerGoogleCredentialLifecycleSweep(
   env: Env,
   options?: { sweep?: () => Promise<unknown> },
 ): Promise<unknown | null> {
-  hydrateProcessEnv(env);
-  if (
-    process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEPER === "false" ||
-    !env.GOOGLE_PROVIDER_CLIENT_ID ||
-    !env.GOOGLE_PROVIDER_CLIENT_SECRET
-  ) {
-    return null;
-  }
-  const sweep =
-    options?.sweep ??
-    (await import("./services/provider-google-lifecycle-scheduler"))
-      .runGoogleCredentialLifecycleRecoverySweep;
-  return sweep();
+  return withWorkerRuntimeAuthority(env, async () => {
+    if (
+      runtimeEnvironmentValue("STEWARD_GOOGLE_LIFECYCLE_SWEEPER") === "false" ||
+      !runtimeEnvironmentValue("GOOGLE_PROVIDER_CLIENT_ID") ||
+      !runtimeEnvironmentValue("GOOGLE_PROVIDER_CLIENT_SECRET")
+    ) {
+      return null;
+    }
+    const sweep =
+      options?.sweep ??
+      (await import("./services/provider-google-lifecycle-scheduler"))
+        .runGoogleCredentialLifecycleRecoverySweep;
+    return sweep();
+  });
 }
 
 export async function runWorkerXCredentialLifecycleSweep(
   env: Env,
   options?: { sweep?: () => Promise<unknown> },
 ): Promise<unknown | null> {
-  hydrateProcessEnv(env);
-  if (
-    process.env.STEWARD_X_LIFECYCLE_SWEEPER === "false" ||
-    !env.X_CLIENT_ID ||
-    !env.X_CLIENT_SECRET ||
-    !env.STEWARD_MASTER_PASSWORD
-  ) {
-    return null;
-  }
-  const sweep =
-    options?.sweep ??
-    (await import("./services/provider-x-lifecycle-scheduler"))
-      .runXCredentialLifecycleRecoverySweep;
-  return sweep();
+  return withWorkerRuntimeAuthority(env, async () => {
+    if (
+      runtimeEnvironmentValue("STEWARD_X_LIFECYCLE_SWEEPER") === "false" ||
+      !runtimeEnvironmentValue("X_CLIENT_ID") ||
+      !runtimeEnvironmentValue("X_CLIENT_SECRET") ||
+      !runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD")
+    ) {
+      return null;
+    }
+    const sweep =
+      options?.sweep ??
+      (await import("./services/provider-x-lifecycle-scheduler"))
+        .runXCredentialLifecycleRecoverySweep;
+    return sweep();
+  });
 }
 
 /**
  * Pull Worker `env` bindings into `globalThis.process.env` so any code that
- * reads `process.env.X` at request time (e.g. JWT secret, RPC URL) can find it.
+ * reads `runtimeEnvironmentValue("X")` at request time (e.g. JWT secret, RPC URL) can find it.
  *
  * Workers expose `nodejs_compat`'s `process.env` as an empty object on cold
  * boot — bindings come in via the `fetch` handler's `env` argument instead.
@@ -324,10 +335,9 @@ export async function runWorkerXCredentialLifecycleSweep(
  * that is inherent to the module registry and unchanged by this.
  *
  * Known trade-off (accepted, SEC-148): string bindings — including secrets —
- * are copied onto the global `process.env`, because the entire codebase reads
- * configuration through `process.env`. Moving every reader onto per-request
- * binding access is out of scope; per-request hydration at least keeps the
- * values current and bounded to the current binding set.
+ * are copied onto the global `process.env` only for audited compatibility
+ * callers. Security and routing decisions resolve the immutable request
+ * snapshot and must not depend on this bridge.
  */
 const hydratedEnvKeys = new Set<string>();
 
@@ -352,7 +362,14 @@ export function hydrateProcessEnv(env: Env): void {
   target.STEWARD_RUNTIME = "workers";
 }
 
-let workerInit: Promise<void> | null = null;
+const workerInitByAuthority = new Map<string, Promise<void>>();
+let workerInitOverride: Promise<void> | null = null;
+
+function workerInitAuthorityKey(): string {
+  return JSON.stringify(
+    Object.entries(runtimeEnvironmentSnapshot()).sort(([a], [b]) => a.localeCompare(b)),
+  );
+}
 
 function workerJwtEnvironment(env: Env): Readonly<JwtRuntimeEnvironment> {
   return Object.freeze({
@@ -402,8 +419,11 @@ function validateWorkerSecurityEnv(): void {
 }
 
 async function ensureWorkerInit(env: Env): Promise<void> {
-  if (workerInit) return workerInit;
-  workerInit = (async () => {
+  if (workerInitOverride) return workerInitOverride;
+  const authorityKey = workerInitAuthorityKey();
+  const existing = workerInitByAuthority.get(authorityKey);
+  if (existing) return existing;
+  const pending = (async () => {
     // Workers bindings are only available inside fetch(). Hydrate process.env
     // before importing app modules that read required env at module init.
     hydrateProcessEnv(env);
@@ -442,7 +462,7 @@ async function ensureWorkerInit(env: Env): Promise<void> {
           dbUrl.includes("sslmode=verify-ca") ||
           dbUrl.includes("sslmode=verify-full"),
         hstsEnabled: isHstsEnabled(),
-        insecureDbAllowed: process.env.STEWARD_ALLOW_INSECURE_DB === "true",
+        insecureDbAllowed: runtimeEnvironmentValue("STEWARD_ALLOW_INSECURE_DB") === "true",
         runtime: "workers",
       },
     });
@@ -465,24 +485,32 @@ async function ensureWorkerInit(env: Env): Promise<void> {
       );
     }
   })();
-  return workerInit;
+  workerInitByAuthority.set(authorityKey, pending);
+  pending.catch(() => workerInitByAuthority.delete(authorityKey));
+  return pending;
 }
 
-// Compose the deployable app once per isolate: lean core + this repo's opt-in
-// plugins (trading). cached so we don't re-register plugins on every request.
-// composeApp() dynamically imports the trading plugin so the lean core graph
-// never statically references the trading stack.
-let composedApp: Awaited<ReturnType<typeof import("./compose").composeApp>> | null = null;
+// Cache composed apps by their complete immutable binding generation. Plugin
+// topology and route gates may change in a binding-only deploy; one isolate
+// must never retain the prior generation's app for a later request.
+const composedApps = new Map<
+  string,
+  Promise<Awaited<ReturnType<typeof import("./compose").composeApp>>>
+>();
 
 export function __setWorkerInitForTests(value: Promise<void> | null): void {
-  workerInit = value;
+  workerInitByAuthority.clear();
+  workerInitOverride = value;
 }
 
 async function getComposedApp() {
-  if (composedApp) return composedApp;
-  const { composeApp } = await import("./compose");
-  composedApp = await composeApp();
-  return composedApp;
+  const authorityKey = workerInitAuthorityKey();
+  const existing = composedApps.get(authorityKey);
+  if (existing) return existing;
+  const pending = import("./compose").then(({ composeApp }) => composeApp());
+  composedApps.set(authorityKey, pending);
+  pending.catch(() => composedApps.delete(authorityKey));
+  return pending;
 }
 
 export default {

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -85,6 +85,9 @@ export interface Env {
   STEWARD_AWS_KMS_KEY_ARN?: string;
   STEWARD_AWS_REGION?: string;
   AWS_REGION?: string;
+  AWS_ACCESS_KEY_ID?: string;
+  AWS_SECRET_ACCESS_KEY?: string;
+  AWS_SESSION_TOKEN?: string;
   STEWARD_PKCS11_MODULE?: string;
   STEWARD_PKCS11_PIN?: string;
   STEWARD_PKCS11_KEY_LABEL?: string;

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -59,7 +59,7 @@ import {
   type NeonTransactionDbHandle,
   withRequestDatabase,
 } from "@stwd/db";
-import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { runtimeEnvironmentValue, withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { initRedis } from "./middleware/redis";
 
 export interface Env {
@@ -232,7 +232,7 @@ export async function runWorkerUpstreamCredentialLeaseSweep(
   const capabilitiesEnabled =
     options?.capabilitiesEnabled ??
     (await import("./plugin-config")).resolveEnabledPlugins().has("capabilities");
-  if (!capabilitiesEnabled || process.env.STEWARD_UPSTREAM_LEASE_SWEEPER === "false") return null;
+  if (!capabilitiesEnabled || runtimeEnvironmentValue("STEWARD_UPSTREAM_LEASE_SWEEPER") === "false") return null;
   const sweep =
     options?.sweep ??
     (await import("./services/upstream-credential-lease-scheduler"))
@@ -246,9 +246,9 @@ export async function runWorkerGoogleCredentialLifecycleSweep(
 ): Promise<unknown | null> {
   hydrateProcessEnv(env);
   if (
-    process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEPER === "false" ||
-    !process.env.GOOGLE_PROVIDER_CLIENT_ID ||
-    !process.env.GOOGLE_PROVIDER_CLIENT_SECRET
+    runtimeEnvironmentValue("STEWARD_GOOGLE_LIFECYCLE_SWEEPER") === "false" ||
+    !runtimeEnvironmentValue("GOOGLE_PROVIDER_CLIENT_ID") ||
+    !runtimeEnvironmentValue("GOOGLE_PROVIDER_CLIENT_SECRET")
   ) {
     return null;
   }
@@ -265,10 +265,10 @@ export async function runWorkerXCredentialLifecycleSweep(
 ): Promise<unknown | null> {
   hydrateProcessEnv(env);
   if (
-    process.env.STEWARD_X_LIFECYCLE_SWEEPER === "false" ||
-    !process.env.X_CLIENT_ID ||
-    !process.env.X_CLIENT_SECRET ||
-    !process.env.STEWARD_MASTER_PASSWORD
+    runtimeEnvironmentValue("STEWARD_X_LIFECYCLE_SWEEPER") === "false" ||
+    !runtimeEnvironmentValue("X_CLIENT_ID") ||
+    !runtimeEnvironmentValue("X_CLIENT_SECRET") ||
+    !runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD")
   ) {
     return null;
   }
@@ -281,7 +281,7 @@ export async function runWorkerXCredentialLifecycleSweep(
 
 /**
  * Pull Worker `env` bindings into `globalThis.process.env` so any code that
- * reads `process.env.X` at request time (e.g. JWT secret, RPC URL) can find it.
+ * reads `runtimeEnvironmentValue("X")` at request time (e.g. JWT secret, RPC URL) can find it.
  *
  * Workers expose `nodejs_compat`'s `process.env` as an empty object on cold
  * boot — bindings come in via the `fetch` handler's `env` argument instead.
@@ -407,7 +407,7 @@ async function ensureWorkerInit(env: Env): Promise<void> {
           dbUrl.includes("sslmode=verify-ca") ||
           dbUrl.includes("sslmode=verify-full"),
         hstsEnabled: isHstsEnabled(),
-        insecureDbAllowed: process.env.STEWARD_ALLOW_INSECURE_DB === "true",
+        insecureDbAllowed: runtimeEnvironmentValue("STEWARD_ALLOW_INSECURE_DB") === "true",
         runtime: "workers",
       },
     });

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -362,6 +362,11 @@ export function hydrateProcessEnv(env: Env): void {
   target.STEWARD_RUNTIME = "workers";
 }
 
+/** @internal prevent mounted Worker tests from changing later Bun test authority. */
+export function __resetWorkerHydrationForTests(): void {
+  hydratedEnvKeys.clear();
+}
+
 const workerInitByAuthority = new Map<string, Promise<void>>();
 let workerInitOverride: Promise<void> | null = null;
 
@@ -497,13 +502,24 @@ const composedApps = new Map<
   string,
   Promise<Awaited<ReturnType<typeof import("./compose").composeApp>>>
 >();
+let composedAppOverride: {
+  fetch(request: Request, env: Env, ctx: unknown): Promise<Response>;
+} | null = null;
 
 export function __setWorkerInitForTests(value: Promise<void> | null): void {
   workerInitByAuthority.clear();
   workerInitOverride = value;
 }
 
+export function __setWorkerComposedAppForTests(
+  value: { fetch(request: Request, env: Env, ctx: unknown): Promise<Response> } | null,
+): void {
+  composedApps.clear();
+  composedAppOverride = value;
+}
+
 async function getComposedApp() {
+  if (composedAppOverride) return composedAppOverride;
   const authorityKey = workerInitAuthorityKey();
   const existing = composedApps.get(authorityKey);
   if (existing) return existing;

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -113,6 +113,10 @@ export interface Env {
   STEWARD_MONERO_NETWORK?: string;
   STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY?: string;
   STEWARD_WEBHOOK_SECRET_KDF_SALT?: string;
+  /** Break-glass local/test override. Never configure on a production Worker. */
+  STEWARD_ALLOW_INSECURE_WEBHOOK_URLS?: string;
+  /** Break-glass local/test override. Never configure on a production Worker. */
+  STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS?: string;
   STEWARD_EMBEDDED?: string;
   STEWARD_EMBEDDED_MODE?: string;
   STEWARD_DB_MODE?: string;

--- a/packages/attestation/package.json
+++ b/packages/attestation/package.json
@@ -21,6 +21,9 @@
     "test": "bun test"
   },
   "license": "MIT",
+  "dependencies": {
+    "@stwd/shared": "workspace:*"
+  },
   "devDependencies": {
     "@types/bun": "1.3.14",
     "@types/node": "^25.5.0"

--- a/packages/attestation/src/__tests__/attestation.test.ts
+++ b/packages/attestation/src/__tests__/attestation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { generateKeyPairSync, sign } from "node:crypto";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import {
   canonicalizeJson,
   createDstackTdxProvider,
@@ -17,6 +18,29 @@ import {
 const now = () => new Date("2026-07-30T00:00:00.000Z");
 
 describe("attestation providers", () => {
+  test("provider authority follows A to B to missing without process fallback", async () => {
+    const allowed = await withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        NODE_ENV: "test",
+        STEWARD_ATTESTATION_NOOP_ALLOW: "true",
+        STEWARD_ALLOW_DEV_SECRETS: "true",
+      },
+      () => createNoopDevProvider({ now }).generateQuote(),
+    );
+    expect(allowed.verified).toBe(true);
+    expect(() =>
+      withRuntimeEnvironment(
+        { STEWARD_RUNTIME: "workers", STEWARD_ATTESTATION_NOOP_ALLOW: "true" },
+        () => createNoopDevProvider({ now }),
+      ),
+    ).toThrow("cannot be explicitly allowed in production");
+    expect(
+      await withRuntimeEnvironment({ STEWARD_RUNTIME: "workers" }, () =>
+        createNoopDevProvider({ now }).generateQuote(),
+      ),
+    ).toMatchObject({ verified: false });
+  });
   test("noop-dev refuses to silently verify", async () => {
     const provider = createNoopDevProvider({ now });
     const quote = await provider.generateQuote();

--- a/packages/attestation/src/dstack.ts
+++ b/packages/attestation/src/dstack.ts
@@ -1,4 +1,5 @@
 import { request as httpRequest } from "node:http";
+import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";
 import type {
   AttestationMeasurement,
   AttestationProvider,
@@ -91,8 +92,9 @@ export class DstackTdxAttestationProvider implements AttestationProvider {
   private readonly now: () => Date;
 
   constructor(options: DstackTdxProviderOptions = {}) {
-    this.socketPath = options.socketPath ?? process.env.DSTACK_SOCKET_PATH ?? DEFAULT_DSTACK_SOCKET;
-    this.verifierUrl = options.verifierUrl ?? process.env.STEWARD_DSTACK_VERIFIER_URL;
+    const env = runtimeEnvironmentSnapshot();
+    this.socketPath = options.socketPath ?? env.DSTACK_SOCKET_PATH ?? DEFAULT_DSTACK_SOCKET;
+    this.verifierUrl = options.verifierUrl ?? env.STEWARD_DSTACK_VERIFIER_URL;
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.now = options.now ?? (() => new Date());
     warnIfVerifierChannelInsecure(this.verifierUrl);

--- a/packages/attestation/src/noop.ts
+++ b/packages/attestation/src/noop.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";
 import type {
   AttestationProvider,
   AttestationQuote,
@@ -23,9 +24,12 @@ export class NoopDevAttestationProvider implements AttestationProvider {
   private readonly now: () => Date;
 
   constructor(options: NoopDevProviderOptions = {}) {
-    const requested =
-      options.allowUnverified ?? process.env.STEWARD_ATTESTATION_NOOP_ALLOW === "true";
-    this.environment = options.environment ?? process.env.NODE_ENV ?? "development";
+    const env = runtimeEnvironmentSnapshot();
+    const requested = options.allowUnverified ?? env.STEWARD_ATTESTATION_NOOP_ALLOW === "true";
+    this.environment =
+      options.environment ??
+      env.NODE_ENV ??
+      (env.STEWARD_RUNTIME === "workers" ? "production" : "development");
     this.now = options.now ?? (() => new Date());
     // SEC-029: keying the insecure mode solely on NODE_ENV means any
     // deployment that forgets NODE_ENV=production gets vacuous-green quotes.
@@ -34,8 +38,7 @@ export class NoopDevAttestationProvider implements AttestationProvider {
     // and never in production.
     const devSecretsAllowed =
       options.allowDevSecrets ??
-      (process.env.STEWARD_ALLOW_DEV_SECRETS === "true" ||
-        process.env.STEWARD_ALLOW_DEV_SECRET === "true");
+      (env.STEWARD_ALLOW_DEV_SECRETS === "true" || env.STEWARD_ALLOW_DEV_SECRET === "true");
     if (requested && this.environment === "production") {
       throw new Error("noop-dev attestation cannot be explicitly allowed in production");
     }

--- a/packages/auth/src/__tests__/oauth.test.ts
+++ b/packages/auth/src/__tests__/oauth.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { createHash } from "node:crypto";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { getEnabledProviders, getProviderConfig, isBuiltInProvider, OAuthClient } from "../oauth";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -65,6 +66,25 @@ describe("isBuiltInProvider", () => {
 // ─── getEnabledProviders ─────────────────────────────────────────────────────
 
 describe("getEnabledProviders", () => {
+  it("observes provider credential rotations and missing bindings per request", () => {
+    const first = withRuntimeEnvironment(
+      { GOOGLE_CLIENT_ID: "google-a", GOOGLE_CLIENT_SECRET: "secret-a" },
+      () => getProviderConfig("google"),
+    );
+    const second = withRuntimeEnvironment(
+      { GOOGLE_CLIENT_ID: "google-b", GOOGLE_CLIENT_SECRET: "secret-b" },
+      () => getProviderConfig("google"),
+    );
+
+    expect(first.clientId).toBe("google-a");
+    expect(first.clientSecret).toBe("secret-a");
+    expect(second.clientId).toBe("google-b");
+    expect(second.clientSecret).toBe("secret-b");
+    expect(() => withRuntimeEnvironment({}, () => getProviderConfig("google"))).toThrow(
+      "Google OAuth not configured",
+    );
+  });
+
   it("returns empty array when no provider env vars are set", () => {
     const orig = {
       GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,

--- a/packages/auth/src/email-provider.ts
+++ b/packages/auth/src/email-provider.ts
@@ -56,6 +56,8 @@ export interface EmailProvider {
     html?: string,
     options?: { replyTo?: string },
   ): Promise<EmailDeliveryReceipt>;
+  /** Drop credential-bearing client state when the provider is retired. */
+  destroy?(): void;
 }
 
 // ---------------------------------------------------------------------------
@@ -69,7 +71,7 @@ export interface ResendProviderConfig {
 }
 
 export class ResendProvider implements EmailProvider {
-  private client: Resend;
+  private client: Resend | null;
   private from: string;
   private replyTo?: string;
 
@@ -86,7 +88,9 @@ export class ResendProvider implements EmailProvider {
     html?: string,
     options?: { replyTo?: string },
   ): Promise<EmailDeliveryReceipt> {
-    const { data, error } = await this.client.emails.send({
+    const client = this.client;
+    if (!client) throw new Error("Resend provider has been retired");
+    const { data, error } = await client.emails.send({
       from: this.from,
       to,
       subject,
@@ -103,6 +107,12 @@ export class ResendProvider implements EmailProvider {
     }
 
     return { provider: "resend", id: data.id };
+  }
+
+  destroy(): void {
+    this.client = null;
+    this.from = "";
+    this.replyTo = undefined;
   }
 }
 

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -1,6 +1,6 @@
 import { createHmac, randomBytes, randomInt, timingSafeEqual } from "node:crypto";
 import { redactedThrownDiagnostics } from "@stwd/shared";
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+import { runtimeEnvironmentSnapshot, runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 
 import { hashSha256Hex } from "./crypto";
 import type { EmailDeliveryReceipt, EmailProvider } from "./email-provider";
@@ -483,7 +483,10 @@ export class EmailAuth {
       // Tests intentionally use an isolated deterministic fallback. Every
       // runnable non-test environment must explicitly opt in to that fallback,
       // matching the repository-wide dev-secret policy.
-      if (runtimeEnvironmentValue("NODE_ENV") !== "test" && !isDevSecretAllowed()) {
+      if (
+        runtimeEnvironmentValue("NODE_ENV") !== "test" &&
+        !isDevSecretAllowed(runtimeEnvironmentValue("NODE_ENV"), runtimeEnvironmentSnapshot())
+      ) {
         throw new Error(
           "STEWARD_EMAIL_CODE_SECRET is required. For local development only, set STEWARD_ALLOW_DEV_SECRETS=true to use the insecure dev secret.",
         );

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -1,6 +1,6 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createHmac, randomBytes, randomInt, timingSafeEqual } from "node:crypto";
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 
 import { hashSha256Hex } from "./crypto";
 import type { EmailDeliveryReceipt, EmailProvider } from "./email-provider";
@@ -469,13 +469,16 @@ export class EmailAuth {
     // Console delivery is forbidden in production. Reject before storing a
     // challenge so the API cannot report success for an undeliverable login.
     this.deliveryNotConfigured =
-      runtimeEnvironmentValue("NODE_ENV") === "production" && this.provider instanceof ConsoleProvider;
+      runtimeEnvironmentValue("NODE_ENV") === "production" &&
+      this.provider instanceof ConsoleProvider;
     this.tokenStore = config.tokenStore ?? new TokenStore();
     this.replyTo = config.replyTo;
     this.templateId = config.templateId;
     this.subjectOverride = config.subjectOverride;
     const configuredCodeSecret =
-      config.codeVerifierSecret?.trim() || runtimeEnvironmentValue("STEWARD_EMAIL_CODE_SECRET")?.trim() || "";
+      config.codeVerifierSecret?.trim() ||
+      runtimeEnvironmentValue("STEWARD_EMAIL_CODE_SECRET")?.trim() ||
+      "";
     if (!configuredCodeSecret) {
       // Tests intentionally use an isolated deterministic fallback. Every
       // runnable non-test environment must explicitly opt in to that fallback,
@@ -485,7 +488,10 @@ export class EmailAuth {
           "STEWARD_EMAIL_CODE_SECRET is required. For local development only, set STEWARD_ALLOW_DEV_SECRETS=true to use the insecure dev secret.",
         );
       }
-    } else if (runtimeEnvironmentValue("NODE_ENV") === "production" && configuredCodeSecret.length < 32) {
+    } else if (
+      runtimeEnvironmentValue("NODE_ENV") === "production" &&
+      configuredCodeSecret.length < 32
+    ) {
       throw new Error("STEWARD_EMAIL_CODE_SECRET must be at least 32 characters in production");
     }
     this.codeVerifierSecret = configuredCodeSecret || "steward-development-email-login-secret";

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createHmac, randomBytes, randomInt, timingSafeEqual } from "node:crypto";
 import { redactedThrownDiagnostics } from "@stwd/shared";
 
@@ -468,23 +469,23 @@ export class EmailAuth {
     // Console delivery is forbidden in production. Reject before storing a
     // challenge so the API cannot report success for an undeliverable login.
     this.deliveryNotConfigured =
-      process.env.NODE_ENV === "production" && this.provider instanceof ConsoleProvider;
+      runtimeEnvironmentValue("NODE_ENV") === "production" && this.provider instanceof ConsoleProvider;
     this.tokenStore = config.tokenStore ?? new TokenStore();
     this.replyTo = config.replyTo;
     this.templateId = config.templateId;
     this.subjectOverride = config.subjectOverride;
     const configuredCodeSecret =
-      config.codeVerifierSecret?.trim() || process.env.STEWARD_EMAIL_CODE_SECRET?.trim() || "";
+      config.codeVerifierSecret?.trim() || runtimeEnvironmentValue("STEWARD_EMAIL_CODE_SECRET")?.trim() || "";
     if (!configuredCodeSecret) {
       // Tests intentionally use an isolated deterministic fallback. Every
       // runnable non-test environment must explicitly opt in to that fallback,
       // matching the repository-wide dev-secret policy.
-      if (process.env.NODE_ENV !== "test" && !isDevSecretAllowed()) {
+      if (runtimeEnvironmentValue("NODE_ENV") !== "test" && !isDevSecretAllowed()) {
         throw new Error(
           "STEWARD_EMAIL_CODE_SECRET is required. For local development only, set STEWARD_ALLOW_DEV_SECRETS=true to use the insecure dev secret.",
         );
       }
-    } else if (process.env.NODE_ENV === "production" && configuredCodeSecret.length < 32) {
+    } else if (runtimeEnvironmentValue("NODE_ENV") === "production" && configuredCodeSecret.length < 32) {
       throw new Error("STEWARD_EMAIL_CODE_SECRET must be at least 32 characters in production");
     }
     this.codeVerifierSecret = configuredCodeSecret || "steward-development-email-login-secret";

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -1228,9 +1228,17 @@ export class EmailAuth {
   }
 
   /**
-   * Clean up background timers.  Call in tests after each suite.
+   * Retire credential-bearing provider state without touching a shared token store.
+   */
+  disposeProvider(): void {
+    this.provider.destroy?.();
+  }
+
+  /**
+   * Clean up background timers and provider state. Call in tests after each suite.
    */
   destroy(): void {
+    this.disposeProvider();
     this.tokenStore.destroy();
   }
 }

--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID, scryptSync } from "node:crypto";
 import {
@@ -53,7 +54,7 @@ export interface RefreshTokenPayload extends StewardJwtPayload {
 }
 
 export interface JwtSecretOptions {
-  /** Defaults to process.env.NODE_ENV. */
+  /** Defaults to runtimeEnvironmentValue("NODE_ENV"). */
   nodeEnv?: string;
   /** Defaults to console.warn. Pass null to silence warnings. */
   warn?: ((message: string) => void) | null;
@@ -164,7 +165,7 @@ function isEmbeddedMode(environment: JwtRuntimeEnvironment = process.env): boole
  * same consistent guard.
  */
 export function isDevSecretAllowed(
-  nodeEnv: string | undefined = process.env.NODE_ENV,
+  nodeEnv: string | undefined = runtimeEnvironmentValue("NODE_ENV"),
   environment: JwtRuntimeEnvironment = process.env,
 ): boolean {
   if (nodeEnv === "production") return false;
@@ -214,7 +215,7 @@ export function checkJwtSecretStrength(
   options: { nodeEnv?: string; warn?: ((message: string) => void) | null } = {},
 ): void {
   if (secret.length >= 32) return;
-  const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV;
+  const nodeEnv = options.nodeEnv ?? runtimeEnvironmentValue("NODE_ENV");
   if (nodeEnv === "production") {
     throw new Error(
       `⛔ ${sourceName} must be at least 32 characters in production (canonical env var: STEWARD_JWT_SECRET).`,
@@ -315,14 +316,14 @@ function getIdentityJwtAlgorithm(): IdentityJwtAlgorithm {
   const authority = jwtRuntimeAuthorityStorage.getStore();
   return (
     authority?.identityJwtAlgorithm ??
-    resolveIdentityJwtAlgorithm(process.env.STEWARD_IDENTITY_JWT_ALG)
+    resolveIdentityJwtAlgorithm(runtimeEnvironmentValue("STEWARD_IDENTITY_JWT_ALG"))
   );
 }
 
 function getIdentityJwtPrivateKeyInput(): string | undefined {
   const authority = jwtRuntimeAuthorityStorage.getStore();
   if (authority) return authority.identityJwtPrivateKey;
-  return process.env.STEWARD_IDENTITY_JWT_PRIVATE_KEY?.trim() || undefined;
+  return runtimeEnvironmentValue("STEWARD_IDENTITY_JWT_PRIVATE_KEY")?.trim() || undefined;
 }
 
 export function isAsymmetricIdentityJwtConfigured(): boolean {
@@ -331,10 +332,10 @@ export function isAsymmetricIdentityJwtConfigured(): boolean {
 
 function resolveIdentityJwtBase(requestOrigin?: string): string {
   const authority = jwtRuntimeAuthorityStorage.getStore();
-  const nodeEnv = authority?.nodeEnv ?? process.env.NODE_ENV;
+  const nodeEnv = authority?.nodeEnv ?? runtimeEnvironmentValue("NODE_ENV");
   const configured = authority
     ? authority.identityJwtIssuer || authority.appUrl
-    : process.env.STEWARD_IDENTITY_JWT_ISSUER?.trim() || process.env.APP_URL?.trim();
+    : runtimeEnvironmentValue("STEWARD_IDENTITY_JWT_ISSUER")?.trim() || runtimeEnvironmentValue("APP_URL")?.trim();
   if (configured) {
     let url: URL;
     try {
@@ -380,7 +381,7 @@ export function getIdentityDiscoveryBaseUrl(requestUrl: string): string {
 export function getIdentityJwtAudience(): string {
   return (
     jwtRuntimeAuthorityStorage.getStore()?.identityJwtAudience ??
-    process.env.STEWARD_IDENTITY_JWT_AUDIENCE?.trim() ??
+    runtimeEnvironmentValue("STEWARD_IDENTITY_JWT_AUDIENCE")?.trim() ??
     JWT_AUDIENCE
   );
 }
@@ -407,7 +408,7 @@ async function identityPublicJwk(alg: IdentityJwtAlgorithm): Promise<JWK | null>
   const authority = jwtRuntimeAuthorityStorage.getStore();
   publicJwk.kid = authority
     ? authority.identityJwtKid || publicJwk.kid || (await calculateJwkThumbprint(publicJwk))
-    : process.env.STEWARD_IDENTITY_JWT_KID?.trim() ||
+    : runtimeEnvironmentValue("STEWARD_IDENTITY_JWT_KID")?.trim() ||
       publicJwk.kid ||
       (await calculateJwkThumbprint(publicJwk));
   delete publicJwk.d;
@@ -524,7 +525,7 @@ export function validateAgentTokenExpiryEnv(value?: string): void {
   const resolved =
     value ??
     jwtRuntimeAuthorityStorage.getStore()?.agentTokenExpiry ??
-    process.env.AGENT_TOKEN_EXPIRY ??
+    runtimeEnvironmentValue("AGENT_TOKEN_EXPIRY") ??
     AGENT_TOKEN_EXPIRY;
   const seconds = parseDurationSeconds(resolved);
   if (seconds === null) {
@@ -544,7 +545,7 @@ export function getAgentTokenExpiry(value?: string): string {
   const normalized = (
     value ??
     jwtRuntimeAuthorityStorage.getStore()?.agentTokenExpiry ??
-    process.env.AGENT_TOKEN_EXPIRY ??
+    runtimeEnvironmentValue("AGENT_TOKEN_EXPIRY") ??
     AGENT_TOKEN_EXPIRY
   ).trim();
   validateAgentTokenExpiryEnv(normalized);

--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -1,6 +1,6 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID, scryptSync } from "node:crypto";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   calculateJwkThumbprint,
   exportJWK,
@@ -335,7 +335,8 @@ function resolveIdentityJwtBase(requestOrigin?: string): string {
   const nodeEnv = authority?.nodeEnv ?? runtimeEnvironmentValue("NODE_ENV");
   const configured = authority
     ? authority.identityJwtIssuer || authority.appUrl
-    : runtimeEnvironmentValue("STEWARD_IDENTITY_JWT_ISSUER")?.trim() || runtimeEnvironmentValue("APP_URL")?.trim();
+    : runtimeEnvironmentValue("STEWARD_IDENTITY_JWT_ISSUER")?.trim() ||
+      runtimeEnvironmentValue("APP_URL")?.trim();
   if (configured) {
     let url: URL;
     try {

--- a/packages/auth/src/oauth.ts
+++ b/packages/auth/src/oauth.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * oauth.ts — Generic OAuth2 authorization-code flow helper
  *
@@ -222,7 +223,7 @@ function overrideUrl(
   kind: "AUTHORIZATION" | "TOKEN" | "USERINFO",
 ): string | undefined {
   const key = `${provider.toUpperCase()}_${kind}_URL`;
-  const value = process.env[key];
+  const value = runtimeEnvironmentValue(key);
   return value && value.trim().length > 0 ? value.trim() : undefined;
 }
 
@@ -231,7 +232,7 @@ function envPrefix(provider: string): string {
 }
 
 function envCredential(provider: string, kind: "CLIENT_ID" | "CLIENT_SECRET"): string | undefined {
-  const value = process.env[`${envPrefix(provider)}_${kind}`];
+  const value = runtimeEnvironmentValue(`${envPrefix(provider)}_${kind}`);
   return value && value.trim().length > 0 ? value.trim() : undefined;
 }
 
@@ -263,8 +264,8 @@ function isHttpsUrl(value: string): boolean {
 
 function allowInsecureProviderUrls(): boolean {
   return (
-    process.env.NODE_ENV !== "production" &&
-    process.env.STEWARD_ALLOW_INSECURE_OAUTH_PROVIDER_URLS === "true"
+    runtimeEnvironmentValue("NODE_ENV") !== "production" &&
+    runtimeEnvironmentValue("STEWARD_ALLOW_INSECURE_OAUTH_PROVIDER_URLS") === "true"
   );
 }
 
@@ -305,7 +306,7 @@ function readMappedValue(source: Record<string, unknown>, path: string): unknown
 type CustomOAuthProviderInput = OAuthProvider & { id: string };
 
 function getCustomProviderConfigs(): CustomOAuthProviderInput[] {
-  const raw = process.env.STEWARD_CUSTOM_OAUTH_PROVIDERS?.trim();
+  const raw = runtimeEnvironmentValue("STEWARD_CUSTOM_OAUTH_PROVIDERS")?.trim();
   if (!raw) return [];
   const parsed = JSON.parse(raw) as unknown;
   if (!Array.isArray(parsed)) {

--- a/packages/auth/src/platform.ts
+++ b/packages/auth/src/platform.ts
@@ -1,6 +1,6 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createHash, timingSafeEqual } from "node:crypto";
 import type { ApiResponse } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createMiddleware } from "hono/factory";
 
 /**
@@ -28,7 +28,10 @@ import { createMiddleware } from "hono/factory";
  */
 
 function getValidPlatformKeys(): string[] {
-  return [runtimeEnvironmentValue("STEWARD_PLATFORM_KEYS"), runtimeEnvironmentValue("STEWARD_PLATFORM_KEY")]
+  return [
+    runtimeEnvironmentValue("STEWARD_PLATFORM_KEYS"),
+    runtimeEnvironmentValue("STEWARD_PLATFORM_KEY"),
+  ]
     .filter((value): value is string => Boolean(value))
     .join(",")
     .split(",")

--- a/packages/auth/src/platform.ts
+++ b/packages/auth/src/platform.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createHash, timingSafeEqual } from "node:crypto";
 import type { ApiResponse } from "@stwd/shared";
 import { createMiddleware } from "hono/factory";
@@ -27,7 +28,7 @@ import { createMiddleware } from "hono/factory";
  */
 
 function getValidPlatformKeys(): string[] {
-  return [process.env.STEWARD_PLATFORM_KEYS, process.env.STEWARD_PLATFORM_KEY]
+  return [runtimeEnvironmentValue("STEWARD_PLATFORM_KEYS"), runtimeEnvironmentValue("STEWARD_PLATFORM_KEY")]
     .filter((value): value is string => Boolean(value))
     .join(",")
     .split(",")
@@ -45,7 +46,7 @@ class PlatformKeyScopesConfigurationError extends Error {
 }
 
 function parsePlatformKeyScopes(): Record<string, string[]> {
-  const raw = process.env.STEWARD_PLATFORM_KEY_SCOPES;
+  const raw = runtimeEnvironmentValue("STEWARD_PLATFORM_KEY_SCOPES");
   if (!raw?.trim()) return {};
 
   let parsed: unknown;

--- a/packages/auth/src/public-endpoint-node.ts
+++ b/packages/auth/src/public-endpoint-node.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { lookup as dnsLookup } from "node:dns";
 import type { LookupFunction } from "node:net";
 import { assertPublicInternetAddress } from "./public-endpoint";
@@ -10,7 +11,7 @@ import { assertPublicInternetAddress } from "./public-endpoint";
  * exposes a transport that can pin a validated address while retaining TLS SNI.
  */
 export function assertPinnedDnsTransportSupported(resource: string): void {
-  if (process.env.STEWARD_RUNTIME === "workers") {
+  if (runtimeEnvironmentValue("STEWARD_RUNTIME") === "workers") {
     throw new Error(`${resource} requires connect-time DNS validation unavailable in Workers`);
   }
 }

--- a/packages/auth/src/public-endpoint-node.ts
+++ b/packages/auth/src/public-endpoint-node.ts
@@ -1,6 +1,6 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { lookup as dnsLookup } from "node:dns";
 import type { LookupFunction } from "node:net";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { assertPublicInternetAddress } from "./public-endpoint";
 
 /**

--- a/packages/auth/src/revocation.ts
+++ b/packages/auth/src/revocation.ts
@@ -123,12 +123,13 @@ class InMemoryRevocationStore implements RevocationStore {
 }
 
 class RedisRevocationStore implements RevocationStore {
-  private redis: Redis | null = null;
+  private readonly redisByAuthority = new Map<string, Redis>();
   private readonly fallback = new InMemoryRevocationStore();
   private warnedMemoryFallback = false;
 
   private getRedis(): Redis | null {
-    if (!runtimeEnvironmentValue("REDIS_URL")) {
+    const redisUrl = runtimeEnvironmentValue("REDIS_URL")?.trim();
+    if (!redisUrl) {
       if (runtimeEnvironmentValue("NODE_ENV") === "production") {
         throw new Error("Shared token revocation store unavailable");
       }
@@ -144,21 +145,31 @@ class RedisRevocationStore implements RevocationStore {
       }
       return null;
     }
-    if (!this.redis) {
+    const authorityKey = JSON.stringify([
+      redisUrl,
+      runtimeEnvironmentValue("NODE_ENV") ?? "",
+      runtimeEnvironmentValue("STEWARD_ALLOW_INSECURE_REDIS") ?? "",
+    ]);
+    let redis = this.redisByAuthority.get(authorityKey);
+    if (!redis) {
       // SEC-032: enforce the same rediss:// production TLS assertion as the
       // shared client in @stwd/redis — revocation state is auth data and must
       // not cross a cleartext link.
-      assertRedisUrlTls(runtimeEnvironmentValue("REDIS_URL"));
-      this.redis = new Redis(runtimeEnvironmentValue("REDIS_URL"), {
+      assertRedisUrlTls(redisUrl, {
+        NODE_ENV: runtimeEnvironmentValue("NODE_ENV"),
+        STEWARD_ALLOW_INSECURE_REDIS: runtimeEnvironmentValue("STEWARD_ALLOW_INSECURE_REDIS"),
+      });
+      redis = new Redis(redisUrl, {
         maxRetriesPerRequest: 1,
         lazyConnect: false,
         enableReadyCheck: true,
       });
-      this.redis.on("error", (err) => {
+      redis.on("error", (err) => {
         console.warn("[steward:auth] Redis revocation unavailable", redactedThrownDiagnostics(err));
       });
+      this.redisByAuthority.set(authorityKey, redis);
     }
-    return this.redis;
+    return redis;
   }
 
   private fallbackAgentRevokedBefore(agentId: string): Promise<number | null> {

--- a/packages/auth/src/revocation.ts
+++ b/packages/auth/src/revocation.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Access-token revocation store.
  *
@@ -127,8 +128,8 @@ class RedisRevocationStore implements RevocationStore {
   private warnedMemoryFallback = false;
 
   private getRedis(): Redis | null {
-    if (!process.env.REDIS_URL) {
-      if (process.env.NODE_ENV === "production") {
+    if (!runtimeEnvironmentValue("REDIS_URL")) {
+      if (runtimeEnvironmentValue("NODE_ENV") === "production") {
         throw new Error("Shared token revocation store unavailable");
       }
       // SEC-056: revocation state silently degrading to per-process memory
@@ -147,8 +148,8 @@ class RedisRevocationStore implements RevocationStore {
       // SEC-032: enforce the same rediss:// production TLS assertion as the
       // shared client in @stwd/redis — revocation state is auth data and must
       // not cross a cleartext link.
-      assertRedisUrlTls(process.env.REDIS_URL);
-      this.redis = new Redis(process.env.REDIS_URL, {
+      assertRedisUrlTls(runtimeEnvironmentValue("REDIS_URL"));
+      this.redis = new Redis(runtimeEnvironmentValue("REDIS_URL"), {
         maxRetriesPerRequest: 1,
         lazyConnect: false,
         enableReadyCheck: true,

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Pluggable backend implementations for ChallengeStore and TokenStore.
  *
@@ -135,7 +136,7 @@ interface MemoryEntry {
  * This is the zero-config default — no external dependencies required.
  */
 const isWorkersRuntime =
-  process.env.STEWARD_RUNTIME === "workers" ||
+  runtimeEnvironmentValue("STEWARD_RUNTIME") === "workers" ||
   (typeof navigator !== "undefined" && navigator.userAgent === "Cloudflare-Workers");
 
 export class MemoryBackend implements StoreBackend {

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -135,16 +135,19 @@ interface MemoryEntry {
  * Simple in-memory backend with automatic TTL expiry.
  * This is the zero-config default — no external dependencies required.
  */
-const isWorkersRuntime =
-  runtimeEnvironmentValue("STEWARD_RUNTIME") === "workers" ||
-  (typeof navigator !== "undefined" && navigator.userAgent === "Cloudflare-Workers");
+function isWorkersRuntime(): boolean {
+  return (
+    runtimeEnvironmentValue("STEWARD_RUNTIME") === "workers" ||
+    (typeof navigator !== "undefined" && navigator.userAgent === "Cloudflare-Workers")
+  );
+}
 
 export class MemoryBackend implements StoreBackend {
   private readonly store = new Map<string, MemoryEntry>();
   private readonly cleanupTimer?: ReturnType<typeof setInterval>;
 
   constructor(cleanupIntervalMs = 60_000) {
-    if (!isWorkersRuntime) {
+    if (!isWorkersRuntime()) {
       this.cleanupTimer = setInterval(() => this._cleanup(), cleanupIntervalMs);
       if (this.cleanupTimer.unref) this.cleanupTimer.unref();
     }

--- a/packages/db/src/__tests__/audit-chain-retry.test.ts
+++ b/packages/db/src/__tests__/audit-chain-retry.test.ts
@@ -9,7 +9,9 @@
  * unearned reliance on the caller's retry-idempotency contract.
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import {
+  __auditHmacDigestForTests,
   __resetAuditHmacKeyCacheForTests,
   withTenantAuditedTransaction,
   withTenantAuditedTransactionOnDb,
@@ -25,6 +27,22 @@ function uniqueViolation(constraint: string): Error {
 }
 
 describe("audit-chain retry classification (SEC-167)", () => {
+  test("HMAC cache is authority-keyed across A to B to missing", () => {
+    const digest = (key?: string) =>
+      withRuntimeEnvironment(
+        {
+          STEWARD_RUNTIME: "workers",
+          NODE_ENV: "production",
+          ...(key ? { STEWARD_AUDIT_HMAC_KEY: key } : {}),
+        },
+        () => __auditHmacDigestForTests("authority-probe"),
+      );
+    const a = digest("a".repeat(64));
+    const b = digest("b".repeat(64));
+    expect(a).not.toBe(b);
+    expect(digest("a".repeat(64))).toBe(a);
+    expect(() => digest()).toThrow("STEWARD_AUDIT_HMAC_KEY is required in production");
+  });
   beforeAll(async () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
     const { db, client } = await createPGLiteDb("memory://");

--- a/packages/db/src/audit-chain.ts
+++ b/packages/db/src/audit-chain.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Shared tamper-evident audit-chain WRITE core.
  *
@@ -30,7 +31,7 @@ import { DatabaseDeadlineExceededError, getDb, hasTenantTransactionDatabase } fr
 const ZERO_HASH = new Uint8Array(32);
 
 function isPGLiteRuntime(): boolean {
-  return process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true";
+  return runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true";
 }
 
 function toU8(value: unknown): Uint8Array {
@@ -138,7 +139,7 @@ export function __resetAuditHmacKeyCacheForTests(): void {
 
 function getHmacKey(): Uint8Array {
   if (cachedKey) return cachedKey;
-  const env = process.env.STEWARD_AUDIT_HMAC_KEY;
+  const env = runtimeEnvironmentValue("STEWARD_AUDIT_HMAC_KEY");
   if (env && env.length > 0) {
     const isHex = /^[0-9a-fA-F]+$/.test(env) && env.length % 2 === 0;
     // Hex keys decode to env.length/2 bytes; raw keys count chars directly.
@@ -154,14 +155,14 @@ function getHmacKey(): Uint8Array {
       isHex && env.length >= MIN_HMAC_RAW_BYTES * 2 ? toU8(env) : new TextEncoder().encode(env);
     return cachedKey;
   }
-  if (process.env.NODE_ENV === "production") {
+  if (runtimeEnvironmentValue("NODE_ENV") === "production") {
     throw new Error(
       "STEWARD_AUDIT_HMAC_KEY is required in production. Generate with `openssl rand -hex 32`.",
     );
   }
   // Default-deny: the dev fallback is only allowed with an explicit opt-in
   // consistent with the rest of the repo (STEWARD_ALLOW_DEV_SECRETS).
-  if (process.env.STEWARD_ALLOW_DEV_SECRETS !== "true") {
+  if (runtimeEnvironmentValue("STEWARD_ALLOW_DEV_SECRETS") !== "true") {
     throw new Error(
       "STEWARD_AUDIT_HMAC_KEY is required. For local development only, set " +
         "STEWARD_ALLOW_DEV_SECRETS=true to use the insecure dev key.",

--- a/packages/db/src/audit-chain.ts
+++ b/packages/db/src/audit-chain.ts
@@ -31,7 +31,10 @@ import { DatabaseDeadlineExceededError, getDb, hasTenantTransactionDatabase } fr
 const ZERO_HASH = new Uint8Array(32);
 
 function isPGLiteRuntime(): boolean {
-  return runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true";
+  return (
+    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" ||
+    runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
+  );
 }
 
 function toU8(value: unknown): Uint8Array {

--- a/packages/db/src/audit-chain.ts
+++ b/packages/db/src/audit-chain.ts
@@ -132,17 +132,23 @@ export function redactWebhookSecrets<T>(value: T): T {
 const MIN_HMAC_RAW_BYTES = 32;
 
 let warnedDevFallback = false;
-let cachedKey: Uint8Array | null = null;
+const cachedKeys = new Map<string, Uint8Array>();
 
 /** @internal test hook: forget the memoized HMAC key so env changes take effect. */
 export function __resetAuditHmacKeyCacheForTests(): void {
-  cachedKey = null;
+  cachedKeys.clear();
   warnedDevFallback = false;
 }
 
 function getHmacKey(): Uint8Array {
-  if (cachedKey) return cachedKey;
   const env = runtimeEnvironmentValue("STEWARD_AUDIT_HMAC_KEY");
+  const authority = JSON.stringify([
+    env ?? "",
+    runtimeEnvironmentValue("NODE_ENV") ?? "",
+    runtimeEnvironmentValue("STEWARD_ALLOW_DEV_SECRETS") ?? "",
+  ]);
+  const cachedKey = cachedKeys.get(authority);
+  if (cachedKey) return cachedKey;
   if (env && env.length > 0) {
     const isHex = /^[0-9a-fA-F]+$/.test(env) && env.length % 2 === 0;
     // Hex keys decode to env.length/2 bytes; raw keys count chars directly.
@@ -154,9 +160,10 @@ function getHmacKey(): Uint8Array {
           "Generate with `openssl rand -hex 32`.",
       );
     }
-    cachedKey =
+    const key =
       isHex && env.length >= MIN_HMAC_RAW_BYTES * 2 ? toU8(env) : new TextEncoder().encode(env);
-    return cachedKey;
+    cachedKeys.set(authority, key);
+    return key;
   }
   if (runtimeEnvironmentValue("NODE_ENV") === "production") {
     throw new Error(
@@ -178,10 +185,16 @@ function getHmacKey(): Uint8Array {
         "(STEWARD_ALLOW_DEV_SECRETS=true). Audit chain is NOT tamper-evident. Never use in production.",
     );
   }
-  cachedKey = new TextEncoder().encode(
+  const key = new TextEncoder().encode(
     "dev-audit-hmac-key-do-not-use-in-production-aaaaaaaaaaaaaaaaaaaaaaaa",
   );
-  return cachedKey;
+  cachedKeys.set(authority, key);
+  return key;
+}
+
+/** @internal authority-isolation regression seam; never returns key material. */
+export function __auditHmacDigestForTests(payload: string): string {
+  return createHmac("sha256", getHmacKey()).update(payload).digest("hex");
 }
 
 export type ActorType = "user" | "agent" | "platform" | "system" | "api-key";

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Pluggable database client for Steward.
  *
@@ -45,14 +46,14 @@ const FULL_SCHEMA = { ...schema, ...schemaAuth };
 type FullSchema = typeof FULL_SCHEMA;
 
 export function getDatabaseDriver(): DatabaseDriver {
-  const raw = process.env.DATABASE_DRIVER?.trim().toLowerCase();
+  const raw = runtimeEnvironmentValue("DATABASE_DRIVER")?.trim().toLowerCase();
   if (raw === "neon-http") return "neon-http";
   if (raw === "neon-websocket") return "neon-websocket";
   return "postgres-js";
 }
 
 export function getDatabaseUrl(): string {
-  const connectionString = process.env.DATABASE_URL;
+  const connectionString = runtimeEnvironmentValue("DATABASE_URL");
 
   if (!connectionString) {
     throw new Error("DATABASE_URL is required");

--- a/packages/db/src/pglite.ts
+++ b/packages/db/src/pglite.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * PGLite adapter for Steward — runs Postgres in-process via WASM.
  *
@@ -29,8 +30,8 @@ let globalPGLite: { client: PGlite; db: PGLiteDb } | undefined;
  * Resolve the data directory for PGLite persistence.
  */
 export function getDataDir(): string {
-  if (process.env.STEWARD_PGLITE_PATH) {
-    return resolve(process.env.STEWARD_PGLITE_PATH);
+  if (runtimeEnvironmentValue("STEWARD_PGLITE_PATH")) {
+    return resolve(runtimeEnvironmentValue("STEWARD_PGLITE_PATH"));
   }
   return join(homedir(), ".steward", "data");
 }
@@ -39,8 +40,8 @@ export function getDataDir(): string {
  * Determine whether PGLite should be used based on environment variables.
  */
 export function shouldUsePGLite(): boolean {
-  if (process.env.STEWARD_DB_MODE === "pglite") return true;
-  if (!process.env.DATABASE_URL) return true;
+  if (runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite") return true;
+  if (!runtimeEnvironmentValue("DATABASE_URL")) return true;
   return false;
 }
 
@@ -113,7 +114,7 @@ async function runPGLiteMigrations(client: PGlite): Promise<void> {
  * @param dataDir - directory for persistence, or "memory://" for in-memory
  */
 export async function createPGLiteDb(dataDir?: string): Promise<{ client: PGlite; db: PGLiteDb }> {
-  const useMemory = process.env.STEWARD_PGLITE_MEMORY === "true";
+  const useMemory = runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true";
 
   let connectionTarget: string;
   if (useMemory) {

--- a/packages/db/src/pglite.ts
+++ b/packages/db/src/pglite.ts
@@ -30,9 +30,8 @@ let globalPGLite: { client: PGlite; db: PGLiteDb } | undefined;
  * Resolve the data directory for PGLite persistence.
  */
 export function getDataDir(): string {
-  if (runtimeEnvironmentValue("STEWARD_PGLITE_PATH")) {
-    return resolve(runtimeEnvironmentValue("STEWARD_PGLITE_PATH"));
-  }
+  const configuredPath = runtimeEnvironmentValue("STEWARD_PGLITE_PATH");
+  if (configuredPath) return resolve(configuredPath);
   return join(homedir(), ".steward", "data");
 }
 

--- a/packages/plugin-capabilities/src/__tests__/client-ip.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/client-ip.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { Hono } from "hono";
 import { trustedClientIp } from "../client-ip";
 
@@ -43,6 +44,17 @@ afterEach(() => {
 });
 
 describe("trustedClientIp (capability audit)", () => {
+  test("uses the current request proxy authority for A, B, and missing generations", async () => {
+    const headers = { "x-forwarded-for": "198.51.100.1, 203.0.113.9" };
+    expect(
+      await withRuntimeEnvironment({ STEWARD_TRUSTED_PROXY_HOPS: "1" }, () => requestIp(headers)),
+    ).toBe("203.0.113.9");
+    expect(
+      await withRuntimeEnvironment({ STEWARD_TRUSTED_PROXY_HOPS: "2" }, () => requestIp(headers)),
+    ).toBe("198.51.100.1");
+    expect(await withRuntimeEnvironment({}, () => requestIp(headers))).toBeNull();
+  });
+
   test("ignores x-forwarded-for entirely when no trust is configured", async () => {
     expect(await requestIp({ "x-forwarded-for": "203.0.113.9" })).toBeNull();
   });

--- a/packages/plugin-capabilities/src/client-ip.ts
+++ b/packages/plugin-capabilities/src/client-ip.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * client-ip.ts - best-effort trustworthy client IP for the capability audit
  * trail.
@@ -34,9 +35,9 @@ import type { Context } from "hono";
  * default); the deprecated STEWARD_TRUST_PROXY_HEADERS=true maps to hops=1.
  */
 function trustedProxyHops(): number {
-  const raw = process.env.STEWARD_TRUSTED_PROXY_HOPS?.trim();
+  const raw = runtimeEnvironmentValue("STEWARD_TRUSTED_PROXY_HOPS")?.trim();
   if (raw === undefined || raw === "") {
-    return process.env.STEWARD_TRUST_PROXY_HEADERS === "true" ? 1 : 0;
+    return runtimeEnvironmentValue("STEWARD_TRUST_PROXY_HEADERS") === "true" ? 1 : 0;
   }
   // Canonical non-negative integer only: "1.5" must not truncate into trust.
   if (!/^\d+$/.test(raw)) return 0;
@@ -65,7 +66,7 @@ function normalizeIpCandidate(value: string | undefined): string | undefined {
 
 /** Best-effort trustworthy client IP, or undefined when none can be derived. */
 export function trustedClientIp(c: Context): string | undefined {
-  const trustCloudflare = process.env.STEWARD_TRUST_CLOUDFLARE === "true";
+  const trustCloudflare = runtimeEnvironmentValue("STEWARD_TRUST_CLOUDFLARE") === "true";
   if (trustCloudflare) {
     const cf = c.req.header("cf-connecting-ip")?.trim();
     if (cf && isIP(cf)) return cf;

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -21,6 +21,7 @@ import {
 } from "@stwd/policy-engine";
 import { StewardProxyClient } from "@stwd/proxy-client";
 import type { ApiResponse, AppVariables, PolicyRule, SignRequest } from "@stwd/shared";
+import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";
 import { Hono } from "hono";
 import type { StewardAppContext } from "./context";
 import { enforceCapabilityRateLimit } from "./rate-limit";
@@ -119,7 +120,9 @@ async function toOpenAICompatible(res: Response): Promise<Response> {
   });
 }
 
-function readProxyEnv(env: NodeJS.ProcessEnv = process.env): ProxyEnv | null {
+function readProxyEnv(
+  env: Readonly<Record<string, string | undefined>> = runtimeEnvironmentSnapshot(),
+): ProxyEnv | null {
   const proxyUrl = (env.STEWARD_PROXY_URL ?? "").trim();
   const signingSecret = (
     env.STEWARD_PROXY_REQUEST_SIGNING_SECRET ??

--- a/packages/plugin-capabilities/src/manifest-routes.ts
+++ b/packages/plugin-capabilities/src/manifest-routes.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * manifest-routes.ts — agent-facing manifest + issuance/renewal surface (A1).
  *
@@ -52,12 +53,12 @@ export function upstreamLeaseIssuanceAvailableInRuntime(): boolean {
   // 30-second delivery recovery contract. Do not expose live provider tokens
   // from a runtime that cannot autonomously revoke abandoned delivery.
   if (
-    process.env.STEWARD_RUNTIME === "workers" ||
-    process.env.STEWARD_UPSTREAM_LEASE_SWEEPER === "false"
+    runtimeEnvironmentValue("STEWARD_RUNTIME") === "workers" ||
+    runtimeEnvironmentValue("STEWARD_UPSTREAM_LEASE_SWEEPER") === "false"
   ) {
     return false;
   }
-  const configured = process.env.STEWARD_UPSTREAM_LEASE_SWEEP_INTERVAL_MS;
+  const configured = runtimeEnvironmentValue("STEWARD_UPSTREAM_LEASE_SWEEP_INTERVAL_MS");
   if (configured === undefined) return true;
   const intervalMs = Number(configured);
   return (

--- a/packages/plugin-trading/src/__tests__/trade-polymarket-creds-cache.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-creds-cache.test.ts
@@ -327,7 +327,7 @@ describe("SEC-108: Polymarket L2 creds Redis cache is encrypted at rest", () => 
     }
   });
 
-  it("skips the cache entirely when no encryption key material is configured", async () => {
+  it("fails the order closed when the current request has no custody key material", async () => {
     const { createTradeRoutes } = await import("../routes/trade");
     const { testCtx } = await import("./_ctx");
     const ctx = {
@@ -394,10 +394,10 @@ describe("SEC-108: Polymarket L2 creds Redis cache is encrypted at rest", () => 
           negRisk: true,
         }),
       });
-      // Fail closed WITHOUT failing the order: the order still executes (creds
-      // are derived fresh), but nothing is written to the shared Redis.
-      expect(res.status).toBe(200);
-      expect(deriveCount).toBe(1);
+      // The late-bound vault rejects the missing current authority before
+      // deriving venue credentials or writing shared cache state.
+      expect(res.status).toBe(409);
+      expect(deriveCount).toBe(0);
       const pmKeys = [...redisStore.keys()].filter((key) => key.startsWith("pm:clob-l2:"));
       expect(pmKeys).toHaveLength(0);
     } finally {

--- a/packages/plugin-trading/src/routes/idempotency.ts
+++ b/packages/plugin-trading/src/routes/idempotency.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Durable, multi-replica idempotency for fund-moving trading routes.
  *
@@ -225,10 +226,10 @@ export class DurableIdempotencyStore<TRecord extends IdempotencyRecord> {
     }
 
     if (
-      (process.env.NODE_ENV === "production" ||
-        process.env.STEWARD_RUNTIME === "workers" ||
-        process.env.CF_PAGES === "1") &&
-      process.env.STEWARD_ALLOW_MEMORY_TRADING_IDEMPOTENCY !== "true"
+      (runtimeEnvironmentValue("NODE_ENV") === "production" ||
+        runtimeEnvironmentValue("STEWARD_RUNTIME") === "workers" ||
+        runtimeEnvironmentValue("CF_PAGES") === "1") &&
+      runtimeEnvironmentValue("STEWARD_ALLOW_MEMORY_TRADING_IDEMPOTENCY") !== "true"
     ) {
       throw new Error(
         "Trading idempotency requires Redis in production; set STEWARD_ALLOW_MEMORY_TRADING_IDEMPOTENCY=true only for an explicitly single-instance deployment",

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * operator-recovery.ts — Operator fund-recovery endpoints.
  *
@@ -484,7 +485,7 @@ export function createOperatorRecoveryRoutes(
       // serializes operator reservations with both other operator rails and
       // on-chain transaction evaluation/commit for the cumulative cap.
       const pgliteRuntime =
-        process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true";
+        runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true";
       if (!pgliteRuntime) {
         await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${input.agentId}, 0))`);
       }

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -485,7 +485,8 @@ export function createOperatorRecoveryRoutes(
       // serializes operator reservations with both other operator rails and
       // on-chain transaction evaluation/commit for the cumulative cap.
       const pgliteRuntime =
-        runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" || runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true";
+        runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" ||
+        runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true";
       if (!pgliteRuntime) {
         await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${input.agentId}, 0))`);
       }

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -56,6 +56,120 @@ import { z } from "zod";
 import type { StewardAppContext } from "../context";
 import { DurableIdempotencyStore } from "./idempotency";
 
+const PM_CREDS_KEY_DOMAIN = "steward-kdf:pm-clob-l2-cache:v2";
+const PM_CREDS_CACHE_PREFIX = "stwd_pmclob_v1:";
+
+function polymarketCredentialCacheAuthority(): {
+  password: string;
+  salt: string;
+} | null {
+  const password = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD")?.trim();
+  if (!password) return null;
+  const salt = runtimeEnvironmentValue("STEWARD_KDF_SALT") ?? "";
+  return { password, salt };
+}
+
+function pmCredsCacheEncryptionKey(): Buffer | null {
+  const authority = polymarketCredentialCacheAuthority();
+  if (!authority) return null;
+  return scryptSync(authority.password, `${PM_CREDS_KEY_DOMAIN}:${authority.salt}`, 32) as Buffer;
+}
+
+/** Encrypt one Redis credential-cache value under the current request authority. */
+export function encryptPolymarketCredentialCacheValue(
+  plaintext: string,
+  cacheKey: string,
+): string | null {
+  const key = pmCredsCacheEncryptionKey();
+  if (!key) return null;
+  try {
+    const iv = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", key, iv);
+    cipher.setAAD(Buffer.from(cacheKey, "utf8"));
+    let ciphertext = cipher.update(plaintext, "utf8", "hex");
+    ciphertext += cipher.final("hex");
+    return `${PM_CREDS_CACHE_PREFIX}${JSON.stringify({
+      ciphertext,
+      iv: iv.toString("hex"),
+      tag: cipher.getAuthTag().toString("hex"),
+    })}`;
+  } finally {
+    key.fill(0);
+  }
+}
+
+/** Decrypt only envelopes authenticated by the current request authority. */
+export function decryptPolymarketCredentialCacheValue(
+  stored: string,
+  cacheKey: string,
+): string | null {
+  if (!stored.startsWith(PM_CREDS_CACHE_PREFIX)) return null;
+  const key = pmCredsCacheEncryptionKey();
+  if (!key) return null;
+  try {
+    const payload = JSON.parse(stored.slice(PM_CREDS_CACHE_PREFIX.length)) as {
+      ciphertext: string;
+      iv: string;
+      tag: string;
+    };
+    const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(payload.iv, "hex"));
+    decipher.setAAD(Buffer.from(cacheKey, "utf8"));
+    decipher.setAuthTag(Buffer.from(payload.tag, "hex"));
+    let plaintext = decipher.update(payload.ciphertext, "hex", "utf8");
+    plaintext += decipher.final("utf8");
+    return plaintext;
+  } catch {
+    return null;
+  } finally {
+    key.fill(0);
+  }
+}
+
+type PolymarketRuntimeConfig = {
+  clobUrl?: string;
+  testCredentialsRequested: boolean;
+  testCredentialsEnabled: boolean;
+};
+
+function resolvePolymarketRuntimeConfig(): PolymarketRuntimeConfig {
+  const configuredNodeEnvironment = runtimeEnvironmentValue("NODE_ENV")?.trim();
+  const nodeEnvironment =
+    configuredNodeEnvironment ||
+    (runtimeEnvironmentValue("STEWARD_RUNTIME") === "workers" ? "production" : undefined);
+  const testCredentialsRequested = runtimeEnvironmentValue("STEWARD_PM_TEST_CREDS") === "1";
+  const raw = runtimeEnvironmentValue("POLYMARKET_CLOB_API_URL")?.trim();
+  let clobUrl: string | undefined;
+  if (raw) {
+    if (raw.length > 2_048 || /[\u0000-\u001f\u007f]/.test(raw)) {
+      throw new Error("POLYMARKET_CLOB_API_URL is invalid");
+    }
+    const url = new URL(raw);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error("POLYMARKET_CLOB_API_URL must use http or https");
+    }
+    if (url.username || url.password || url.search || url.hash) {
+      throw new Error("POLYMARKET_CLOB_API_URL must not contain credentials, query, or fragment");
+    }
+    if (nodeEnvironment === "production" && url.protocol !== "https:") {
+      throw new Error("POLYMARKET_CLOB_API_URL must use https in production");
+    }
+    clobUrl = url.toString().replace(/\/$/, "");
+  }
+  return {
+    ...(clobUrl ? { clobUrl } : {}),
+    testCredentialsRequested,
+    testCredentialsEnabled: testCredentialsRequested && nodeEnvironment !== "production",
+  };
+}
+
+function configuredPolymarketClobUrl(): string | undefined {
+  return resolvePolymarketRuntimeConfig().clobUrl;
+}
+
+/** Internal behavior hook for request-authority isolation tests. */
+export function _polymarketRuntimeConfigForTests(): PolymarketRuntimeConfig {
+  return resolvePolymarketRuntimeConfig();
+}
 // Prediction-market session asset: pm:<tokenId> (a single outcome token) or
 // pm:cond:<conditionId> (a whole market). Mirrors @stwd/trade-sessions'
 // predictionMarketAssetSchema so a Polymarket session can be created through the
@@ -1456,87 +1570,15 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
   // SEC-108: the cached L2 creds carry full trading authority on the venue as
   // the agent (outside Steward's session caps and audit), so they never touch
   // the shared Redis in plaintext. The cache value is AES-256-GCM encrypted
-  // with a key scrypt-derived from STEWARD_MASTER_PASSWORD under a
+  // with a key scrypt-derived from the request-local password + KDF salt under a
   // domain-separated label (same idiom as the webhook secret codec + embedded
   // JWT derivation), so a process or tenant with read access to Redis cannot
   // lift them. If no master password is configured the cache is SKIPPED
   // entirely (fail closed: never write plaintext; re-derive per order).
-  const PM_CREDS_CACHE_PREFIX = "stwd_pmclob_v1:";
-  let pmCredsDerivedKey: { source: string; key: Buffer } | null = null;
-
-  function pmCredsCacheEncryptionKey(): Buffer | null {
-    const masterPassword = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD");
-    if (!masterPassword) return null;
-    if (pmCredsDerivedKey?.source === masterPassword) return pmCredsDerivedKey.key;
-    const key = scryptSync(masterPassword, "steward-kdf:pm-clob-l2-cache:v1", 32) as Buffer;
-    pmCredsDerivedKey = { source: masterPassword, key };
-    return key;
-  }
-
-  function encryptPmCredsCacheValue(plaintext: string, cacheKey: string): string | null {
-    const key = pmCredsCacheEncryptionKey();
-    if (!key) return null;
-    const iv = randomBytes(12);
-    const cipher = createCipheriv("aes-256-gcm", key, iv);
-    cipher.setAAD(Buffer.from(cacheKey, "utf8"));
-    let ciphertext = cipher.update(plaintext, "utf8", "hex");
-    ciphertext += cipher.final("hex");
-    return `${PM_CREDS_CACHE_PREFIX}${JSON.stringify({
-      ciphertext,
-      iv: iv.toString("hex"),
-      tag: cipher.getAuthTag().toString("hex"),
-    })}`;
-  }
-
-  // Returns null for anything that is not a valid envelope for THIS key —
-  // including legacy plaintext entries — so the caller treats it as a cache
-  // miss, re-derives, and overwrites with an encrypted value.
-  function decryptPmCredsCacheValue(stored: string, cacheKey: string): string | null {
-    if (!stored.startsWith(PM_CREDS_CACHE_PREFIX)) return null;
-    const key = pmCredsCacheEncryptionKey();
-    if (!key) return null;
-    try {
-      const payload = JSON.parse(stored.slice(PM_CREDS_CACHE_PREFIX.length)) as {
-        ciphertext: string;
-        iv: string;
-        tag: string;
-      };
-      const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(payload.iv, "hex"));
-      decipher.setAAD(Buffer.from(cacheKey, "utf8"));
-      decipher.setAuthTag(Buffer.from(payload.tag, "hex"));
-      let plaintext = decipher.update(payload.ciphertext, "hex", "utf8");
-      plaintext += decipher.final("utf8");
-      return plaintext;
-    } catch {
-      return null;
-    }
-  }
-
   // Optional endpoint override for deterministic integration environments and
   // compatible CLOB gateways. It is deployment configuration, not a test-creds
   // bypass: the real clob-client still performs L1 derivation, EIP-712 signing,
   // L2 HMAC auth, and order serialization against the configured HTTP edge.
-  // SEC-111: in production the override must use https — a stray plain-http
-  // endpoint would send L1-signed derivations + L2 HMAC headers in cleartext.
-  function configuredPolymarketClobUrl(): string | undefined {
-    const raw = runtimeEnvironmentValue("POLYMARKET_CLOB_API_URL")?.trim();
-    if (!raw) return undefined;
-    if (raw.length > 2_048 || /[\u0000-\u001f\u007f]/.test(raw)) {
-      throw new Error("POLYMARKET_CLOB_API_URL is invalid");
-    }
-    const url = new URL(raw);
-    if (url.protocol !== "http:" && url.protocol !== "https:") {
-      throw new Error("POLYMARKET_CLOB_API_URL must use http or https");
-    }
-    if (url.username || url.password || url.search || url.hash) {
-      throw new Error("POLYMARKET_CLOB_API_URL must not contain credentials, query, or fragment");
-    }
-    if (runtimeEnvironmentValue("NODE_ENV") === "production" && url.protocol !== "https:") {
-      throw new Error("POLYMARKET_CLOB_API_URL must use https in production");
-    }
-    return url.toString().replace(/\/$/, "");
-  }
-
   function pmCredsCacheKey(
     tenantId: string,
     agentId: string,
@@ -1621,7 +1663,9 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     if (redis) {
       try {
         const cached = await redis.get(cacheKey);
-        const cachedPlaintext = cached ? decryptPmCredsCacheValue(cached, cacheKey) : null;
+        const cachedPlaintext = cached
+          ? decryptPolymarketCredentialCacheValue(cached, cacheKey)
+          : null;
         if (cachedPlaintext) {
           const parsed = clobApiCredentialsSchema.safeParse(JSON.parse(cachedPlaintext));
           if (parsed.success) {
@@ -1651,7 +1695,10 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     if (redis) {
       // Fail closed: without cache encryption key material, skip the write and
       // re-derive per order rather than ever storing the creds in plaintext.
-      const cacheValue = encryptPmCredsCacheValue(JSON.stringify(apiCredentials), cacheKey);
+      const cacheValue = encryptPolymarketCredentialCacheValue(
+        JSON.stringify(apiCredentials),
+        cacheKey,
+      );
       if (cacheValue) {
         await redis.setex(cacheKey, PM_CREDS_CACHE_TTL_SECONDS, cacheValue).catch(() => undefined);
       }

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * trade.ts — trade-session management + venue order routes (Hyperliquid +
  * Polymarket).
@@ -1464,7 +1465,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
   let pmCredsDerivedKey: { source: string; key: Buffer } | null = null;
 
   function pmCredsCacheEncryptionKey(): Buffer | null {
-    const masterPassword = process.env.STEWARD_MASTER_PASSWORD;
+    const masterPassword = runtimeEnvironmentValue("STEWARD_MASTER_PASSWORD");
     if (!masterPassword) return null;
     if (pmCredsDerivedKey?.source === masterPassword) return pmCredsDerivedKey.key;
     const key = scryptSync(masterPassword, "steward-kdf:pm-clob-l2-cache:v1", 32) as Buffer;
@@ -1518,7 +1519,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
   // SEC-111: in production the override must use https — a stray plain-http
   // endpoint would send L1-signed derivations + L2 HMAC headers in cleartext.
   function configuredPolymarketClobUrl(): string | undefined {
-    const raw = process.env.POLYMARKET_CLOB_API_URL?.trim();
+    const raw = runtimeEnvironmentValue("POLYMARKET_CLOB_API_URL")?.trim();
     if (!raw) return undefined;
     if (raw.length > 2_048 || /[\u0000-\u001f\u007f]/.test(raw)) {
       throw new Error("POLYMARKET_CLOB_API_URL is invalid");
@@ -1530,7 +1531,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     if (url.username || url.password || url.search || url.hash) {
       throw new Error("POLYMARKET_CLOB_API_URL must not contain credentials, query, or fragment");
     }
-    if (process.env.NODE_ENV === "production" && url.protocol !== "https:") {
+    if (runtimeEnvironmentValue("NODE_ENV") === "production" && url.protocol !== "https:") {
       throw new Error("POLYMARKET_CLOB_API_URL must use https in production");
     }
     return url.toString().replace(/\/$/, "");
@@ -1597,8 +1598,8 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     // SEC-111: hard-disabled in production (same force-off idiom as the
     // unsigned-webhook escape hatch) so a stray env var can never swap in the
     // hardcoded test creds on a live deployment.
-    if (process.env.STEWARD_PM_TEST_CREDS === "1") {
-      if (process.env.NODE_ENV === "production") {
+    if (runtimeEnvironmentValue("STEWARD_PM_TEST_CREDS") === "1") {
+      if (runtimeEnvironmentValue("NODE_ENV") === "production") {
         console.error(
           "[trade] STEWARD_PM_TEST_CREDS is set but ignored in production; real L2 creds stay required.",
         );

--- a/packages/plugin-wxmr/src/__tests__/wxmr-bridge.test.ts
+++ b/packages/plugin-wxmr/src/__tests__/wxmr-bridge.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { PublicKey } from "@solana/web3.js";
 import { AdapterProviderError, AdapterValidationError, type BridgeQuote } from "@stwd/adapters";
 import { MONERO_ON_SOLANA } from "@stwd/shared";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import bs58 from "bs58";
-import { resolveRpcUrl, wxmrPlugin } from "../index";
+import { createWxmrBridgeAdapter, resolveRpcUrl, wxmrPlugin } from "../index";
 import {
   WXMR_BRIDGE_CONFIG_ACCOUNT,
   WXMR_BRIDGE_PROGRAM_ID,
@@ -584,7 +585,8 @@ describe("WxmrBridgeAdapter", () => {
       solana: process.env.SOLANA_RPC_URL,
     };
     try {
-      // Both unset -> undefined so the adapter falls back to the public default.
+      // Both unset -> undefined. The plugin factory fails closed rather than
+      // borrowing an endpoint from an earlier Worker generation.
       process.env.WXMR_SOLANA_RPC_URL = undefined;
       process.env.SOLANA_RPC_URL = undefined;
       delete process.env.WXMR_SOLANA_RPC_URL;
@@ -629,6 +631,24 @@ describe("WxmrBridgeAdapter", () => {
       category: "bridge",
       provider: WXMR_PROVIDER,
     });
-    expect(wxmrPlugin.adapters?.[0]?.adapter).toBeInstanceOf(WxmrBridgeAdapter);
+    expect(wxmrPlugin.adapters?.[0]?.adapter).toBeUndefined();
+    expect(wxmrPlugin.adapters?.[0]?.createAdapter).toBe(createWxmrBridgeAdapter);
+  });
+
+  test("request-owned provider instances preserve only authority-free session state", async () => {
+    await withRuntimeEnvironment(
+      { WXMR_SOLANA_RPC_URL: "https://request-rpc.example.test" },
+      async () => {
+        const first = createWxmrBridgeAdapter();
+        const quote = await inboundQuote(first);
+        const session = await first.createSession(quote, {
+          tenantId: "tenant-a",
+          userId: "user-a",
+        });
+
+        const nextRequest = createWxmrBridgeAdapter();
+        expect(await nextRequest.getSession(session.id)).toEqual(session);
+      },
+    );
   });
 });

--- a/packages/plugin-wxmr/src/index.ts
+++ b/packages/plugin-wxmr/src/index.ts
@@ -1,6 +1,6 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /** Opt-in wxmr.io bridge provider for Steward. */
 import type { StewardPlugin } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { WxmrBridgeAdapter } from "./wxmr-bridge";
 
 export * from "./wxmr-bridge";
@@ -13,7 +13,10 @@ export * from "./wxmr-bridge";
  * and silently drop the operator's RPC in favor of the public default.
  */
 export function resolveRpcUrl(): string | undefined {
-  for (const candidate of [runtimeEnvironmentValue("WXMR_SOLANA_RPC_URL"), runtimeEnvironmentValue("SOLANA_RPC_URL")]) {
+  for (const candidate of [
+    runtimeEnvironmentValue("WXMR_SOLANA_RPC_URL"),
+    runtimeEnvironmentValue("SOLANA_RPC_URL"),
+  ]) {
     const trimmed = candidate?.trim();
     if (trimmed) return trimmed;
   }

--- a/packages/plugin-wxmr/src/index.ts
+++ b/packages/plugin-wxmr/src/index.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /** Opt-in wxmr.io bridge provider for Steward. */
 import type { StewardPlugin } from "@stwd/shared";
 import { WxmrBridgeAdapter } from "./wxmr-bridge";
@@ -12,7 +13,7 @@ export * from "./wxmr-bridge";
  * and silently drop the operator's RPC in favor of the public default.
  */
 export function resolveRpcUrl(): string | undefined {
-  for (const candidate of [process.env.WXMR_SOLANA_RPC_URL, process.env.SOLANA_RPC_URL]) {
+  for (const candidate of [runtimeEnvironmentValue("WXMR_SOLANA_RPC_URL"), runtimeEnvironmentValue("SOLANA_RPC_URL")]) {
     const trimmed = candidate?.trim();
     if (trimmed) return trimmed;
   }

--- a/packages/plugin-wxmr/src/index.ts
+++ b/packages/plugin-wxmr/src/index.ts
@@ -1,4 +1,5 @@
 /** Opt-in wxmr.io bridge provider for Steward. */
+import { AdapterNotConfiguredError } from "@stwd/adapters";
 import type { StewardPlugin } from "@stwd/shared";
 import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { WxmrBridgeAdapter } from "./wxmr-bridge";
@@ -23,7 +24,20 @@ export function resolveRpcUrl(): string | undefined {
   return undefined;
 }
 
-const rpcUrl = resolveRpcUrl();
+// Session records contain no endpoint or credential authority. Keep them
+// separate from request-owned provider instances so the existing create/get
+// session API survives isolate reuse without retaining a prior binding set.
+const sessions = new Map<
+  string,
+  { session: import("@stwd/adapters").BridgeSession; expiresAt: number }
+>();
+
+/** Build one request-owned provider from the current immutable authority. */
+export function createWxmrBridgeAdapter(): WxmrBridgeAdapter {
+  const rpcUrl = resolveRpcUrl();
+  if (!rpcUrl) throw new AdapterNotConfiguredError("bridge");
+  return new WxmrBridgeAdapter({ rpcUrl, sessions });
+}
 
 export const wxmrPlugin: StewardPlugin = {
   name: "wxmr",
@@ -32,7 +46,7 @@ export const wxmrPlugin: StewardPlugin = {
     {
       category: "bridge",
       provider: "wxmr",
-      adapter: new WxmrBridgeAdapter({ rpcUrl }),
+      createAdapter: createWxmrBridgeAdapter,
     },
   ],
 };

--- a/packages/plugin-wxmr/src/wxmr-bridge.ts
+++ b/packages/plugin-wxmr/src/wxmr-bridge.ts
@@ -116,6 +116,8 @@ export interface WxmrBridgeAdapterOptions {
   randomId?: () => string;
   rpcTimeoutMs?: number;
   getTrustedXmrUsdPrice?: () => Promise<number | null>;
+  /** Authority-free session state shared by request-owned provider instances. */
+  sessions?: Map<string, { session: BridgeSession; expiresAt: number }>;
 }
 
 function assertRpcUrl(value: string): string {
@@ -331,7 +333,7 @@ export class WxmrBridgeAdapter implements BridgeAdapter {
   private readonly randomId: () => string;
   private readonly rpcTimeoutMs: number;
   private readonly getTrustedXmrUsdPrice: () => Promise<number | null>;
-  private readonly sessions = new Map<string, { session: BridgeSession; expiresAt: number }>();
+  private readonly sessions: Map<string, { session: BridgeSession; expiresAt: number }>;
 
   constructor(options: WxmrBridgeAdapterOptions = {}) {
     this.rpcUrl = assertRpcUrl(options.rpcUrl?.trim() || DEFAULT_SOLANA_RPC_URL);
@@ -341,6 +343,7 @@ export class WxmrBridgeAdapter implements BridgeAdapter {
     this.rpcTimeoutMs = options.rpcTimeoutMs ?? DEFAULT_RPC_TIMEOUT_MS;
     this.getTrustedXmrUsdPrice =
       options.getTrustedXmrUsdPrice ?? (() => this.fetchTrustedXmrUsdPrice());
+    this.sessions = options.sessions ?? new Map();
     if (!Number.isSafeInteger(this.rpcTimeoutMs) || this.rpcTimeoutMs <= 0) {
       throw new Error("rpcTimeoutMs must be a positive integer");
     }

--- a/packages/proxy-client/package.json
+++ b/packages/proxy-client/package.json
@@ -21,6 +21,9 @@
   },
   "author": "Steward-Fi",
   "license": "MIT",
+  "dependencies": {
+    "@stwd/shared": "workspace:*"
+  },
   "devDependencies": {
     "@stwd/auth": "workspace:*",
     "@stwd/db": "workspace:*",

--- a/packages/proxy-client/src/__tests__/client.test.ts
+++ b/packages/proxy-client/src/__tests__/client.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { StewardProxyClient } from "../client";
 
 interface Captured {
@@ -30,6 +31,16 @@ function makeCapturingFetch(): { fetch: typeof fetch; calls: Captured[] } {
 }
 
 describe("StewardProxyClient construction", () => {
+  test("default transport policy follows A to B to missing Worker authority", () => {
+    const construct = (env: Record<string, string>) =>
+      withRuntimeEnvironment(
+        { STEWARD_RUNTIME: "workers", ...env },
+        () => new StewardProxyClient({ proxyUrl: "http://localhost:8080", token: "t" }),
+      );
+    expect(() => construct({ NODE_ENV: "production" })).toThrow("must be https");
+    expect(() => construct({ NODE_ENV: "test" })).toThrow("must be https");
+    expect(() => construct({})).toThrow("must be https");
+  });
   test("requires proxyUrl and token", () => {
     // @ts-expect-error missing token
     expect(() => new StewardProxyClient({ proxyUrl: "https://p" })).toThrow("token is required");

--- a/packages/proxy-client/src/client.ts
+++ b/packages/proxy-client/src/client.ts
@@ -21,6 +21,7 @@
  * Callers build the path (e.g. "/openai/v1/chat/completions") and body.
  */
 
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { signProxyRequest } from "./signature";
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
@@ -96,7 +97,10 @@ export class StewardProxyClient {
     if (!options.proxyUrl) throw new Error("proxyUrl is required");
     if (!options.token) throw new Error("token is required");
 
-    const requireHttps = options.requireHttps ?? process.env.NODE_ENV === "production";
+    const requireHttps =
+      options.requireHttps ??
+      (runtimeEnvironmentValue("NODE_ENV") === "production" ||
+        runtimeEnvironmentValue("STEWARD_RUNTIME") === "workers");
     if (requireHttps && !/^https:\/\//i.test(options.proxyUrl)) {
       throw new Error("proxyUrl must be https in production");
     }

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -23,6 +23,7 @@
     "test": "bun test src/__tests__/"
   },
   "dependencies": {
+    "@stwd/shared": "workspace:*",
     "@upstash/redis": "^1.34.3",
     "ioredis": "^5.6.1"
   },

--- a/packages/redis/src/client.ts
+++ b/packages/redis/src/client.ts
@@ -24,14 +24,35 @@
  *               set (assertUpstashRestUrlTls).
  */
 
+import {
+  type RuntimeEnvironment,
+  runtimeEnvironmentSnapshot,
+  runtimeEnvironmentValue,
+} from "@stwd/shared/runtime-env";
 import { Redis as UpstashRedis } from "@upstash/redis";
 import { Redis } from "ioredis";
 import { createUpstashIoredisAdapter, type IoredisLike } from "./upstash-adapter.js";
 
 export type RedisDriver = "ioredis" | "upstash";
 
-let instance: IoredisLike | null = null;
+const instances = new Map<string, IoredisLike>();
 let shutdownRegistered = false;
+
+function redisAuthority(): RuntimeEnvironment {
+  return runtimeEnvironmentSnapshot();
+}
+
+function authorityFingerprint(environment: RuntimeEnvironment): string {
+  return JSON.stringify([
+    environment.REDIS_DRIVER ?? "ioredis",
+    environment.REDIS_URL ?? "",
+    environment.KV_REST_API_URL ?? environment.UPSTASH_REDIS_REST_URL ?? "",
+    environment.KV_REST_API_TOKEN ?? environment.UPSTASH_REDIS_REST_TOKEN ?? "",
+    environment.NODE_ENV ?? "",
+    environment.STEWARD_RUNTIME ?? "",
+    environment.STEWARD_ALLOW_INSECURE_REDIS ?? "",
+  ]);
+}
 
 /**
  * Refuse to start in production if REDIS_URL is not using TLS (rediss://).
@@ -42,7 +63,10 @@ let shutdownRegistered = false;
  * deployments (logs a loud warning), matching the STEWARD_ALLOW_INSECURE_DB
  * posture in @stwd/db.
  */
-export function assertRedisUrlTls(url: string, env: NodeJS.ProcessEnv = process.env): void {
+export function assertRedisUrlTls(
+  url: string,
+  env: Readonly<Record<string, string | undefined>> = redisAuthority(),
+): void {
   if (env.NODE_ENV !== "production") return;
 
   const allowInsecure = env.STEWARD_ALLOW_INSECURE_REDIS === "true";
@@ -90,7 +114,10 @@ export function assertRedisUrlTls(url: string, env: NodeJS.ProcessEnv = process.
  * unless the endpoint is loopback; STEWARD_ALLOW_INSECURE_REDIS=true overrides
  * (loud warning), matching assertRedisUrlTls.
  */
-export function assertUpstashRestUrlTls(url: string, env: NodeJS.ProcessEnv = process.env): void {
+export function assertUpstashRestUrlTls(
+  url: string,
+  env: Readonly<Record<string, string | undefined>> = redisAuthority(),
+): void {
   const allowInsecure = env.STEWARD_ALLOW_INSECURE_REDIS === "true";
   let parsed: URL;
   try {
@@ -129,14 +156,18 @@ export function assertUpstashRestUrlTls(url: string, env: NodeJS.ProcessEnv = pr
 }
 
 export function getRedisDriver(): RedisDriver {
-  const raw = process.env.REDIS_DRIVER?.trim().toLowerCase();
+  const raw = runtimeEnvironmentValue("REDIS_DRIVER")?.trim().toLowerCase();
   if (raw === "upstash") return "upstash";
   return "ioredis";
 }
 
-function buildIoredis(): Redis {
-  const url = process.env.REDIS_URL || "redis://localhost:6379";
-  assertRedisUrlTls(url);
+function buildIoredis(environment: RuntimeEnvironment): Redis {
+  const configuredUrl = environment.REDIS_URL?.trim();
+  if (!configuredUrl && environment.STEWARD_RUNTIME === "workers") {
+    throw new Error("REDIS_URL is required for the ioredis driver on Workers");
+  }
+  const url = configuredUrl || "redis://localhost:6379";
+  assertRedisUrlTls(url, environment);
   const client = new Redis(url, {
     maxRetriesPerRequest: 3,
     retryStrategy(times: number) {
@@ -161,11 +192,13 @@ function buildIoredis(): Redis {
   if (!shutdownRegistered) {
     shutdownRegistered = true;
     const shutdown = async () => {
-      if (instance && "quit" in instance && typeof instance.quit === "function") {
-        console.log("[steward:redis] shutting down connection...");
-        await (instance as Redis).quit().catch(() => {});
-        instance = null;
+      for (const client of instances.values()) {
+        if ("quit" in client && typeof client.quit === "function") {
+          console.log("[steward:redis] shutting down connection...");
+          await (client as Redis).quit().catch(() => {});
+        }
       }
+      instances.clear();
     };
     process.on("SIGINT", shutdown);
     process.on("SIGTERM", shutdown);
@@ -175,9 +208,9 @@ function buildIoredis(): Redis {
   return client;
 }
 
-function buildUpstash(): IoredisLike {
-  const url = process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL || "";
-  const token = process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN || "";
+function buildUpstash(environment: RuntimeEnvironment): IoredisLike {
+  const url = environment.KV_REST_API_URL || environment.UPSTASH_REDIS_REST_URL || "";
+  const token = environment.KV_REST_API_TOKEN || environment.UPSTASH_REDIS_REST_TOKEN || "";
 
   if (!url || !token) {
     throw new Error(
@@ -188,7 +221,7 @@ function buildUpstash(): IoredisLike {
 
   // SEC-032: same TLS posture as the ioredis path — the REST token rides every
   // request, so a cleartext http:// endpoint in production is fail-closed.
-  assertUpstashRestUrlTls(url);
+  assertUpstashRestUrlTls(url, environment);
 
   const upstash = new UpstashRedis({ url, token });
   console.log("[steward:redis] using upstash REST adapter");
@@ -200,22 +233,29 @@ function buildUpstash(): IoredisLike {
  * Creates the connection on first call.
  */
 export function getRedis(): IoredisLike {
-  if (!instance) {
-    const driver = getRedisDriver();
-    instance = driver === "upstash" ? buildUpstash() : (buildIoredis() as unknown as IoredisLike);
-  }
-  return instance;
+  const environment = redisAuthority();
+  const fingerprint = authorityFingerprint(environment);
+  const cached = instances.get(fingerprint);
+  if (cached) return cached;
+  const driver = getRedisDriver();
+  const client =
+    driver === "upstash"
+      ? buildUpstash(environment)
+      : (buildIoredis(environment) as unknown as IoredisLike);
+  instances.set(fingerprint, client);
+  return client;
 }
 
 /**
  * Disconnect and reset the singleton (useful for tests).
  */
 export async function disconnectRedis(): Promise<void> {
-  if (!instance) return;
-  if ("quit" in instance && typeof instance.quit === "function") {
-    await (instance as Redis).quit().catch(() => {});
+  for (const client of instances.values()) {
+    if ("quit" in client && typeof client.quit === "function") {
+      await (client as Redis).quit().catch(() => {});
+    }
   }
-  instance = null;
+  instances.clear();
 }
 
 export type { IoredisLike };

--- a/packages/shared/src/__tests__/runtime-env.test.ts
+++ b/packages/shared/src/__tests__/runtime-env.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { runtimeEnvironmentValue, withRuntimeEnvironment } from "../runtime-env";
+import {
+  runtimeEnvironmentSnapshot,
+  runtimeEnvironmentValue,
+  withRuntimeEnvironment,
+} from "../runtime-env";
 
 function deferred() {
   let resolve!: () => void;
@@ -46,5 +50,79 @@ describe("request-local runtime environment", () => {
 
     expect(second).toEqual({ age: "120000", override: "true" });
     expect(await first).toEqual({ age: "60000", override: "false" });
+  });
+
+  test("isolates fetch and scheduled security authorities across awaits", async () => {
+    const fetchEntered = deferred();
+    const releaseFetch = deferred();
+    const authorityNames = [
+      "STEWARD_REQUEST_SIGNING_SECRET",
+      "STEWARD_TRUSTED_PROXY_HOPS",
+      "STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL",
+      "STEWARD_CUSTOM_OAUTH_PROVIDERS",
+      "PASSKEY_ALLOWED_ORIGINS",
+      "SIWE_ALLOWED_DOMAINS",
+      "RESEND_API_KEY",
+      "REDIS_URL",
+      "STEWARD_IDEMPOTENCY_TTL_MS",
+      "STEWARD_GOOGLE_LIFECYCLE_SWEEPER",
+    ] as const;
+    const bindings = (generation: "fetch-a" | "scheduled-b") =>
+      Object.fromEntries(authorityNames.map((name) => [name, `${generation}:${name}`]));
+    const readAuthority = () =>
+      Object.fromEntries(authorityNames.map((name) => [name, runtimeEnvironmentValue(name)]));
+
+    const fetchWork = withRuntimeEnvironment(bindings("fetch-a"), async () => {
+      fetchEntered.resolve();
+      await releaseFetch.promise;
+      return readAuthority();
+    });
+    await fetchEntered.promise;
+    const scheduled = await withRuntimeEnvironment(bindings("scheduled-b"), async () => {
+      await Promise.resolve();
+      return readAuthority();
+    });
+    releaseFetch.resolve();
+
+    expect(await fetchWork).toEqual(bindings("fetch-a"));
+    expect(scheduled).toEqual(bindings("scheduled-b"));
+  });
+
+  test("observes sequential binding rotations and fails closed on missing values", () => {
+    const read = () => ({
+      signingSecret: runtimeEnvironmentValue("STEWARD_REQUEST_SIGNING_SECRET"),
+      providerCredential: runtimeEnvironmentValue("RESEND_API_KEY"),
+      redisUrl: runtimeEnvironmentValue("REDIS_URL"),
+      snapshotKeys: Object.keys(runtimeEnvironmentSnapshot()).sort(),
+    });
+
+    expect(
+      withRuntimeEnvironment(
+        { STEWARD_REQUEST_SIGNING_SECRET: "a", RESEND_API_KEY: "a", REDIS_URL: "a" },
+        read,
+      ),
+    ).toEqual({
+      signingSecret: "a",
+      providerCredential: "a",
+      redisUrl: "a",
+      snapshotKeys: ["REDIS_URL", "RESEND_API_KEY", "STEWARD_REQUEST_SIGNING_SECRET"],
+    });
+    expect(
+      withRuntimeEnvironment(
+        { STEWARD_REQUEST_SIGNING_SECRET: "b", RESEND_API_KEY: "b", REDIS_URL: "b" },
+        read,
+      ),
+    ).toEqual({
+      signingSecret: "b",
+      providerCredential: "b",
+      redisUrl: "b",
+      snapshotKeys: ["REDIS_URL", "RESEND_API_KEY", "STEWARD_REQUEST_SIGNING_SECRET"],
+    });
+    expect(withRuntimeEnvironment({}, read)).toEqual({
+      signingSecret: undefined,
+      providerCredential: undefined,
+      redisUrl: undefined,
+      snapshotKeys: [],
+    });
   });
 });

--- a/packages/shared/src/provider-execution-auth.ts
+++ b/packages/shared/src/provider-execution-auth.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "./runtime-env.js";
 /**
  * Provider execution authorization v2 signing (spec §3.2).
  *
@@ -66,7 +67,7 @@ function constantTimeEqual(left: string, right: string): boolean {
  * can never collide with the v1 (STEWARD_JWT_SECRET) key material.
  */
 export function loadExecutionAuthV2Keys(): ProviderExecutionAuthV2KeyEntry[] {
-  const raw = process.env.STEWARD_EXECUTION_AUTH_SECRET?.trim();
+  const raw = runtimeEnvironmentValue("STEWARD_EXECUTION_AUTH_SECRET")?.trim();
   if (!raw) {
     throw new ProviderExecutionAuthV2Error(
       "STEWARD_EXECUTION_AUTH_SECRET is required for provider execution authorization v2",

--- a/packages/shared/src/runtime-env.ts
+++ b/packages/shared/src/runtime-env.ts
@@ -25,3 +25,15 @@ export function runtimeEnvironmentValue(name: string): string | undefined {
   const requestEnvironment = runtimeEnvironmentStorage.getStore();
   return requestEnvironment ? requestEnvironment[name] : process.env[name];
 }
+
+/**
+ * Resolve the complete immutable environment authority for the current unit of
+ * work. Bun callers receive a frozen snapshot of process.env; Worker callers
+ * receive the snapshot bound by withRuntimeEnvironment. Consumers that need to
+ * enumerate prefixed settings must use this instead of Object.keys(process.env)
+ * so an overlapping Worker request cannot replace their authority mid-read.
+ */
+export function runtimeEnvironmentSnapshot(): RuntimeEnvironment {
+  const requestEnvironment = runtimeEnvironmentStorage.getStore();
+  return requestEnvironment ?? snapshotRuntimeEnvironment(process.env);
+}

--- a/packages/shared/src/runtime-env.ts
+++ b/packages/shared/src/runtime-env.ts
@@ -2,7 +2,12 @@ import { AsyncLocalStorage } from "node:async_hooks";
 
 export type RuntimeEnvironment = Readonly<Record<string, string | undefined>>;
 
-const runtimeEnvironmentStorage = new AsyncLocalStorage<RuntimeEnvironment>();
+interface RuntimeEnvironmentContext {
+  readonly environment: RuntimeEnvironment;
+  readonly identity: object;
+}
+
+const runtimeEnvironmentStorage = new AsyncLocalStorage<RuntimeEnvironmentContext>();
 
 function snapshotRuntimeEnvironment(environment: Record<string, unknown>): RuntimeEnvironment {
   const snapshot: Record<string, string | undefined> = {};
@@ -17,13 +22,33 @@ export function withRuntimeEnvironment<T>(
   environment: Record<string, unknown>,
   callback: () => T,
 ): T {
-  return runtimeEnvironmentStorage.run(snapshotRuntimeEnvironment(environment), callback);
+  return runtimeEnvironmentStorage.run(
+    {
+      environment: snapshotRuntimeEnvironment(environment),
+      identity: Object.freeze({}),
+    },
+    callback,
+  );
 }
 
 /** Resolve one setting from the current request snapshot or Bun process. */
 export function runtimeEnvironmentValue(name: string): string | undefined {
-  const requestEnvironment = runtimeEnvironmentStorage.getStore();
-  return requestEnvironment ? requestEnvironment[name] : process.env[name];
+  const context = runtimeEnvironmentStorage.getStore();
+  return context ? context.environment[name] : process.env[name];
+}
+
+/**
+ * Return an opaque identity for the active request environment.
+ *
+ * Callers may use this object as a WeakMap key for request-local memoization.
+ * The environment values themselves deliberately remain hidden behind the
+ * `object` return type: cache identity must never be derived from, serialize,
+ * or expose secret binding values. Outside an explicitly bound request there
+ * is no safe generation identity, so callers must not reuse authority-bearing
+ * instances across calls.
+ */
+export function runtimeEnvironmentIdentity(): object | undefined {
+  return runtimeEnvironmentStorage.getStore()?.identity;
 }
 
 /**

--- a/packages/shared/src/runtime-env.ts
+++ b/packages/shared/src/runtime-env.ts
@@ -59,6 +59,6 @@ export function runtimeEnvironmentIdentity(): object | undefined {
  * so an overlapping Worker request cannot replace their authority mid-read.
  */
 export function runtimeEnvironmentSnapshot(): RuntimeEnvironment {
-  const requestEnvironment = runtimeEnvironmentStorage.getStore();
-  return requestEnvironment ?? snapshotRuntimeEnvironment(process.env);
+  const context = runtimeEnvironmentStorage.getStore();
+  return context?.environment ?? snapshotRuntimeEnvironment(process.env);
 }

--- a/packages/shared/src/security-metrics.ts
+++ b/packages/shared/src/security-metrics.ts
@@ -217,4 +217,5 @@ export function __resetSecurityMetricsForTests(): void {
   lastCheckpointAtMs = null;
   failObserverForTests = false;
 }
+
 import { runtimeEnvironmentSnapshot } from "./runtime-env.js";

--- a/packages/shared/src/security-metrics.ts
+++ b/packages/shared/src/security-metrics.ts
@@ -183,14 +183,14 @@ export function renderSecurityMetrics(nowMs = Date.now()): string {
 }
 
 export function securityMetricsEnabled(
-  env: Record<string, string | undefined> = process.env,
+  env: Readonly<Record<string, string | undefined>> = runtimeEnvironmentSnapshot(),
 ): boolean {
   return env.STEWARD_METRICS_ENABLED === "true";
 }
 
 export function metricsTokenIsValid(
   candidate: string | undefined,
-  env: Record<string, string | undefined> = process.env,
+  env: Readonly<Record<string, string | undefined>> = runtimeEnvironmentSnapshot(),
 ): boolean {
   const configured = env.STEWARD_METRICS_TOKEN;
   if (!configured || configured.length < 32 || !candidate) return false;
@@ -217,3 +217,4 @@ export function __resetSecurityMetricsForTests(): void {
   lastCheckpointAtMs = null;
   failObserverForTests = false;
 }
+import { runtimeEnvironmentSnapshot } from "./runtime-env.js";

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -142,8 +142,8 @@ export interface PluginMigrationSource {
  * provider integration (a concrete swap/earn/onramp/.../exchange adapter).
  *
  * WIRED in Phase 2d. The host registers each contribution into the core's
- * {@link AdapterRegistry} via its existing `register(category, provider, adapter)`
- * seam, in `dependsOn` order, FAIL-CLOSED on a `(category, provider)` collision
+ * {@link AdapterRegistry} via its instance or request-factory registration seam,
+ * in `dependsOn` order, FAIL-CLOSED on a `(category, provider)` collision
  * with another plugin's contribution (the host never silently overwrites a real
  * money-route adapter — see the host's conflict detection). The registry's own
  * fail-closed-in-production RESOLUTION is untouched: a contributed adapter is
@@ -155,8 +155,8 @@ export interface PluginMigrationSource {
  * (`@stwd/adapters` depends on `@stwd/shared`, so importing the concrete
  * per-category adapter types here would create a dependency CYCLE). The category
  * is therefore a plain `string` (assignable to the registry's `AdapterCategory`,
- * validated by the host) and the concrete adapter instance is typed `unknown` —
- * the host casts it to the registry's per-category type at the api boundary,
+ * validated by the host) and the adapter instance/factory result is typed
+ * `unknown` — the host casts it to the registry's per-category type at the api boundary,
  * where `@stwd/adapters` is a legitimate dependency.
  */
 export interface AdapterContribution {
@@ -170,13 +170,17 @@ export interface AdapterContribution {
   /** the provider name this contribution registers under (must be non-empty). */
   readonly provider: string;
   /**
-   * the concrete adapter instance to register under `(category, provider)`.
-   * typed `unknown` at the shared layer to avoid a shared->adapters cycle (the
-   * concrete per-category adapter types live in `@stwd/adapters`); the host
-   * casts it to the registry's expected per-category type when it calls
-   * `adapterRegistry.register(...)`.
+   * A concrete, configuration-free adapter instance. Binding-dependent
+   * providers must use `createAdapter` instead so Worker binding generations
+   * cannot share endpoint or credential authority.
    */
-  readonly adapter: unknown;
+  readonly adapter?: unknown;
+  /**
+   * Request-authority factory. It is invoked only when this provider is selected
+   * under the current request environment; its result is never module-cached by
+   * the registry.
+   */
+  readonly createAdapter?: () => unknown;
 }
 
 export interface StewardPlugin<App = unknown, Ctx = unknown, EvalCtx = unknown> {

--- a/packages/vault/src/aws-kms-external-custody.ts
+++ b/packages/vault/src/aws-kms-external-custody.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { isIP } from "node:net";
 import { secp256k1 } from "@noble/curves/secp256k1";
 import {
@@ -91,7 +92,7 @@ export interface AwsKmsExternalKeyCustodyOptions {
 }
 
 function positiveBigIntEnv(name: string): bigint {
-  const raw = process.env[name]?.trim();
+  const raw = runtimeEnvironmentValue(name)?.trim();
   if (!raw || !/^\d+$/.test(raw) || BigInt(raw) <= 0n) {
     throw new Error(`${name} is required and must be a positive integer`);
   }
@@ -399,7 +400,7 @@ export class AwsKmsExternalKeyCustodyProvider implements ExternalKeyCustodyProvi
 
   static fromEnv(): AwsKmsExternalKeyCustodyProvider {
     return new AwsKmsExternalKeyCustodyProvider({
-      region: process.env.STEWARD_EXTERNAL_CUSTODY_AWS_REGION,
+      region: runtimeEnvironmentValue("STEWARD_EXTERNAL_CUSTODY_AWS_REGION"),
       maxGasLimit: positiveBigIntEnv("STEWARD_EXTERNAL_CUSTODY_AWS_MAX_GAS_LIMIT"),
       maxGasPriceWei: positiveBigIntEnv("STEWARD_EXTERNAL_CUSTODY_AWS_MAX_GAS_PRICE_WEI"),
       maxTotalFeeWei: positiveBigIntEnv("STEWARD_EXTERNAL_CUSTODY_AWS_MAX_TOTAL_FEE_WEI"),

--- a/packages/vault/src/aws-kms-external-custody.ts
+++ b/packages/vault/src/aws-kms-external-custody.ts
@@ -70,6 +70,12 @@ export interface AwsKmsSigningClientLike {
   send(command: unknown, options?: { abortSignal?: AbortSignal }): Promise<unknown>;
 }
 
+export interface AwsKmsExternalCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
 export interface AwsKmsEvmRpc {
   getChainId(): Promise<number>;
   prepareTransaction(
@@ -84,6 +90,7 @@ export interface AwsKmsEvmRpc {
 export interface AwsKmsExternalKeyCustodyOptions {
   client?: AwsKmsSigningClientLike;
   region?: string;
+  credentials?: AwsKmsExternalCredentials;
   rpcFactory?: (rpcUrl: string) => AwsKmsEvmRpc;
   maxGasLimit?: bigint;
   maxGasPriceWei?: bigint;
@@ -376,6 +383,7 @@ export class AwsKmsExternalKeyCustodyProvider implements ExternalKeyCustodyProvi
   private readonly clientIsInjected: boolean;
   private client?: AwsKmsSigningClientLike;
   private readonly region: string;
+  private readonly credentials?: AwsKmsExternalCredentials;
   private readonly rpcFactory: (rpcUrl: string) => AwsKmsEvmRpc;
   private readonly maxGasLimit?: bigint;
   private readonly maxGasPriceWei?: bigint;
@@ -387,6 +395,7 @@ export class AwsKmsExternalKeyCustodyProvider implements ExternalKeyCustodyProvi
     this.client = options.client;
     this.clientIsInjected = Boolean(options.client);
     this.region = options.region;
+    this.credentials = options.credentials;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_EXTERNAL_REQUEST_TIMEOUT_MS;
     if (!Number.isSafeInteger(this.requestTimeoutMs) || this.requestTimeoutMs <= 0) {
       throw new Error("AWS KMS external custody requestTimeoutMs must be a positive safe integer");
@@ -648,9 +657,12 @@ export class AwsKmsExternalKeyCustodyProvider implements ExternalKeyCustodyProvi
     if (this.client) return this.client;
     const moduleName = "@aws-sdk/client-kms";
     const aws = (await import(moduleName)) as {
-      KMSClient: new (options: { region?: string }) => AwsKmsSigningClientLike;
+      KMSClient: new (options: {
+        region?: string;
+        credentials?: AwsKmsExternalCredentials;
+      }) => AwsKmsSigningClientLike;
     };
-    this.client = new aws.KMSClient({ region: this.region });
+    this.client = new aws.KMSClient({ region: this.region, credentials: this.credentials });
     return this.client;
   }
 

--- a/packages/vault/src/aws-kms-external-custody.ts
+++ b/packages/vault/src/aws-kms-external-custody.ts
@@ -1,6 +1,6 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { isIP } from "node:net";
 import { secp256k1 } from "@noble/curves/secp256k1";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   type Address,
   createPublicClient,

--- a/packages/vault/src/evm-nonce-manager.ts
+++ b/packages/vault/src/evm-nonce-manager.ts
@@ -1,4 +1,3 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   and,
   asc,
@@ -9,6 +8,7 @@ import {
   getDb,
   sql,
 } from "@stwd/db";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type { Address } from "viem";
 
 type PendingNonceReader = (address: Address) => Promise<number>;
@@ -16,7 +16,10 @@ type PendingNonceReader = (address: Address) => Promise<number>;
 const locks = new Map<string, Promise<void>>();
 
 function usesAdvisoryLock(): boolean {
-  return runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" && runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true";
+  return (
+    runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" &&
+    runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true"
+  );
 }
 
 async function withNonceLock<T>(key: string, fn: () => Promise<T>): Promise<T> {

--- a/packages/vault/src/evm-nonce-manager.ts
+++ b/packages/vault/src/evm-nonce-manager.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   and,
   asc,
@@ -15,7 +16,7 @@ type PendingNonceReader = (address: Address) => Promise<number>;
 const locks = new Map<string, Promise<void>>();
 
 function usesAdvisoryLock(): boolean {
-  return process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true";
+  return runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" && runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true";
 }
 
 async function withNonceLock<T>(key: string, fn: () => Promise<T>): Promise<T> {

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -75,7 +75,7 @@ export {
   isValidMnemonic,
   mnemonicToSeed,
 } from "./hd-wallet";
-export type { EncryptedKey } from "./keystore";
+export type { EncryptedKey, KeyStoreDomain, KeyStoreRuntimeOptions } from "./keystore";
 export { KeyStore } from "./keystore";
 export type { KeystoreBackend, KeystoreContext } from "./keystore-backend";
 export { backendFromKeyStore } from "./keystore-backend";

--- a/packages/vault/src/keystore-kms.ts
+++ b/packages/vault/src/keystore-kms.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 
 import type { EncryptedKey } from "./keystore";
@@ -290,14 +291,14 @@ export class KmsEnvelopeKeystore implements KeystoreBackend {
 export function resolveKmsEnvelopeOptions(
   options?: Partial<KmsEnvelopeOptions>,
 ): KmsEnvelopeOptions {
-  const provider = (options?.provider ?? process.env.STEWARD_KMS_PROVIDER ?? "aws") as KmsProvider;
+  const provider = (options?.provider ?? runtimeEnvironmentValue("STEWARD_KMS_PROVIDER") ?? "aws") as KmsProvider;
   if (provider === "aws") {
     const awsOptions = options as Partial<AwsKmsEnvelopeOptions> | undefined;
     return {
       provider: "aws",
       keyId:
-        awsOptions?.keyId ?? process.env.STEWARD_KMS_KEY_ID ?? process.env.STEWARD_AWS_KMS_KEY_ARN,
-      region: awsOptions?.region ?? process.env.STEWARD_AWS_REGION ?? process.env.AWS_REGION,
+        awsOptions?.keyId ?? runtimeEnvironmentValue("STEWARD_KMS_KEY_ID") ?? runtimeEnvironmentValue("STEWARD_AWS_KMS_KEY_ARN"),
+      region: awsOptions?.region ?? runtimeEnvironmentValue("STEWARD_AWS_REGION") ?? runtimeEnvironmentValue("AWS_REGION"),
       client: awsOptions?.client,
     };
   }
@@ -305,9 +306,9 @@ export function resolveKmsEnvelopeOptions(
     const pkcs11Options = options as Partial<Pkcs11KmsEnvelopeOptions> | undefined;
     return {
       provider: "pkcs11",
-      modulePath: pkcs11Options?.modulePath ?? process.env.STEWARD_PKCS11_MODULE,
-      pin: pkcs11Options?.pin ?? process.env.STEWARD_PKCS11_PIN,
-      keyLabel: pkcs11Options?.keyLabel ?? process.env.STEWARD_PKCS11_KEY_LABEL,
+      modulePath: pkcs11Options?.modulePath ?? runtimeEnvironmentValue("STEWARD_PKCS11_MODULE"),
+      pin: pkcs11Options?.pin ?? runtimeEnvironmentValue("STEWARD_PKCS11_PIN"),
+      keyLabel: pkcs11Options?.keyLabel ?? runtimeEnvironmentValue("STEWARD_PKCS11_KEY_LABEL"),
       client: pkcs11Options?.client,
     };
   }

--- a/packages/vault/src/keystore-kms.ts
+++ b/packages/vault/src/keystore-kms.ts
@@ -14,10 +14,17 @@ export interface AwsKmsClientLike {
   send(command: unknown): Promise<unknown>;
 }
 
+export interface AwsKmsCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
 export interface AwsKmsEnvelopeOptions {
   provider: "aws";
   keyId?: string;
   region?: string;
+  credentials?: AwsKmsCredentials;
   client?: AwsKmsClientLike;
 }
 
@@ -250,9 +257,15 @@ export class KmsEnvelopeKeystore implements KeystoreBackend {
 
     const moduleName = "@aws-sdk/client-kms";
     const aws = (await import(moduleName)) as {
-      KMSClient: new (config: { region?: string }) => AwsKmsClientLike;
+      KMSClient: new (config: {
+        region?: string;
+        credentials?: AwsKmsCredentials;
+      }) => AwsKmsClientLike;
     };
-    this.awsClient = new aws.KMSClient({ region: this.options.region });
+    this.awsClient = new aws.KMSClient({
+      region: this.options.region,
+      credentials: this.options.credentials,
+    });
     return this.awsClient;
   }
 

--- a/packages/vault/src/keystore-kms.ts
+++ b/packages/vault/src/keystore-kms.ts
@@ -1,5 +1,5 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 
 import type { EncryptedKey } from "./keystore";
 import type { KeystoreBackend, KeystoreContext } from "./keystore-backend";
@@ -304,14 +304,21 @@ export class KmsEnvelopeKeystore implements KeystoreBackend {
 export function resolveKmsEnvelopeOptions(
   options?: Partial<KmsEnvelopeOptions>,
 ): KmsEnvelopeOptions {
-  const provider = (options?.provider ?? runtimeEnvironmentValue("STEWARD_KMS_PROVIDER") ?? "aws") as KmsProvider;
+  const provider = (options?.provider ??
+    runtimeEnvironmentValue("STEWARD_KMS_PROVIDER") ??
+    "aws") as KmsProvider;
   if (provider === "aws") {
     const awsOptions = options as Partial<AwsKmsEnvelopeOptions> | undefined;
     return {
       provider: "aws",
       keyId:
-        awsOptions?.keyId ?? runtimeEnvironmentValue("STEWARD_KMS_KEY_ID") ?? runtimeEnvironmentValue("STEWARD_AWS_KMS_KEY_ARN"),
-      region: awsOptions?.region ?? runtimeEnvironmentValue("STEWARD_AWS_REGION") ?? runtimeEnvironmentValue("AWS_REGION"),
+        awsOptions?.keyId ??
+        runtimeEnvironmentValue("STEWARD_KMS_KEY_ID") ??
+        runtimeEnvironmentValue("STEWARD_AWS_KMS_KEY_ARN"),
+      region:
+        awsOptions?.region ??
+        runtimeEnvironmentValue("STEWARD_AWS_REGION") ??
+        runtimeEnvironmentValue("AWS_REGION"),
       client: awsOptions?.client,
     };
   }

--- a/packages/vault/src/keystore.ts
+++ b/packages/vault/src/keystore.ts
@@ -1,4 +1,3 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 // node:crypto under Cloudflare nodejs_compat:
 //   - createCipheriv / createDecipheriv (AES-256-GCM) - supported.
 //   - randomBytes                                      - supported.
@@ -44,8 +43,16 @@ export interface EncryptedKey {
  */
 export type KeyStoreDomain = "signing-vault" | "secret-vault" | "credential-lease";
 
+export interface KeyStoreRuntimeOptions {
+  /** Immutable runtime classification captured with the custody authority. */
+  nodeEnvironment?: string;
+  /** Immutable legacy-AAD compatibility decision for this keystore instance. */
+  allowLegacyDecryptFallback?: boolean;
+}
+
 export class KeyStore {
   private masterKey: Buffer;
+  private readonly legacyDecryptFallback?: boolean;
 
   /**
    * @param masterPassword  The master password to derive the root encryption key from.
@@ -58,17 +65,22 @@ export class KeyStore {
    *                        roots derived from the same master password. Omit for the legacy
    *                        (undifferentiated) root used before domain separation.
    */
-  constructor(masterPassword: string, masterSalt?: string, domain?: KeyStoreDomain) {
+  constructor(
+    masterPassword: string,
+    masterSalt?: string,
+    domain?: KeyStoreDomain,
+    runtimeOptions: KeyStoreRuntimeOptions = {},
+  ) {
     // Derive a 256-bit root key from master password via scrypt.
     // Each encrypt() call further derives a unique key with a random per-record salt,
     // so the master key salt does not need to be per-record, but SHOULD be unique
     // per deployment to resist precomputed/rainbow-table attacks on the password.
-    const envSalt = masterSalt ?? runtimeEnvironmentValue("STEWARD_KDF_SALT");
+    const envSalt = masterSalt ?? process.env.STEWARD_KDF_SALT;
     let salt: Buffer;
     if (envSalt) {
       salt = decodeKdfSalt(envSalt);
     } else {
-      if (runtimeEnvironmentValue("NODE_ENV") === "production") {
+      if ((runtimeOptions.nodeEnvironment ?? process.env.NODE_ENV) === "production") {
         throw new Error(
           "STEWARD_KDF_SALT is required in production. Generate with: openssl rand -hex 32",
         );
@@ -80,6 +92,7 @@ export class KeyStore {
     // (domain undefined) keep the exact pre-separation derivation for backward compat.
     const domainSalt = domain ? Buffer.from(`steward-kdf:${domain}:${salt.toString("hex")}`) : salt;
     this.masterKey = scryptSync(masterPassword, domainSalt, 32) as Buffer;
+    this.legacyDecryptFallback = runtimeOptions.allowLegacyDecryptFallback;
   }
 
   /**
@@ -119,7 +132,7 @@ export class KeyStore {
         // Keep them readable outside production so operators can migrate by
         // re-encrypting rows. Production fallback must be an explicit break-glass
         // setting; otherwise copied legacy ciphertext can defeat tenant/agent AAD.
-        if (!allowLegacyDecryptFallback()) throw error;
+        if (!(this.legacyDecryptFallback ?? allowLegacyDecryptFallback())) throw error;
       }
     }
     return this.decryptWithContext(encrypted);
@@ -161,6 +174,6 @@ function allowLegacyDecryptFallback(): boolean {
   // ciphertext row would decrypt across contexts). It is ONLY for migrating
   // pre-context-binding ciphertext outside production. Production NEVER takes
   // this path, regardless of the env flag — the flag cannot enable it in prod.
-  if (runtimeEnvironmentValue("NODE_ENV") === "production") return false;
-  return runtimeEnvironmentValue("STEWARD_ALLOW_LEGACY_KEYSTORE_DECRYPT_FALLBACK") === "true";
+  if (process.env.NODE_ENV === "production") return false;
+  return process.env.STEWARD_ALLOW_LEGACY_KEYSTORE_DECRYPT_FALLBACK === "true";
 }

--- a/packages/vault/src/keystore.ts
+++ b/packages/vault/src/keystore.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 // node:crypto under Cloudflare nodejs_compat:
 //   - createCipheriv / createDecipheriv (AES-256-GCM) - supported.
 //   - randomBytes                                      - supported.
@@ -62,12 +63,12 @@ export class KeyStore {
     // Each encrypt() call further derives a unique key with a random per-record salt,
     // so the master key salt does not need to be per-record, but SHOULD be unique
     // per deployment to resist precomputed/rainbow-table attacks on the password.
-    const envSalt = masterSalt ?? process.env.STEWARD_KDF_SALT;
+    const envSalt = masterSalt ?? runtimeEnvironmentValue("STEWARD_KDF_SALT");
     let salt: Buffer;
     if (envSalt) {
       salt = decodeKdfSalt(envSalt);
     } else {
-      if (process.env.NODE_ENV === "production") {
+      if (runtimeEnvironmentValue("NODE_ENV") === "production") {
         throw new Error(
           "STEWARD_KDF_SALT is required in production. Generate with: openssl rand -hex 32",
         );
@@ -160,6 +161,6 @@ function allowLegacyDecryptFallback(): boolean {
   // ciphertext row would decrypt across contexts). It is ONLY for migrating
   // pre-context-binding ciphertext outside production. Production NEVER takes
   // this path, regardless of the env flag — the flag cannot enable it in prod.
-  if (process.env.NODE_ENV === "production") return false;
-  return process.env.STEWARD_ALLOW_LEGACY_KEYSTORE_DECRYPT_FALLBACK === "true";
+  if (runtimeEnvironmentValue("NODE_ENV") === "production") return false;
+  return runtimeEnvironmentValue("STEWARD_ALLOW_LEGACY_KEYSTORE_DECRYPT_FALLBACK") === "true";
 }

--- a/packages/vault/src/keystore.ts
+++ b/packages/vault/src/keystore.ts
@@ -8,6 +8,7 @@
 //     alternative - note that switching KDFs invalidates existing encrypted
 //     records (operator decision, not a transparent migration).
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:crypto";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { decodeKdfSalt } from "./kdf-salt.mjs";
 import type { KeystoreContext } from "./keystore-backend";
 
@@ -75,12 +76,14 @@ export class KeyStore {
     // Each encrypt() call further derives a unique key with a random per-record salt,
     // so the master key salt does not need to be per-record, but SHOULD be unique
     // per deployment to resist precomputed/rainbow-table attacks on the password.
-    const envSalt = masterSalt ?? process.env.STEWARD_KDF_SALT;
+    const envSalt = masterSalt ?? runtimeEnvironmentValue("STEWARD_KDF_SALT");
     let salt: Buffer;
     if (envSalt) {
       salt = decodeKdfSalt(envSalt);
     } else {
-      if ((runtimeOptions.nodeEnvironment ?? process.env.NODE_ENV) === "production") {
+      if (
+        (runtimeOptions.nodeEnvironment ?? runtimeEnvironmentValue("NODE_ENV")) === "production"
+      ) {
         throw new Error(
           "STEWARD_KDF_SALT is required in production. Generate with: openssl rand -hex 32",
         );
@@ -174,6 +177,6 @@ function allowLegacyDecryptFallback(): boolean {
   // ciphertext row would decrypt across contexts). It is ONLY for migrating
   // pre-context-binding ciphertext outside production. Production NEVER takes
   // this path, regardless of the env flag — the flag cannot enable it in prod.
-  if (process.env.NODE_ENV === "production") return false;
-  return process.env.STEWARD_ALLOW_LEGACY_KEYSTORE_DECRYPT_FALLBACK === "true";
+  if (runtimeEnvironmentValue("NODE_ENV") === "production") return false;
+  return runtimeEnvironmentValue("STEWARD_ALLOW_LEGACY_KEYSTORE_DECRYPT_FALLBACK") === "true";
 }

--- a/packages/vault/src/monero.ts
+++ b/packages/vault/src/monero.ts
@@ -1104,7 +1104,7 @@ export interface MoneroEnv {
  * Monero support is not configured (callers fail closed on null).
  */
 export function createMoneroBackendFromEnv(
-  env: MoneroEnv = process.env as MoneroEnv,
+  env: MoneroEnv = runtimeEnvironmentSnapshot(),
 ): MoneroWalletBackend | null {
   const rpcUrl = env.STEWARD_MONERO_WALLET_RPC_URL;
   if (!rpcUrl) return null;
@@ -1127,3 +1127,4 @@ export function createMoneroBackendFromEnv(
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";

--- a/packages/vault/src/monero.ts
+++ b/packages/vault/src/monero.ts
@@ -1127,4 +1127,5 @@ export function createMoneroBackendFromEnv(
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
 import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";

--- a/packages/vault/src/secret-route-validator.ts
+++ b/packages/vault/src/secret-route-validator.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Shared secret-route config validator — single source of truth.
  *
@@ -148,7 +149,7 @@ export type SecretRouteConfigInput = {
 };
 
 function allowBroadSecretRoutes(): boolean {
-  return process.env.STEWARD_ALLOW_BROAD_SECRET_ROUTES === "true";
+  return runtimeEnvironmentValue("STEWARD_ALLOW_BROAD_SECRET_ROUTES") === "true";
 }
 
 /**
@@ -158,7 +159,7 @@ function allowBroadSecretRoutes(): boolean {
  * cookie injection blocked.
  */
 function allowCookieInjection(): boolean {
-  return process.env.STEWARD_ALLOW_COOKIE_INJECTION === "true";
+  return runtimeEnvironmentValue("STEWARD_ALLOW_COOKIE_INJECTION") === "true";
 }
 
 /**
@@ -168,7 +169,7 @@ function allowCookieInjection(): boolean {
 export function configuredSecretRouteHosts(): string[] {
   return [
     ...DEFAULT_SECRET_ROUTE_HOSTS,
-    ...(process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS ?? "")
+    ...(runtimeEnvironmentValue("STEWARD_SECRET_ROUTE_ALLOWED_HOSTS") ?? "")
       .split(",")
       .map((host) => host.trim().toLowerCase())
       .filter(Boolean),

--- a/packages/vault/src/secret-vault.ts
+++ b/packages/vault/src/secret-vault.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 /**
  * Secret Vault — encrypted credential storage for tenant API keys and secrets.
  *
@@ -944,8 +945,8 @@ export class SecretVault {
  * then remove the flag. Non-production retains the compatibility default.
  */
 function allowLegacySecretRootFallback(): boolean {
-  const configured = process.env.STEWARD_SECRET_VAULT_LEGACY_ROOT_FALLBACK;
+  const configured = runtimeEnvironmentValue("STEWARD_SECRET_VAULT_LEGACY_ROOT_FALLBACK");
   if (configured === "true") return true;
   if (configured === "false") return false;
-  return process.env.NODE_ENV !== "production";
+  return runtimeEnvironmentValue("NODE_ENV") !== "production";
 }

--- a/packages/vault/src/secret-vault.ts
+++ b/packages/vault/src/secret-vault.ts
@@ -39,7 +39,7 @@ import {
   secretRoutes,
   secrets,
 } from "@stwd/db";
-import { type EncryptedKey, KeyStore } from "./keystore";
+import { type EncryptedKey, KeyStore, type KeyStoreRuntimeOptions } from "./keystore";
 import {
   assertGovernedRouteUpdateIsSafe,
   assertNoOppositeAuthorityOverlap,
@@ -108,12 +108,18 @@ export class SecretVault {
   // {@link migrateLegacyRootSecrets} to re-encrypt legacy rows into the domain
   // root, then disable the fallback (see allowLegacySecretRootFallback).
   private legacyKeyStore: KeyStore;
+  private readonly legacyRootFallback?: boolean;
 
-  constructor(masterPassword: string) {
+  constructor(
+    masterPassword: string,
+    masterSalt?: string,
+    runtimeOptions: KeyStoreRuntimeOptions & { allowLegacySecretRootFallback?: boolean } = {},
+  ) {
     // Domain-separate the secret-vault root from the wallet signing-vault root so
     // compromising one path does not compromise the other (they share masterPassword).
-    this.keyStore = new KeyStore(masterPassword, undefined, "secret-vault");
-    this.legacyKeyStore = new KeyStore(masterPassword);
+    this.keyStore = new KeyStore(masterPassword, masterSalt, "secret-vault", runtimeOptions);
+    this.legacyKeyStore = new KeyStore(masterPassword, masterSalt, undefined, runtimeOptions);
+    this.legacyRootFallback = runtimeOptions.allowLegacySecretRootFallback;
   }
 
   /**
@@ -307,7 +313,7 @@ export class SecretVault {
       // legacy (shared) root. New secrets always use the domain-separated root above.
       // SEC-164: the fallback stays enabled until an operator migrates legacy
       // rows (migrateLegacyRootSecrets) and opts out via env; then it fails closed.
-      if (!allowLegacySecretRootFallback()) throw error;
+      if (!(this.legacyRootFallback ?? allowLegacySecretRootFallback())) throw error;
       return this.legacyKeyStore.decrypt(encrypted, context);
     }
   }

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -25,6 +25,7 @@ import type {
   WalletAddressMetadata,
 } from "@stwd/shared";
 import { canonicalJsonStringify, toCaip2 } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import bs58 from "bs58";
 import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
 import {
@@ -564,7 +565,10 @@ function custodyTransitionLockKey(
  * transitions across replicas/connections cannot interleave check-then-act.
  */
 function usesCustodyAdvisoryLock(): boolean {
-  return process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true";
+  return (
+    runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" &&
+    runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true"
+  );
 }
 
 interface MnemonicWalletMaterial {
@@ -1881,7 +1885,8 @@ export class Vault {
         // falls back to safe defaults on RPC error. Set STEWARD_SOLANA_PRIORITY_FEES=0
         // to revert to the legacy no-compute-budget transfer.
         computeBudget:
-          (this.config.solanaPriorityFees ?? process.env.STEWARD_SOLANA_PRIORITY_FEES !== "0")
+          (this.config.solanaPriorityFees ??
+          runtimeEnvironmentValue("STEWARD_SOLANA_PRIORITY_FEES") !== "0")
             ? {}
             : false,
       });
@@ -3868,7 +3873,7 @@ export class Vault {
 
     const configured =
       this.config.rpcPassthroughAllowlist === undefined
-        ? process.env.STEWARD_VAULT_RPC_ALLOWLIST
+        ? runtimeEnvironmentValue("STEWARD_VAULT_RPC_ALLOWLIST")
         : (this.config.rpcPassthroughAllowlist ?? undefined);
     const configuredMethods = configured
       ?.split(",")

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -1,4 +1,3 @@
-import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createHash, randomUUID } from "node:crypto";
 import {
   agents,
@@ -117,8 +116,18 @@ import {
 
 export interface VaultConfig {
   masterPassword: string;
+  /** Explicit deployment KDF salt; request-scoped runtimes must never read it globally. */
+  masterSalt?: string;
+  /** Immutable compatibility decision captured with the custody authority. */
+  allowLegacyKeystoreDecryptFallback?: boolean;
+  /** Immutable runtime classification captured with the custody authority. */
+  nodeEnvironment?: string;
   rpcUrl?: string;
   chainId?: number;
+  /** Immutable request-local priority-fee gate; undefined preserves legacy env lookup. */
+  solanaPriorityFees?: boolean;
+  /** Immutable request-local RPC allowlist; null selects the built-in default. */
+  rpcPassthroughAllowlist?: string | null;
   keystoreBackend?: KeystoreBackend;
   externalKeyCustodyProvider?: ExternalKeyCustodyProvider;
   /**
@@ -555,7 +564,7 @@ function custodyTransitionLockKey(
  * transitions across replicas/connections cannot interleave check-then-act.
  */
 function usesCustodyAdvisoryLock(): boolean {
-  return runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" && runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true";
+  return process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true";
 }
 
 interface MnemonicWalletMaterial {
@@ -664,7 +673,13 @@ export class Vault {
     // stays decryptable; the SecretVault uses a distinct domain-separated root, so
     // the two roots are cryptographically independent despite sharing masterPassword.
     this.keyStore =
-      config.keystoreBackend ?? backendFromKeyStore(new KeyStore(config.masterPassword));
+      config.keystoreBackend ??
+      backendFromKeyStore(
+        new KeyStore(config.masterPassword, config.masterSalt, undefined, {
+          nodeEnvironment: config.nodeEnvironment,
+          allowLegacyDecryptFallback: config.allowLegacyKeystoreDecryptFallback,
+        }),
+      );
   }
 
   /** Resolve the Monero backend, or fail closed when Monero is unconfigured. */
@@ -1866,7 +1881,9 @@ export class Vault {
         // falls back to safe defaults on RPC error. Set STEWARD_SOLANA_PRIORITY_FEES=0
         // to revert to the legacy no-compute-budget transfer.
         computeBudget:
-          runtimeEnvironmentValue("STEWARD_SOLANA_PRIORITY_FEES") === "0" ? false : {},
+          (this.config.solanaPriorityFees ?? process.env.STEWARD_SOLANA_PRIORITY_FEES !== "0")
+            ? {}
+            : false,
       });
     } else {
       assertEvmWalletAddressMatches(secretKey, request.walletAddress);
@@ -3849,7 +3866,10 @@ export class Vault {
       throw new Error(`No RPC URL configured for chainId ${chainId}`);
     }
 
-    const configured = runtimeEnvironmentValue("STEWARD_VAULT_RPC_ALLOWLIST");
+    const configured =
+      this.config.rpcPassthroughAllowlist === undefined
+        ? process.env.STEWARD_VAULT_RPC_ALLOWLIST
+        : (this.config.rpcPassthroughAllowlist ?? undefined);
     const configuredMethods = configured
       ?.split(",")
       .map((method) => method.trim())

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createHash, randomUUID } from "node:crypto";
 import {
   agents,
@@ -554,7 +555,7 @@ function custodyTransitionLockKey(
  * transitions across replicas/connections cannot interleave check-then-act.
  */
 function usesCustodyAdvisoryLock(): boolean {
-  return process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true";
+  return runtimeEnvironmentValue("STEWARD_DB_MODE") !== "pglite" && runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") !== "true";
 }
 
 interface MnemonicWalletMaterial {
@@ -1864,7 +1865,8 @@ export class Vault {
         // price, bounded by COMPUTE_BUDGET_BOUNDS). Estimation never throws and
         // falls back to safe defaults on RPC error. Set STEWARD_SOLANA_PRIORITY_FEES=0
         // to revert to the legacy no-compute-budget transfer.
-        computeBudget: process.env.STEWARD_SOLANA_PRIORITY_FEES === "0" ? false : {},
+        computeBudget:
+          runtimeEnvironmentValue("STEWARD_SOLANA_PRIORITY_FEES") === "0" ? false : {},
       });
     } else {
       assertEvmWalletAddressMatches(secretKey, request.walletAddress);
@@ -3847,7 +3849,7 @@ export class Vault {
       throw new Error(`No RPC URL configured for chainId ${chainId}`);
     }
 
-    const configured = process.env.STEWARD_VAULT_RPC_ALLOWLIST;
+    const configured = runtimeEnvironmentValue("STEWARD_VAULT_RPC_ALLOWLIST");
     const configuredMethods = configured
       ?.split(",")
       .map((method) => method.trim())

--- a/packages/venue-hyperliquid/package.json
+++ b/packages/venue-hyperliquid/package.json
@@ -13,6 +13,7 @@
     "test": "ls src/**/*.test.ts src/**/*.spec.ts 2>/dev/null | grep -q . && bun test || echo 'no tests'"
   },
   "dependencies": {
+    "@stwd/shared": "workspace:*",
     "viem": "^2.30.0",
     "zod": "^4.3.6"
   },

--- a/packages/venue-hyperliquid/src/index.test.ts
+++ b/packages/venue-hyperliquid/src/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { privateKeyToAccount } from "viem/accounts";
 import {
   actionHash,
@@ -59,6 +60,20 @@ const xyzSpcxTransport = (extra?: {
 });
 
 describe("Hyperliquid L1 signing", () => {
+  test("builder authority follows A to B to missing", () => {
+    const validate = (env: Record<string, string>) =>
+      withRuntimeEnvironment({ STEWARD_RUNTIME: "workers", ...env }, () => validateBuilderFeeEnv());
+    expect(() =>
+      validate({
+        HL_BUILDER_ADDRESS: "0xABCDEF0123456789abcdef0123456789ABCDEF01",
+        HL_BUILDER_FEE_TENTHS_BP: "10",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validate({ HL_BUILDER_ADDRESS: "not-an-address", HL_BUILDER_FEE_TENTHS_BP: "10" }),
+    ).toThrow("Invalid HL builder fee configuration");
+    expect(() => validate({})).not.toThrow();
+  });
   test("builds the documented wire action and deterministic L1 typed data", async () => {
     const action = toExchangeAction({
       coin: "BTC",

--- a/packages/venue-hyperliquid/src/index.ts
+++ b/packages/venue-hyperliquid/src/index.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentSnapshot, runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { concatBytes, type Hex, keccak256, parseSignature, toBytes } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { z } from "zod";
@@ -53,7 +54,9 @@ const approveBuilderFeePrimaryType = "HyperliquidTransaction:ApproveBuilderFee";
 // or a much larger percentage would let a compromised builder configuration
 // charge materially more than Steward itself will stamp on an order.
 const MAX_APPROVED_BUILDER_FEE_PERCENT = 0.1;
-const DEFAULT_FETCH_TIMEOUT_MS = Number(process.env.HYPERLIQUID_FETCH_TIMEOUT_MS ?? 10_000);
+function defaultFetchTimeoutMs(): number {
+  return Number(runtimeEnvironmentValue("HYPERLIQUID_FETCH_TIMEOUT_MS") ?? 10_000);
+}
 
 const BUILDER_PERP_ASSET_ID_OFFSET = 100_000;
 const BUILDER_PERP_DEX_STRIDE = 10_000;
@@ -100,8 +103,9 @@ export type HyperliquidBuilderFee = z.infer<typeof builderFeeSchema>;
  * builder attribution.
  */
 export function validateBuilderFeeEnv(): void {
-  const address = process.env.HL_BUILDER_ADDRESS;
-  const rawFee = process.env.HL_BUILDER_FEE_TENTHS_BP;
+  const env = runtimeEnvironmentSnapshot();
+  const address = env.HL_BUILDER_ADDRESS;
+  const rawFee = env.HL_BUILDER_FEE_TENTHS_BP;
   const hasAddress = Boolean(address?.trim());
   const hasFee = rawFee !== undefined && rawFee.trim() !== "";
   if (!hasAddress && !hasFee) return;
@@ -333,8 +337,9 @@ function nextNonce(): number {
 }
 
 function withTimeoutSignal(init: RequestInit): RequestInit {
-  if (init.signal || DEFAULT_FETCH_TIMEOUT_MS <= 0) return init;
-  return { ...init, signal: AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS) };
+  const timeoutMs = defaultFetchTimeoutMs();
+  if (init.signal || timeoutMs <= 0) return init;
+  return { ...init, signal: AbortSignal.timeout(timeoutMs) };
 }
 
 async function postInfo(
@@ -515,8 +520,9 @@ async function withMarketableLimitPx(
   return { ...order, limitPx: await getMarketableLimitPx(coin, isBuy, options) };
 }
 function configuredBuilderFee(): HyperliquidBuilderFee | undefined {
-  const address = process.env.HL_BUILDER_ADDRESS;
-  const rawFee = process.env.HL_BUILDER_FEE_TENTHS_BP;
+  const env = runtimeEnvironmentSnapshot();
+  const address = env.HL_BUILDER_ADDRESS;
+  const rawFee = env.HL_BUILDER_FEE_TENTHS_BP;
   if (!address || rawFee === undefined || rawFee === "") return undefined;
   const feeTenthsBps = Number(rawFee);
   return builderFeeSchema.parse({ address, feeTenthsBps });

--- a/packages/venue-polymarket/src/builder.ts
+++ b/packages/venue-polymarket/src/builder.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentSnapshot } from "@stwd/shared/runtime-env";
 import { z } from "zod";
 
 // ---------------------------------------------------------------------------
@@ -105,14 +106,15 @@ export type ResolvedBuilderConfig = z.infer<typeof builderConfigInputSchema>;
 export function resolveBuilderConfig(input?: BuilderConfigInput): ResolvedBuilderConfig {
   if (input) return builderConfigInputSchema.parse(input);
 
-  const envEnabled = process.env.POLYMARKET_BUILDER_ENABLED === "true";
-  const envFeeRaw = process.env.POLYMARKET_BUILDER_FEE_BPS;
+  const env = runtimeEnvironmentSnapshot();
+  const envEnabled = env.POLYMARKET_BUILDER_ENABLED === "true";
+  const envFeeRaw = env.POLYMARKET_BUILDER_FEE_BPS;
   return builderConfigInputSchema.parse({
     enabled: envEnabled,
-    receiver: process.env.POLYMARKET_BUILDER_RECEIVER || undefined,
+    receiver: env.POLYMARKET_BUILDER_RECEIVER || undefined,
     feeBps: envFeeRaw !== undefined && envFeeRaw !== "" ? Number(envFeeRaw) : 0,
-    signingServerUrl: process.env.POLYMARKET_SIGNING_SERVER_URL || undefined,
-    signingServerToken: process.env.POLYMARKET_SIGNING_SERVER_TOKEN || undefined,
+    signingServerUrl: env.POLYMARKET_SIGNING_SERVER_URL || undefined,
+    signingServerToken: env.POLYMARKET_SIGNING_SERVER_TOKEN || undefined,
   });
 }
 

--- a/packages/venue-polymarket/src/constants.ts
+++ b/packages/venue-polymarket/src/constants.ts
@@ -22,4 +22,8 @@ export const POLYMARKET_BATCH_PRICE_HISTORY_LIMIT = 20;
 // hardcode operator config in callers.
 export const DEFAULT_POLYGON_RPC_URL = "https://polygon-rpc.com";
 
-export const DEFAULT_FETCH_TIMEOUT_MS = Number(process.env.POLYMARKET_FETCH_TIMEOUT_MS ?? 15_000);
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
+export function defaultFetchTimeoutMs(): number {
+  return Number(runtimeEnvironmentValue("POLYMARKET_FETCH_TIMEOUT_MS") ?? 15_000);
+}

--- a/packages/venue-polymarket/src/data.ts
+++ b/packages/venue-polymarket/src/data.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_FETCH_TIMEOUT_MS, POLYMARKET_DATA_API_BASE } from "./constants";
+import { defaultFetchTimeoutMs, POLYMARKET_DATA_API_BASE } from "./constants";
 import type { PolymarketFetchOptions } from "./discovery";
 import { type PolymarketPosition } from "./types";
 
@@ -11,8 +11,9 @@ import { type PolymarketPosition } from "./types";
 
 function timeoutSignal(opts?: PolymarketFetchOptions): AbortSignal | undefined {
   if (opts?.signal) return opts.signal;
-  if (DEFAULT_FETCH_TIMEOUT_MS <= 0) return undefined;
-  return AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS);
+  const timeoutMs = defaultFetchTimeoutMs();
+  if (timeoutMs <= 0) return undefined;
+  return AbortSignal.timeout(timeoutMs);
 }
 
 interface RawDataApiPosition {

--- a/packages/venue-polymarket/src/discovery.ts
+++ b/packages/venue-polymarket/src/discovery.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_FETCH_TIMEOUT_MS, POLYMARKET_GAMMA_API_BASE } from "./constants";
+import { defaultFetchTimeoutMs, POLYMARKET_GAMMA_API_BASE } from "./constants";
 import { getClobTokenIds, getOutcomePrices, getOutcomes } from "./parsing";
 import { type PolymarketEvent, type PolymarketMarket } from "./types";
 
@@ -32,8 +32,9 @@ function gammaUrl(
 
 function timeoutSignal(opts?: PolymarketFetchOptions): AbortSignal | undefined {
   if (opts?.signal) return opts.signal;
-  if (DEFAULT_FETCH_TIMEOUT_MS <= 0) return undefined;
-  return AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS);
+  const timeoutMs = defaultFetchTimeoutMs();
+  if (timeoutMs <= 0) return undefined;
+  return AbortSignal.timeout(timeoutMs);
 }
 
 // Raw Gamma market shape (JSON-string fields parsed inside the adapter).

--- a/packages/venue-polymarket/src/index.test.ts
+++ b/packages/venue-polymarket/src/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import type { EthersSignerLike, PolymarketAccount } from "./credentials";
 import { listPositions } from "./data";
 import { normalizeGammaMarket } from "./discovery";
@@ -272,6 +273,23 @@ describe("signEndpointUrl normalization", () => {
 });
 
 describe("builder attribution defaults OFF", () => {
+  test("builder authority follows A to B to missing", () => {
+    const resolve = (env: Record<string, string>) =>
+      withRuntimeEnvironment({ STEWARD_RUNTIME: "workers", ...env }, () => resolveBuilderConfig());
+    expect(
+      resolve({
+        POLYMARKET_BUILDER_ENABLED: "true",
+        POLYMARKET_BUILDER_RECEIVER: FUNDER,
+        POLYMARKET_BUILDER_FEE_BPS: "10",
+        POLYMARKET_SIGNING_SERVER_URL: "https://signer.example.com",
+        POLYMARKET_SIGNING_SERVER_TOKEN: "a",
+      }).enabled,
+    ).toBe(true);
+    expect(() => resolve({ POLYMARKET_BUILDER_ENABLED: "true" })).toThrow(
+      "enabled builder requires receiver",
+    );
+    expect(resolve({})).toMatchObject({ enabled: false, feeBps: 0 });
+  });
   test("resolveBuilderConfig with no input/env defaults disabled, feeBps 0", () => {
     // Ensure env doesn't leak in.
     const saved = {

--- a/packages/venue-polymarket/src/marketdata.ts
+++ b/packages/venue-polymarket/src/marketdata.ts
@@ -1,6 +1,6 @@
 import { strictParseJson } from "@stwd/shared";
 import {
-  DEFAULT_FETCH_TIMEOUT_MS,
+  defaultFetchTimeoutMs,
   POLYMARKET_BATCH_PRICE_HISTORY_LIMIT,
   POLYMARKET_CLOB_API_BASE,
 } from "./constants";
@@ -24,15 +24,16 @@ import {
 
 function timeoutSignal(opts?: PolymarketFetchOptions): AbortSignal | undefined {
   if (opts?.signal) return opts.signal;
-  if (DEFAULT_FETCH_TIMEOUT_MS <= 0) return undefined;
-  return AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS);
+  const timeoutMs = defaultFetchTimeoutMs();
+  if (timeoutMs <= 0) return undefined;
+  return AbortSignal.timeout(timeoutMs);
 }
 
 const MAX_MARKET_BY_TOKEN_RESPONSE_BYTES = 16 * 1024;
-const MARKET_BY_TOKEN_TIMEOUT_MS =
-  Number.isSafeInteger(DEFAULT_FETCH_TIMEOUT_MS) && DEFAULT_FETCH_TIMEOUT_MS > 0
-    ? Math.min(DEFAULT_FETCH_TIMEOUT_MS, 60_000)
-    : 15_000;
+function marketByTokenTimeoutMs(): number {
+  const timeoutMs = defaultFetchTimeoutMs();
+  return Number.isSafeInteger(timeoutMs) && timeoutMs > 0 ? Math.min(timeoutMs, 60_000) : 15_000;
+}
 
 class PolymarketMarketMetadataError extends Error {}
 
@@ -167,7 +168,7 @@ export async function getMarketByToken(
       timedOut = true;
       controller.abort();
       reject(marketMetadataError("Polymarket market metadata request timed out"));
-    }, MARKET_BY_TOKEN_TIMEOUT_MS);
+    }, marketByTokenTimeoutMs());
   });
   opts?.signal?.addEventListener("abort", abortFromCaller, { once: true });
 

--- a/packages/webhooks/src/__tests__/dispatcher-ssrf-literal.test.ts
+++ b/packages/webhooks/src/__tests__/dispatcher-ssrf-literal.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { createServer, type IncomingMessage } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { WebhookEvent } from "@stwd/shared";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { WebhookDispatcher } from "../dispatcher";
 
 const SECRET = "ssrf-literal-test-secret";
@@ -14,12 +15,30 @@ const makeEvent = (): WebhookEvent => ({
   timestamp: new Date("2026-05-30T09:00:00.000Z"),
 });
 
-async function withLoopbackServer() {
+async function withLoopbackServer(
+  options: { holdResponses?: boolean; status?: number; location?: string } = {},
+) {
   let hits = 0;
+  let recordFirstHit!: () => void;
+  const firstHit = new Promise<void>((resolve) => {
+    recordFirstHit = resolve;
+  });
+  let releaseResponse: (() => void) | undefined;
+  const responseGate = options.holdResponses
+    ? new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+      })
+    : Promise.resolve();
   const server = createServer((_req: IncomingMessage, res) => {
     hits += 1;
-    res.writeHead(200, { "Content-Type": "text/plain" });
-    res.end("ok");
+    recordFirstHit();
+    void responseGate.then(() => {
+      res.writeHead(options.status ?? 200, {
+        "Content-Type": "text/plain",
+        ...(options.location ? { Location: options.location } : {}),
+      });
+      res.end("ok");
+    });
   });
   await new Promise<void>((resolve, reject) => {
     server.listen(0, "127.0.0.1", (error?: Error) => {
@@ -31,17 +50,146 @@ async function withLoopbackServer() {
   return {
     port,
     hits: () => hits,
+    firstHit,
+    releaseResponse: () => releaseResponse?.(),
     close: () =>
       new Promise<void>((resolve, reject) => {
         server.close((error) => {
           if (error) reject(error);
           else resolve();
         });
+        server.closeAllConnections();
       }),
   };
 }
 
 describe("WebhookDispatcher SSRF guard for IP-literal URLs", () => {
+  it("re-evaluates omitted private-network policy for every dispatch", async () => {
+    const server = await withLoopbackServer();
+    const dispatcher = new WebhookDispatcher({
+      maxRetries: 0,
+      timeoutMs: 1_000,
+      allowInsecureHttp: true,
+    });
+
+    try {
+      const enabled = await withRuntimeEnvironment(
+        { STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS: "true" },
+        () =>
+          dispatcher.dispatch(makeEvent(), {
+            url: `http://127.0.0.1:${server.port}/hook`,
+            secret: SECRET,
+          }),
+      );
+      expect(enabled.success).toBe(true);
+      expect(server.hits()).toBe(1);
+
+      const removed = await withRuntimeEnvironment({}, () =>
+        dispatcher.dispatch(makeEvent(), {
+          url: `http://127.0.0.1:${server.port}/hook`,
+          secret: SECRET,
+        }),
+      );
+      expect(removed.success).toBe(false);
+      expect(removed.error).toBe("Webhook validation failed");
+      expect(server.hits()).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("re-evaluates omitted insecure-HTTP policy for every dispatch", async () => {
+    const server = await withLoopbackServer();
+    const dispatcher = new WebhookDispatcher({
+      maxRetries: 0,
+      timeoutMs: 1_000,
+      allowPrivateNetwork: true,
+    });
+
+    try {
+      const enabled = await withRuntimeEnvironment(
+        { STEWARD_ALLOW_INSECURE_WEBHOOK_URLS: "true" },
+        () =>
+          dispatcher.dispatch(makeEvent(), {
+            url: `http://127.0.0.1:${server.port}/hook`,
+            secret: SECRET,
+          }),
+      );
+      expect(enabled.success).toBe(true);
+      expect(server.hits()).toBe(1);
+
+      const removed = await withRuntimeEnvironment({}, () =>
+        dispatcher.dispatch(makeEvent(), {
+          url: `http://127.0.0.1:${server.port}/hook`,
+          secret: SECRET,
+        }),
+      );
+      expect(removed.success).toBe(false);
+      expect(removed.error).toBe("Webhook validation failed");
+      expect(server.hits()).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("keeps an enabled delivery isolated from an overlapping disabled request", async () => {
+    const server = await withLoopbackServer();
+    const dispatcher = new WebhookDispatcher({
+      maxRetries: 0,
+      timeoutMs: 1_000,
+      allowInsecureHttp: true,
+    });
+
+    try {
+      const [enabled, disabled] = await Promise.all([
+        withRuntimeEnvironment({ STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS: "true" }, () =>
+          dispatcher.dispatch(makeEvent(), {
+            url: `http://127.0.0.1:${server.port}/hook`,
+            secret: SECRET,
+          }),
+        ),
+        withRuntimeEnvironment({}, () =>
+          dispatcher.dispatch(makeEvent(), {
+            url: `http://127.0.0.1:${server.port}/hook`,
+            secret: SECRET,
+          }),
+        ),
+      ]);
+      expect(disabled.success).toBe(false);
+      expect(server.hits()).toBe(1);
+      expect(enabled.success).toBe(true);
+      expect(server.hits()).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("does not follow an unvalidated redirect destination", async () => {
+    const server = await withLoopbackServer({
+      status: 302,
+      location: "http://169.254.169.254/latest/meta-data",
+    });
+    const dispatcher = new WebhookDispatcher({
+      maxRetries: 0,
+      timeoutMs: 1_000,
+      allowPrivateNetwork: true,
+      allowInsecureHttp: true,
+    });
+
+    try {
+      const result = await dispatcher.dispatch(makeEvent(), {
+        url: `http://127.0.0.1:${server.port}/hook`,
+        secret: SECRET,
+      });
+      expect(result.success).toBe(false);
+      expect(result.statusCode).toBe(302);
+      expect(result.attempts).toBe(1);
+      expect(server.hits()).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
   // Node's http client skips options.lookup for IPv4 literals, so the guarded
   // lookup alone never fired for these forms (SEC-006). The guard must reject
   // the literal hostname before any socket is opened.

--- a/packages/webhooks/src/__tests__/runtime-authority.test.ts
+++ b/packages/webhooks/src/__tests__/runtime-authority.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { currentWebhookRuntimeAuthority } from "../runtime-authority";
+
+const insecureName = "STEWARD_ALLOW_INSECURE_WEBHOOK_URLS";
+const privateName = "STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS";
+
+describe("webhook runtime authority", () => {
+  it("uses current Bun process values when no request snapshot exists", () => {
+    const priorInsecure = process.env[insecureName];
+    const priorPrivate = process.env[privateName];
+    try {
+      process.env[insecureName] = "true";
+      process.env[privateName] = "true";
+      expect(currentWebhookRuntimeAuthority()).toEqual({
+        allowInsecureHttp: true,
+        allowPrivateNetwork: true,
+      });
+
+      delete process.env[insecureName];
+      delete process.env[privateName];
+      expect(currentWebhookRuntimeAuthority()).toEqual({
+        allowInsecureHttp: false,
+        allowPrivateNetwork: false,
+      });
+    } finally {
+      if (priorInsecure === undefined) delete process.env[insecureName];
+      else process.env[insecureName] = priorInsecure;
+      if (priorPrivate === undefined) delete process.env[privateName];
+      else process.env[privateName] = priorPrivate;
+    }
+  });
+
+  it("does not fall back to stale process values inside a Worker request", () => {
+    const priorInsecure = process.env[insecureName];
+    const priorPrivate = process.env[privateName];
+    try {
+      process.env[insecureName] = "true";
+      process.env[privateName] = "true";
+      expect(withRuntimeEnvironment({}, () => currentWebhookRuntimeAuthority())).toEqual({
+        allowInsecureHttp: false,
+        allowPrivateNetwork: false,
+      });
+    } finally {
+      if (priorInsecure === undefined) delete process.env[insecureName];
+      else process.env[insecureName] = priorInsecure;
+      if (priorPrivate === undefined) delete process.env[privateName];
+      else process.env[privateName] = priorPrivate;
+    }
+  });
+});

--- a/packages/webhooks/src/__tests__/secret-codec.test.ts
+++ b/packages/webhooks/src/__tests__/secret-codec.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { decryptWebhookSecret, encryptWebhookSecret } from "../secret-codec";
 
 /**
@@ -11,6 +12,8 @@ describe("webhook secret-codec dev-key gate (SEC-102)", () => {
     "NODE_ENV",
     "STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY",
     "STEWARD_MASTER_PASSWORD",
+    "STEWARD_KDF_SALT",
+    "STEWARD_WEBHOOK_SECRET_KDF_SALT",
     "STEWARD_ALLOW_DEV_SECRETS",
     "STEWARD_ALLOW_DEV_SECRET",
   ] as const;
@@ -74,5 +77,93 @@ describe("webhook secret-codec dev-key gate (SEC-102)", () => {
     process.env.STEWARD_MASTER_PASSWORD = "a-real-master-password-for-tests";
     const encrypted = encryptWebhookSecret("tenant-secret");
     expect(decryptWebhookSecret(encrypted)).toBe("tenant-secret");
+  });
+
+  it("does not mistake an invalid configured salt for the internal dev default", () => {
+    process.env.STEWARD_MASTER_PASSWORD = "a-real-master-password-for-tests";
+    process.env.STEWARD_WEBHOOK_SECRET_KDF_SALT = "steward-webhook-secret-v1";
+    expect(() => encryptWebhookSecret("tenant-secret")).toThrow(
+      /Webhook secret KDF salt must decode to at least 16 bytes/,
+    );
+  });
+
+  it("keeps sequential Worker webhook roots separate across key and KDF rotations", () => {
+    const authorityA = {
+      NODE_ENV: "production",
+      STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY: "webhook-authority-a",
+      STEWARD_WEBHOOK_SECRET_KDF_SALT: "a1".repeat(16),
+    };
+    const authorityB = {
+      NODE_ENV: "production",
+      STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY: "webhook-authority-b",
+      STEWARD_WEBHOOK_SECRET_KDF_SALT: "b2".repeat(16),
+    };
+    const encryptedA = withRuntimeEnvironment(authorityA, () => encryptWebhookSecret("secret-a"));
+    const encryptedB = withRuntimeEnvironment(authorityB, () => encryptWebhookSecret("secret-b"));
+
+    expect(withRuntimeEnvironment(authorityA, () => decryptWebhookSecret(encryptedA))).toBe(
+      "secret-a",
+    );
+    expect(withRuntimeEnvironment(authorityB, () => decryptWebhookSecret(encryptedB))).toBe(
+      "secret-b",
+    );
+    expect(() =>
+      withRuntimeEnvironment(authorityB, () => decryptWebhookSecret(encryptedA)),
+    ).toThrow();
+    expect(() =>
+      withRuntimeEnvironment(authorityA, () => decryptWebhookSecret(encryptedB)),
+    ).toThrow();
+  });
+
+  it("does not inherit a stale webhook root when the current Worker binding is absent", () => {
+    process.env.STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY = "stale-isolate-webhook-root";
+    process.env.STEWARD_WEBHOOK_SECRET_KDF_SALT = "cc".repeat(16);
+    expect(() =>
+      withRuntimeEnvironment({ NODE_ENV: "production" }, () =>
+        encryptWebhookSecret("must-fail-closed"),
+      ),
+    ).toThrow(/STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY or STEWARD_MASTER_PASSWORD is required/);
+  });
+
+  it("preserves webhook authority when A suspends, B runs, then A resumes", async () => {
+    const authorityA = {
+      NODE_ENV: "production",
+      STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY: "webhook-overlap-a",
+      STEWARD_WEBHOOK_SECRET_KDF_SALT: "d4".repeat(16),
+    };
+    const authorityB = {
+      NODE_ENV: "production",
+      STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY: "webhook-overlap-b",
+      STEWARD_WEBHOOK_SECRET_KDF_SALT: "e5".repeat(16),
+    };
+    let releaseA: (() => void) | undefined;
+    let signalAStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      signalAStarted = resolve;
+    });
+    const resume = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    const requestA = withRuntimeEnvironment(authorityA, async () => {
+      signalAStarted?.();
+      await resume;
+      return encryptWebhookSecret("overlap-secret-a");
+    });
+    await started;
+    const encryptedB = withRuntimeEnvironment(authorityB, () =>
+      encryptWebhookSecret("overlap-secret-b"),
+    );
+    releaseA?.();
+    const encryptedA = await requestA;
+
+    expect(withRuntimeEnvironment(authorityA, () => decryptWebhookSecret(encryptedA))).toBe(
+      "overlap-secret-a",
+    );
+    expect(withRuntimeEnvironment(authorityB, () => decryptWebhookSecret(encryptedB))).toBe(
+      "overlap-secret-b",
+    );
+    expect(() =>
+      withRuntimeEnvironment(authorityB, () => decryptWebhookSecret(encryptedA)),
+    ).toThrow();
   });
 });

--- a/packages/webhooks/src/__tests__/secret-codec.test.ts
+++ b/packages/webhooks/src/__tests__/secret-codec.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
-import { decryptWebhookSecret, encryptWebhookSecret } from "../secret-codec";
+import {
+  decryptWebhookSecret,
+  encryptWebhookSecret,
+  resolveWebhookSecretAuthority,
+} from "../secret-codec";
 
 /**
  * SEC-102: the hardcoded dev key must require BOTH an explicit opt-in flag AND
@@ -100,6 +104,10 @@ describe("webhook secret-codec dev-key gate (SEC-102)", () => {
     };
     const encryptedA = withRuntimeEnvironment(authorityA, () => encryptWebhookSecret("secret-a"));
     const encryptedB = withRuntimeEnvironment(authorityB, () => encryptWebhookSecret("secret-b"));
+
+    expect(
+      withRuntimeEnvironment(authorityA, () => "fingerprint" in resolveWebhookSecretAuthority()),
+    ).toBe(false);
 
     expect(withRuntimeEnvironment(authorityA, () => decryptWebhookSecret(encryptedA))).toBe(
       "secret-a",

--- a/packages/webhooks/src/__tests__/secret-codec.test.ts
+++ b/packages/webhooks/src/__tests__/secret-codec.test.ts
@@ -86,9 +86,13 @@ describe("webhook secret-codec dev-key gate (SEC-102)", () => {
   it("does not mistake an invalid configured salt for the internal dev default", () => {
     process.env.STEWARD_MASTER_PASSWORD = "a-real-master-password-for-tests";
     process.env.STEWARD_WEBHOOK_SECRET_KDF_SALT = "steward-webhook-secret-v1";
-    expect(() => encryptWebhookSecret("tenant-secret")).toThrow(
-      /Webhook secret KDF salt must decode to at least 16 bytes/,
-    );
+    expect(() => encryptWebhookSecret("tenant-secret")).toThrow(/even-length hexadecimal string/);
+  });
+
+  it("rejects a configured salt with a valid hex prefix and invalid suffix", () => {
+    process.env.STEWARD_MASTER_PASSWORD = "a-real-master-password-for-tests";
+    process.env.STEWARD_WEBHOOK_SECRET_KDF_SALT = `${"ab".repeat(16)}zz`;
+    expect(() => encryptWebhookSecret("tenant-secret")).toThrow(/even-length hexadecimal string/);
   });
 
   it("keeps sequential Worker webhook roots separate across key and KDF rotations", () => {

--- a/packages/webhooks/src/dispatcher.ts
+++ b/packages/webhooks/src/dispatcher.ts
@@ -3,7 +3,7 @@ import type { LookupAddress } from "node:dns";
 import type { RequestOptions } from "node:http";
 import { isIP, type LookupFunction } from "node:net";
 import { redactedThrownDiagnostics, type WebhookEvent } from "@stwd/shared";
-
+import { currentWebhookRuntimeAuthority } from "./runtime-authority";
 import type { WebhookConfig, WebhookDeliveryResult, WebhookDispatcherOptions } from "./types";
 
 // Signature scheme version. v2 binds timestamp + deliveryId + event type into the HMAC.
@@ -28,10 +28,6 @@ const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_RETRY_DELAY_MS = 1_000;
 const DEFAULT_TIMEOUT_MS = 5_000;
 const MAX_RESPONSE_BYTES = 64 * 1024;
-const ALLOW_PRIVATE_WEBHOOK_NETWORKS =
-  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
-    ?.STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS === "true";
-
 // Once-per-process latch for the SEC-102 escape-hatch warning below.
 let warnedPrivateWebhookNetworks = false;
 
@@ -424,27 +420,17 @@ export class WebhookDispatcher {
   private readonly maxRetries: number;
   private readonly retryDelayMs: number;
   private readonly timeoutMs: number;
-  private readonly allowPrivateNetwork: boolean;
-  private readonly allowInsecureHttp: boolean;
+  private readonly allowPrivateNetwork?: boolean;
+  private readonly allowInsecureHttp?: boolean;
   private readonly lookup?: LookupFunction;
 
   constructor(options: WebhookDispatcherOptions = {}) {
     this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
     this.retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    this.allowPrivateNetwork = options.allowPrivateNetwork ?? ALLOW_PRIVATE_WEBHOOK_NETWORKS;
-    this.allowInsecureHttp = options.allowInsecureHttp ?? false;
+    this.allowPrivateNetwork = options.allowPrivateNetwork;
+    this.allowInsecureHttp = options.allowInsecureHttp;
     this.lookup = options.lookup;
-    // SEC-102: the SSRF escape hatch disables the private-network guard for
-    // every delivery this dispatcher makes (STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS
-    // does it process-wide at module load). Announce it loudly once per process
-    // instead of running unguarded in silence.
-    if (this.allowPrivateNetwork && !warnedPrivateWebhookNetworks) {
-      warnedPrivateWebhookNetworks = true;
-      console.warn(
-        "[steward] WARNING: webhook SSRF guard is DISABLED (allowPrivateNetwork / STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS=true). Loopback, link-local, and private-range webhook targets will be fetched. Use only for local development or trusted test harnesses.",
-      );
-    }
   }
 
   async dispatch(
@@ -452,6 +438,19 @@ export class WebhookDispatcher {
     webhook: WebhookConfig | string,
   ): Promise<WebhookDeliveryResult> {
     const config = normalizeWebhook(webhook);
+    // Resolve omitted policy once per dispatch. The request-local runtime
+    // environment is immutable, and explicit constructor options remain
+    // available to callers such as test sinks. A cached dispatcher therefore
+    // cannot retain a prior Worker's escape-hatch acknowledgement.
+    const runtimeAuthority = currentWebhookRuntimeAuthority();
+    const allowPrivateNetwork = this.allowPrivateNetwork ?? runtimeAuthority.allowPrivateNetwork;
+    const allowInsecureHttp = this.allowInsecureHttp ?? runtimeAuthority.allowInsecureHttp;
+    if (allowPrivateNetwork && !warnedPrivateWebhookNetworks) {
+      warnedPrivateWebhookNetworks = true;
+      console.warn(
+        "[steward] WARNING: webhook SSRF guard is DISABLED (allowPrivateNetwork / STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS=true). Loopback, link-local, and private-range webhook targets will be fetched. Use only for local development or trusted test harnesses.",
+      );
+    }
 
     // An empty events array means "subscribe to all" everywhere else
     // (acceptsConfiguredWebhookEvent, persistent-queue) — a truthy [] must
@@ -507,8 +506,8 @@ export class WebhookDispatcher {
           },
           body,
           timeoutMs: this.timeoutMs,
-          allowPrivateNetwork: this.allowPrivateNetwork,
-          allowInsecureHttp: this.allowInsecureHttp,
+          allowPrivateNetwork,
+          allowInsecureHttp,
           lookup: this.lookup,
         });
 

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -5,11 +5,11 @@ export type {
 } from "./persistent-queue";
 export { PersistentQueue } from "./persistent-queue";
 export { RetryQueue } from "./queue";
-export type { WebhookSecretAuthority } from "./secret-codec";
 export {
   currentWebhookRuntimeAuthority,
   type WebhookRuntimeAuthority,
 } from "./runtime-authority";
+export type { WebhookSecretAuthority } from "./secret-codec";
 export {
   decryptWebhookSecret,
   encryptWebhookSecret,

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -5,10 +5,12 @@ export type {
 } from "./persistent-queue";
 export { PersistentQueue } from "./persistent-queue";
 export { RetryQueue } from "./queue";
+export type { WebhookSecretAuthority } from "./secret-codec";
 export {
   decryptWebhookSecret,
   encryptWebhookSecret,
   isEncryptedWebhookSecret,
+  resolveWebhookSecretAuthority,
 } from "./secret-codec";
 export type {
   QueuedWebhookDelivery,

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -7,6 +7,10 @@ export { PersistentQueue } from "./persistent-queue";
 export { RetryQueue } from "./queue";
 export type { WebhookSecretAuthority } from "./secret-codec";
 export {
+  currentWebhookRuntimeAuthority,
+  type WebhookRuntimeAuthority,
+} from "./runtime-authority";
+export {
   decryptWebhookSecret,
   encryptWebhookSecret,
   isEncryptedWebhookSecret,

--- a/packages/webhooks/src/runtime-authority.ts
+++ b/packages/webhooks/src/runtime-authority.ts
@@ -1,0 +1,20 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
+/** Immutable transport and destination policy for one webhook operation. */
+export type WebhookRuntimeAuthority = Readonly<{
+  allowInsecureHttp: boolean;
+  allowPrivateNetwork: boolean;
+}>;
+
+/**
+ * Snapshot webhook escape hatches from the current Worker request, or from the
+ * Bun process when no request environment is active. Only the exact lowercase
+ * acknowledgement enables either fail-open boundary.
+ */
+export function currentWebhookRuntimeAuthority(): WebhookRuntimeAuthority {
+  return Object.freeze({
+    allowInsecureHttp: runtimeEnvironmentValue("STEWARD_ALLOW_INSECURE_WEBHOOK_URLS") === "true",
+    allowPrivateNetwork:
+      runtimeEnvironmentValue("STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS") === "true",
+  });
+}

--- a/packages/webhooks/src/secret-codec.ts
+++ b/packages/webhooks/src/secret-codec.ts
@@ -1,4 +1,5 @@
-import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:crypto";
+import { createCipheriv, createDecipheriv, createHash, randomBytes, scryptSync } from "node:crypto";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 
 const PREFIX = "stwd_whsec_v1:";
 const DEFAULT_KDF_SALT = "steward-webhook-secret-v1";
@@ -10,39 +11,49 @@ type EncryptedWebhookSecret = {
   salt: string;
 };
 
-function env(): Record<string, string | undefined> {
-  return (
-    (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {}
-  );
+let warnedDevSecret = false;
+const rootKeysByAuthority = new Map<string, Buffer>();
+const MAX_CACHED_WEBHOOK_AUTHORITIES = 8;
+
+export interface WebhookSecretAuthority {
+  readonly fingerprint: string;
+  readonly nodeEnvironment?: string;
+  readonly encryptionKey: string;
+  readonly kdfSalt: string;
+  readonly kdfSaltIsHex: boolean;
 }
 
-let warnedDevSecret = false;
+function runtimeValue(name: string): string | undefined {
+  const value = runtimeEnvironmentValue(name);
+  return value ? value : undefined;
+}
 
-function rootKey(): Buffer {
-  const currentEnv = env();
-  const masterPassword =
-    currentEnv.STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY ?? currentEnv.STEWARD_MASTER_PASSWORD;
-  if (!masterPassword) {
-    if (currentEnv.NODE_ENV === "production") {
+/** Resolve one immutable webhook encryption root from the current runtime. */
+export function resolveWebhookSecretAuthority(): WebhookSecretAuthority {
+  const nodeEnvironment =
+    runtimeValue("NODE_ENV") ??
+    (runtimeValue("STEWARD_RUNTIME") === "workers" ? "production" : undefined);
+  let encryptionKey =
+    runtimeValue("STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY") ??
+    runtimeValue("STEWARD_MASTER_PASSWORD");
+  let kdfSalt = runtimeValue("STEWARD_WEBHOOK_SECRET_KDF_SALT") ?? runtimeValue("STEWARD_KDF_SALT");
+  let kdfSaltIsHex = kdfSalt !== undefined;
+  if (!encryptionKey) {
+    if (nodeEnvironment === "production") {
       throw new Error(
         "STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY or STEWARD_MASTER_PASSWORD is required to encrypt webhook secrets",
       );
     }
-    // SEC-102: the insecure dev key is reachable ONLY when NODE_ENV is
-    // explicitly a development value. A deploy that simply forgot NODE_ENV must
-    // not fall through to a publicly-known key on the strength of an env flag.
-    if (currentEnv.NODE_ENV !== "development" && currentEnv.NODE_ENV !== "test") {
+    if (nodeEnvironment !== "development" && nodeEnvironment !== "test") {
       throw new Error(
         `Refusing the insecure webhook dev key: NODE_ENV is not an explicit development value (${
-          currentEnv.NODE_ENV === undefined ? "unset" : JSON.stringify(currentEnv.NODE_ENV)
+          nodeEnvironment === undefined ? "unset" : JSON.stringify(nodeEnvironment)
         }). Set NODE_ENV=development for local development, or configure STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY / STEWARD_MASTER_PASSWORD.`,
       );
     }
-    // The insecure dev fallback must be explicitly opted into; never in production.
-    // Canonical var is STEWARD_ALLOW_DEV_SECRETS; singular accepted for back-compat.
     if (
-      currentEnv.STEWARD_ALLOW_DEV_SECRETS !== "true" &&
-      currentEnv.STEWARD_ALLOW_DEV_SECRET !== "true"
+      runtimeValue("STEWARD_ALLOW_DEV_SECRETS") !== "true" &&
+      runtimeValue("STEWARD_ALLOW_DEV_SECRET") !== "true"
     ) {
       throw new Error(
         "No webhook secret encryption key set. Set STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY / STEWARD_MASTER_PASSWORD, or set STEWARD_ALLOW_DEV_SECRETS=true to use the insecure dev key (local development only).",
@@ -54,20 +65,49 @@ function rootKey(): Buffer {
         "[steward] WARNING: using the insecure hardcoded dev key to encrypt webhook secrets (STEWARD_ALLOW_DEV_SECRET=true). Secrets are trivially decryptable. Never use this outside local development.",
       );
     }
-    return scryptSync("dev-secret", DEFAULT_KDF_SALT, 32) as Buffer;
-  }
-
-  const configuredSalt = currentEnv.STEWARD_WEBHOOK_SECRET_KDF_SALT ?? currentEnv.STEWARD_KDF_SALT;
-  if (!configuredSalt && currentEnv.NODE_ENV === "production") {
+    encryptionKey = "dev-secret";
+    kdfSalt = DEFAULT_KDF_SALT;
+    kdfSaltIsHex = false;
+  } else if (!kdfSalt && nodeEnvironment === "production") {
     throw new Error(
       "STEWARD_WEBHOOK_SECRET_KDF_SALT or STEWARD_KDF_SALT is required in production",
     );
   }
-  const salt = configuredSalt ? Buffer.from(configuredSalt, "hex") : Buffer.from(DEFAULT_KDF_SALT);
-  if (configuredSalt && salt.length < 16) {
+  if (!kdfSalt) {
+    kdfSalt = DEFAULT_KDF_SALT;
+    kdfSaltIsHex = false;
+  }
+  const salt = Buffer.from(kdfSalt, kdfSaltIsHex ? "hex" : "utf8");
+  if (kdfSaltIsHex && salt.length < 16) {
     throw new Error("Webhook secret KDF salt must decode to at least 16 bytes");
   }
-  return scryptSync(masterPassword, salt, 32) as Buffer;
+  const fingerprint = createHash("sha256")
+    .update(JSON.stringify({ nodeEnvironment, encryptionKey, kdfSalt, kdfSaltIsHex }))
+    .digest("hex");
+  return Object.freeze({
+    fingerprint,
+    nodeEnvironment,
+    encryptionKey,
+    kdfSalt,
+    kdfSaltIsHex,
+  });
+}
+
+function rootKey(): Buffer {
+  const authority = resolveWebhookSecretAuthority();
+  let key = rootKeysByAuthority.get(authority.fingerprint);
+  if (key) return key;
+  const salt = Buffer.from(authority.kdfSalt, authority.kdfSaltIsHex ? "hex" : "utf8");
+  key = scryptSync(authority.encryptionKey, salt, 32) as Buffer;
+  if (rootKeysByAuthority.size >= MAX_CACHED_WEBHOOK_AUTHORITIES) {
+    const oldest = rootKeysByAuthority.keys().next().value as string | undefined;
+    if (oldest) {
+      rootKeysByAuthority.get(oldest)?.fill(0);
+      rootKeysByAuthority.delete(oldest);
+    }
+  }
+  rootKeysByAuthority.set(authority.fingerprint, key);
+  return key;
 }
 
 function deriveRecordKey(recordSalt: Buffer): Buffer {

--- a/packages/webhooks/src/secret-codec.ts
+++ b/packages/webhooks/src/secret-codec.ts
@@ -22,13 +22,27 @@ export interface WebhookSecretAuthority {
 
 function runtimeValue(name: string): string | undefined {
   const value = runtimeEnvironmentValue(name);
-  return value ? value : undefined;
+  // A blank binding is an omission, never an encryption root. Preserve the
+  // exact bytes of non-blank secrets for compatibility with existing records.
+  return value?.trim() ? value : undefined;
+}
+
+function decodeConfiguredKdfSalt(value: string): Buffer {
+  // Buffer.from(value, "hex") silently accepts a valid prefix and discards an
+  // invalid suffix. Validate the complete binding before deriving authority.
+  if (value.length < 32 || value.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(value)) {
+    throw new Error(
+      "Webhook secret KDF salt must be an even-length hexadecimal string of at least 32 characters (16 bytes)",
+    );
+  }
+  return Buffer.from(value, "hex");
 }
 
 /** Resolve one immutable webhook encryption root from the current runtime. */
 export function resolveWebhookSecretAuthority(): WebhookSecretAuthority {
+  const configuredNodeEnvironment = runtimeValue("NODE_ENV")?.trim();
   const nodeEnvironment =
-    runtimeValue("NODE_ENV") ??
+    configuredNodeEnvironment ||
     (runtimeValue("STEWARD_RUNTIME") === "workers" ? "production" : undefined);
   let encryptionKey =
     runtimeValue("STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY") ??

--- a/packages/webhooks/src/secret-codec.ts
+++ b/packages/webhooks/src/secret-codec.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, createDecipheriv, createHash, randomBytes, scryptSync } from "node:crypto";
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:crypto";
 import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 
 const PREFIX = "stwd_whsec_v1:";
@@ -12,11 +12,8 @@ type EncryptedWebhookSecret = {
 };
 
 let warnedDevSecret = false;
-const rootKeysByAuthority = new Map<string, Buffer>();
-const MAX_CACHED_WEBHOOK_AUTHORITIES = 8;
 
 export interface WebhookSecretAuthority {
-  readonly fingerprint: string;
   readonly nodeEnvironment?: string;
   readonly encryptionKey: string;
   readonly kdfSalt: string;
@@ -77,15 +74,8 @@ export function resolveWebhookSecretAuthority(): WebhookSecretAuthority {
     kdfSalt = DEFAULT_KDF_SALT;
     kdfSaltIsHex = false;
   }
-  const salt = Buffer.from(kdfSalt, kdfSaltIsHex ? "hex" : "utf8");
-  if (kdfSaltIsHex && salt.length < 16) {
-    throw new Error("Webhook secret KDF salt must decode to at least 16 bytes");
-  }
-  const fingerprint = createHash("sha256")
-    .update(JSON.stringify({ nodeEnvironment, encryptionKey, kdfSalt, kdfSaltIsHex }))
-    .digest("hex");
+  if (kdfSaltIsHex) decodeConfiguredKdfSalt(kdfSalt).fill(0);
   return Object.freeze({
-    fingerprint,
     nodeEnvironment,
     encryptionKey,
     kdfSalt,
@@ -95,23 +85,23 @@ export function resolveWebhookSecretAuthority(): WebhookSecretAuthority {
 
 function rootKey(): Buffer {
   const authority = resolveWebhookSecretAuthority();
-  let key = rootKeysByAuthority.get(authority.fingerprint);
-  if (key) return key;
-  const salt = Buffer.from(authority.kdfSalt, authority.kdfSaltIsHex ? "hex" : "utf8");
-  key = scryptSync(authority.encryptionKey, salt, 32) as Buffer;
-  if (rootKeysByAuthority.size >= MAX_CACHED_WEBHOOK_AUTHORITIES) {
-    const oldest = rootKeysByAuthority.keys().next().value as string | undefined;
-    if (oldest) {
-      rootKeysByAuthority.get(oldest)?.fill(0);
-      rootKeysByAuthority.delete(oldest);
-    }
+  const salt = authority.kdfSaltIsHex
+    ? decodeConfiguredKdfSalt(authority.kdfSalt)
+    : Buffer.from(authority.kdfSalt, "utf8");
+  try {
+    return scryptSync(authority.encryptionKey, salt, 32) as Buffer;
+  } finally {
+    salt.fill(0);
   }
-  rootKeysByAuthority.set(authority.fingerprint, key);
-  return key;
 }
 
 function deriveRecordKey(recordSalt: Buffer): Buffer {
-  return scryptSync(rootKey(), recordSalt, 32) as Buffer;
+  const root = rootKey();
+  try {
+    return scryptSync(root, recordSalt, 32) as Buffer;
+  } finally {
+    root.fill(0);
+  }
 }
 
 export function isEncryptedWebhookSecret(value: string): boolean {
@@ -122,16 +112,21 @@ export function encryptWebhookSecret(secret: string): string {
   if (isEncryptedWebhookSecret(secret)) return secret;
   const iv = randomBytes(16);
   const salt = randomBytes(16);
-  const cipher = createCipheriv("aes-256-gcm", deriveRecordKey(salt), iv);
-  let ciphertext = cipher.update(secret, "utf8", "hex");
-  ciphertext += cipher.final("hex");
-  const payload: EncryptedWebhookSecret = {
-    ciphertext,
-    iv: iv.toString("hex"),
-    tag: cipher.getAuthTag().toString("hex"),
-    salt: salt.toString("hex"),
-  };
-  return `${PREFIX}${JSON.stringify(payload)}`;
+  const recordKey = deriveRecordKey(salt);
+  try {
+    const cipher = createCipheriv("aes-256-gcm", recordKey, iv);
+    let ciphertext = cipher.update(secret, "utf8", "hex");
+    ciphertext += cipher.final("hex");
+    const payload: EncryptedWebhookSecret = {
+      ciphertext,
+      iv: iv.toString("hex"),
+      tag: cipher.getAuthTag().toString("hex"),
+      salt: salt.toString("hex"),
+    };
+    return `${PREFIX}${JSON.stringify(payload)}`;
+  } finally {
+    recordKey.fill(0);
+  }
 }
 
 export function decryptWebhookSecret(secret: string): string {
@@ -141,9 +136,14 @@ export function decryptWebhookSecret(secret: string): string {
   const iv = Buffer.from(payload.iv, "hex");
   const salt = Buffer.from(payload.salt, "hex");
   const tag = Buffer.from(payload.tag, "hex");
-  const decipher = createDecipheriv("aes-256-gcm", deriveRecordKey(salt), iv);
-  decipher.setAuthTag(tag);
-  let plaintext = decipher.update(payload.ciphertext, "hex", "utf8");
-  plaintext += decipher.final("utf8");
-  return plaintext;
+  const recordKey = deriveRecordKey(salt);
+  try {
+    const decipher = createDecipheriv("aes-256-gcm", recordKey, iv);
+    decipher.setAuthTag(tag);
+    let plaintext = decipher.update(payload.ciphertext, "hex", "utf8");
+    plaintext += decipher.final("utf8");
+    return plaintext;
+  } finally {
+    recordKey.fill(0);
+  }
 }

--- a/scripts/__tests__/check-worker-runtime-env.test.ts
+++ b/scripts/__tests__/check-worker-runtime-env.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  APPROVED_WORKER_PROCESS_ENV_READERS,
+  assertWorkerRuntimeEnvInventory,
+  workerProcessEnvReaders,
+} from "../check-worker-runtime-env";
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("Worker runtime environment inventory", () => {
+  test("the repository has no unapproved Worker-reachable process.env reader", () => {
+    const root = resolve(import.meta.dir, "../..");
+    expect(() => assertWorkerRuntimeEnvInventory(root)).not.toThrow();
+    expect(workerProcessEnvReaders(root)).toEqual(
+      Object.keys(APPROVED_WORKER_PROCESS_ENV_READERS).sort(),
+    );
+  });
+
+  test("a new security reader fails the guard", () => {
+    const root = mkdtempSync(join(tmpdir(), "steward-worker-env-inventory-"));
+    temporaryRoots.push(root);
+    const directory = join(root, "packages/api/src/routes");
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(join(directory, "unsafe.ts"), "export const secret = process.env.SECRET;\n");
+    expect(() => assertWorkerRuntimeEnvInventory(root)).toThrow(
+      "unapproved Worker process.env readers: packages/api/src/routes/unsafe.ts",
+    );
+  });
+});

--- a/scripts/__tests__/check-worker-runtime-env.test.ts
+++ b/scripts/__tests__/check-worker-runtime-env.test.ts
@@ -28,9 +28,39 @@ describe("Worker runtime environment inventory", () => {
     temporaryRoots.push(root);
     const directory = join(root, "packages/api/src/routes");
     mkdirSync(directory, { recursive: true });
+    writeFileSync(
+      join(root, "packages/api/src/worker.ts"),
+      'import "./routes/unsafe";\nexport default {};\n',
+    );
     writeFileSync(join(directory, "unsafe.ts"), "export const secret = process.env.SECRET;\n");
     expect(() => assertWorkerRuntimeEnvInventory(root)).toThrow(
       "unapproved Worker process.env readers: packages/api/src/routes/unsafe.ts",
     );
+  });
+
+  test("traverses runtime workspace imports but ignores unreachable source", () => {
+    const root = mkdtempSync(join(tmpdir(), "steward-worker-env-graph-"));
+    temporaryRoots.push(root);
+    mkdirSync(join(root, "packages/api/src"), { recursive: true });
+    mkdirSync(join(root, "packages/consumer/src"), { recursive: true });
+    writeFileSync(join(root, "packages/api/package.json"), '{"name":"@stwd/api"}\n');
+    writeFileSync(
+      join(root, "packages/consumer/package.json"),
+      '{"name":"@stwd/consumer","exports":{".":{"import":"./dist/runtime-entry.js"}}}\n',
+    );
+    writeFileSync(
+      join(root, "packages/api/src/worker.ts"),
+      'import { value } from "@stwd/consumer";\nexport default value;\n',
+    );
+    writeFileSync(
+      join(root, "packages/consumer/src/runtime-entry.ts"),
+      "export const value = process.env.SECRET;\n",
+    );
+    writeFileSync(
+      join(root, "packages/api/src/unreachable.ts"),
+      "export const decoy = process.env.DECOY;\n",
+    );
+
+    expect(workerProcessEnvReaders(root)).toEqual(["packages/consumer/src/runtime-entry.ts"]);
   });
 });

--- a/scripts/check-worker-runtime-env.ts
+++ b/scripts/check-worker-runtime-env.ts
@@ -14,10 +14,6 @@ export type WorkerRuntimeEnvInventoryEntry = {
 export const APPROVED_WORKER_PROCESS_ENV_READERS: Readonly<
   Record<string, WorkerRuntimeEnvInventoryEntry>
 > = Object.freeze({
-  "packages/api/src/services/context.ts": {
-    classification: "compatibility",
-    reason: "one DATABASE_URL normalization write remains for Bun-only legacy consumers",
-  },
   "packages/api/src/services/version.ts": {
     classification: "immutable-build",
     reason: "API_VERSION is build and release metadata, never request authority",

--- a/scripts/check-worker-runtime-env.ts
+++ b/scripts/check-worker-runtime-env.ts
@@ -1,5 +1,5 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join, relative, resolve } from "node:path";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
 
 export type WorkerRuntimeEnvInventoryEntry = {
   classification: "bun-entry" | "immutable-build" | "typed-bun-fallback" | "compatibility";
@@ -14,14 +14,6 @@ export type WorkerRuntimeEnvInventoryEntry = {
 export const APPROVED_WORKER_PROCESS_ENV_READERS: Readonly<
   Record<string, WorkerRuntimeEnvInventoryEntry>
 > = Object.freeze({
-  "packages/api/src/embedded.ts": {
-    classification: "bun-entry",
-    reason: "embedded Bun bootstrap establishes process configuration before importing the app",
-  },
-  "packages/api/src/index.ts": {
-    classification: "bun-entry",
-    reason: "Bun server startup configuration is immutable for the process lifetime",
-  },
   "packages/api/src/services/context.ts": {
     classification: "compatibility",
     reason: "one DATABASE_URL normalization write remains for Bun-only legacy consumers",
@@ -48,34 +40,6 @@ export const APPROVED_WORKER_PROCESS_ENV_READERS: Readonly<
   },
 });
 
-const WORKER_GRAPH_ROOTS = [
-  "packages/api/src",
-  "packages/auth/src",
-  "packages/db/src",
-  "packages/plugin-capabilities/src",
-  "packages/plugin-trading/src",
-  "packages/plugin-wxmr/src",
-  "packages/redis/src",
-  "packages/shared/src",
-  "packages/vault/src",
-];
-
-function productionTypeScriptFiles(root: string): string[] {
-  if (!existsSync(root)) return [];
-  const output: string[] = [];
-  for (const name of readdirSync(root)) {
-    const path = join(root, name);
-    const stats = statSync(path);
-    if (stats.isDirectory()) {
-      if (name === "__tests__" || name === "dist") continue;
-      output.push(...productionTypeScriptFiles(path));
-    } else if (/\.(?:ts|tsx)$/.test(name) && !/\.(?:test|spec)\.(?:ts|tsx)$/.test(name)) {
-      output.push(path);
-    }
-  }
-  return output;
-}
-
 function executableSource(source: string): string {
   return source
     .replace(/\/\*[\s\S]*?\*\//g, "")
@@ -83,9 +47,139 @@ function executableSource(source: string): string {
     .replace(/\/\/[^\n]*process\.env[^\n]*/g, "");
 }
 
+type WorkspacePackage = {
+  directory: string;
+  exports: ReadonlyMap<string, string>;
+  main?: string;
+};
+
+function exportTarget(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  for (const key of ["worker", "browser", "import", "default"]) {
+    const target = exportTarget((value as Record<string, unknown>)[key]);
+    if (target) return target;
+  }
+  return null;
+}
+
+function workspacePackages(repoRoot: string): Map<string, WorkspacePackage> {
+  const packages = new Map<string, WorkspacePackage>();
+  const packagesRoot = join(repoRoot, "packages");
+  for (const entry of readdirSync(packagesRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const directory = join(packagesRoot, entry.name);
+    const manifestPath = join(directory, "package.json");
+    if (!existsSync(manifestPath)) continue;
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      name?: unknown;
+      exports?: unknown;
+      main?: unknown;
+    };
+    if (typeof manifest.name !== "string") continue;
+    const exports = new Map<string, string>();
+    if (typeof manifest.exports === "string") exports.set(".", manifest.exports);
+    else if (manifest.exports && typeof manifest.exports === "object") {
+      const entries = Object.entries(manifest.exports as Record<string, unknown>);
+      if (entries.some(([key]) => key.startsWith("."))) {
+        for (const [key, value] of entries) {
+          const target = exportTarget(value);
+          if (target) exports.set(key, target);
+        }
+      } else {
+        const target = exportTarget(manifest.exports);
+        if (target) exports.set(".", target);
+      }
+    }
+    packages.set(manifest.name, {
+      directory,
+      exports,
+      main: typeof manifest.main === "string" ? manifest.main : undefined,
+    });
+  }
+  return packages;
+}
+
+function sourceCandidate(path: string): string | null {
+  const withoutJs = path.replace(/\.(?:js|mjs|cjs)$/, "");
+  for (const candidate of [
+    path,
+    withoutJs,
+    `${withoutJs}.ts`,
+    `${withoutJs}.tsx`,
+    join(withoutJs, "index.ts"),
+    join(withoutJs, "index.tsx"),
+  ]) {
+    if (existsSync(candidate) && /\.(?:ts|tsx)$/.test(candidate)) return resolve(candidate);
+  }
+  return null;
+}
+
+function resolveImport(
+  specifier: string,
+  importer: string,
+  packages: ReadonlyMap<string, WorkspacePackage>,
+): string | null {
+  if (specifier.startsWith(".")) return sourceCandidate(resolve(dirname(importer), specifier));
+  for (const [name, workspacePackage] of packages) {
+    const { directory, exports, main } = workspacePackage;
+    const sourceTarget = (target: string) => {
+      const sourcePath = target.replace(/^\.\/dist\//, "./src/");
+      return sourceCandidate(join(directory, sourcePath));
+    };
+    if (specifier === name) {
+      const target = exports.get(".") ?? main;
+      return target ? sourceTarget(target) : sourceCandidate(join(directory, "src/index.ts"));
+    }
+    if (specifier.startsWith(`${name}/`)) {
+      const subpath = specifier.slice(name.length + 1);
+      const target = exports.get(`./${subpath}`);
+      return target ? sourceTarget(target) : sourceCandidate(join(directory, "src", subpath));
+    }
+  }
+  return null;
+}
+
+function importedSpecifiers(source: string): string[] {
+  const specifiers = new Set<string>();
+  const runtimeSource = executableSource(source).replace(
+    /\b(?:import|export)\s+type\b[\s\S]*?\bfrom\s+["'][^"']+["'];?/g,
+    "",
+  );
+  const patterns = [
+    /\b(?:import|export)\s+(?:type\s+)?(?:[^"']*?\s+from\s+)?["']([^"']+)["']/g,
+    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+    /\brequire\s*\(\s*["']([^"']+)["']\s*\)/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of runtimeSource.matchAll(pattern)) specifiers.add(match[1]);
+  }
+  return [...specifiers];
+}
+
+export function workerReachableFiles(repoRoot: string): string[] {
+  const absoluteRoot = resolve(repoRoot);
+  const packages = workspacePackages(absoluteRoot);
+  const entry = resolve(absoluteRoot, "packages/api/src/worker.ts");
+  const pending = [entry];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const path = pending.pop();
+    if (!path || visited.has(path)) continue;
+    visited.add(path);
+    const source = readFileSync(path, "utf8");
+    for (const specifier of importedSpecifiers(source)) {
+      const dependency = resolveImport(specifier, path, packages);
+      if (dependency && !visited.has(dependency)) pending.push(dependency);
+    }
+  }
+  return [...visited].map((path) => relative(absoluteRoot, path).replaceAll("\\", "/")).sort();
+}
+
 export function workerProcessEnvReaders(repoRoot: string): string[] {
   const absoluteRoot = resolve(repoRoot);
-  return WORKER_GRAPH_ROOTS.flatMap((path) => productionTypeScriptFiles(join(absoluteRoot, path)))
+  return workerReachableFiles(absoluteRoot)
+    .map((path) => join(absoluteRoot, path))
     .filter((path) => /\bprocess\.env\b/.test(executableSource(readFileSync(path, "utf8"))))
     .map((path) => relative(absoluteRoot, path).replaceAll("\\", "/"))
     .sort();

--- a/scripts/check-worker-runtime-env.ts
+++ b/scripts/check-worker-runtime-env.ts
@@ -1,0 +1,119 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+export type WorkerRuntimeEnvInventoryEntry = {
+  classification: "bun-entry" | "immutable-build" | "typed-bun-fallback" | "compatibility";
+  reason: string;
+};
+
+/**
+ * Every executable direct process.env reader in the Worker-reachable graph must
+ * appear here with a narrow non-request-scoped classification. Request-scoped
+ * policy belongs behind runtimeEnvironmentValue or an explicit authority.
+ */
+export const APPROVED_WORKER_PROCESS_ENV_READERS: Readonly<
+  Record<string, WorkerRuntimeEnvInventoryEntry>
+> = Object.freeze({
+  "packages/api/src/embedded.ts": {
+    classification: "bun-entry",
+    reason: "embedded Bun bootstrap establishes process configuration before importing the app",
+  },
+  "packages/api/src/index.ts": {
+    classification: "bun-entry",
+    reason: "Bun server startup configuration is immutable for the process lifetime",
+  },
+  "packages/api/src/services/context.ts": {
+    classification: "compatibility",
+    reason: "one DATABASE_URL normalization write remains for Bun-only legacy consumers",
+  },
+  "packages/api/src/services/version.ts": {
+    classification: "immutable-build",
+    reason: "API_VERSION is build and release metadata, never request authority",
+  },
+  "packages/api/src/services/webhook-url.ts": {
+    classification: "compatibility",
+    reason: "request-local webhook transport policy is independently owned by issue 769",
+  },
+  "packages/auth/src/jwt.ts": {
+    classification: "typed-bun-fallback",
+    reason: "typed authority parameters and JWT AsyncLocalStorage are authoritative on Workers",
+  },
+  "packages/db/src/client.ts": {
+    classification: "typed-bun-fallback",
+    reason: "Workers pass an explicit immutable DatabaseSecurityEnv and request database handle",
+  },
+  "packages/shared/src/runtime-env.ts": {
+    classification: "typed-bun-fallback",
+    reason: "the accessor itself falls back to Bun process env outside a bound runtime snapshot",
+  },
+});
+
+const WORKER_GRAPH_ROOTS = [
+  "packages/api/src",
+  "packages/auth/src",
+  "packages/db/src",
+  "packages/plugin-capabilities/src",
+  "packages/plugin-trading/src",
+  "packages/plugin-wxmr/src",
+  "packages/redis/src",
+  "packages/shared/src",
+  "packages/vault/src",
+];
+
+function productionTypeScriptFiles(root: string): string[] {
+  if (!existsSync(root)) return [];
+  const output: string[] = [];
+  for (const name of readdirSync(root)) {
+    const path = join(root, name);
+    const stats = statSync(path);
+    if (stats.isDirectory()) {
+      if (name === "__tests__" || name === "dist") continue;
+      output.push(...productionTypeScriptFiles(path));
+    } else if (/\.(?:ts|tsx)$/.test(name) && !/\.(?:test|spec)\.(?:ts|tsx)$/.test(name)) {
+      output.push(path);
+    }
+  }
+  return output;
+}
+
+function executableSource(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "")
+    .replace(/\/\/[^\n]*process\.env[^\n]*/g, "");
+}
+
+export function workerProcessEnvReaders(repoRoot: string): string[] {
+  const absoluteRoot = resolve(repoRoot);
+  return WORKER_GRAPH_ROOTS.flatMap((path) => productionTypeScriptFiles(join(absoluteRoot, path)))
+    .filter((path) => /\bprocess\.env\b/.test(executableSource(readFileSync(path, "utf8"))))
+    .map((path) => relative(absoluteRoot, path).replaceAll("\\", "/"))
+    .sort();
+}
+
+export function assertWorkerRuntimeEnvInventory(repoRoot: string): void {
+  const actual = workerProcessEnvReaders(repoRoot);
+  const approved = Object.keys(APPROVED_WORKER_PROCESS_ENV_READERS).sort();
+  const unapproved = actual.filter((path) => !approved.includes(path));
+  const stale = approved.filter((path) => !actual.includes(path));
+  if (unapproved.length > 0 || stale.length > 0) {
+    throw new Error(
+      [
+        unapproved.length > 0
+          ? `unapproved Worker process.env readers: ${unapproved.join(", ")}`
+          : "",
+        stale.length > 0 ? `stale Worker process.env inventory: ${stale.join(", ")}` : "",
+      ]
+        .filter(Boolean)
+        .join("; "),
+    );
+  }
+}
+
+if (import.meta.main) {
+  const repoRoot = resolve(import.meta.dir, "..");
+  assertWorkerRuntimeEnvInventory(repoRoot);
+  console.log(
+    `Worker runtime environment inventory verified (${workerProcessEnvReaders(repoRoot).length} classified readers)`,
+  );
+}

--- a/scripts/check-worker-runtime-env.ts
+++ b/scripts/check-worker-runtime-env.ts
@@ -18,10 +18,6 @@ export const APPROVED_WORKER_PROCESS_ENV_READERS: Readonly<
     classification: "immutable-build",
     reason: "API_VERSION is build and release metadata, never request authority",
   },
-  "packages/api/src/services/webhook-url.ts": {
-    classification: "compatibility",
-    reason: "request-local webhook transport policy is independently owned by issue 769",
-  },
   "packages/auth/src/jwt.ts": {
     classification: "typed-bun-fallback",
     reason: "typed authority parameters and JWT AsyncLocalStorage are authoritative on Workers",


### PR DESCRIPTION
Closes #770.

## Outcome

- derive the Worker runtime-environment inventory from the actual fetch and scheduled import graph across workspace package exports
- bind one immutable request-local environment snapshot before initialization and imports
- eliminate per-request, scheduled, and compatibility writes, deletes, proxies, or replacements of global process.env
- migrate every reachable request-authority reader and key caches by the complete environment authority
- isolate adapters, attestation, proxy client, venue clients, audit HMAC, email auth, user-link stores, custody, and scheduler state across A to B to missing generations

## Exact candidate

- base: 201c1869d40ffca8a207a32a24eecc7eb6f24cd6
- head: 1382006eaca99088448f2c32edf616d1438f002f
- tree: a6a82354102e0d7d7d67c3c6c8c5c77fc1e3a875

## Exact local evidence

- import-derived Worker graph: 309 reachable files and exactly five classified direct readers
- runtime environment plus graph guard: 6/6
- Worker sentinel: 21/21 before final no-global-mutation refinement
- email authority: 10/10
- audit authority: 7/7
- affected consumer suites: 250/250; focused authority suites: 160/160
- adapters, attestation, Hyperliquid, Polymarket, auth, DB, and API typechecks green
- changed-file Biome across 126 files, metadata, and diff checks green
- independent exact audit: PASS; no Worker-reachable production process.env write/delete/replacement remains

## Pending gates

- exact hosted clean-install full matrix on this SHA
- required independent GitHub review

This PR is intentionally draft. Do not ready or merge until exact hosted checks and review are terminal green.
