### PR TITLE
fix(trading): fence session wallet authority races

### DIFF
--- a/packages/plugin-trading/src/__tests__/trade-session-create-atomic-postgres.integration.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-session-create-atomic-postgres.integration.test.ts
@@ -13,6 +13,8 @@ import {
   tenants,
   tradeSessions,
 } from "@stwd/db";
+import { custodyTransitionLockKey } from "@stwd/vault";
+import { sql } from "drizzle-orm";
 import { Hono } from "hono";
 import type { StewardAppContext } from "../context";
 
@@ -97,12 +99,31 @@ async function cleanup(admin: ReturnType<typeof createDb>, tenantId: string, age
   await admin.db.delete(tenants).where(eq(tenants.id, tenantId));
 }
 
-function sessionRequest(app: Hono, agentId: string) {
+async function waitForAdvisoryWaiter(
+  admin: ReturnType<typeof createDb>,
+  blockerPid: number,
+): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const rows = await admin.client<{ count: string }[]>`
+      select count(*)::text as count
+      from pg_stat_activity
+      where wait_event = 'advisory'
+        and ${blockerPid} = any(pg_blocking_pids(pid))
+    `;
+    if (Number(rows[0]?.count ?? 0) > 0) return;
+    await Bun.sleep(25);
+  }
+  throw new Error("mounted create did not wait on the custody transition lock");
+}
+
+function sessionRequest(app: Hono, agentId: string, walletAddress?: string) {
   return app.request("/v1/trade/sessions", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       agentId,
+      ...(walletAddress ? { walletAddress } : {}),
       venue: "hyperliquid",
       dailyCap: 200,
       perOrderCap: 40,
@@ -261,6 +282,167 @@ realPostgresIt(
     } finally {
       await cleanup(admin, tenantId, agentId);
       await writer.client.end();
+      await admin.client.end();
+    }
+  },
+  120_000,
+);
+
+realPostgresIt(
+  "rejects a mounted create when an absent venue wallet is concurrently provisioned",
+  async () => {
+    const suffix = crypto.randomUUID().replaceAll("-", "");
+    const tenantId = `tenant-session-wallet-insert-${suffix}`;
+    const agentId = `agent-session-wallet-insert-${suffix}`;
+    const fallbackAddress = "0x0000000000000000000000000000000000000755";
+    const insertedAddress = "0x0000000000000000000000000000000000000756";
+    const admin = createDb(databaseUrl!);
+    const writer = createDb(databaseUrl!);
+    try {
+      await seedAgent(admin, tenantId, agentId);
+      await admin.db.delete(agentWallets).where(eq(agentWallets.agentId, agentId));
+      let releaseTransaction!: () => void;
+      const transactionReleased = new Promise<void>((resolve) => {
+        releaseTransaction = resolve;
+      });
+      let reachedTransaction!: () => void;
+      const transactionReached = new Promise<void>((resolve) => {
+        reachedTransaction = resolve;
+      });
+      const { app } = await mountSessionRoute(tenantId, (ctx) => {
+        const realAuditedTransaction = ctx.withTenantAuditedTransaction;
+        ctx.withTenantAuditedTransaction = async (targetTenantId, fn) => {
+          reachedTransaction();
+          await transactionReleased;
+          return realAuditedTransaction(targetTenantId, fn);
+        };
+      });
+
+      const request = sessionRequest(app, agentId, fallbackAddress);
+      await Promise.race([
+        transactionReached,
+        Bun.sleep(10_000).then(() => {
+          throw new Error("mounted create did not reach the audited transaction boundary");
+        }),
+      ]);
+      await writer.db.insert(agentWallets).values({
+        agentId,
+        chainFamily: "evm",
+        venue: "hyperliquid",
+        address: insertedAddress,
+      });
+      releaseTransaction();
+
+      const response = await request;
+      expect(response.status).toBe(500);
+      expect(await response.json()).toMatchObject({
+        ok: false,
+        error: "Agent wallet changed during session creation",
+      });
+      expect(
+        await admin.db
+          .select({ id: tradeSessions.id })
+          .from(tradeSessions)
+          .where(and(eq(tradeSessions.tenantId, tenantId), eq(tradeSessions.agentId, agentId))),
+      ).toHaveLength(0);
+    } finally {
+      await cleanup(admin, tenantId, agentId);
+      await writer.client.end();
+      await admin.client.end();
+    }
+  },
+  120_000,
+);
+
+realPostgresIt(
+  "rejects a mounted create when the canonical venue wallet is deleted after preflight",
+  async () => {
+    const suffix = crypto.randomUUID().replaceAll("-", "");
+    const tenantId = `tenant-session-wallet-delete-${suffix}`;
+    const agentId = `agent-session-wallet-delete-${suffix}`;
+    const canonicalAddress = "0x0000000000000000000000000000000000000753";
+    const admin = createDb(databaseUrl!);
+    const writer = createDb(databaseUrl!);
+    try {
+      await seedAgent(admin, tenantId, agentId);
+      let releaseTransaction!: () => void;
+      const transactionReleased = new Promise<void>((resolve) => {
+        releaseTransaction = resolve;
+      });
+      let reachedTransaction!: () => void;
+      const transactionReached = new Promise<void>((resolve) => {
+        reachedTransaction = resolve;
+      });
+      const { app } = await mountSessionRoute(tenantId, (ctx) => {
+        const realAuditedTransaction = ctx.withTenantAuditedTransaction;
+        ctx.withTenantAuditedTransaction = async (targetTenantId, fn) => {
+          reachedTransaction();
+          await transactionReleased;
+          return realAuditedTransaction(targetTenantId, fn);
+        };
+      });
+
+      // Supplying the same address exercises provenance: it must remain a
+      // canonical-row authorization and may not silently become caller fallback.
+      const request = sessionRequest(app, agentId, canonicalAddress);
+      await Promise.race([
+        transactionReached,
+        Bun.sleep(10_000).then(() => {
+          throw new Error("mounted create did not reach the audited transaction boundary");
+        }),
+      ]);
+      await writer.db.delete(agentWallets).where(eq(agentWallets.agentId, agentId));
+      releaseTransaction();
+
+      const response = await request;
+      expect(response.status).toBe(500);
+      expect(await response.json()).toMatchObject({
+        ok: false,
+        error: "Agent wallet changed during session creation",
+      });
+      expect(
+        await admin.db
+          .select({ id: tradeSessions.id })
+          .from(tradeSessions)
+          .where(and(eq(tradeSessions.tenantId, tenantId), eq(tradeSessions.agentId, agentId))),
+      ).toHaveLength(0);
+    } finally {
+      await cleanup(admin, tenantId, agentId);
+      await writer.client.end();
+      await admin.client.end();
+    }
+  },
+  120_000,
+);
+
+realPostgresIt(
+  "serializes the no-row authority check with the shared custody transition lock",
+  async () => {
+    const suffix = crypto.randomUUID().replaceAll("-", "");
+    const tenantId = `tenant-session-wallet-lock-${suffix}`;
+    const agentId = `agent-session-wallet-lock-${suffix}`;
+    const fallbackAddress = "0x0000000000000000000000000000000000000757";
+    const admin = createDb(databaseUrl!);
+    const lockOwner = createDb(databaseUrl!);
+    try {
+      await seedAgent(admin, tenantId, agentId);
+      await admin.db.delete(agentWallets).where(eq(agentWallets.agentId, agentId));
+      await lockOwner.client.unsafe("begin");
+      const blockerRows = await lockOwner.client<{ pid: number }[]>`select pg_backend_pid() as pid`;
+      const blockerPid = Number(blockerRows[0]?.pid);
+      await lockOwner.db.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${custodyTransitionLockKey(tenantId, agentId, "evm", "hyperliquid")}, 0))`,
+      );
+      const { app } = await mountSessionRoute(tenantId);
+      const request = sessionRequest(app, agentId, fallbackAddress);
+      await waitForAdvisoryWaiter(admin, blockerPid);
+      await lockOwner.client.unsafe("commit");
+      const response = await request;
+      expect(response.status).toBe(201);
+    } finally {
+      await lockOwner.client.unsafe("rollback").catch(() => undefined);
+      await cleanup(admin, tenantId, agentId);
+      await lockOwner.client.end();
       await admin.client.end();
     }
   },

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -38,6 +38,7 @@ import { checkRateLimit } from "@stwd/redis";
 import { type ApiResponse, type AppVariables, redactedThrownDiagnostics } from "@stwd/shared";
 import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { type TradeSession, TradeSessionManager } from "@stwd/trade-sessions";
+import { custodyTransitionLockKey } from "@stwd/vault";
 import {
   getMarketableLimitPx,
   HyperliquidAdapter,
@@ -866,6 +867,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     const venueWallet = isPolymarket
       ? await resolvePolymarketWallet(agentId)
       : await resolveHyperliquidWallet(agentId, agent);
+    const walletAuthoritySource = venueWallet !== null ? "venue-wallet" : "caller-fallback";
     // Polymarket order execution resolves creds strictly via the venue-scoped
     // wallet (vault.getWallet({venue:"polymarket"})). Allowing a caller-supplied
     // walletAddress fallback here would mint a session that can never execute
@@ -908,14 +910,21 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       tenantId,
       async (rawTx, appendRequiredAudit) => {
         const tx = rawTx as typeof db;
+        const pgliteRuntime =
+          process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true";
+        if (!pgliteRuntime) {
+          // Share the vault's custody-transition lock. Unlike SELECT FOR UPDATE,
+          // this also serializes the no-row case with venue-wallet provisioning.
+          await tx.execute(
+            sql`SELECT pg_advisory_xact_lock(hashtextextended(${custodyTransitionLockKey(tenantId, agentId, "evm", venue)}, 0))`,
+          );
+        }
         const [lockedAgent] = await tx
           .select({ id: agents.id })
           .from(agents)
           .where(and(eq(agents.id, agentId), eq(agents.tenantId, tenantId)))
           .for("update");
         if (!lockedAgent) throw new Error("Agent not found");
-        const pgliteRuntime =
-          process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true";
         if (!pgliteRuntime) {
           // Match the policy mutation route's scoped lock. This also serializes
           // the no-row case without taking a global table lock.
@@ -955,13 +964,11 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           )
           .for("update");
         const lockedWalletAddress = lockedVenueWallet?.address ?? null;
-        if (
-          (isPolymarket && lockedWalletAddress !== walletAddress) ||
-          (!isPolymarket && lockedWalletAddress !== null && lockedWalletAddress !== walletAddress)
-        ) {
-          throw new Error("Agent venue wallet changed during session creation");
-        }
-        if (!lockedVenueWallet && !isPolymarket && walletAddress !== parsed.data.walletAddress) {
+        const walletAuthorityChanged =
+          walletAuthoritySource === "venue-wallet"
+            ? lockedWalletAddress !== venueWallet
+            : lockedWalletAddress !== null || walletAddress !== parsed.data.walletAddress;
+        if (walletAuthorityChanged) {
           throw new Error("Agent wallet changed during session creation");
         }
         await tx.insert(tradeSessions).values(prepared.values);

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -235,6 +235,7 @@ export type {
 } from "./vault";
 export {
   BackendBindingMismatchError,
+  custodyTransitionLockKey,
   externalCustodyIdentityDigest,
   SolanaRecoveryOwnershipLostError,
   Vault,

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -545,7 +545,7 @@ export class BackendBindingMismatchError extends Error {
  * one (agent, chain family, venue) tuple. importKey always operates on the
  * venue-less scope, matching the legacy/unscoped key rows it writes.
  */
-function custodyTransitionLockKey(
+export function custodyTransitionLockKey(
   tenantId: string,
   agentId: string,
   chainFamily: string,
@@ -4077,6 +4077,11 @@ export class Vault {
     ];
 
     await db.transaction(async (tx) => {
+      if (usesCustodyAdvisoryLock()) {
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${custodyTransitionLockKey(tenantId, agentId, chainFamily, venue)}, 0))`,
+        );
+      }
       await tx.insert(encryptedChainKeys).values({
         agentId,
         chainFamily,
@@ -4267,6 +4272,11 @@ export class Vault {
     const createdAt = new Date();
 
     await db.transaction(async (tx) => {
+      if (usesCustodyAdvisoryLock()) {
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${custodyTransitionLockKey(agentRow.tenantId, agentId, chainType, venue)}, 0))`,
+        );
+      }
       await tx.insert(encryptedChainKeys).values({
         agentId,
         chainFamily: chainType,


### PR DESCRIPTION
Follow-up to #837. The merged session transaction still locked only an existing `agent_wallets` row, so absence-to-insert and canonical-delete races could commit a session against stale or caller-supplied wallet authority.

This change shares the tuple-safe custody transition advisory lock between wallet provisioning and session creation, records canonical-vs-fallback provenance, and revalidates the exact authority at mutation time. It adds real-Postgres two-connection coverage for absence→insert, canonical deletion, explicit advisory waiters, existing updates, audit rollback, policy races, and concurrent winners.

Evidence:
- Prior exact repair head: mounted PGLite 9/9 (24 assertions); trade-sessions, Vault, plugin-trading, and API builds green.
- Current post-merge head is based on exact merged `develop` f7125cdab; conflict resolution preserved the merged validated transfer idempotency key.
- Biome on all 4 changed files and `git diff --check` are clean.
- Local rerun on the current head was harness-blocked because shared package symlinks resolved stale workspace sources; hosted exact-head CI is required before readiness.

Do not merge until hosted checks pass and an independent reviewer approves.