### PR TITLE
fix(adapters): authenticate valuation quote bindings

### DIFF
--- a/packages/adapters/src/__tests__/bridge.test.ts
+++ b/packages/adapters/src/__tests__/bridge.test.ts
@@ -29,7 +29,7 @@ describe("MockBridgeAdapter", () => {
 
     expect(quote).toEqual({
       provider: "mock",
-      quoteId: "mock-bridge-1-8453-1000000-100",
+      quoteId: `mock-bridge-1-8453-1000000-100-${USDC.address}-${BASE_USDC.address}-1779819360000`,
       fromChainId: 1,
       toChainId: 8453,
       fromToken: USDC,
@@ -74,6 +74,8 @@ describe("MockBridgeAdapter", () => {
         toChainId: 8453,
         recipient: RECIPIENT,
         amountIn: "1000000",
+        sourceChainId: 1,
+        sourceTokenAddress: USDC.address,
         minAmountOut: "993010",
         slippageBps: 50,
       },
@@ -136,5 +138,26 @@ describe("MockBridgeAdapter", () => {
 
     const later = new MockBridgeAdapter({ now: () => 1779819360001 });
     await expect(later.buildBridge({ quote, owner: OWNER })).rejects.toThrow("quote has expired");
+  });
+
+  test("rejects a caller-tampered source token with a forged matching quote id", async () => {
+    const adapter = new MockBridgeAdapter({ now: () => 1779819300000 });
+    const quote = await adapter.getQuote({
+      fromChainId: 1,
+      toChainId: 8453,
+      fromToken: USDC,
+      toToken: BASE_USDC,
+      amount: "1000000",
+      recipient: RECIPIENT,
+    });
+    const tampered = {
+      ...quote,
+      fromToken: BASE_USDC,
+      quoteId: `mock-bridge-${quote.fromChainId}-${quote.toChainId}-${quote.amountIn}-${quote.slippageBps}-${BASE_USDC.address}-${quote.toToken.address}-${quote.expiresAt}`,
+    };
+
+    await expect(adapter.buildBridge({ quote: tampered, owner: OWNER })).rejects.toThrow(
+      "quote binding is invalid",
+    );
   });
 });

--- a/packages/adapters/src/__tests__/swap.test.ts
+++ b/packages/adapters/src/__tests__/swap.test.ts
@@ -108,6 +108,11 @@ describe("MockSwapAdapter.buildSwap", () => {
     expect(intent.kind).toBe("evm-tx");
     expect(intent.category).toBe("swap");
     expect(intent.owner).toBe("0x1111111111111111111111111111111111111111");
+    expect(intent.metadata).toMatchObject({
+      amountIn: "1000",
+      sourceChainId: 8453,
+      sourceTokenAddress: USDC.address,
+    });
     // No signature-bearing fields.
     expect((intent as Record<string, unknown>).signature).toBeUndefined();
     expect((intent as Record<string, unknown>).rawTransaction).toBeUndefined();
@@ -126,6 +131,25 @@ describe("MockSwapAdapter.buildSwap", () => {
     await expect(
       later.buildSwap(quote, "0x1111111111111111111111111111111111111111"),
     ).rejects.toBeInstanceOf(AdapterValidationError);
+  });
+
+  test("rejects a caller-tampered source token with a forged matching quote id", async () => {
+    const swap = new MockSwapAdapter(fixedClock(1_000));
+    const quote = await swap.getQuote({
+      fromToken: USDC,
+      toToken: WETH,
+      amount: "1000000",
+      chainId: 8453,
+    });
+    const tampered = {
+      ...quote,
+      fromToken: WETH,
+      quoteId: `mock-swap-${quote.chainId}-${quote.amountIn}-${quote.slippageBps}-${WETH.address}-${quote.toToken.address}-${quote.expiresAt}`,
+    };
+
+    await expect(
+      swap.buildSwap(tampered, "0x1111111111111111111111111111111111111111"),
+    ).rejects.toThrow("quote binding is invalid");
   });
 
   test("rejects a malformed agent address", async () => {

--- a/packages/adapters/src/adapters/bridge.ts
+++ b/packages/adapters/src/adapters/bridge.ts
@@ -121,6 +121,10 @@ export type BridgeBuildResult = UnsignedTxIntent | BridgeHandoff;
 export interface BridgeAdapter extends BaseAdapter {
   readonly category: "bridge";
   getQuote(request: BridgeQuoteRequest): Promise<BridgeQuote>;
+  /**
+   * Unsigned transaction results MUST bind their validated input amount,
+   * source chain, and source-token address in metadata for policy valuation.
+   */
   buildBridge(request: BridgeBuildRequest): Promise<BridgeBuildResult>;
   createSession(
     quote: BridgeQuote,
@@ -130,7 +134,20 @@ export interface BridgeAdapter extends BaseAdapter {
 }
 
 const MOCK_QUOTE_TTL_MS = 60_000;
+const MAX_MOCK_QUOTE_RECEIPTS = 4_096;
 const MOCK_BRIDGE_FEE_BPS = 20n;
+
+function mockQuoteId(
+  fromChainId: number,
+  toChainId: number,
+  amountIn: string,
+  slippageBps: number,
+  fromToken: string,
+  toToken: string,
+  expiresAt: number,
+): string {
+  return `mock-bridge-${fromChainId}-${toChainId}-${amountIn}-${slippageBps}-${fromToken.toLowerCase()}-${toToken.toLowerCase()}-${expiresAt}`;
+}
 
 export class MockBridgeAdapter implements BridgeAdapter {
   readonly category = "bridge" as const;
@@ -138,6 +155,7 @@ export class MockBridgeAdapter implements BridgeAdapter {
   readonly enabled = true;
 
   private readonly sessions = new Map<string, BridgeSession>();
+  private readonly issuedQuotes = new Map<string, number>();
   private readonly now: () => number;
 
   constructor(options?: { now?: () => number }) {
@@ -151,18 +169,35 @@ export class MockBridgeAdapter implements BridgeAdapter {
       throw new AdapterValidationError("fromChainId and toChainId must differ");
     }
     const amountIn = assertUint256(request.amount, "amount");
-    if (!request.fromToken?.address || !request.toToken?.address) {
-      throw new AdapterValidationError("fromToken and toToken addresses are required");
-    }
+    const fromTokenAddress = assertEvmAddress(request.fromToken?.address, "fromToken.address");
+    const toTokenAddress = assertEvmAddress(request.toToken?.address, "toToken.address");
     const recipient = assertEvmAddress(request.recipient, "recipient");
     const slippageBps = assertSlippageBps(request.slippageBps);
     const amount = BigInt(amountIn);
     const feeAmount = (amount * MOCK_BRIDGE_FEE_BPS) / 10_000n;
     const amountOut = amount - feeAmount;
     const minAmountOut = (amountOut * BigInt(10_000 - slippageBps)) / 10_000n;
+    const now = this.now();
+    const expiresAt = now + MOCK_QUOTE_TTL_MS;
+    const quoteId = mockQuoteId(
+      fromChainId,
+      toChainId,
+      amountIn,
+      slippageBps,
+      fromTokenAddress,
+      toTokenAddress,
+      expiresAt,
+    );
+    for (const [issuedId, issuedExpiry] of this.issuedQuotes) {
+      if (issuedExpiry <= now) this.issuedQuotes.delete(issuedId);
+    }
+    if (!this.issuedQuotes.has(quoteId) && this.issuedQuotes.size >= MAX_MOCK_QUOTE_RECEIPTS) {
+      throw new AdapterValidationError("mock quote receipt capacity reached; retry later");
+    }
+    this.issuedQuotes.set(quoteId, expiresAt);
     return {
       provider: this.provider,
-      quoteId: `mock-bridge-${fromChainId}-${toChainId}-${amountIn}-${slippageBps}`,
+      quoteId,
       fromChainId,
       toChainId,
       fromToken: request.fromToken,
@@ -174,19 +209,39 @@ export class MockBridgeAdapter implements BridgeAdapter {
       recipient,
       route: [{ bridge: "mock-bridge", fromChainId, toChainId }],
       slippageBps,
-      expiresAt: this.now() + MOCK_QUOTE_TTL_MS,
+      expiresAt,
     };
   }
 
   async buildBridge(request: BridgeBuildRequest): Promise<UnsignedTxIntent> {
     const quote = validateQuote(request.quote, this.now());
     const owner = assertEvmAddress(request.owner, "owner");
-    const bridgeContract = assertEvmAddress(quote.fromToken.address, "quote.fromToken.address");
+    const sourceTokenAddress = assertEvmAddress(quote.fromToken.address, "quote.fromToken.address");
+    const destinationTokenAddress = assertEvmAddress(
+      quote.toToken.address,
+      "quote.toToken.address",
+    );
+    if (
+      quote.provider !== this.provider ||
+      this.issuedQuotes.get(quote.quoteId) !== quote.expiresAt ||
+      quote.quoteId !==
+        mockQuoteId(
+          quote.fromChainId,
+          quote.toChainId,
+          quote.amountIn,
+          quote.slippageBps,
+          sourceTokenAddress,
+          destinationTokenAddress,
+          quote.expiresAt,
+        )
+    ) {
+      throw new AdapterValidationError("quote binding is invalid; request a fresh quote");
+    }
     return {
       signed: false,
       kind: "evm-tx",
       chainId: quote.fromChainId,
-      to: bridgeContract,
+      to: sourceTokenAddress,
       value: "0",
       data: "0x",
       owner,
@@ -198,6 +253,8 @@ export class MockBridgeAdapter implements BridgeAdapter {
         toChainId: quote.toChainId,
         recipient: quote.recipient,
         amountIn: quote.amountIn,
+        sourceChainId: quote.fromChainId,
+        sourceTokenAddress,
         minAmountOut: quote.minAmountOut,
         slippageBps: quote.slippageBps,
       },

--- a/packages/adapters/src/adapters/swap.ts
+++ b/packages/adapters/src/adapters/swap.ts
@@ -55,14 +55,28 @@ export interface SwapAdapter extends BaseAdapter {
   getQuote(request: SwapQuoteRequest): Promise<SwapQuote>;
   /**
    * Produce an unsigned swap transaction for `agentAddress` to sign via the
-   * existing vault/policy path. MUST NOT sign or broadcast.
+   * existing vault/policy path. MUST NOT sign or broadcast. The returned
+   * intent MUST bind its validated input amount, chain, and source-token
+   * address in metadata so policy code never has to trust the echoed quote.
    */
   buildSwap(quote: SwapQuote, agentAddress: string): Promise<UnsignedTxIntent>;
 }
 
 const MOCK_QUOTE_TTL_MS = 60_000;
+const MAX_MOCK_QUOTE_RECEIPTS = 4_096;
 // Deterministic mock pricing: 0.3% fee, 1:1 nominal rate. No external calls.
 const MOCK_FEE_BPS = 30n;
+
+function mockQuoteId(
+  chainId: number,
+  amountIn: string,
+  slippageBps: number,
+  fromToken: string,
+  toToken: string,
+  expiresAt: number,
+): string {
+  return `mock-swap-${chainId}-${amountIn}-${slippageBps}-${fromToken.toLowerCase()}-${toToken.toLowerCase()}-${expiresAt}`;
+}
 
 export class MockSwapAdapter implements SwapAdapter {
   readonly category = "swap" as const;
@@ -70,6 +84,7 @@ export class MockSwapAdapter implements SwapAdapter {
   readonly enabled = true;
 
   private now: () => number;
+  private readonly issuedQuotes = new Map<string, number>();
 
   constructor(options?: { now?: () => number }) {
     this.now = options?.now ?? (() => Date.now());
@@ -79,10 +94,9 @@ export class MockSwapAdapter implements SwapAdapter {
     const chainId = assertChainId(request.chainId);
     const amountIn = assertUint256(request.amount, "amount");
     const slippageBps = assertSlippageBps(request.slippageBps);
-    if (!request.fromToken?.address || !request.toToken?.address) {
-      throw new AdapterValidationError("fromToken and toToken addresses are required");
-    }
-    if (request.fromToken.address === request.toToken.address) {
+    const fromTokenAddress = assertEvmAddress(request.fromToken?.address, "fromToken.address");
+    const toTokenAddress = assertEvmAddress(request.toToken?.address, "toToken.address");
+    if (fromTokenAddress.toLowerCase() === toTokenAddress.toLowerCase()) {
       throw new AdapterValidationError("fromToken and toToken must differ");
     }
 
@@ -91,6 +105,23 @@ export class MockSwapAdapter implements SwapAdapter {
     const amountOut = amount - feeAmount; // deterministic 1:1 minus fee
     const minAmountOut = (amountOut * BigInt(10_000 - slippageBps)) / 10_000n;
 
+    const now = this.now();
+    const expiresAt = now + MOCK_QUOTE_TTL_MS;
+    const quoteId = mockQuoteId(
+      chainId,
+      amountIn,
+      slippageBps,
+      fromTokenAddress,
+      toTokenAddress,
+      expiresAt,
+    );
+    for (const [issuedId, issuedExpiry] of this.issuedQuotes) {
+      if (issuedExpiry <= now) this.issuedQuotes.delete(issuedId);
+    }
+    if (!this.issuedQuotes.has(quoteId) && this.issuedQuotes.size >= MAX_MOCK_QUOTE_RECEIPTS) {
+      throw new AdapterValidationError("mock quote receipt capacity reached; retry later");
+    }
+    this.issuedQuotes.set(quoteId, expiresAt);
     return {
       provider: this.provider,
       fromToken: request.fromToken,
@@ -108,8 +139,8 @@ export class MockSwapAdapter implements SwapAdapter {
       ],
       feeAmount: feeAmount.toString(),
       slippageBps,
-      expiresAt: this.now() + MOCK_QUOTE_TTL_MS,
-      quoteId: `mock-swap-${chainId}-${amountIn}-${slippageBps}`,
+      expiresAt,
+      quoteId,
     };
   }
 
@@ -121,17 +152,29 @@ export class MockSwapAdapter implements SwapAdapter {
     if (quote.expiresAt <= this.now()) {
       throw new AdapterValidationError("quote has expired; request a fresh quote");
     }
-    // Re-validate quote internals (untrusted even though we produced it).
-    assertUint256(quote.amountIn, "quote.amountIn");
+    // Re-validate quote internals and their immutable receipt binding. The
+    // caller round-trips this object and may mutate any field before build.
+    const chainId = assertChainId(quote.chainId);
+    const amountIn = assertUint256(quote.amountIn, "quote.amountIn");
     assertUint256(quote.minAmountOut, "quote.minAmountOut", true);
+    const slippageBps = assertSlippageBps(quote.slippageBps);
+    const fromTokenAddress = assertEvmAddress(quote.fromToken?.address, "quote.fromToken.address");
     const to = assertEvmAddress(quote.toToken.address, "quote.toToken.address");
+    if (
+      quote.provider !== this.provider ||
+      this.issuedQuotes.get(quote.quoteId) !== quote.expiresAt ||
+      quote.quoteId !==
+        mockQuoteId(chainId, amountIn, slippageBps, fromTokenAddress, to, quote.expiresAt)
+    ) {
+      throw new AdapterValidationError("quote binding is invalid; request a fresh quote");
+    }
 
     // The mock targets the toToken contract as a stand-in router. A real adapter
     // would encode the aggregator's calldata. Crucially: this is UNSIGNED.
     return {
       signed: false,
       kind: "evm-tx",
-      chainId: quote.chainId,
+      chainId,
       to,
       value: "0",
       data: "0x",
@@ -140,7 +183,9 @@ export class MockSwapAdapter implements SwapAdapter {
       provider: this.provider,
       metadata: {
         quoteId: quote.quoteId,
-        amountIn: quote.amountIn,
+        amountIn,
+        sourceChainId: chainId,
+        sourceTokenAddress: fromTokenAddress,
         minAmountOut: quote.minAmountOut,
         slippageBps: quote.slippageBps,
       },

--- a/packages/api/src/__tests__/adapters-policy-gate.test.ts
+++ b/packages/api/src/__tests__/adapters-policy-gate.test.ts
@@ -405,6 +405,50 @@ describe("adapter fund-moving policy gate", () => {
     expect(body.data.unsignedIntent.category).toBe("swap");
   });
 
+  it("rejects a swap quote whose source token and deterministic id were forged cheaply", async () => {
+    process.env.STEWARD_ADAPTER_PER_OP_CAP_USD = "0.5";
+    process.env.STEWARD_ADAPTER_DAILY_CAP_USD = "1000";
+    const { app, agentId } = await makeApp(`tenant-adapter-swap-token-tamper-${Date.now()}`);
+    const quoteRes = await app.request("/adapters/swap/quote", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        agentId,
+        fromToken: USDC,
+        toToken: WETH,
+        amount: "1000000",
+        chainId: 8453,
+      }),
+    });
+    const { data } = (await quoteRes.json()) as {
+      data: {
+        quote: Record<string, unknown> & {
+          chainId: number;
+          amountIn: string;
+          slippageBps: number;
+          toToken: { address: string };
+          expiresAt: number;
+        };
+      };
+    };
+    const tamperedQuote = {
+      ...data.quote,
+      fromToken: WETH,
+      quoteId: `mock-swap-${data.quote.chainId}-${data.quote.amountIn}-${data.quote.slippageBps}-${WETH.address}-${data.quote.toToken.address}-${data.quote.expiresAt}`,
+    };
+
+    const response = await app.request("/adapters/swap/build", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId, agentAddress: AGENT_WALLET, quote: tamperedQuote }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.error).toContain("quote binding is invalid");
+    expect(body.unsignedIntent).toBeUndefined();
+  });
+
   it("rejects caller-supplied USD valuations instead of trusting an understatement", async () => {
     const { app, agentId } = await makeApp(`tenant-adapter-caller-price-${Date.now()}`);
     const quoteRes = await app.request("/adapters/swap/quote", {
@@ -530,6 +574,98 @@ describe("adapter fund-moving policy gate", () => {
     expect(body.data.unsignedIntent.signed).toBe(false);
     expect(body.data.unsignedIntent.category).toBe("bridge");
     expect(body.data.unsignedIntent.metadata.toChainId).toBe(42161);
+  });
+
+  it("rejects a bridge quote whose source token and deterministic id were forged cheaply", async () => {
+    process.env.STEWARD_ADAPTER_PER_OP_CAP_USD = "0.5";
+    process.env.STEWARD_ADAPTER_DAILY_CAP_USD = "1000";
+    const { app, agentId } = await makeApp(`tenant-adapter-bridge-token-tamper-${Date.now()}`);
+    const quoteRes = await app.request("/adapters/bridge/quote", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        agentId,
+        fromChainId: 8453,
+        toChainId: 42161,
+        fromToken: USDC,
+        toToken: WETH,
+        amount: "1000000",
+        recipient: AGENT_WALLET,
+      }),
+    });
+    const { data } = (await quoteRes.json()) as {
+      data: {
+        quote: Record<string, unknown> & {
+          fromChainId: number;
+          toChainId: number;
+          amountIn: string;
+          slippageBps: number;
+          toToken: { address: string };
+          expiresAt: number;
+        };
+      };
+    };
+    const tamperedQuote = {
+      ...data.quote,
+      fromToken: WETH,
+      quoteId: `mock-bridge-${data.quote.fromChainId}-${data.quote.toChainId}-${data.quote.amountIn}-${data.quote.slippageBps}-${WETH.address}-${data.quote.toToken.address}-${data.quote.expiresAt}`,
+    };
+
+    const response = await app.request("/adapters/bridge/build", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Idempotency-Key": "bridge-source-token-tamper",
+      },
+      body: JSON.stringify({ agentId, owner: AGENT_WALLET, quote: tamperedQuote }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.error).toContain("quote binding is invalid");
+    expect(body.unsignedIntent).toBeUndefined();
+  });
+
+  it("fails closed when a bridge artifact omits or mismatches its valuation binding", async () => {
+    const { app, agentId } = await makeApp(`tenant-adapter-bridge-binding-${Date.now()}`);
+    for (const [caseName, metadata] of [
+      ["missing", { amountIn: "1000000", sourceChainId: 8453 }],
+      [
+        "chain-mismatch",
+        { amountIn: "1000000", sourceChainId: 1, sourceTokenAddress: USDC.address },
+      ],
+    ] as const) {
+      const provider = `test-artifact-binding-${caseName}-${Date.now()}`;
+      selectBridgeAdapter(provider, {
+        signed: false,
+        kind: "evm-tx",
+        chainId: 8453,
+        to: USDC.address,
+        value: "0",
+        data: "0x",
+        owner: AGENT_WALLET,
+        category: "bridge",
+        provider,
+        metadata,
+      });
+      const response = await app.request("/adapters/bridge/build", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": `bridge-artifact-binding-${caseName}`,
+        },
+        body: JSON.stringify({
+          agentId,
+          owner: AGENT_WALLET,
+          quote: { quoteId: `binding-${caseName}` },
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.reason).toBe("authoritative USD valuation is unavailable (fail-closed)");
+      expect(body.unsignedIntent).toBeUndefined();
+    }
   });
 
   it("rejects a regenerated bridge artifact that changed under the same idempotency key", async () => {

--- a/packages/api/src/routes/adapters.ts
+++ b/packages/api/src/routes/adapters.ts
@@ -31,7 +31,6 @@ import {
   type BridgeHandoff,
   type BridgeQuote,
   type SparkWallet,
-  type SwapQuote,
   type UnsignedTxIntent,
 } from "@stwd/adapters";
 import { getDb, tenantAppClients, userTenants } from "@stwd/db";
@@ -593,6 +592,18 @@ async function tokenNotionalUsd(
   }
 }
 
+async function artifactTokenNotionalUsd(intent: UnsignedTxIntent): Promise<number | null> {
+  const metadata = intent.metadata;
+  if (
+    !metadata ||
+    metadata.sourceChainId !== intent.chainId ||
+    typeof metadata.sourceTokenAddress !== "string"
+  ) {
+    return null;
+  }
+  return tokenNotionalUsd(metadata.amountIn, metadata.sourceChainId, metadata.sourceTokenAddress);
+}
+
 async function bitcoinNotionalUsd(satoshis: unknown): Promise<number | null> {
   if (typeof satoshis !== "string" || !/^\d+$/.test(satoshis)) return null;
   try {
@@ -865,12 +876,7 @@ adapterRoutes.post("/swap/build", async (c) => {
 
     // Fund-moving: gate BEFORE returning anything signable.
     const caps = spendCaps();
-    const metadata = intent.metadata ?? {};
-    const estimatedUsd = await tokenNotionalUsd(
-      metadata.amountIn,
-      intent.chainId,
-      (quoteInput as SwapQuote).fromToken?.address,
-    );
+    const estimatedUsd = await artifactTokenNotionalUsd(intent);
     if (estimatedUsd === null) {
       return c.json(
         {
@@ -1115,11 +1121,7 @@ adapterRoutes.post("/bridge/build", async (c) => {
     const estimatedUsd =
       result.kind === "external-handoff"
         ? result.estimatedUsd
-        : await tokenNotionalUsd(
-            result.metadata?.amountIn,
-            result.chainId,
-            (parsed.data.quote as unknown as BridgeQuote).fromToken?.address,
-          );
+        : await artifactTokenNotionalUsd(result);
     if (estimatedUsd === null) {
       return c.json(
         {


### PR DESCRIPTION
Post-merge corrective for #860. Develop commit a521e7ae8 merged server-priced adapter spend, but swap and internal bridge valuation still selected source-token identity from caller-round-tripped quote objects. A caller could replace that identity with a cheaper token before build.

This successor:
- makes swap and unsigned bridge adapters bind validated amount, source chain, and source-token identity into their returned artifact
- prices only that adapter-produced artifact binding; missing or chain-mismatched bindings fail closed
- requires the mock adapters to validate caller-round-tripped quotes against bounded, expiring server-issued receipts
- rejects cheap-token substitution even when the caller forges the matching deterministic quote id
- bounds retained mock receipts to 4096 and expires them after the quote TTL

Exact tested head: 682b9a14d14bf8c35f362e90bfd1503799a6af57
Exact base: 9dc65e8d829b4d106ae1c5b8165fb8ae41eb857c

Validation:
- adapter policy gate: 25/25 (162 assertions)
- swap + bridge adapter tests: 18/18 (35 assertions)
- API TypeScript check
- adapters TypeScript check
- Biome and git diff --check

The separately merged staging drift issue remains outside this six-file correction. Hosted exact-head checks and independent approval are required before merge.