### PR TITLE
fix(api): fence email authority cache at outer commit

### DIFF
--- a/packages/api/src/__tests__/auth-email-config.test.ts
+++ b/packages/api/src/__tests__/auth-email-config.test.ts
@@ -10,6 +10,7 @@ import { Hono } from "hono";
 import {
   clearEmailAuthTenantCacheForTests,
   emailAuthRequestCacheSizeForTests,
+  expireEmailAuthTenantCacheForTests,
   getEmailAuthForTenant,
   initAuthStores,
   invalidateEmailAuthForTenant,
@@ -415,6 +416,32 @@ describe("getEmailAuthForTenant", () => {
 
         const replacement = await getEmailAuthForTenant(TEST_TENANT_ID);
         expect(replacement).not.toBe(first);
+        expect(emailAuthRequestCacheSizeForTests()).toBe(1);
+      },
+    );
+  });
+
+  it("expires and retires request-local email authority after the bounded TTL", async () => {
+    clearEmailAuthTenantCacheForTests();
+    await getDb().delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TEST_TENANT_ID));
+
+    await withRuntimeEnvironment(
+      {
+        NODE_ENV: "test",
+        RESEND_API_KEY: "expiring-request-resend-key",
+        EMAIL_FROM: "Expiring <login@request.example>",
+      },
+      async () => {
+        const first = await getEmailAuthForTenant(TEST_TENANT_ID);
+        const firstProvider = (first as any).provider;
+        expireEmailAuthTenantCacheForTests(TEST_TENANT_ID);
+
+        const replacement = await getEmailAuthForTenant(TEST_TENANT_ID);
+        await Promise.resolve();
+
+        expect(replacement).not.toBe(first);
+        expect(firstProvider.client).toBeNull();
+        expect(firstProvider.from).toBe("");
         expect(emailAuthRequestCacheSizeForTests()).toBe(1);
       },
     );

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1777,7 +1777,12 @@ function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
 
 // ─── EmailAuth cache ──────────────────────────────────────────────────────────
 
-let _emailAuthByRequest = new WeakMap<object, Map<string, Promise<EmailAuth>>>();
+const EMAIL_AUTH_REQUEST_CACHE_TTL_MS = 30_000;
+interface EmailAuthRequestCacheEntry {
+  readonly createdAt: number;
+  readonly pending: Promise<EmailAuth>;
+}
+let _emailAuthByRequest = new WeakMap<object, Map<string, EmailAuthRequestCacheEntry>>();
 
 function getEmailKeyStore(): KeyStore {
   return getConfiguredKeyStore(undefined, { allowDevSecretFallback: true });
@@ -2078,17 +2083,28 @@ export async function getEmailAuthForTenant(tenantId: string): Promise<EmailAuth
 
   let tenants = _emailAuthByRequest.get(requestIdentity);
   const cached = tenants?.get(tenantId);
-  if (cached) return cached;
-
-  const pending = createEmailAuthForTenant(tenantId).catch((error) => {
+  if (cached && Date.now() - cached.createdAt < EMAIL_AUTH_REQUEST_CACHE_TTL_MS) {
+    return cached.pending;
+  }
+  if (cached) {
     tenants?.delete(tenantId);
+    void cached.pending.then(
+      (auth) => auth.disposeProvider(),
+      () => undefined,
+    );
+  }
+
+  let entry: EmailAuthRequestCacheEntry;
+  const pending = createEmailAuthForTenant(tenantId).catch((error) => {
+    if (tenants?.get(tenantId) === entry) tenants.delete(tenantId);
     throw error;
   });
   if (!tenants) {
     tenants = new Map();
     _emailAuthByRequest.set(requestIdentity, tenants);
   }
-  tenants.set(tenantId, pending);
+  entry = { createdAt: Date.now(), pending };
+  tenants.set(tenantId, entry);
   return pending;
 }
 
@@ -2098,7 +2114,7 @@ export function invalidateEmailAuthForTenant(tenantId: string): void {
   const tenants = _emailAuthByRequest.get(identity);
   const cached = tenants?.get(tenantId);
   tenants?.delete(tenantId);
-  void cached?.then(
+  void cached?.pending.then(
     (auth) => auth.disposeProvider(),
     () => undefined,
   );
@@ -2112,6 +2128,15 @@ export function clearEmailAuthTenantCacheForTests(): void {
 export function emailAuthRequestCacheSizeForTests(): number {
   const identity = runtimeEnvironmentIdentity();
   return identity ? (_emailAuthByRequest.get(identity)?.size ?? 0) : 0;
+}
+
+/** Test-only seam for exercising the bounded request-local authority lifetime. */
+export function expireEmailAuthTenantCacheForTests(tenantId: string): void {
+  const identity = runtimeEnvironmentIdentity();
+  if (!identity) return;
+  const tenants = _emailAuthByRequest.get(identity);
+  const cached = tenants?.get(tenantId);
+  if (cached) tenants?.set(tenantId, { ...cached, createdAt: 0 });
 }
 
 export function clearOAuthTokenKeyStoreForTests(): void {

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -23,6 +23,7 @@ import {
 import {
   type AppendRequiredAudit,
   accounts,
+  afterTenantTransactionCommit,
   agents,
   agentWallets,
   approvalQueue,
@@ -102,6 +103,12 @@ import {
 import { getConfiguredKeyStore, getConfiguredVault } from "../services/vault-factory";
 import { dispatchWebhook } from "../services/webhook-dispatch";
 import { getEmailAuthForTenant, invalidateEmailAuthForTenant } from "./auth";
+
+function invalidateEmailAuthAfterTenantCommit(tenantId: string): void {
+  if (!afterTenantTransactionCommit(() => invalidateEmailAuthForTenant(tenantId))) {
+    invalidateEmailAuthForTenant(tenantId);
+  }
+}
 
 const TENANT_MEMBER_ROLES = new Set(["owner", "admin", "member"]);
 const TENANT_INVITATION_ROLES = new Set(["admin", "developer", "billing", "viewer", "member"]);
@@ -1560,8 +1567,9 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
     },
   );
 
-  // Consumers may only observe the new authority after mutation + audit commit.
-  invalidateEmailAuthForTenant(tenantId);
+  // The audited helper may be a savepoint inside the middleware-owned tenant
+  // transaction. Retire request-local authority only after that outer commit.
+  invalidateEmailAuthAfterTenantCommit(tenantId);
 
   return c.json<
     ApiResponse<{
@@ -2052,7 +2060,7 @@ platform.delete("/tenants/:tenantId/email-config", async (c) => {
   });
 
   // Cache invalidation follows the durable mutation + completion audit commit.
-  invalidateEmailAuthForTenant(tenantId);
+  invalidateEmailAuthAfterTenantCommit(tenantId);
 
   return c.json<ApiResponse>({ ok: true });
 });

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -721,14 +721,23 @@ export async function withAuthenticatedTenantDatabase<T>(
   if (hasTenantTransactionDatabase({ tenantId, userId, ...characteristics })) return callback();
   const context = tenantContextFromAuthenticatedPrincipal({ tenantId, method, subject, userId });
   const driver = isPGLiteRuntime ? "pglite" : getDatabaseDriver();
-  return withTenantRlsTransaction(
+  const afterCommitTasks: Array<() => void | Promise<void>> = [];
+  const result = await withTenantRlsTransaction(
     getDb() as never,
     driver,
     context,
     async (tx) =>
-      withTenantTransactionDatabase(tx as never, { tenantId, userId }, callback, characteristics),
+      withTenantTransactionDatabase(
+        tx as never,
+        { tenantId, userId },
+        callback,
+        characteristics,
+        afterCommitTasks,
+      ),
     characteristics,
   );
+  for (const task of afterCommitTasks) await task();
+  return result;
 }
 
 /**

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -4,6 +4,7 @@ import { live } from "@electric-sql/pglite/live";
 import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import {
+  afterTenantTransactionCommit,
   closeDb,
   getDb,
   getSql,
@@ -52,6 +53,32 @@ describe("request-scoped database context", () => {
       });
       expect((getDb() as unknown as { marker: string }).marker).toBe("request");
     });
+  });
+
+  test("queues side effects for the outer commit owner", async () => {
+    const transactionDb = { marker: "tenant-transaction" } as unknown as ReturnType<typeof getDb>;
+    const afterCommitTasks: Array<() => void | Promise<void>> = [];
+    const events: string[] = [];
+
+    await withTenantTransactionDatabase(
+      transactionDb,
+      { tenantId: "tenant-a" },
+      async () => {
+        expect(afterTenantTransactionCommit(() => events.push("committed"))).toBe(true);
+        events.push("callback-complete");
+      },
+      undefined,
+      afterCommitTasks,
+    );
+
+    expect(events).toEqual(["callback-complete"]);
+    expect(afterCommitTasks).toHaveLength(1);
+    await afterCommitTasks[0]?.();
+    expect(events).toEqual(["callback-complete", "committed"]);
+  });
+
+  test("declines commit deferral when no outer owner is present", () => {
+    expect(afterTenantTransactionCommit(() => undefined)).toBe(false);
   });
 
   test("rejects reuse of an active tenant transaction for another tenant or user", async () => {

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -524,6 +524,7 @@ interface RequestDatabaseContext {
   isolationLevel?: "repeatable read";
   readOnly?: boolean;
   pendingTasks: Set<Promise<unknown>>;
+  afterCommitTasks?: Array<() => void | Promise<void>>;
   guardedObjects: WeakMap<object, object>;
 }
 const requestDatabaseStorage = new AsyncLocalStorage<RequestDatabaseContext>();
@@ -720,6 +721,7 @@ export async function withTenantTransactionDatabase<T>(
   identity: { tenantId: string; userId?: string },
   callback: () => Promise<T>,
   characteristics?: { isolationLevel?: "repeatable read"; readOnly?: boolean },
+  afterCommitTasks?: Array<() => void | Promise<void>>,
 ): Promise<T> {
   if (tenantTransactionDatabaseStorage.getStore()) {
     throw new Error("RLS_TENANT_DATABASE_CONTEXT_NESTED");
@@ -733,6 +735,7 @@ export async function withTenantTransactionDatabase<T>(
     isolationLevel: characteristics?.isolationLevel,
     readOnly: characteristics?.readOnly,
     pendingTasks: new Set(),
+    afterCommitTasks,
     guardedObjects: new WeakMap(),
   };
   context.db = guardRequestDatabaseValue(transactionDb, context);
@@ -746,6 +749,18 @@ export async function withTenantTransactionDatabase<T>(
     context.active = false;
     context.db = undefined;
   }
+}
+
+/**
+ * Defer a side effect until the owner of the active tenant transaction has
+ * observed a successful outer commit. Returns false when there is no commit
+ * owner so callers can perform the side effect immediately.
+ */
+export function afterTenantTransactionCommit(task: () => void | Promise<void>): boolean {
+  const context = tenantTransactionDatabaseStorage.getStore();
+  if (!context?.active || !context.afterCommitTasks) return false;
+  context.afterCommitTasks.push(task);
+  return true;
 }
 
 /**

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -23,6 +23,7 @@ export {
 } from "./audit-chain";
 export type { DatabaseDriver, NeonTransactionDbHandle } from "./client";
 export {
+  afterTenantTransactionCommit,
   closeDb,
   createDb,
   createDbForRequest,


### PR DESCRIPTION
Post-merge corrective for #828 / #716.

## What this fixes

- queues email-authority invalidation on the middleware-owned tenant transaction and executes it only after the outer commit succeeds
- falls back to immediate invalidation when there is no transaction owner
- bounds request-local EmailAuth memoization to 30 seconds and retires the old provider on expiry
- prevents a rejected stale pending load from deleting a newer replacement cache entry

## Exact candidate

- base: `9dc65e8d829b4d106ae1c5b8165fb8ae41eb857c`
- head: `83c26a956043965f938905a0cb9a49d77bbd0175`

## Validation

- DB request-database context: 24/24 tests, 140 assertions
- isolated API `auth-email-config`: pass
- isolated API `platform-email-config`: pass
- `@stwd/db` TypeScript build: pass
- `@stwd/api` TypeScript build: pass
- targeted Biome and diff checks: pass

Hosted exact-head checks and independent review remain required before merge.