### PR TITLE
fix(ci): stabilize isolated web browser tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,12 +416,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install Chromium
+        run: bunx playwright install --with-deps chromium
+
       - name: Build workspace dependencies
         run: bunx turbo run build --filter=@stwd/react --filter=@stwd/sdk --filter=@stwd/shared
 
       - name: Test web/src
         working-directory: web
-        run: bun test src e2e/wallets/wallet-e2e-contract.test.ts
+        run: bun test --isolate src e2e/wallets/wallet-e2e-contract.test.ts
 
   unit-redis:
     name: Unit Tests (packages/redis)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -503,12 +503,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install Chromium
+        run: bunx playwright install --with-deps chromium
+
       - name: Build workspace dependencies
         run: bunx turbo run build --filter=@stwd/react --filter=@stwd/sdk --filter=@stwd/shared
 
       - name: Test web/src
         working-directory: web
-        run: bun test src e2e/wallets/wallet-e2e-contract.test.ts
+        run: bun test --isolate src e2e/wallets/wallet-e2e-contract.test.ts
 
   unit-redis:
     name: Unit Tests (packages/redis)

--- a/bun.lock
+++ b/bun.lock
@@ -635,6 +635,7 @@
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",
+        "@depay/web3-mock": "14.19.1",
         "@opennextjs/cloudflare": "^1.19.11",
         "@playwright/test": "^1.60.0",
         "@scure/bip39": "1.6.0",

--- a/web/e2e/provider-trust-ux-a11y.spec.ts
+++ b/web/e2e/provider-trust-ux-a11y.spec.ts
@@ -243,11 +243,10 @@ async function mockAccessibilityApis(
       if (options.caseErrorStatus) {
         return route.fulfill({
           status: options.caseErrorStatus,
-          json:
-            options.caseErrorBody ?? {
-              ok: false,
-              error: { code: `PRIVATE_${options.caseErrorStatus}` },
-            },
+          json: options.caseErrorBody ?? {
+            ok: false,
+            error: { code: `PRIVATE_${options.caseErrorStatus}` },
+          },
         });
       }
       return route.fulfill({ json: options.manifest ?? caseManifest() });

--- a/web/package.json
+++ b/web/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.13.0",
+    "@depay/web3-mock": "14.19.1",
     "@opennextjs/cloudflare": "^1.19.11",
     "@playwright/test": "^1.60.0",
     "@scure/bip39": "1.6.0",


### PR DESCRIPTION
## Summary
- provision the pinned Chromium browser in web unit-test jobs
- run the mixed web suites with Bun module isolation
- depend directly on `@depay/web3-mock` and format the trust-UX spec

## Exact-head verification
- workflow-equivalent web suite: 106/106, 320 assertions
- real Chromium auth-sync proof: pass
- wallet contract harness: pass
- Next production build: pass
- frozen-lock dry run: pass
- changed-file Biome, YAML parse, and diff-check: pass

The current develop SDK BufferSource type errors are independent of this five-file delta.