### PR TITLE
fix(security): close secret cross-writer authority gaps

### DIFF
--- a/packages/api/src/routes/kms.ts
+++ b/packages/api/src/routes/kms.ts
@@ -62,7 +62,11 @@ import { getDb, type Secret, secrets as secretRows } from "@stwd/db";
 import type { SecretVault } from "@stwd/vault";
 import { and, asc, eq } from "drizzle-orm";
 import { type Context, Hono } from "hono";
-import { type AuditEventInput, writeAuditEvent } from "../services/audit";
+import {
+  type AuditEventInput,
+  withTenantAuditedTransaction,
+  writeAuditEvent,
+} from "../services/audit";
 import {
   AGENT_SCOPE,
   type ApiResponse,
@@ -74,6 +78,8 @@ import {
 import { getConfiguredSecretVault } from "../services/vault-factory";
 
 export const kmsRoutes = new Hono<{ Variables: AppVariables }>();
+type VaultDb = ReturnType<typeof getDb>;
+type VaultTx = Parameters<Parameters<VaultDb["transaction"]>[0]>[0];
 
 // HKDF domain for deriving per-use working keys from a version root. Versioned
 // so a future derivation change can coexist with old material.
@@ -155,14 +161,14 @@ function decodeB64Field(value: unknown): Buffer | null {
   return decoded;
 }
 
-async function auditKms(
+function kmsAuditEvent(
   c: Context<{ Variables: AppVariables }>,
   principal: KmsPrincipal,
   action: string,
   keyId: string,
   metadata: Record<string, unknown> = {},
-): Promise<void> {
-  const event: AuditEventInput = {
+): AuditEventInput {
+  return {
     tenantId: principal.tenantId,
     actorType: "agent",
     actorId: principal.agentId,
@@ -175,7 +181,16 @@ async function auditKms(
     userAgent: c.req.header("user-agent") ?? null,
     requestId: c.get("requestId") ?? null,
   };
-  await writeAuditEvent(event);
+}
+
+async function auditKms(
+  c: Context<{ Variables: AppVariables }>,
+  principal: KmsPrincipal,
+  action: string,
+  keyId: string,
+  metadata: Record<string, unknown> = {},
+): Promise<void> {
+  await writeAuditEvent(kmsAuditEvent(c, principal, action, keyId, metadata));
 }
 
 // ── key-material access (existing secrets table, per-version rows) ───────────
@@ -253,10 +268,21 @@ kmsRoutes.post("/keys", async (c) => {
 
   const rootHex = randomBytes(32).toString("hex");
   try {
-    const created = await getSecretVault().createSecret(principal.tenantId, name, rootHex, {
-      description: `KMS key material for agent ${principal.agentId}`,
+    const created = await withTenantAuditedTransaction(principal.tenantId, async (tx, append) => {
+      const secret = await getSecretVault().createSecretWithinTx(
+        tx as VaultTx,
+        principal.tenantId,
+        name,
+        rootHex,
+        {
+          description: `KMS key material for agent ${principal.agentId}`,
+        },
+      );
+      await append(
+        kmsAuditEvent(c, principal, "kms.key.created", keyId, { version: secret.version }),
+      );
+      return secret;
     });
-    await auditKms(c, principal, "kms.key.created", keyId, { version: created.version });
     return c.json({ keyId, version: created.version });
   } catch {
     // lost a create race — the unique (tenant, name, version) index rejected the
@@ -278,12 +304,18 @@ kmsRoutes.post("/keys/:keyId/rotate", async (c) => {
   const existing = currentRow(await listKeyRows(principal.tenantId, name));
   if (!existing) return c.json<ApiResponse>({ ok: false, error: "key not found" }, 404);
 
-  const rotated = await getSecretVault().rotateSecret(
-    principal.tenantId,
-    name,
-    randomBytes(32).toString("hex"),
-  );
-  await auditKms(c, principal, "kms.key.rotated", keyId, { newVersion: rotated.version });
+  const rotated = await withTenantAuditedTransaction(principal.tenantId, async (tx, append) => {
+    const secret = await getSecretVault().rotateSecretWithinTx(
+      tx as VaultTx,
+      principal.tenantId,
+      name,
+      randomBytes(32).toString("hex"),
+    );
+    await append(
+      kmsAuditEvent(c, principal, "kms.key.rotated", keyId, { newVersion: secret.version }),
+    );
+    return secret;
+  });
   return c.json({ keyId, newVersion: rotated.version });
 });
 

--- a/packages/vault/src/__tests__/secret-cross-writer-postgres.integration.test.ts
+++ b/packages/vault/src/__tests__/secret-cross-writer-postgres.integration.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, expect, it, setDefaultTimeout } from "bun:test";
+import { closeDb, createDb, eq, secrets, tenants } from "@stwd/db";
+import { SecretVault } from "../secret-vault";
+
+const databaseUrl = process.env.DATABASE_URL;
+const realPostgresIt = databaseUrl && !process.env.STEWARD_PGLITE_MEMORY ? it : it.skip;
+setDefaultTimeout(30_000);
+
+afterAll(async () => {
+  await closeDb().catch(() => undefined);
+});
+
+realPostgresIt("legacy public rotation waits on the canonical lineage lock", async () => {
+  const suffix = crypto.randomUUID().replaceAll("-", "");
+  const tenantId = `secret-cross-writer-${suffix}`;
+  const name = `kms/agent-${suffix}/key`;
+  const admin = createDb(databaseUrl!);
+  const blocker = await admin.client.reserve();
+  const vault = new SecretVault(`secret-cross-writer-master-${suffix}`);
+  let transactionOpen = false;
+
+  try {
+    await admin.db.insert(tenants).values({
+      id: tenantId,
+      name: tenantId,
+      apiKeyHash: `hash-${suffix}`,
+    });
+    const first = await vault.createSecret(tenantId, name, "version-one");
+
+    await blocker`begin`;
+    transactionOpen = true;
+    const [owner] = await blocker<{ pid: number }[]>`select pg_backend_pid() as pid`;
+    await blocker`
+      select pg_advisory_xact_lock(
+        hashtextextended(${`steward_secret_${tenantId}:${name}`}, 0)
+      )
+    `;
+
+    const rotation = vault.rotateSecret(tenantId, name, "version-two");
+    const deadline = Date.now() + 10_000;
+    let observedWaiter = false;
+    while (Date.now() < deadline) {
+      const rows = await admin.client<{ count: string }[]>`
+        select count(*)::text as count
+        from pg_stat_activity
+        where wait_event = 'advisory'
+          and ${Number(owner?.pid)} = any(pg_blocking_pids(pid))
+      `;
+      if (Number(rows[0]?.count ?? 0) > 0) {
+        observedWaiter = true;
+        break;
+      }
+      await Bun.sleep(20);
+    }
+    expect(observedWaiter).toBe(true);
+    expect(
+      await admin.db
+        .select({ version: secrets.version })
+        .from(secrets)
+        .where(eq(secrets.id, first.id)),
+    ).toEqual([{ version: 1 }]);
+
+    await blocker`commit`;
+    transactionOpen = false;
+    const rotated = await rotation;
+    expect(rotated.version).toBe(2);
+    expect(await vault.decryptSecret(tenantId, rotated.id)).toBe("version-two");
+  } finally {
+    if (transactionOpen) await blocker`rollback`;
+    blocker.release();
+    await admin.db.delete(secrets).where(eq(secrets.tenantId, tenantId));
+    await admin.db.delete(tenants).where(eq(tenants.id, tenantId));
+    await admin.client.end();
+  }
+});

--- a/packages/vault/src/__tests__/secret-vault-lifecycle.test.ts
+++ b/packages/vault/src/__tests__/secret-vault-lifecycle.test.ts
@@ -173,6 +173,33 @@ describe("SecretVault lifecycle semantics", () => {
     expect(await vault.listRoutes(tenantId)).toEqual([]);
   });
 
+  it("refuses generic deletion of governed provider authority", async () => {
+    const tenantId = `tenant-governed-delete-${crypto.randomUUID()}`;
+    const agentId = `agent-governed-delete-${crypto.randomUUID()}`;
+    await ensureTenant(tenantId);
+    await ensureAgent(tenantId, agentId);
+
+    const secret = await vault.createSecret(tenantId, "governed-provider", "provider-token");
+    const route = await vault.createRoute(tenantId, secret.id, {
+      agentId,
+      hostPattern: "api.github.com",
+      pathPattern: "/repos/acme/widgets",
+      method: "GET",
+      injectAs: "header",
+      injectKey: "authorization",
+    });
+    await promoteRoute(tenantId, route.id);
+
+    await expect(vault.deleteRoute(tenantId, route.id)).rejects.toThrow(
+      /provider-operation lifecycle/,
+    );
+    await expect(vault.deleteSecret(tenantId, secret.id)).rejects.toThrow(
+      /provider-operation lifecycle/,
+    );
+    expect(await vault.getRoute(tenantId, route.id)).not.toBeNull();
+    expect(await vault.getSecretById(tenantId, secret.id)).not.toBeNull();
+  });
+
   it("rejects creating routes for expired secrets", async () => {
     const tenantId = `tenant-expired-${crypto.randomUUID()}`;
     await ensureTenant(tenantId);

--- a/packages/vault/src/secret-vault.ts
+++ b/packages/vault/src/secret-vault.ts
@@ -132,24 +132,7 @@ export class SecretVault {
     options?: CreateSecretOptions,
   ): Promise<SecretMetadata> {
     const db = getDb();
-    const encrypted = this.keyStore.encrypt(value, { tenantId, name, version: 1 });
-
-    const [row] = await db
-      .insert(secrets)
-      .values({
-        tenantId,
-        name,
-        description: options?.description ?? null,
-        ciphertext: encrypted.ciphertext,
-        iv: encrypted.iv,
-        authTag: encrypted.tag,
-        salt: encrypted.salt,
-        version: 1,
-        expiresAt: options?.expiresAt ?? null,
-      })
-      .returning();
-
-    return this.toMetadata(row);
+    return db.transaction((tx) => this.createSecretWithinTx(tx, tenantId, name, value, options));
   }
 
   /**
@@ -431,6 +414,22 @@ export class SecretVault {
     if (!lineage.some((row) => row.id === secretId && row.deletedAt === null)) return false;
     const ids = lineage.map((row) => row.id);
     if (ids.length > 0) {
+      const governedRoutes = await tx
+        .select({ id: secretRoutes.id })
+        .from(secretRoutes)
+        .where(
+          and(
+            eq(secretRoutes.tenantId, tenantId),
+            inArray(secretRoutes.secretId, ids),
+            sql`(${secretRoutes.authorityMode} = 'governed_v2' OR ${secretRoutes.providerOperationId} IS NOT NULL)`,
+          ),
+        )
+        .limit(1);
+      if (governedRoutes.length > 0) {
+        throw new Error(
+          "Governed secret authority must be revoked through its provider-operation lifecycle",
+        );
+      }
       await tx
         .delete(secretRoutes)
         .where(and(eq(secretRoutes.tenantId, tenantId), inArray(secretRoutes.secretId, ids)));
@@ -454,46 +453,7 @@ export class SecretVault {
    */
   async rotateSecret(tenantId: string, name: string, newValue: string): Promise<SecretMetadata> {
     const db = getDb();
-
-    // Find current version
-    const current = await this.getSecret(tenantId, name);
-    if (!current) {
-      throw new Error(`Secret "${name}" not found for tenant ${tenantId}`);
-    }
-
-    const newVersion = current.version + 1;
-    const encrypted = this.keyStore.encrypt(newValue, { tenantId, name, version: newVersion });
-    const now = new Date();
-
-    return db.transaction(async (tx) => {
-      const [row] = await tx
-        .insert(secrets)
-        .values({
-          tenantId,
-          name,
-          description: current.description,
-          ciphertext: encrypted.ciphertext,
-          iv: encrypted.iv,
-          authTag: encrypted.tag,
-          salt: encrypted.salt,
-          version: newVersion,
-          rotatedAt: now,
-          expiresAt: current.expiresAt,
-        })
-        .returning();
-
-      await tx
-        .update(secretRoutes)
-        .set({ secretId: row.id })
-        .where(and(eq(secretRoutes.tenantId, tenantId), eq(secretRoutes.secretId, current.id)));
-
-      await tx
-        .update(secrets)
-        .set({ deletedAt: now, updatedAt: now })
-        .where(and(eq(secrets.id, current.id), eq(secrets.tenantId, tenantId)));
-
-      return this.toMetadata(row);
-    });
+    return db.transaction((tx) => this.rotateSecretWithinTx(tx, tenantId, name, newValue));
   }
 
   /**
@@ -501,49 +461,16 @@ export class SecretVault {
    */
   async deleteSecret(tenantId: string, secretId: string): Promise<boolean> {
     const db = getDb();
-
-    const [row] = await db
-      .select()
-      .from(secrets)
-      .where(
-        and(eq(secrets.id, secretId), eq(secrets.tenantId, tenantId), isNull(secrets.deletedAt)),
-      );
-
-    if (!row) return false;
-
-    const relatedSecretRows = await db
-      .select({ id: secrets.id })
-      .from(secrets)
-      .where(and(eq(secrets.tenantId, tenantId), eq(secrets.name, row.name)));
-
-    const relatedSecretIds = relatedSecretRows.map((secretRow) => secretRow.id);
-    const now = new Date();
-
-    await db.transaction(async (tx) => {
-      if (relatedSecretIds.length > 0) {
-        await tx
-          .delete(secretRoutes)
-          .where(
-            and(
-              eq(secretRoutes.tenantId, tenantId),
-              inArray(secretRoutes.secretId, relatedSecretIds),
-            ),
-          );
-      }
-
-      await tx
-        .update(secrets)
-        .set({ deletedAt: now, updatedAt: now })
+    return db.transaction(async (tx) => {
+      const [row] = await tx
+        .select({ name: secrets.name })
+        .from(secrets)
         .where(
-          and(
-            eq(secrets.tenantId, tenantId),
-            eq(secrets.name, row.name),
-            isNull(secrets.deletedAt),
-          ),
+          and(eq(secrets.id, secretId), eq(secrets.tenantId, tenantId), isNull(secrets.deletedAt)),
         );
+      if (!row) return false;
+      return this.deleteSecretWithinTx(tx, tenantId, secretId, row.name);
     });
-
-    return true;
   }
 
   /**
@@ -984,11 +911,27 @@ export class SecretVault {
 
   async deleteRoute(tenantId: string, routeId: string): Promise<boolean> {
     const db = getDb();
-    const result = await db
-      .delete(secretRoutes)
-      .where(and(eq(secretRoutes.id, routeId), eq(secretRoutes.tenantId, tenantId)))
-      .returning();
-    return result.length > 0;
+    return db.transaction(async (tx) => {
+      const [route] = await tx
+        .select({
+          authorityMode: secretRoutes.authorityMode,
+          providerOperationId: secretRoutes.providerOperationId,
+        })
+        .from(secretRoutes)
+        .where(and(eq(secretRoutes.id, routeId), eq(secretRoutes.tenantId, tenantId)))
+        .for("update");
+      if (!route) return false;
+      if (route.authorityMode === "governed_v2" || route.providerOperationId !== null) {
+        throw new Error(
+          "Governed secret routes must be revoked through their provider-operation lifecycle",
+        );
+      }
+      const result = await tx
+        .delete(secretRoutes)
+        .where(and(eq(secretRoutes.id, routeId), eq(secretRoutes.tenantId, tenantId)))
+        .returning();
+      return result.length > 0;
+    });
   }
 
   // ─── Private helpers ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Post-merge corrective for #820 / #736.

The merged carrier made HTTP secret CRUD audit-atomic but left public SecretVault writers and KMS on bypass paths. This patch:

- delegates public create/rotate/delete to the canonical lineage-locked transaction primitives;
- moves KMS create/rotate and their audit events into one tenant-audited transaction;
- rejects generic route or lineage deletion when authority is governed/provider-bound;
- adds a real-Postgres advisory-waiter proof for the legacy public rotation entrypoint and governed deletion behavior coverage.

Exact base: f6bdb04f7d5db673fd8a034c3627d0a20a724b6d
Exact head: fe33a07c7

Local evidence:
- secret CRUD mounted PGLite audit atomicity: 3/3, 16 assertions
- SecretVault lifecycle: 9/9, 26 assertions
- SecretVault no-read-back plus audit/order suites: green except an initial dependency-link harness error subsequently corrected
- real PostgreSQL public cross-writer lock proof: 1/1, 4 assertions
- Vault build: pass
- targeted Biome and diff check: pass

Hosted exact-head matrix is required before merge.