### PR TITLE
fix(auth): restore email code after failed login

### DIFF
--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -9066,25 +9066,32 @@ auth.post("/email/code/verify", async (c) => {
   }
 
   const emailAuth = await getEmailAuthForTenant(resolvedTenantId);
-  const result = await emailAuth.verifyEmailLoginCode(email, code, resolvedTenantId);
-  if (!result.valid) {
+  const claim = await emailAuth.claimEmailLoginCode(email, code, resolvedTenantId);
+  if (!claim.valid) {
     return c.json<ApiResponse>(
       {
         ok: false,
         error:
-          result.reason === "locked"
+          claim.reason === "locked"
             ? "Too many verification attempts. Try again later."
             : "Invalid or expired code",
       },
-      result.reason === "locked" ? 429 : 401,
+      claim.reason === "locked" ? 429 : 401,
     );
   }
 
-  const authResult = await completeEmailAuth(c, email, body.tenantId);
-  if (!authResult.ok) {
-    return c.json<ApiResponse>({ ok: false, error: authResult.error }, authResult.status);
+  let committed = false;
+  try {
+    const authResult = await completeEmailAuth(c, email, body.tenantId);
+    if (!authResult.ok) {
+      return c.json<ApiResponse>({ ok: false, error: authResult.error }, authResult.status);
+    }
+    await claim.commit();
+    committed = true;
+    return authExchangeJson(c, authResult.response);
+  } finally {
+    if (!committed) await claim.rollback();
   }
-  return authExchangeJson(c, authResult.response);
 });
 
 auth.post("/email/status", async (c) => {

--- a/packages/auth/src/__tests__/email.test.ts
+++ b/packages/auth/src/__tests__/email.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Exercises email-auth credential issuance and redemption against deterministic store backends.
+ */
 import { describe, expect, it, mock } from "bun:test";
 
 import { EmailAuth } from "../email";
@@ -212,6 +215,31 @@ describe("EmailAuth.sendMagicLink", () => {
     const linkAfterCode = await auth.verifyMagicLink(token2, "user@example.com", "tenant-a");
     expect(linkAfterCode.valid).toBe(false);
 
+    auth.destroy();
+  });
+
+  it("restores a claimed login code when downstream authentication fails", async () => {
+    let text = "";
+    const auth = new EmailAuth({
+      from: "login@steward.fi",
+      baseUrl: "https://steward.fi",
+      provider: { send: async (_to, _subject, body) => ((text = body), { provider: "test" }) },
+    });
+
+    await auth.sendMagicLink("retry@example.com", { tenantId: "tenant-a" });
+    const code = text.match(/\b(\d{6})\b/)?.[1] ?? "";
+    const failedAttempt = await auth.claimEmailLoginCode("retry@example.com", code, "tenant-a");
+    expect(failedAttempt.valid).toBe(true);
+    if (!failedAttempt.valid) throw new Error("expected a valid login-code claim");
+    await failedAttempt.rollback();
+
+    const retry = await auth.claimEmailLoginCode("retry@example.com", code, "tenant-a");
+    expect(retry.valid).toBe(true);
+    if (!retry.valid) throw new Error("expected the rolled-back code to be claimable");
+    await retry.commit();
+
+    const replay = await auth.verifyEmailLoginCode("retry@example.com", code, "tenant-a");
+    expect(replay.valid).toBe(false);
     auth.destroy();
   });
 

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -180,6 +180,17 @@ export type EmailLoginVerifyResult =
   | { valid: true; email: string; tenantId?: string; challengeId: string }
   | { valid: false; email: ""; reason?: "invalid" | "locked" };
 
+export type EmailLoginCodeClaimResult =
+  | {
+      valid: true;
+      email: string;
+      tenantId?: string;
+      challengeId: string;
+      commit: () => Promise<void>;
+      rollback: () => Promise<boolean>;
+    }
+  | { valid: false; email: ""; reason?: "invalid" | "locked" };
+
 export type EmailLoginChallengeStatus =
   | { status: "pending"; expiresAt: string }
   | { status: "consumed" | "locked" | "expired" | "invalid" };
@@ -1120,6 +1131,27 @@ export class EmailAuth {
     code: string,
     tenantId?: string,
   ): Promise<EmailLoginVerifyResult> {
+    const claim = await this.claimEmailLoginCode(email, code, tenantId);
+    if (!claim.valid) return claim;
+    await claim.commit();
+    return {
+      valid: true,
+      email: claim.email,
+      tenantId: claim.tenantId,
+      challengeId: claim.challengeId,
+    };
+  }
+
+  /**
+   * Atomically claim a login code while its downstream authentication work runs.
+   * Commit makes the credential single-use; rollback restores the same challenge
+   * only while its email, tenant, and code aliases still identify this claim.
+   */
+  async claimEmailLoginCode(
+    email: string,
+    code: string,
+    tenantId?: string,
+  ): Promise<EmailLoginCodeClaimResult> {
     email = email.toLowerCase().trim();
     if (!/^\d{6}$/.test(code)) {
       const reason = await this.recordEmailLoginCodeFailure(email, tenantId);
@@ -1149,11 +1181,51 @@ export class EmailAuth {
       await this.tokenStore.consume(emailLoginChallengeKey(challengeId)),
     );
     if (!consumed || consumed.status !== "active") return { email: "", valid: false };
-    await Promise.allSettled([
-      this.tokenStore.delete(emailLoginCodeAliasKey(verifier)),
-      this.markEmailLoginConsumed(challengeId),
-    ]);
-    return { email, tenantId: payload.tenantId, valid: true, challengeId };
+    let settled = false;
+    return {
+      email,
+      tenantId: payload.tenantId,
+      valid: true,
+      challengeId,
+      commit: async () => {
+        if (settled) return;
+        settled = true;
+        await Promise.allSettled([
+          this.tokenStore.delete(emailLoginCodeAliasKey(verifier)),
+          this.markEmailLoginConsumed(challengeId),
+        ]);
+      },
+      rollback: async () => {
+        if (settled) return false;
+        const expiresAt = new Date(consumed.expiresAt).getTime();
+        if (expiresAt <= Date.now()) {
+          settled = true;
+          return false;
+        }
+        const restored = await this.publishChallenge([
+          {
+            key: emailLoginChallengeKey(challengeId),
+            value: JSON.stringify(consumed),
+            expiresAt,
+            expected: null,
+          },
+          {
+            key: emailLoginCodeAliasKey(verifier),
+            value: challengeId,
+            expiresAt,
+            expected: challengeId,
+          },
+          {
+            key: emailLoginTargetKey(email, tenantId),
+            value: challengeId,
+            expiresAt,
+            expected: challengeId,
+          },
+        ]);
+        settled = true;
+        return restored;
+      },
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

- claim companion email codes atomically while downstream authentication runs
- commit consumption only after user/session completion succeeds
- restore the same challenge with compare-and-publish guards when downstream authentication fails
- retain the existing `verifyEmailLoginCode` one-shot API for other callers

Closes #853.

## Why

The code challenge was previously consumed before `completeEmailAuth`. A database, tenant-link, or session failure therefore turned a transient HTTP 500 into a permanently invalid code. The new claim lifecycle keeps concurrent requests mutually exclusive while allowing the owning failed request to release the credential safely.

## Verification

- `bunx biome check packages/auth/src/email.ts packages/auth/src/__tests__/email.test.ts packages/api/src/routes/auth.ts`
- `bun run --cwd packages/auth build`
- `bun test packages/auth/src/__tests__/email.test.ts` (11 pass)
- `bun test packages/api/src/__tests__/auth-email-route-lifecycle.test.ts` (7 pass)

## Repository-wide gate

`bun run lint` currently fails on pre-existing formatting in `web/e2e/provider-trust-ux-a11y.spec.ts:246`; this PR does not modify that file. A filtered API dependency build also reaches and passes `@stwd/auth:build`, then stops on the pre-existing `packages/plugin-trading/src/routes/operator-recovery.ts:1761` TypeScript error.