### PR TITLE
fix(vault): make Solana recovery evidence and effects durable

### DIFF
--- a/packages/api/src/__tests__/redis-enforcement.test.ts
+++ b/packages/api/src/__tests__/redis-enforcement.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "bun:test";
 import type { PolicyRule } from "@stwd/shared";
 import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import {
+  conservativeNativeSpendUsd,
   enforceRateLimit,
   extractRateLimitPolicy,
   extractSpendLimitPolicy,
@@ -259,6 +260,27 @@ describe("nativePriceFallbackUsd", () => {
         nativePriceFallbackUsd(),
       ),
     ).toBe(10_000);
+  });
+});
+
+describe("conservativeNativeSpendUsd", () => {
+  it("uses Solana's 9-decimal base units when no oracle price is available", () => {
+    expect(
+      withRuntimeEnvironment({ STEWARD_NATIVE_PRICE_FALLBACK_USD: "10000" }, () =>
+        conservativeNativeSpendUsd(1_000_000_000n, 101),
+      ),
+    ).toBe(10_000);
+    expect(
+      withRuntimeEnvironment({ STEWARD_NATIVE_PRICE_FALLBACK_USD: "10000" }, () =>
+        conservativeNativeSpendUsd(1_500_000_000n, 102),
+      ),
+    ).toBe(15_000);
+  });
+
+  it("fails closed when native decimals are unknown", () => {
+    expect(() => conservativeNativeSpendUsd(1n, 999_999)).toThrow(
+      "Native-token decimals are not configured",
+    );
   });
 });
 

--- a/packages/api/src/__tests__/secrets-audit-atomicity.test.ts
+++ b/packages/api/src/__tests__/secrets-audit-atomicity.test.ts
@@ -27,7 +27,8 @@ describe("secret CRUD audit atomicity", () => {
   let app: Hono<{ Variables: AppVariables }>;
   let vault: SecretVault;
   beforeAll(async () => {
-    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_DB_MODE = "pglite";
+    delete process.env.STEWARD_PGLITE_MEMORY;
     process.env.STEWARD_MASTER_PASSWORD = "secret-audit-atomic-master";
     process.env.STEWARD_AUDIT_HMAC_KEY = "secret-audit-atomic-hmac-key-32-bytes";
     const { db, client } = await createPGLiteDb("memory://");
@@ -64,7 +65,7 @@ describe("secret CRUD audit atomicity", () => {
     await getDb().execute(sql.raw(`DROP TRIGGER IF EXISTS ${trigger} ON audit_events`));
     await getDb().execute(sql.raw(`DROP FUNCTION IF EXISTS ${fn}()`));
     await closeDb();
-    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_DB_MODE;
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_AUDIT_HMAC_KEY;
   });
@@ -173,7 +174,6 @@ describe("secret CRUD audit atomicity", () => {
         .where(and(eq(auditEvents.tenantId, tenantId), eq(auditEvents.action, "secret.rotate"))),
     ).toHaveLength(0);
   });
-
   it("uses the transaction lock path supported by file-backed PGLite", async () => {
     const previousMemory = process.env.STEWARD_PGLITE_MEMORY;
     const previousMode = process.env.STEWARD_DB_MODE;
@@ -199,6 +199,41 @@ describe("secret CRUD audit atomicity", () => {
       else process.env.STEWARD_PGLITE_MEMORY = previousMemory;
       if (previousMode === undefined) delete process.env.STEWARD_DB_MODE;
       else process.env.STEWARD_DB_MODE = previousMode;
+    }
+  });
+
+  it("audits create, rotate, and delete in explicit PGLite mode", async () => {
+    const name = `explicit-pglite-${crypto.randomUUID()}`;
+    await rejectAuditActions(["__never_reject_explicit_pglite__"]);
+    try {
+      const create = await app.request("/secrets", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name, value: "initial-explicit-pglite-value" }),
+      });
+      expect(create.status).toBe(201);
+      const createBody = (await create.json()) as { data: { id: string } };
+
+      const rotate = await app.request(`/secrets/${createBody.data.id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ value: "rotated-explicit-pglite-value" }),
+      });
+      expect(rotate.status).toBe(200);
+      const rotateBody = (await rotate.json()) as { data: { id: string } };
+
+      const remove = await app.request(`/secrets/${rotateBody.data.id}`, { method: "DELETE" });
+      expect(remove.status).toBe(200);
+
+      const lifecycle = await getDb()
+        .select({ action: auditEvents.action })
+        .from(auditEvents)
+        .where(and(eq(auditEvents.tenantId, tenantId), eq(auditEvents.resourceType, "secret")));
+      expect(lifecycle.map((row) => row.action)).toEqual(
+        expect.arrayContaining(["secret.create", "secret.rotate", "secret.delete"]),
+      );
+    } finally {
+      await rejectAuditActions(["secret.create", "secret.rotate", "secret.delete"]);
     }
   });
 });

--- a/packages/api/src/__tests__/sign-solana-policy-derivation.test.ts
+++ b/packages/api/src/__tests__/sign-solana-policy-derivation.test.ts
@@ -131,9 +131,10 @@ describe("sign-solana — parser-derived policy wiring", () => {
   it("records the spend using the authoritative parsed value", () => {
     const route = routeSlice();
     const evalCall = route.indexOf("await policyEngine.evaluate(policySet");
-    const recordSpend = route.indexOf("recordVaultSpend(agentId, tenantId, txValue, chainId)");
+    const recordSpend = route.indexOf("await tryCompleteSolanaRecoveryEffects({", evalCall);
     expect(evalCall).toBeGreaterThanOrEqual(0);
     expect(recordSpend).toBeGreaterThan(evalCall);
+    expect(route.slice(recordSpend, recordSpend + 180)).toContain("signature: result.signature");
   });
 
   it("requires idempotency for broadcast requests before signing", () => {

--- a/packages/api/src/__tests__/sign-solana-policy-derivation.test.ts
+++ b/packages/api/src/__tests__/sign-solana-policy-derivation.test.ts
@@ -109,10 +109,11 @@ describe("sign-solana — parser-derived policy wiring", () => {
     expect(guard).toBeGreaterThanOrEqual(0);
     // Whitespace-normalized so formatter rewrapping does not break the wiring
     // assertion: the envelope stays conditioned on the guard, and (SEC-163)
-    // every other shape must carry the explicit blind-sign attestation.
+    // every other parsed shape must carry the parsed-sign attestation. Only
+    // the separately audited unsafe-blind route may opt into blind signing.
     const normalized = route.replace(/\s+/g, " ");
     const envelopeSpread = normalized.indexOf(
-      "isSingleNativeTransfer ? { expectedTo: toAddress, expectedValue: txValue } : { allowBlindSign: true }",
+      "isSingleNativeTransfer ? { expectedTo: toAddress, expectedValue: txValue } : { allowParsedSign: true }",
     );
     expect(envelopeSpread).toBeGreaterThanOrEqual(0);
     expect(route).toContain('instructionType === "system:Transfer"');

--- a/packages/api/src/__tests__/sign-solana-policy-derivation.test.ts
+++ b/packages/api/src/__tests__/sign-solana-policy-derivation.test.ts
@@ -99,7 +99,7 @@ describe("sign-solana — parser-derived policy wiring", () => {
 
   it("defines the blind-sign flag default-off, mirroring other unsafe flags", () => {
     expect(vaultSource).toContain(
-      'const allowUnsafeSolanaBlindSigning = (): boolean =>\n  process.env.STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING === "true"',
+      'const allowUnsafeSolanaBlindSigning = (): boolean =>\n  runtimeCustodyValue("STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING") === "true"',
     );
   });
 

--- a/packages/api/src/__tests__/sign-solana-policy-derivation.test.ts
+++ b/packages/api/src/__tests__/sign-solana-policy-derivation.test.ts
@@ -103,20 +103,31 @@ describe("sign-solana — parser-derived policy wiring", () => {
     );
   });
 
-  it("only passes the legacy single-transfer envelope for a single native SOL transfer", () => {
+  it("only uses the raw legacy envelope for a single native SOL transfer", () => {
     const route = routeSlice();
     const guard = route.indexOf("const isSingleNativeTransfer =");
     expect(guard).toBeGreaterThanOrEqual(0);
     // Whitespace-normalized so formatter rewrapping does not break the wiring
-    // assertion: the envelope stays conditioned on the guard, and (SEC-163)
-    // every other parsed shape must carry the parsed-sign attestation. Only
-    // the separately audited unsafe-blind route may opt into blind signing.
+    // assertion: the envelope stays conditioned on the guard, while every
+    // other parsed shape must pass through the durable governed gateway.
     const normalized = route.replace(/\s+/g, " ");
-    const envelopeSpread = normalized.indexOf(
-      "isSingleNativeTransfer ? { expectedTo: toAddress, expectedValue: txValue } : { allowParsedSign: true }",
+    expect(normalized).toContain(
+      "const result = isSingleNativeTransfer ? await vault.signSolanaTransaction(",
     );
-    expect(envelopeSpread).toBeGreaterThanOrEqual(0);
+    expect(normalized).toContain(".signSolanaParsedTransactionAuthorized(");
+    expect(vaultSource).not.toContain("allowParsedSign");
     expect(route).toContain('instructionType === "system:Transfer"');
+  });
+
+  it("binds parsed signing to message, effects, policy revision, tx id, and execution token", () => {
+    const route = routeSlice();
+    const normalized = route.replace(/\s+/g, " ");
+    expect(normalized).toContain("messageDigest = normalizedSolanaMessageDigest(body.transaction)");
+    expect(normalized).toContain("parsedEffects = solanaParsedEffects(derived)");
+    expect(normalized).toContain("policyRevisionHashForPolicySet(policySet)");
+    expect(normalized).toContain("executionToken: ownerToken");
+    expect(normalized).toContain("txId,");
+    expect(normalized).toContain("consumeExecutionClaim: consumeParsedSolanaExecutionClaim");
   });
 
   it("preserves the existing policy-evaluation, rate-limit, audit, and webhook gates", () => {

--- a/packages/api/src/__tests__/solana-approval-takeover-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/solana-approval-takeover-postgres.integration.test.ts
@@ -1,0 +1,124 @@
+import { expect, it } from "bun:test";
+import {
+  agents,
+  approvalQueue,
+  auditChainHeads,
+  auditEvents,
+  createDb,
+  tenants,
+  transactions,
+} from "@stwd/db";
+import { eq } from "drizzle-orm";
+
+const databaseUrl = process.env.DATABASE_URL;
+const realPostgresIt = databaseUrl && !process.env.STEWARD_PGLITE_MEMORY ? it : it.skip;
+
+realPostgresIt(
+  "allows exactly one authorized different-admin takeover of an expired Solana claim",
+  async () => {
+    const suffix = crypto.randomUUID().replaceAll("-", "");
+    const tenantId = `solana-takeover-${suffix}`;
+    const agentId = `solana-takeover-agent-${suffix}`;
+    const txId = `solana-takeover-tx-${suffix}`;
+    const admin = createDb(databaseUrl!);
+    try {
+      await admin.db.insert(tenants).values({
+        id: tenantId,
+        name: tenantId,
+        apiKeyHash: `hash-${tenantId}`,
+      });
+      await admin.db.insert(agents).values({
+        id: agentId,
+        tenantId,
+        name: agentId,
+        walletAddress: "7v54NWdBtkjuAFJrLGsS2SXnuk8nKam81mZJeeYxVFi9",
+      });
+      await admin.db.insert(transactions).values({
+        id: txId,
+        agentId,
+        status: "pending",
+        toAddress: "6TcyBfPdBt1kjsvDZLzmBFnuMaLWiTaAt4RjUr9VA5YD",
+        value: "42",
+        data: "serialized-solana-takeover",
+        chainId: 101,
+        actionType: "transaction",
+        actionPayload: {
+          type: "transaction",
+          broadcast: true,
+        },
+        policyResults: [],
+      });
+      await admin.db.insert(approvalQueue).values({
+        id: `approval-${suffix}`,
+        txId,
+        agentId,
+        status: "approved",
+        resolvedAt: new Date(),
+        resolvedBy: "user:original-admin",
+        resolvedByType: "user",
+        resolvedById: "original-admin",
+      });
+
+      const { claimApprovedSolanaExecution } = await import("../routes/vault");
+      const [unclaimed] = await admin.db
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, txId));
+      const initial = await claimApprovedSolanaExecution(unclaimed, {
+        takeover: false,
+        resolver: { type: "user", id: "original-admin" },
+      });
+      await admin.db
+        .update(transactions)
+        .set({
+          actionPayload: {
+            ...initial.actionPayload,
+            attemptLeaseUntil: new Date(Date.now() - 60_000).toISOString(),
+          },
+        })
+        .where(eq(transactions.id, txId));
+      const [row] = await admin.db.select().from(transactions).where(eq(transactions.id, txId));
+      const attempts = await Promise.allSettled([
+        claimApprovedSolanaExecution(row, {
+          takeover: true,
+          resolver: { type: "user", id: "replacement-admin-a" },
+        }),
+        claimApprovedSolanaExecution(row, {
+          takeover: true,
+          resolver: { type: "user", id: "replacement-admin-b" },
+        }),
+      ]);
+      expect(attempts.filter((attempt) => attempt.status === "fulfilled")).toHaveLength(1);
+      expect(attempts.filter((attempt) => attempt.status === "rejected")).toHaveLength(1);
+
+      const winner = attempts.find((attempt) => attempt.status === "fulfilled");
+      if (!winner || winner.status !== "fulfilled") throw new Error("takeover winner missing");
+      const [storedTransaction] = await admin.db
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, txId));
+      const [storedApproval] = await admin.db
+        .select()
+        .from(approvalQueue)
+        .where(eq(approvalQueue.txId, txId));
+      expect(storedTransaction.actionPayload).toMatchObject({
+        executionToken: winner.value.executionToken,
+      });
+      expect(["replacement-admin-a", "replacement-admin-b"]).toContain(storedApproval.resolvedById);
+      expect(storedApproval.resolvedBy).toBe(`user:${storedApproval.resolvedById}`);
+    } finally {
+      await admin.db.delete(approvalQueue).where(eq(approvalQueue.agentId, agentId));
+      await admin.db
+        .update(transactions)
+        .set({ status: "failed" })
+        .where(eq(transactions.id, txId));
+      await admin.db.delete(transactions).where(eq(transactions.id, txId));
+      await admin.db.delete(auditEvents).where(eq(auditEvents.tenantId, tenantId));
+      await admin.db.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, tenantId));
+      await admin.db.delete(agents).where(eq(agents.id, agentId));
+      await admin.db.delete(tenants).where(eq(tenants.id, tenantId));
+      await admin.client.end();
+    }
+  },
+  120_000,
+);

--- a/packages/api/src/__tests__/solana-recovery-anchor.test.ts
+++ b/packages/api/src/__tests__/solana-recovery-anchor.test.ts
@@ -350,8 +350,100 @@ describe("Solana durable recovery anchors", () => {
       const surviving = await onlyRecoveryRow();
       expect(surviving.status).toBe("outcome_unknown");
       expect(surviving.txHash).toBe(SIGNATURE);
+      expect(readPayload(surviving.actionPayload).recoveryEffectsState).toBe("accounted_unknown");
+      expect(
+        await getDb()
+          .select()
+          .from(auditEvents)
+          .where(
+            and(
+              eq(auditEvents.resourceId, surviving.id),
+              eq(auditEvents.action, "vault.sign.solana.effects_completed"),
+            ),
+          ),
+      ).toHaveLength(0);
     } finally {
       context.vault.signSolanaTransaction = originalSign;
+    }
+  });
+
+  it("serializes ambiguous accounting against a failed reconciliation without success evidence", async () => {
+    const context = await import("../services/context");
+    const routes = await import("../routes/vault");
+    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
+    const originalReconcile = context.vault.reconcileSolanaBroadcast.bind(context.vault);
+    let releaseClaim!: () => void;
+    const claimRelease = new Promise<void>((resolve) => {
+      releaseClaim = resolve;
+    });
+    let reportClaim!: () => void;
+    const claimEntered = new Promise<void>((resolve) => {
+      reportClaim = resolve;
+    });
+    const restoreClaimHook = routes.__setSolanaRecoveryEffectsClaimHookForTests(async (input) => {
+      if (input.status !== "outcome_unknown") return;
+      reportClaim();
+      await claimRelease;
+    });
+    context.vault.signSolanaTransaction = async (request) => {
+      await request.onBroadcastPrepared?.({
+        signature: SIGNATURE,
+        recentBlockhash: RECENT_BLOCKHASH,
+      });
+      throw new ExternalBroadcastOutcomeUnknownError(SIGNATURE);
+    };
+    context.vault.reconcileSolanaBroadcast = async () => "failed";
+
+    try {
+      const first = app.request(`/vault/${AGENT_ID}/sign-solana`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "solana-recovery-effects-reconcile-race",
+        },
+        body: JSON.stringify({ transaction: WITHIN_CAP_V0_TRANSFER, broadcast: true }),
+      });
+      await claimEntered;
+      const staged = await onlyRecoveryRow();
+      expect(readPayload(staged.actionPayload).recoveryEffectsState).toBe("processing");
+
+      const blocked = await app.request(
+        `/vault/${AGENT_ID}/transactions/${staged.id}/reconcile-solana`,
+        { method: "POST" },
+      );
+      expect(blocked.status).toBe(409);
+      expect((await onlyRecoveryRow()).status).toBe("outcome_unknown");
+
+      releaseClaim();
+      expect((await first).status).toBe(202);
+      expect(readPayload((await onlyRecoveryRow()).actionPayload).recoveryEffectsState).toBe(
+        "accounted_unknown",
+      );
+
+      const reconciled = await app.request(
+        `/vault/${AGENT_ID}/transactions/${staged.id}/reconcile-solana`,
+        { method: "POST" },
+      );
+      expect(reconciled.status).toBe(200);
+      const final = await onlyRecoveryRow();
+      expect(final.status).toBe("failed");
+      expect(readPayload(final.actionPayload).recoveryEffectsState).toBe("accounted_unknown");
+      expect(
+        await getDb()
+          .select()
+          .from(auditEvents)
+          .where(
+            and(
+              eq(auditEvents.resourceId, staged.id),
+              eq(auditEvents.action, "vault.sign.solana.effects_completed"),
+            ),
+          ),
+      ).toHaveLength(0);
+    } finally {
+      releaseClaim();
+      restoreClaimHook();
+      context.vault.signSolanaTransaction = originalSign;
+      context.vault.reconcileSolanaBroadcast = originalReconcile;
     }
   });
 

--- a/packages/api/src/__tests__/solana-recovery-anchor.test.ts
+++ b/packages/api/src/__tests__/solana-recovery-anchor.test.ts
@@ -14,6 +14,7 @@ import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import {
   ExternalBroadcastOutcomeUnknownError,
   SolanaBroadcastNotSubmittedError,
+  Vault,
 } from "@stwd/vault";
 import { and, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
@@ -164,9 +165,8 @@ describe("Solana durable recovery anchors", () => {
   });
 
   it("keeps the parsed-route anchor and submitted signature when final bookkeeping fails", async () => {
-    const context = await import("../services/context");
-    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
-    context.vault.signSolanaTransaction = async (request) => {
+    const originalSign = Vault.prototype.signSolanaTransaction;
+    Vault.prototype.signSolanaTransaction = async (request) => {
       const staged = await onlyRecoveryRow();
       expect(staged.status).toBe("approved");
       expect(staged.data).toBe(WITHIN_CAP_V0_TRANSFER);
@@ -214,7 +214,7 @@ describe("Solana durable recovery anchors", () => {
       expect(surviving.txHash).toBe(SIGNATURE);
       expect(surviving.data).toBe(WITHIN_CAP_V0_TRANSFER);
     } finally {
-      context.vault.signSolanaTransaction = originalSign;
+      Vault.prototype.signSolanaTransaction = originalSign;
       await getDb().execute(
         sql.raw("ALTER TABLE transactions DROP CONSTRAINT test_reject_solana_finalization"),
       );
@@ -223,9 +223,8 @@ describe("Solana durable recovery anchors", () => {
 
   it("keeps the blind-route broadcast row and success response when final audit fails", async () => {
     process.env.STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING = "true";
-    const context = await import("../services/context");
-    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
-    context.vault.signSolanaTransaction = async (request) => {
+    const originalSign = Vault.prototype.signSolanaTransaction;
+    Vault.prototype.signSolanaTransaction = async (request) => {
       const staged = await onlyRecoveryRow();
       expect(staged.status).toBe("approved");
       expect(staged.data).toBe("not-a-solana-transaction");
@@ -270,7 +269,7 @@ describe("Solana durable recovery anchors", () => {
       expect(surviving.data).toBe("not-a-solana-transaction");
       expect(readPayload(surviving.actionPayload).recoveryEffectsState).toBe("pending");
     } finally {
-      context.vault.signSolanaTransaction = originalSign;
+      Vault.prototype.signSolanaTransaction = originalSign;
       process.env.STEWARD_AUDIT_HMAC_KEY =
         "solana-recovery-anchor-audit-hmac-key-with-more-than-32-bytes";
       __resetAuditHmacKeyCacheForTests();
@@ -279,9 +278,8 @@ describe("Solana durable recovery anchors", () => {
 
   it("keeps recovery effects pending while a configured Redis backend is unavailable", async () => {
     process.env.REDIS_URL = "redis://127.0.0.1:1";
-    const context = await import("../services/context");
-    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
-    context.vault.signSolanaTransaction = async (request) => {
+    const originalSign = Vault.prototype.signSolanaTransaction;
+    Vault.prototype.signSolanaTransaction = async (request) => {
       await request.onBroadcastPrepared?.({
         signature: SIGNATURE,
         recentBlockhash: RECENT_BLOCKHASH,
@@ -309,15 +307,14 @@ describe("Solana durable recovery anchors", () => {
       expect(surviving.txHash).toBe(SIGNATURE);
       expect(readPayload(surviving.actionPayload).recoveryEffectsState).toBe("pending");
     } finally {
-      context.vault.signSolanaTransaction = originalSign;
+      Vault.prototype.signSolanaTransaction = originalSign;
       delete process.env.REDIS_URL;
     }
   });
 
   it("returns a non-retryable 202 with the durable hash when confirmation is ambiguous", async () => {
-    const context = await import("../services/context");
-    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
-    context.vault.signSolanaTransaction = async (request) => {
+    const originalSign = Vault.prototype.signSolanaTransaction;
+    Vault.prototype.signSolanaTransaction = async (request) => {
       expect((await onlyRecoveryRow()).status).toBe("approved");
       await request.onBroadcastPrepared?.({
         signature: SIGNATURE,
@@ -363,15 +360,14 @@ describe("Solana durable recovery anchors", () => {
           ),
       ).toHaveLength(0);
     } finally {
-      context.vault.signSolanaTransaction = originalSign;
+      Vault.prototype.signSolanaTransaction = originalSign;
     }
   });
 
   it("serializes ambiguous accounting against a failed reconciliation without success evidence", async () => {
-    const context = await import("../services/context");
     const routes = await import("../routes/vault");
-    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
-    const originalReconcile = context.vault.reconcileSolanaBroadcast.bind(context.vault);
+    const originalSign = Vault.prototype.signSolanaTransaction;
+    const originalReconcile = Vault.prototype.reconcileSolanaBroadcast;
     let releaseClaim!: () => void;
     const claimRelease = new Promise<void>((resolve) => {
       releaseClaim = resolve;
@@ -385,14 +381,14 @@ describe("Solana durable recovery anchors", () => {
       reportClaim();
       await claimRelease;
     });
-    context.vault.signSolanaTransaction = async (request) => {
+    Vault.prototype.signSolanaTransaction = async (request) => {
       await request.onBroadcastPrepared?.({
         signature: SIGNATURE,
         recentBlockhash: RECENT_BLOCKHASH,
       });
       throw new ExternalBroadcastOutcomeUnknownError(SIGNATURE);
     };
-    context.vault.reconcileSolanaBroadcast = async () => "failed";
+    Vault.prototype.reconcileSolanaBroadcast = async () => "failed";
 
     try {
       const first = app.request(`/vault/${AGENT_ID}/sign-solana`, {
@@ -442,15 +438,14 @@ describe("Solana durable recovery anchors", () => {
     } finally {
       releaseClaim();
       restoreClaimHook();
-      context.vault.signSolanaTransaction = originalSign;
-      context.vault.reconcileSolanaBroadcast = originalReconcile;
+      Vault.prototype.signSolanaTransaction = originalSign;
+      Vault.prototype.reconcileSolanaBroadcast = originalReconcile;
     }
   });
 
   it("replays the confirmed winner when definite-preflight cleanup loses its signature CAS", async () => {
-    const context = await import("../services/context");
-    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
-    context.vault.signSolanaTransaction = async (request) => {
+    const originalSign = Vault.prototype.signSolanaTransaction;
+    Vault.prototype.signSolanaTransaction = async (request) => {
       await request.onBroadcastPrepared?.({
         signature: SIGNATURE,
         recentBlockhash: RECENT_BLOCKHASH,
@@ -489,13 +484,13 @@ describe("Solana durable recovery anchors", () => {
         );
       expect(notSubmittedAudits).toHaveLength(0);
     } finally {
-      context.vault.signSolanaTransaction = originalSign;
+      Vault.prototype.signSolanaTransaction = originalSign;
     }
   });
 
   it("durably replays across both cache-unsafe and cache-safe session auth", async () => {
     const context = await import("../services/context");
-    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
+    const originalSign = Vault.prototype.signSolanaTransaction;
     let signCalls = 0;
     let releaseAttempt!: () => void;
     const attemptBarrier = new Promise<void>((resolve) => {
@@ -505,7 +500,7 @@ describe("Solana durable recovery anchors", () => {
     const attemptStarted = new Promise<void>((resolve) => {
       signalAttemptStarted = resolve;
     });
-    context.vault.signSolanaTransaction = async (request) => {
+    Vault.prototype.signSolanaTransaction = async (request) => {
       signCalls += 1;
       signalAttemptStarted();
       await attemptBarrier;
@@ -590,13 +585,13 @@ describe("Solana durable recovery anchors", () => {
       expect(mismatch.status).toBe(409);
       expect(signCalls).toBe(1);
     } finally {
-      context.vault.signSolanaTransaction = originalSign;
+      Vault.prototype.signSolanaTransaction = originalSign;
     }
   });
 
   it("never takes over an expired lease after its parsed claim entered raw custody", async () => {
     const context = await import("../services/context");
-    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
+    const originalSign = Vault.prototype.signSolanaTransaction;
     let signCalls = 0;
     let submittedCalls = 0;
     let releaseStale!: () => void;
@@ -607,7 +602,7 @@ describe("Solana durable recovery anchors", () => {
     const staleStarted = new Promise<void>((resolve) => {
       signalStaleStarted = resolve;
     });
-    context.vault.signSolanaTransaction = async (request) => {
+    Vault.prototype.signSolanaTransaction = async (request) => {
       signCalls += 1;
       signalStaleStarted();
       await staleBarrier;
@@ -662,13 +657,12 @@ describe("Solana durable recovery anchors", () => {
       expect((await onlyRecoveryRow()).status).toBe("broadcast");
     } finally {
       releaseStale();
-      context.vault.signSolanaTransaction = originalSign;
+      Vault.prototype.signSolanaTransaction = originalSign;
     }
   });
 
   it("reconciles only the stored signature and blockhash through guarded transitions", async () => {
-    const context = await import("../services/context");
-    const originalReconcile = context.vault.reconcileSolanaBroadcast.bind(context.vault);
+    const originalReconcile = Vault.prototype.reconcileSolanaBroadcast;
     const cases = [
       { outcome: "confirmed" as const, status: 200 },
       { outcome: "broadcast" as const, status: 200 },
@@ -703,7 +697,7 @@ describe("Solana durable recovery anchors", () => {
                 : {}),
             },
           });
-        context.vault.reconcileSolanaBroadcast = async (input) => {
+        Vault.prototype.reconcileSolanaBroadcast = async (input) => {
           expect(input).toEqual({
             signature: SIGNATURE,
             recentBlockhash: RECENT_BLOCKHASH,
@@ -733,15 +727,14 @@ describe("Solana durable recovery anchors", () => {
         }
       }
     } finally {
-      context.vault.reconcileSolanaBroadcast = originalReconcile;
+      Vault.prototype.reconcileSolanaBroadcast = originalReconcile;
     }
   });
 
   it("retries durable effects without re-querying Solana after reconciliation committed", async () => {
-    const context = await import("../services/context");
-    const originalReconcile = context.vault.reconcileSolanaBroadcast.bind(context.vault);
+    const originalReconcile = Vault.prototype.reconcileSolanaBroadcast;
     let reconcileCalls = 0;
-    context.vault.reconcileSolanaBroadcast = async () => {
+    Vault.prototype.reconcileSolanaBroadcast = async () => {
       reconcileCalls++;
       return "broadcast";
     };
@@ -780,7 +773,7 @@ describe("Solana durable recovery anchors", () => {
       expect(readPayload(committed.actionPayload).recoveryEffectsState).toBe("pending");
 
       delete process.env.REDIS_URL;
-      context.vault.reconcileSolanaBroadcast = async () => {
+      Vault.prototype.reconcileSolanaBroadcast = async () => {
         throw new Error("a committed reconciliation must not be queried again");
       };
       const response = await app.request(
@@ -797,7 +790,7 @@ describe("Solana durable recovery anchors", () => {
       expect(reconcileCalls).toBe(1);
     } finally {
       delete process.env.REDIS_URL;
-      context.vault.reconcileSolanaBroadcast = originalReconcile;
+      Vault.prototype.reconcileSolanaBroadcast = originalReconcile;
     }
   });
 });

--- a/packages/api/src/__tests__/solana-recovery-anchor.test.ts
+++ b/packages/api/src/__tests__/solana-recovery-anchor.test.ts
@@ -783,12 +783,14 @@ describe("Solana durable recovery anchors", () => {
       // Force the effects phase to fail only after the authoritative RPC result
       // has already transitioned the row to broadcast.
       process.env.REDIS_URL = "redis://127.0.0.1:1";
-      const first = await app.request(
-        `/vault/${AGENT_ID}/transactions/${txId}/reconcile-solana`,
-        { method: "POST" },
-      );
+      const first = await app.request(`/vault/${AGENT_ID}/transactions/${txId}/reconcile-solana`, {
+        method: "POST",
+      });
       expect(first.status).toBe(500);
-      const [committed] = await getDb().select().from(transactions).where(eq(transactions.id, txId));
+      const [committed] = await getDb()
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, txId));
       expect(committed.status).toBe("broadcast");
       expect(readPayload(committed.actionPayload).recoveryEffectsState).toBe("pending");
 

--- a/packages/api/src/__tests__/solana-recovery-anchor.test.ts
+++ b/packages/api/src/__tests__/solana-recovery-anchor.test.ts
@@ -30,6 +30,40 @@ const RECENT_BLOCKHASH = "11111111111111111111111111111111";
 const WITHIN_CAP_V0_TRANSFER =
   "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQACBGa+fjMsekUzMr2dCn99sFX1xe8aBq2mbZizn7aBDEc6URw0oaLLUh3xa7JGuN6OeZfOI1x+drIqPXUDokgZ3YoDBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcDAgAFAkANAwACAAkD6AMAAAAAAAADAgABDAIAAAB7AAAAAAAAAAA=";
 
+function withRecentBlockhash(transaction: string, blockhash: string): string {
+  const bytes = Buffer.from(transaction, "base64");
+  const readShortVec = (offset: number): [number, number] => {
+    let value = 0;
+    let shift = 0;
+    let cursor = offset;
+    while (true) {
+      const byte = bytes[cursor++];
+      value |= (byte & 0x7f) << shift;
+      if ((byte & 0x80) === 0) return [value, cursor];
+      shift += 7;
+    }
+  };
+  const [signatureCount, messageOffset] = readShortVec(0);
+  let cursor = messageOffset + signatureCount * 64;
+  if ((bytes[cursor] & 0x80) !== 0) cursor += 1;
+  cursor += 3;
+  const [accountCount, accountsOffset] = readShortVec(cursor);
+  cursor = accountsOffset + accountCount * 32;
+  const replacement = Buffer.alloc(32);
+  Buffer.from(blockhash).copy(replacement, 0, 0, 32);
+  replacement.copy(bytes, cursor);
+  return bytes.toString("base64");
+}
+
+function withComputeUnitLimit(transaction: string, units: number): string {
+  const bytes = Buffer.from(transaction, "base64");
+  const marker = Buffer.from([2, 0x40, 0x0d, 0x03, 0]);
+  const offset = bytes.indexOf(marker);
+  if (offset < 0) throw new Error("compute-unit-limit instruction not found");
+  bytes.writeUInt32LE(units, offset + 1);
+  return bytes.toString("base64");
+}
+
 setDefaultTimeout(30_000);
 
 async function makeApp() {
@@ -225,7 +259,11 @@ describe("Solana durable recovery anchors", () => {
         }),
       });
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        data: { txId: expect.any(String), signature: SIGNATURE, broadcast: true },
+      });
       const surviving = await onlyRecoveryRow();
       expect(surviving.status).toBe("broadcast");
       expect(surviving.txHash).toBe(SIGNATURE);
@@ -261,7 +299,11 @@ describe("Solana durable recovery anchors", () => {
         body: JSON.stringify({ transaction: WITHIN_CAP_V0_TRANSFER, broadcast: true }),
       });
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        data: { txId: expect.any(String), signature: SIGNATURE, broadcast: true },
+      });
       const surviving = await onlyRecoveryRow();
       expect(surviving.status).toBe("broadcast");
       expect(surviving.txHash).toBe(SIGNATURE);
@@ -386,7 +428,7 @@ describe("Solana durable recovery anchors", () => {
         caip2: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       };
     };
-    const request = (recentMfa = false) =>
+    const request = (recentMfa = false, transaction = WITHIN_CAP_V0_TRANSFER) =>
       app.request(`/vault/${AGENT_ID}/sign-solana`, {
         method: "POST",
         headers: {
@@ -394,7 +436,7 @@ describe("Solana durable recovery anchors", () => {
           "Idempotency-Key": "session-admin-durable-solana-replay",
           ...(recentMfa ? { "x-test-recent-mfa": "true" } : {}),
         },
-        body: JSON.stringify({ transaction: WITHIN_CAP_V0_TRANSFER, broadcast: true }),
+        body: JSON.stringify({ transaction, broadcast: true }),
       });
 
     try {
@@ -410,7 +452,16 @@ describe("Solana durable recovery anchors", () => {
 
       releaseAttempt();
       const first = await firstPromise;
-      const replay = await request(true);
+      const changedComputeBudget = await request(
+        true,
+        withComputeUnitLimit(WITHIN_CAP_V0_TRANSFER, 210_000),
+      );
+      expect(changedComputeBudget.status).toBe(409);
+      expect(await changedComputeBudget.json()).toMatchObject({
+        ok: false,
+        error: "Idempotency-Key was already used for a different Solana transaction",
+      });
+      const replay = await request(true, withRecentBlockhash(WITHIN_CAP_V0_TRANSFER, RECIPIENT));
       expect(first.status).toBe(200);
       expect(replay.status).toBe(200);
       expect(replay.headers.get("Idempotency-Replayed")).toBeNull();

--- a/packages/api/src/__tests__/solana-recovery-anchor.test.ts
+++ b/packages/api/src/__tests__/solana-recovery-anchor.test.ts
@@ -751,6 +751,68 @@ describe("Solana durable recovery anchors", () => {
       context.vault.reconcileSolanaBroadcast = originalReconcile;
     }
   });
+
+  it("retries durable effects without re-querying Solana after reconciliation committed", async () => {
+    const context = await import("../services/context");
+    const originalReconcile = context.vault.reconcileSolanaBroadcast.bind(context.vault);
+    let reconcileCalls = 0;
+    context.vault.reconcileSolanaBroadcast = async () => {
+      reconcileCalls++;
+      return "broadcast";
+    };
+    const txId = "solana-reconcile-effects-retry";
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: txId,
+        agentId: AGENT_ID,
+        status: "outcome_unknown",
+        toAddress: RECIPIENT,
+        value: "123",
+        chainId: 101,
+        txHash: SIGNATURE,
+        actionType: "solana_transaction",
+        actionPayload: {
+          type: "solana_transaction",
+          recoveryAnchor: true,
+          recentBlockhash: RECENT_BLOCKHASH,
+          recoveryEffectsState: "pending",
+        },
+      });
+    try {
+      // Force the effects phase to fail only after the authoritative RPC result
+      // has already transitioned the row to broadcast.
+      process.env.REDIS_URL = "redis://127.0.0.1:1";
+      const first = await app.request(
+        `/vault/${AGENT_ID}/transactions/${txId}/reconcile-solana`,
+        { method: "POST" },
+      );
+      expect(first.status).toBe(500);
+      const [committed] = await getDb().select().from(transactions).where(eq(transactions.id, txId));
+      expect(committed.status).toBe("broadcast");
+      expect(readPayload(committed.actionPayload).recoveryEffectsState).toBe("pending");
+
+      delete process.env.REDIS_URL;
+      context.vault.reconcileSolanaBroadcast = async () => {
+        throw new Error("a committed reconciliation must not be queried again");
+      };
+      const response = await app.request(
+        `/vault/${AGENT_ID}/transactions/${txId}/reconcile-solana`,
+        { method: "POST" },
+      );
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        data: { txId, signature: SIGNATURE, status: "broadcast" },
+      });
+      const [row] = await getDb().select().from(transactions).where(eq(transactions.id, txId));
+      expect(readPayload(row.actionPayload).recoveryEffectsState).toBe("complete");
+      expect(reconcileCalls).toBe(1);
+    } finally {
+      delete process.env.REDIS_URL;
+      context.vault.reconcileSolanaBroadcast = originalReconcile;
+    }
+  });
 });
 
 function readPayload(value: unknown): Record<string, unknown> {

--- a/packages/api/src/__tests__/solana-recovery-anchor.test.ts
+++ b/packages/api/src/__tests__/solana-recovery-anchor.test.ts
@@ -594,7 +594,7 @@ describe("Solana durable recovery anchors", () => {
     }
   });
 
-  it("fences a stale callback after an expired signing lease is taken over", async () => {
+  it("never takes over an expired lease after its parsed claim entered raw custody", async () => {
     const context = await import("../services/context");
     const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
     let signCalls = 0;
@@ -607,23 +607,10 @@ describe("Solana durable recovery anchors", () => {
     const staleStarted = new Promise<void>((resolve) => {
       signalStaleStarted = resolve;
     });
-    let releaseWinner!: () => void;
-    const winnerBarrier = new Promise<void>((resolve) => {
-      releaseWinner = resolve;
-    });
-    let signalWinnerStarted!: () => void;
-    const winnerStarted = new Promise<void>((resolve) => {
-      signalWinnerStarted = resolve;
-    });
     context.vault.signSolanaTransaction = async (request) => {
       signCalls += 1;
-      if (signCalls === 1) {
-        signalStaleStarted();
-        await staleBarrier;
-      } else {
-        signalWinnerStarted();
-        await winnerBarrier;
-      }
+      signalStaleStarted();
+      await staleBarrier;
       await request.onBroadcastPrepared?.({
         signature: SIGNATURE,
         recentBlockhash: RECENT_BLOCKHASH,
@@ -660,23 +647,21 @@ describe("Solana durable recovery anchors", () => {
         })
         .where(eq(transactions.id, staged.id));
 
-      const takeoverResponse = request();
-      await winnerStarted;
-      expect(signCalls).toBe(2);
+      const takeoverResponse = await request();
+      expect(takeoverResponse.status).toBe(409);
+      expect(await takeoverResponse.json()).toMatchObject({
+        ok: false,
+        data: { status: "processing" },
+      });
+      expect(signCalls).toBe(1);
       expect(submittedCalls).toBe(0);
 
       releaseStale();
-      expect((await staleResponse).status).toBe(409);
-      expect((await onlyRecoveryRow()).status).toBe("approved");
-      expect(submittedCalls).toBe(0);
-
-      releaseWinner();
-      expect((await takeoverResponse).status).toBe(200);
+      expect((await staleResponse).status).toBe(200);
       expect(submittedCalls).toBe(1);
       expect((await onlyRecoveryRow()).status).toBe("broadcast");
     } finally {
       releaseStale();
-      releaseWinner();
       context.vault.signSolanaTransaction = originalSign;
     }
   });

--- a/packages/api/src/__tests__/solana-signing-authority-inventory.test.ts
+++ b/packages/api/src/__tests__/solana-signing-authority-inventory.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const routeSource = readFileSync(join(import.meta.dir, "..", "routes", "vault.ts"), "utf8");
+const rawVaultSource = readFileSync(
+  join(import.meta.dir, "..", "..", "..", "vault", "src", "vault.ts"),
+  "utf8",
+);
+
+function occurrences(source: string, needle: string): number[] {
+  const indexes: number[] = [];
+  let cursor = 0;
+  while (true) {
+    const index = source.indexOf(needle, cursor);
+    if (index < 0) return indexes;
+    indexes.push(index);
+    cursor = index + needle.length;
+  }
+}
+
+describe("raw Solana signer authority inventory", () => {
+  it("has no boolean parsed-sign exemption anywhere in production", () => {
+    expect(routeSource).not.toContain("allowParsedSign");
+    expect(rawVaultSource).not.toContain("allowParsedSign");
+  });
+
+  it("pins all API raw serialized-transaction callers to blind or native-envelope modes", () => {
+    const rawCalls = occurrences(routeSource, "vault.signSolanaTransaction({");
+    expect(rawCalls).toHaveLength(3);
+    const contexts = rawCalls.map((index) => routeSource.slice(index, index + 900));
+
+    // Approval fallback: only a reviewed unsafe-blind row or the native envelope.
+    expect(contexts[0]).toContain('queuedSolanaSigningMode === "blind"');
+    expect(contexts[0]).toContain("allowBlindSign: true");
+    expect(contexts[0]).toContain("expectedTo: transactionRow.toAddress");
+    expect(contexts[0]).toContain("expectedValue: transactionRow.value");
+
+    // Dedicated unsafe-blind helper still supplies a concrete policy envelope.
+    expect(contexts[1]).toContain("expectedTo: toAddress");
+    expect(contexts[1]).toContain("expectedValue: txValue");
+
+    // Fully parsed direct signing reaches raw custody only for one native transfer.
+    expect(routeSource.slice(rawCalls[2] - 250, rawCalls[2] + 700)).toContain(
+      "isSingleNativeTransfer",
+    );
+    expect(contexts[2]).toContain("expectedTo: toAddress");
+    expect(contexts[2]).toContain("expectedValue: txValue");
+  });
+
+  it("routes every parsed production family through the governed claim consumer", () => {
+    expect(occurrences(routeSource, ".signSolanaParsedTransactionAuthorized(")).toHaveLength(3);
+    expect(
+      occurrences(routeSource, "consumeExecutionClaim: consumeParsedSolanaExecutionClaim"),
+    ).toHaveLength(3);
+    expect(routeSource).toContain("parsedExecutionClaimDigest");
+    expect(routeSource).toContain("parsedClaimConsumedAt");
+  });
+
+  it("checks the opaque governed grant before querying encrypted Solana keys", () => {
+    const method = rawVaultSource.indexOf("async signSolanaTransaction(");
+    const grantCheck = rawVaultSource.indexOf(
+      "assertGovernedParsedSolanaSigningGrant(request.governedParsedSign, request)",
+      method,
+    );
+    const keyLookup = rawVaultSource.indexOf(".from(encryptedChainKeys)", grantCheck);
+    expect(method).toBeGreaterThanOrEqual(0);
+    expect(grantCheck).toBeGreaterThan(method);
+    expect(keyLookup).toBeGreaterThan(grantCheck);
+  });
+});

--- a/packages/api/src/__tests__/transaction-stats-chain-scope.test.ts
+++ b/packages/api/src/__tests__/transaction-stats-chain-scope.test.ts
@@ -31,6 +31,7 @@ import {
   transactions,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
 
 // context.ts reads required env and touches the DB at module import time, so
 // install the PGLite override before importing it.
@@ -139,6 +140,36 @@ describe("getTransactionStats chain scoping (issue #110)", () => {
     const stats = await getTransactionStats(AGENT_ID, SOLANA);
     expect(stats.spentToday.toString()).toBe(SOL_SPEND);
     expect(stats.spentThisWeek.toString()).toBe(SOL_SPEND);
+  });
+
+  it("counts SPL activity but excludes token base units from native SOL spend", async () => {
+    const id = `${AGENT_ID}-spl`;
+    const before = await getTransactionStats(AGENT_ID, SOLANA);
+    await getDb()
+      .insert(transactions)
+      .values({
+        id,
+        agentId: AGENT_ID,
+        status: "broadcast",
+        toAddress: RECIPIENT,
+        value: "9000000000000",
+        chainId: SOLANA,
+        actionType: "transfer",
+        actionPayload: {
+          type: "transfer",
+          token: "So11111111111111111111111111111111111111112",
+        },
+        policyResults: [],
+        signedAt: new Date(),
+      });
+    try {
+      const after = await getTransactionStats(AGENT_ID, SOLANA);
+      expect(after.spentToday).toBe(before.spentToday);
+      expect(after.spentThisWeek).toBe(before.spentThisWeek);
+      expect(after.recentTxCount24h).toBe(before.recentTxCount24h + 1);
+    } finally {
+      await getDb().delete(transactions).where(eq(transactions.id, id));
+    }
   });
 
   it("returns zero spend for a chain the agent has not transacted on", async () => {

--- a/packages/api/src/__tests__/vault-aggregation-enforcement.test.ts
+++ b/packages/api/src/__tests__/vault-aggregation-enforcement.test.ts
@@ -170,9 +170,7 @@ describe("aggregation cap enforcement (vault.ts wiring)", () => {
  * `await recordAggregationEvent({ … })`, and that record is AWAITED (not
  * fire-and-forget) so the next in-lock snapshot includes this contribution.
  *
- * EVM signing uses the gateway-authorized form
- * `signTransactionAuthorized(signRequest, …)` while the non-EVM (Solana)
- * fallback still uses the raw `vault.signTransaction(signRequest, …)`. A brittle
+ * EVM and Solana native signing use their gateway-authorized forms. A brittle
  * anchor on one literal spelling (or on `await` vs `return`) drifts the moment
  * either branch is reshaped. Instead we recognize BOTH signing call shapes
  * structurally, require at least one to be present (fail helpfully if a refactor
@@ -183,16 +181,18 @@ describe("aggregation cap enforcement (vault.ts wiring)", () => {
  * in-memory fixture in this file's proof tests below.
  */
 function signingCallIndices(route: string): number[] {
-  // Both recognized signing forms on the primary sign money path. Decoupled
+  // Recognized signing forms on the primary sign money path. Decoupled
   // from `await` vs `return` and from the surrounding call chain: we anchor on
   // the signing method name immediately applied to `signRequest`.
   //   • EVM (gateway-authorized): `…signTransactionAuthorized(signRequest, …)`
-  //   • non-EVM (raw fallback):   `…vault.signTransaction(signRequest, …)`
+  //   • Solana gateway: `…signSolanaNativeTransferAuthorized(signRequest, …)`
+  //   • legacy raw fallback (kept in the helper proof): `…vault.signTransaction(signRequest, …)`
   // `signTransactionAuthorized(signRequest` is matched exclusively so it is not
   // also double-counted by the `signTransaction(signRequest` substring.
   const indices: number[] = [];
   const patterns = [
     /signTransactionAuthorized\(\s*signRequest\b/g,
+    /signSolanaNativeTransferAuthorized\(\s*signRequest\b/g,
     /(?<!Authorized\()\bvault\.signTransaction\(\s*signRequest\b/g,
   ];
   for (const pattern of patterns) {
@@ -217,8 +217,7 @@ function assertRecordAfterSigning(route: string): void {
   // rather than silently passing an ordering check over zero signing sites.
   expect(
     signingIndices.length,
-    "expected at least one recognized signing call (signTransactionAuthorized(signRequest …) " +
-      "or vault.signTransaction(signRequest …)) on the sign money path",
+    "expected at least one recognized governed or raw signing call on the sign money path",
   ).toBeGreaterThan(0);
 
   // EVERY present signing form must precede the awaited record. Moving the
@@ -243,6 +242,7 @@ function assertRecordAfterSigning(route: string): void {
 describe("aggregation source-contract assertion (self-proof)", () => {
   const RECORD = "await recordAggregationEvent({\n  valueRaw: signRequest.value,\n});";
   const EVM_SIGN = "await gv.signTransactionAuthorized(signRequest, { txId });";
+  const SOLANA_SIGN = "await gv.signSolanaNativeTransferAuthorized(signRequest, { txId });";
   const RAW_SIGN = "return vault.signTransaction(signRequest, { txId });";
 
   it("PASSES when both EVM-authorized and raw signing precede the awaited record", () => {
@@ -258,6 +258,10 @@ describe("aggregation source-contract assertion (self-proof)", () => {
   it("PASSES for a non-EVM-only route (raw fallback precedes the record)", () => {
     const route = `${RAW_SIGN}\n${RECORD}`;
     expect(() => assertRecordAfterSigning(route)).not.toThrow();
+  });
+
+  it("PASSES for a governed Solana-only route", () => {
+    expect(() => assertRecordAfterSigning(`${SOLANA_SIGN}\n${RECORD}`)).not.toThrow();
   });
 
   it("FAILS when NO recognized signing form is present", () => {

--- a/packages/api/src/__tests__/vault-approval-gates.test.ts
+++ b/packages/api/src/__tests__/vault-approval-gates.test.ts
@@ -618,6 +618,36 @@ describe("vault approval gates (real /approve path)", () => {
       agentId: AGENT_SOLANA,
       status: "pending",
     });
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: "tx-solana-spl-transfer-blind-mode",
+        agentId: AGENT_SOLANA,
+        status: "pending",
+        toAddress: SOLANA_RECIPIENT,
+        value: "123",
+        data: PARSED_SPL_APPROVAL,
+        chainId: 101,
+        actionType: "transfer",
+        actionPayload: {
+          type: "transfer",
+          token: SOLANA_MINT,
+          recipient: SOLANA_RECIPIENT,
+          amount: "123",
+          broadcast: true,
+          signingMode: "blind",
+          blindSigned: true,
+          parsedEffects: parsedSplEffects,
+          reviewedRequestDigest: parsedSplRequestDigest,
+        },
+        policyResults: [],
+      });
+    await getDb().insert(approvalQueue).values({
+      id: "aq-tx-solana-spl-transfer-blind-mode",
+      txId: "tx-solana-spl-transfer-blind-mode",
+      agentId: AGENT_SOLANA,
+      status: "pending",
+    });
 
     const seen: Array<{
       transaction: string;
@@ -647,6 +677,9 @@ describe("vault approval gates (real /approve path)", () => {
         200,
       );
       expect((await approve(app, AGENT_SOLANA, "tx-solana-spl-transfer-tampered")).status).toBe(
+        409,
+      );
+      expect((await approve(app, AGENT_SOLANA, "tx-solana-spl-transfer-blind-mode")).status).toBe(
         409,
       );
       expect((await approve(app, AGENT_SOLANA, "tx-solana-parsed-tampered-approval")).status).toBe(

--- a/packages/api/src/__tests__/vault-approval-gates.test.ts
+++ b/packages/api/src/__tests__/vault-approval-gates.test.ts
@@ -431,6 +431,92 @@ describe("vault approval gates (real /approve path)", () => {
     }
   });
 
+  it("replays parsed and blind Solana approvals with their durably bound signing modes", async () => {
+    const app = await makeApp({ authType: "session-jwt", role: "owner", mfa: true });
+    for (const mode of ["parsed", "blind"] as const) {
+      const txId = `tx-solana-${mode}-approval`;
+      await getDb()
+        .insert(transactions)
+        .values({
+          id: txId,
+          agentId: AGENT_SOLANA,
+          status: "pending",
+          toAddress: SOLANA_RECIPIENT,
+          value: mode === "parsed" ? "301" : "302",
+          data: `serialized-${mode}-solana-approval`,
+          chainId: 101,
+          actionType: "solana_transaction",
+          actionPayload: {
+            type: "solana_transaction",
+            recoveryType: "solana_transaction",
+            recoveryActionType: "solana_transaction",
+            broadcast: true,
+            signingMode: mode,
+            blindSigned: mode === "blind",
+            parsedEffects:
+              mode === "parsed"
+                ? { movesNativeSol: false, programIds: ["memo-program"], tokenTransfers: [] }
+                : undefined,
+            requestDigest: `${mode}-request-digest`,
+          },
+          policyResults: [],
+        });
+      await getDb()
+        .insert(approvalQueue)
+        .values({
+          id: `aq-${txId}`,
+          txId,
+          agentId: AGENT_SOLANA,
+          status: "pending",
+        });
+    }
+
+    const seen: Array<{ transaction: string; allowBlindSign?: boolean }> = [];
+    const sign = spyOn(Vault.prototype, "signSolanaTransaction").mockImplementation(
+      async (request) => {
+        seen.push({ transaction: request.transaction, allowBlindSign: request.allowBlindSign });
+        const signature =
+          "4oL4p7QvN3UH7V5wMGZgW5PuzEk4A9LXLHk9RxAoKjDKuLbQBsfXN8kEvKfj5K1oEJa8wFF6RVp2h7pP9w2f51ZV";
+        await request.onBroadcastPrepared?.({
+          signature,
+          recentBlockhash: "11111111111111111111111111111111",
+        });
+        return { signature, broadcast: true, chainId: 101 };
+      },
+    );
+    try {
+      expect((await approve(app, AGENT_SOLANA, "tx-solana-parsed-approval")).status).toBe(200);
+      expect((await approve(app, AGENT_SOLANA, "tx-solana-blind-approval")).status).toBe(200);
+      expect(seen).toEqual([
+        { transaction: "serialized-parsed-solana-approval", allowBlindSign: true },
+        { transaction: "serialized-blind-solana-approval", allowBlindSign: true },
+      ]);
+      const rows = await getDb()
+        .select({ id: transactions.id, actionPayload: transactions.actionPayload })
+        .from(transactions)
+        .where(
+          sql`${transactions.id} in ('tx-solana-parsed-approval', 'tx-solana-blind-approval')`,
+        );
+      expect(rows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "tx-solana-parsed-approval",
+            actionPayload: expect.objectContaining({
+              signingMode: "parsed",
+              parsedEffects: expect.objectContaining({ programIds: ["memo-program"] }),
+            }),
+          }),
+          expect.objectContaining({
+            id: "tx-solana-blind-approval",
+            actionPayload: expect.objectContaining({ signingMode: "blind", blindSigned: true }),
+          }),
+        ]),
+      );
+    } finally {
+      sign.mockRestore();
+    }
+  });
+
   it("atomically rolls back fresh queue approval when the Solana claim faults and a new app can retry", async () => {
     const txId = "tx-fresh-solana-claim-rollback";
     const queueId = `aq-${txId}`;

--- a/packages/api/src/__tests__/vault-approval-gates.test.ts
+++ b/packages/api/src/__tests__/vault-approval-gates.test.ts
@@ -81,10 +81,13 @@ const AGENT_SEPARATION = `approval-separation-${Date.now()}`;
 const AGENT_REMOVED_REVIEWER = `approval-removed-reviewer-${Date.now()}`;
 const AGENT_SOLANA = `approval-solana-${Date.now()}`;
 const SOLANA_RECIPIENT = "7J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg";
+const SOLANA_MINT = "So11111111111111111111111111111111111111112";
 const SOLANA_SIGNATURE =
   "4oL4p7QvN3UH7V5wMGZgW5PuzEk4A9LXLHk9RxAoKjDKuLbQBsfXN8kEvKfj5K1oEJa8wFF6RVp2h7pP9w2f51ZV";
 const PARSED_SOLANA_APPROVAL =
   "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDE2JOpI+vbFRBKrMBRo65Mmbpvxu+OB3jAD7OG1gkRxwBnOCkX3JAiColqvYSlWPsVuUlI49mXDMD4GFd2CRJhQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAgIAAQwCAAAALQEAAAAAAAA=";
+const PARSED_SPL_APPROVAL =
+  "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAIF6UPMZDHYTBaZ84s4PYnN/eY1HN26Qb0JbdXSFq+/tZZh2lmTgEh2HN5KGa6apfFlq4jJQUkI4Gb/A5au2FTWSwR4o/Pr5Ke0sw7ZpMZJP/G4jcxjJ16HXZc5252A2hpABpuIV/6rgYT7aH9jRhjANdrEOdwa6ztVmKDwAAAAAAEG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQQEAgMBAAoMewAAAAAAAAAJ";
 
 // One app per auth posture. The approve route reads auth purely from context
 // variables, so a per-test middleware that sets exactly the desired posture is
@@ -193,7 +196,7 @@ async function seedPendingSolanaApproval() {
     name: "Approval Gate Solana Agent",
     walletAddress: "9J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg",
   });
-  await seedWhitelist(AGENT_SOLANA, [SOLANA_RECIPIENT]);
+  await seedWhitelist(AGENT_SOLANA, [SOLANA_RECIPIENT, SOLANA_MINT]);
   await getDb()
     .insert(transactions)
     .values({
@@ -464,6 +467,34 @@ describe("vault approval gates (real /approve path)", () => {
         }),
       )
       .digest("hex");
+    const parsedSpl = deriveSolanaPolicyFields(parseSolanaTransaction(PARSED_SPL_APPROVAL));
+    const parsedSplEffects = {
+      movesNativeSol: parsedSpl.movesNativeSol,
+      programIds: parsedSpl.programIds,
+      tokenTransfers: parsedSpl.summary.tokenTransfers.map((transfer) => ({
+        mint: transfer.mint,
+        destination: transfer.destination,
+        amount: transfer.amount,
+      })),
+    };
+    const parsedSplRequestDigest = createHash("sha256")
+      .update(
+        canonicalJsonStringify({
+          route: "transfer",
+          tenantId: TENANT_ID,
+          agentId: AGENT_SOLANA,
+          chainId: 101,
+          broadcast: true,
+          signingMode: "spl",
+          to: SOLANA_RECIPIENT,
+          value: "123",
+          token: SOLANA_MINT,
+          sponsor: false,
+          messageDigest: normalizedSolanaMessageDigest(PARSED_SPL_APPROVAL),
+          parsedEffects: parsedSplEffects,
+        }),
+      )
+      .digest("hex");
     for (const mode of ["parsed", "blind"] as const) {
       const txId = `tx-solana-${mode}-approval`;
       await getDb()
@@ -527,6 +558,66 @@ describe("vault approval gates (real /approve path)", () => {
       agentId: AGENT_SOLANA,
       status: "pending",
     });
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: "tx-solana-spl-transfer-approval",
+        agentId: AGENT_SOLANA,
+        status: "pending",
+        toAddress: SOLANA_RECIPIENT,
+        value: "123",
+        data: PARSED_SPL_APPROVAL,
+        chainId: 101,
+        actionType: "transfer",
+        actionPayload: {
+          type: "transfer",
+          token: SOLANA_MINT,
+          recipient: SOLANA_RECIPIENT,
+          amount: "123",
+          broadcast: true,
+          signingMode: "parsed",
+          blindSigned: false,
+          parsedEffects: parsedSplEffects,
+          reviewedRequestDigest: parsedSplRequestDigest,
+        },
+        policyResults: [],
+      });
+    await getDb().insert(approvalQueue).values({
+      id: "aq-tx-solana-spl-transfer-approval",
+      txId: "tx-solana-spl-transfer-approval",
+      agentId: AGENT_SOLANA,
+      status: "pending",
+    });
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: "tx-solana-spl-transfer-tampered",
+        agentId: AGENT_SOLANA,
+        status: "pending",
+        toAddress: SOLANA_RECIPIENT,
+        value: "123",
+        data: PARSED_SOLANA_APPROVAL,
+        chainId: 101,
+        actionType: "transfer",
+        actionPayload: {
+          type: "transfer",
+          token: SOLANA_MINT,
+          recipient: SOLANA_RECIPIENT,
+          amount: "123",
+          broadcast: true,
+          signingMode: "parsed",
+          blindSigned: false,
+          parsedEffects: parsedSplEffects,
+          reviewedRequestDigest: parsedSplRequestDigest,
+        },
+        policyResults: [],
+      });
+    await getDb().insert(approvalQueue).values({
+      id: "aq-tx-solana-spl-transfer-tampered",
+      txId: "tx-solana-spl-transfer-tampered",
+      agentId: AGENT_SOLANA,
+      status: "pending",
+    });
 
     const seen: Array<{
       transaction: string;
@@ -552,12 +643,19 @@ describe("vault approval gates (real /approve path)", () => {
     try {
       expect((await approve(app, AGENT_SOLANA, "tx-solana-parsed-approval")).status).toBe(200);
       expect((await approve(app, AGENT_SOLANA, "tx-solana-blind-approval")).status).toBe(200);
+      expect((await approve(app, AGENT_SOLANA, "tx-solana-spl-transfer-approval")).status).toBe(
+        200,
+      );
+      expect((await approve(app, AGENT_SOLANA, "tx-solana-spl-transfer-tampered")).status).toBe(
+        409,
+      );
       expect((await approve(app, AGENT_SOLANA, "tx-solana-parsed-tampered-approval")).status).toBe(
         409,
       );
       expect(seen).toEqual([
         { transaction: PARSED_SOLANA_APPROVAL, allowParsedSign: true },
         { transaction: "serialized-blind-solana-approval", allowBlindSign: true },
+        { transaction: PARSED_SPL_APPROVAL, allowParsedSign: true },
       ]);
       const rows = await getDb()
         .select({ id: transactions.id, actionPayload: transactions.actionPayload })

--- a/packages/api/src/__tests__/vault-approval-gates.test.ts
+++ b/packages/api/src/__tests__/vault-approval-gates.test.ts
@@ -47,6 +47,7 @@ import { canonicalJsonStringify } from "@stwd/shared";
 import {
   deriveSolanaPolicyFields,
   ExternalBroadcastOutcomeUnknownError,
+  GovernedVault,
   normalizedSolanaMessageDigest,
   parseSolanaTransaction,
   SolanaBroadcastNotSubmittedError,
@@ -652,14 +653,14 @@ describe("vault approval gates (real /approve path)", () => {
     const seen: Array<{
       transaction: string;
       allowBlindSign?: boolean;
-      allowParsedSign?: boolean;
+      governedParsedSign?: boolean;
     }> = [];
     const sign = spyOn(Vault.prototype, "signSolanaTransaction").mockImplementation(
       async (request) => {
         seen.push({
           transaction: request.transaction,
-          allowBlindSign: request.allowBlindSign,
-          allowParsedSign: request.allowParsedSign,
+          ...(request.allowBlindSign ? { allowBlindSign: true } : {}),
+          ...(request.governedParsedSign ? { governedParsedSign: true } : {}),
         });
         const signature =
           "4oL4p7QvN3UH7V5wMGZgW5PuzEk4A9LXLHk9RxAoKjDKuLbQBsfXN8kEvKfj5K1oEJa8wFF6RVp2h7pP9w2f51ZV";
@@ -686,9 +687,9 @@ describe("vault approval gates (real /approve path)", () => {
         409,
       );
       expect(seen).toEqual([
-        { transaction: PARSED_SOLANA_APPROVAL, allowParsedSign: true },
+        { transaction: PARSED_SOLANA_APPROVAL, governedParsedSign: true },
         { transaction: "serialized-blind-solana-approval", allowBlindSign: true },
-        { transaction: PARSED_SPL_APPROVAL, allowParsedSign: true },
+        { transaction: PARSED_SPL_APPROVAL, governedParsedSign: true },
       ]);
       const rows = await getDb()
         .select({ id: transactions.id, actionPayload: transactions.actionPayload })
@@ -715,6 +716,115 @@ describe("vault approval gates (real /approve path)", () => {
       );
     } finally {
       sign.mockRestore();
+    }
+  });
+
+  it("fails closed before raw custody when the durable parsed claim is tampered after approval", async () => {
+    const txId = "tx-solana-parsed-claim-tamper";
+    const parsed = deriveSolanaPolicyFields(parseSolanaTransaction(PARSED_SOLANA_APPROVAL));
+    const parsedEffects = {
+      movesNativeSol: parsed.movesNativeSol,
+      programIds: parsed.programIds,
+      tokenTransfers: parsed.summary.tokenTransfers.map((transfer) => ({
+        mint: transfer.mint,
+        destination: transfer.destination,
+        amount: transfer.amount,
+      })),
+    };
+    const requestDigest = createHash("sha256")
+      .update(
+        canonicalJsonStringify({
+          route: "sign-solana",
+          tenantId: TENANT_ID,
+          agentId: AGENT_SOLANA,
+          chainId: 101,
+          broadcast: true,
+          signingMode: "parsed",
+          to: SOLANA_RECIPIENT,
+          value: "301",
+          messageDigest: normalizedSolanaMessageDigest(PARSED_SOLANA_APPROVAL),
+          parsedEffects,
+        }),
+      )
+      .digest("hex");
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: txId,
+        agentId: AGENT_SOLANA,
+        status: "pending",
+        toAddress: SOLANA_RECIPIENT,
+        value: "301",
+        data: PARSED_SOLANA_APPROVAL,
+        chainId: 101,
+        actionType: "solana_transaction",
+        actionPayload: {
+          type: "solana_transaction",
+          recoveryType: "solana_transaction",
+          recoveryActionType: "solana_transaction",
+          broadcast: true,
+          signingMode: "parsed",
+          blindSigned: false,
+          parsedEffects,
+          requestDigest,
+        },
+        policyResults: [],
+      });
+    await getDb()
+      .insert(approvalQueue)
+      .values({
+        id: `aq-${txId}`,
+        txId,
+        agentId: AGENT_SOLANA,
+        status: "pending",
+      });
+
+    const originalGateway = GovernedVault.prototype.signSolanaParsedTransactionAuthorized;
+    let rawCalls = 0;
+    const rawSpy = spyOn(Vault.prototype, "signSolanaTransaction").mockImplementation(async () => {
+      rawCalls += 1;
+      throw new Error("raw custody must not be reached");
+    });
+    const gatewaySpy = spyOn(
+      GovernedVault.prototype,
+      "signSolanaParsedTransactionAuthorized",
+    ).mockImplementation(async function (request, options) {
+      const [row] = await getDb()
+        .select({ actionPayload: transactions.actionPayload })
+        .from(transactions)
+        .where(eq(transactions.id, txId));
+      await getDb()
+        .update(transactions)
+        .set({
+          actionPayload: {
+            ...(row.actionPayload as Record<string, unknown>),
+            parsedExecutionClaimDigest: "tampered-after-approval",
+          },
+        })
+        .where(eq(transactions.id, txId));
+      return originalGateway.call(this, request, options);
+    });
+    try {
+      const app = await makeApp({ authType: "session-jwt", role: "owner", mfa: true });
+      const response = await approve(app, AGENT_SOLANA, txId);
+      expect(response.status).not.toBe(200);
+      expect(await response.json()).toMatchObject({ ok: false });
+      expect(rawCalls).toBe(0);
+
+      const [row] = await getDb()
+        .select({ status: transactions.status, actionPayload: transactions.actionPayload })
+        .from(transactions)
+        .where(eq(transactions.id, txId));
+      const [queue] = await getDb()
+        .select({ status: approvalQueue.status })
+        .from(approvalQueue)
+        .where(eq(approvalQueue.txId, txId));
+      expect(row.status).toBe("pending");
+      expect(row.actionPayload).not.toHaveProperty("parsedClaimConsumedAt");
+      expect(queue.status).toBe("pending");
+    } finally {
+      gatewaySpy.mockRestore();
+      rawSpy.mockRestore();
     }
   });
 

--- a/packages/api/src/__tests__/vault-approval-gates.test.ts
+++ b/packages/api/src/__tests__/vault-approval-gates.test.ts
@@ -45,7 +45,10 @@ import {
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { canonicalJsonStringify } from "@stwd/shared";
 import {
+  deriveSolanaPolicyFields,
   ExternalBroadcastOutcomeUnknownError,
+  normalizedSolanaMessageDigest,
+  parseSolanaTransaction,
   SolanaBroadcastNotSubmittedError,
   Vault,
 } from "@stwd/vault";
@@ -80,6 +83,8 @@ const AGENT_SOLANA = `approval-solana-${Date.now()}`;
 const SOLANA_RECIPIENT = "7J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg";
 const SOLANA_SIGNATURE =
   "4oL4p7QvN3UH7V5wMGZgW5PuzEk4A9LXLHk9RxAoKjDKuLbQBsfXN8kEvKfj5K1oEJa8wFF6RVp2h7pP9w2f51ZV";
+const PARSED_SOLANA_APPROVAL =
+  "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDE2JOpI+vbFRBKrMBRo65Mmbpvxu+OB3jAD7OG1gkRxwBnOCkX3JAiColqvYSlWPsVuUlI49mXDMD4GFd2CRJhQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAgIAAQwCAAAALQEAAAAAAAA=";
 
 // One app per auth posture. The approve route reads auth purely from context
 // variables, so a per-test middleware that sets exactly the desired posture is
@@ -433,6 +438,32 @@ describe("vault approval gates (real /approve path)", () => {
 
   it("replays parsed and blind Solana approvals with their durably bound signing modes", async () => {
     const app = await makeApp({ authType: "session-jwt", role: "owner", mfa: true });
+    const parsed = deriveSolanaPolicyFields(parseSolanaTransaction(PARSED_SOLANA_APPROVAL));
+    const parsedEffects = {
+      movesNativeSol: parsed.movesNativeSol,
+      programIds: parsed.programIds,
+      tokenTransfers: parsed.summary.tokenTransfers.map((transfer) => ({
+        mint: transfer.mint,
+        destination: transfer.destination,
+        amount: transfer.amount,
+      })),
+    };
+    const parsedRequestDigest = createHash("sha256")
+      .update(
+        canonicalJsonStringify({
+          route: "sign-solana",
+          tenantId: TENANT_ID,
+          agentId: AGENT_SOLANA,
+          chainId: 101,
+          broadcast: true,
+          signingMode: "parsed",
+          to: SOLANA_RECIPIENT,
+          value: "301",
+          messageDigest: normalizedSolanaMessageDigest(PARSED_SOLANA_APPROVAL),
+          parsedEffects,
+        }),
+      )
+      .digest("hex");
     for (const mode of ["parsed", "blind"] as const) {
       const txId = `tx-solana-${mode}-approval`;
       await getDb()
@@ -443,7 +474,7 @@ describe("vault approval gates (real /approve path)", () => {
           status: "pending",
           toAddress: SOLANA_RECIPIENT,
           value: mode === "parsed" ? "301" : "302",
-          data: `serialized-${mode}-solana-approval`,
+          data: mode === "parsed" ? PARSED_SOLANA_APPROVAL : "serialized-blind-solana-approval",
           chainId: 101,
           actionType: "solana_transaction",
           actionPayload: {
@@ -453,11 +484,8 @@ describe("vault approval gates (real /approve path)", () => {
             broadcast: true,
             signingMode: mode,
             blindSigned: mode === "blind",
-            parsedEffects:
-              mode === "parsed"
-                ? { movesNativeSol: false, programIds: ["memo-program"], tokenTransfers: [] }
-                : undefined,
-            requestDigest: `${mode}-request-digest`,
+            parsedEffects: mode === "parsed" ? parsedEffects : undefined,
+            requestDigest: mode === "parsed" ? parsedRequestDigest : "blind-request-digest",
           },
           policyResults: [],
         });
@@ -470,11 +498,48 @@ describe("vault approval gates (real /approve path)", () => {
           status: "pending",
         });
     }
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: "tx-solana-parsed-tampered-approval",
+        agentId: AGENT_SOLANA,
+        status: "pending",
+        toAddress: SOLANA_RECIPIENT,
+        value: "301",
+        data: PARSED_SOLANA_APPROVAL,
+        chainId: 101,
+        actionType: "solana_transaction",
+        actionPayload: {
+          type: "solana_transaction",
+          recoveryType: "solana_transaction",
+          recoveryActionType: "solana_transaction",
+          broadcast: true,
+          signingMode: "parsed",
+          blindSigned: false,
+          parsedEffects: { ...parsedEffects, movesNativeSol: false },
+          requestDigest: parsedRequestDigest,
+        },
+        policyResults: [],
+      });
+    await getDb().insert(approvalQueue).values({
+      id: "aq-tx-solana-parsed-tampered-approval",
+      txId: "tx-solana-parsed-tampered-approval",
+      agentId: AGENT_SOLANA,
+      status: "pending",
+    });
 
-    const seen: Array<{ transaction: string; allowBlindSign?: boolean }> = [];
+    const seen: Array<{
+      transaction: string;
+      allowBlindSign?: boolean;
+      allowParsedSign?: boolean;
+    }> = [];
     const sign = spyOn(Vault.prototype, "signSolanaTransaction").mockImplementation(
       async (request) => {
-        seen.push({ transaction: request.transaction, allowBlindSign: request.allowBlindSign });
+        seen.push({
+          transaction: request.transaction,
+          allowBlindSign: request.allowBlindSign,
+          allowParsedSign: request.allowParsedSign,
+        });
         const signature =
           "4oL4p7QvN3UH7V5wMGZgW5PuzEk4A9LXLHk9RxAoKjDKuLbQBsfXN8kEvKfj5K1oEJa8wFF6RVp2h7pP9w2f51ZV";
         await request.onBroadcastPrepared?.({
@@ -487,8 +552,11 @@ describe("vault approval gates (real /approve path)", () => {
     try {
       expect((await approve(app, AGENT_SOLANA, "tx-solana-parsed-approval")).status).toBe(200);
       expect((await approve(app, AGENT_SOLANA, "tx-solana-blind-approval")).status).toBe(200);
+      expect((await approve(app, AGENT_SOLANA, "tx-solana-parsed-tampered-approval")).status).toBe(
+        409,
+      );
       expect(seen).toEqual([
-        { transaction: "serialized-parsed-solana-approval", allowBlindSign: true },
+        { transaction: PARSED_SOLANA_APPROVAL, allowParsedSign: true },
         { transaction: "serialized-blind-solana-approval", allowBlindSign: true },
       ]);
       const rows = await getDb()
@@ -503,7 +571,9 @@ describe("vault approval gates (real /approve path)", () => {
             id: "tx-solana-parsed-approval",
             actionPayload: expect.objectContaining({
               signingMode: "parsed",
-              parsedEffects: expect.objectContaining({ programIds: ["memo-program"] }),
+              parsedEffects: expect.objectContaining({
+                programIds: ["11111111111111111111111111111111"],
+              }),
             }),
           }),
           expect.objectContaining({

--- a/packages/api/src/__tests__/vault-approval-gates.test.ts
+++ b/packages/api/src/__tests__/vault-approval-gates.test.ts
@@ -49,7 +49,7 @@ import {
   SolanaBroadcastNotSubmittedError,
   Vault,
 } from "@stwd/vault";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
 
@@ -428,6 +428,105 @@ describe("vault approval gates (real /approve path)", () => {
       expect(approval.status).toBe("approved");
     } finally {
       sign.mockRestore();
+    }
+  });
+
+  it("atomically rolls back fresh queue approval when the Solana claim faults and a new app can retry", async () => {
+    const txId = "tx-fresh-solana-claim-rollback";
+    const queueId = `aq-${txId}`;
+    const triggerFunction = "fail_fresh_solana_claim";
+    const triggerName = "fail_fresh_solana_claim";
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: txId,
+        agentId: AGENT_SOLANA,
+        status: "pending",
+        toAddress: SOLANA_RECIPIENT,
+        value: "125",
+        data: "serialized-fresh-solana-claim",
+        chainId: 101,
+        actionType: "transaction",
+        actionPayload: { type: "transaction", broadcast: true },
+        policyResults: [],
+      });
+    await getDb().insert(approvalQueue).values({
+      id: queueId,
+      txId,
+      agentId: AGENT_SOLANA,
+      status: "pending",
+    });
+    await getDb().execute(
+      sql.raw(`
+      create function ${triggerFunction}() returns trigger language plpgsql as $$
+      begin
+        if new.id = '${queueId}' and new.status = 'approved' then
+          raise exception 'forced fresh Solana approval claim failure';
+        end if;
+        return new;
+      end
+      $$
+    `),
+    );
+    await getDb().execute(
+      sql.raw(`
+      create trigger ${triggerName}
+      after update on approval_queue
+      for each row execute function ${triggerFunction}()
+    `),
+    );
+
+    const firstApp = await makeApp({ authType: "session-jwt", role: "owner", mfa: true });
+    let signCalls = 0;
+    const sign = spyOn(Vault.prototype, "signSolanaTransaction").mockImplementation(
+      async (request) => {
+        signCalls += 1;
+        await request.onBroadcastPrepared?.({
+          signature: SOLANA_SIGNATURE,
+          recentBlockhash: "11111111111111111111111111111111",
+        });
+        return { signature: SOLANA_SIGNATURE, broadcast: true, chainId: 101 };
+      },
+    );
+    try {
+      const failed = await approve(firstApp, AGENT_SOLANA, txId);
+      expect(failed.status).toBe(500);
+      expect(signCalls).toBe(0);
+      const [failedTransaction] = await getDb()
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, txId));
+      const [failedQueue] = await getDb()
+        .select()
+        .from(approvalQueue)
+        .where(eq(approvalQueue.id, queueId));
+      expect(failedTransaction).toMatchObject({ status: "pending" });
+      expect(failedTransaction.actionPayload).toEqual({ type: "transaction", broadcast: true });
+      expect(failedQueue).toMatchObject({ status: "pending", resolvedById: null });
+
+      await getDb().execute(sql.raw(`drop trigger ${triggerName} on approval_queue`));
+      await getDb().execute(sql.raw(`drop function ${triggerFunction}()`));
+      const restartedApp = await makeApp({ authType: "session-jwt", role: "owner", mfa: true });
+      const retried = await approve(restartedApp, AGENT_SOLANA, txId);
+      expect(retried.status).toBe(200);
+      expect(signCalls).toBe(1);
+      const [completedTransaction] = await getDb()
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, txId));
+      const [completedQueue] = await getDb()
+        .select()
+        .from(approvalQueue)
+        .where(eq(approvalQueue.id, queueId));
+      expect(completedTransaction).toMatchObject({
+        status: "broadcast",
+        txHash: SOLANA_SIGNATURE,
+      });
+      expect(completedQueue).toMatchObject({ status: "approved", resolvedById: ACTOR_ID });
+    } finally {
+      sign.mockRestore();
+      await getDb().execute(sql.raw(`drop trigger if exists ${triggerName} on approval_queue`));
+      await getDb().execute(sql.raw(`drop function if exists ${triggerFunction}()`));
     }
   });
 

--- a/packages/api/src/__tests__/vault-approval-gates.test.ts
+++ b/packages/api/src/__tests__/vault-approval-gates.test.ts
@@ -65,6 +65,7 @@ import { getConfiguredVault } from "../services/vault-factory";
 const TENANT_ID = `approval-gate-tenant-${Date.now()}`;
 const ACTOR_ID = "00000000-0000-4000-8000-000000000001";
 const REMOVED_ACTOR_ID = "00000000-0000-4000-8000-000000000002";
+const TAKEOVER_ACTOR_ID = "00000000-0000-4000-8000-000000000003";
 // Recipient the pending transactions pay; "code" is irrelevant here because the
 // approve path re-evaluates POLICY (not the native-transfer eth_getCode guard).
 const RECIPIENT = "0x1234567890123456789012345678901234567890";
@@ -298,12 +299,14 @@ describe("vault approval gates (real /approve path)", () => {
       .values([
         { id: ACTOR_ID, email: "approval-gate-owner@example.test" },
         { id: REMOVED_ACTOR_ID, email: "approval-gate-removed@example.test" },
+        { id: TAKEOVER_ACTOR_ID, email: "approval-gate-takeover@example.test" },
       ]);
     await getDb()
       .insert(userTenants)
       .values([
         { userId: ACTOR_ID, tenantId: TENANT_ID, role: "owner" },
         { userId: REMOVED_ACTOR_ID, tenantId: TENANT_ID, role: "owner" },
+        { userId: TAKEOVER_ACTOR_ID, tenantId: TENANT_ID, role: "admin" },
       ]);
 
     // Reject scenario: the agent's ONLY allowlisted address is some OTHER address,
@@ -503,9 +506,60 @@ describe("vault approval gates (real /approve path)", () => {
     }
   });
 
-  it("blocks a live approved owner then CAS-takes over its expired pre-checkpoint lease once", async () => {
+  it("consumes a durable claim before the primary raw Solana signer", async () => {
     const app = await makeApp({ authType: "session-jwt", role: "owner", mfa: true });
-    const live = await approve(app, AGENT_SOLANA, "tx-crashed-approved-solana");
+    let rawSignCalls = 0;
+    const sign = spyOn(Vault.prototype, "signTransaction").mockImplementation(async () => {
+      rawSignCalls += 1;
+      const [claimed] = await getDb()
+        .select()
+        .from(transactions)
+        .where(and(eq(transactions.agentId, AGENT_SOLANA), eq(transactions.status, "approved")))
+        .limit(1);
+      expect(claimed?.actionPayload).toMatchObject({
+        recoveryType: "solana_transaction",
+        executionToken: expect.any(String),
+        executionDigest: expect.any(String),
+      });
+      await getDb()
+        .update(transactions)
+        .set({ status: "signed", signedAt: new Date() })
+        .where(eq(transactions.id, claimed.id));
+      return "signed-solana-primary-route";
+    });
+    try {
+      const response = await app.request(`/vault/${AGENT_SOLANA}/sign`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          to: SOLANA_RECIPIENT,
+          value: "100",
+          chainId: 101,
+          broadcast: false,
+        }),
+      });
+      const responseBody = await response.json();
+      expect({ status: response.status, body: responseBody }).toMatchObject({
+        status: 200,
+        body: {
+          ok: true,
+          data: { signedTx: "signed-solana-primary-route" },
+        },
+      });
+      expect(rawSignCalls).toBe(1);
+    } finally {
+      sign.mockRestore();
+    }
+  });
+
+  it("blocks a live approved owner then CAS-takes over its expired pre-checkpoint lease once", async () => {
+    const takeoverAdmin = await makeApp({
+      authType: "session-jwt",
+      role: "admin",
+      mfa: true,
+      userId: TAKEOVER_ACTOR_ID,
+    });
+    const live = await approve(takeoverAdmin, AGENT_SOLANA, "tx-crashed-approved-solana");
     expect(live.status).toBe(409);
     expect(await live.json()).toMatchObject({
       ok: false,
@@ -550,9 +604,9 @@ describe("vault approval gates (real /approve path)", () => {
       },
     );
     try {
-      const winnerPromise = approve(app, AGENT_SOLANA, "tx-crashed-approved-solana");
+      const winnerPromise = approve(takeoverAdmin, AGENT_SOLANA, "tx-crashed-approved-solana");
       await winnerStarted;
-      const concurrentPromise = approve(app, AGENT_SOLANA, "tx-crashed-approved-solana");
+      const concurrentPromise = approve(takeoverAdmin, AGENT_SOLANA, "tx-crashed-approved-solana");
       await Bun.sleep(10);
       expect(signCalls).toBe(1);
       expect(submitted).toBe(0);
@@ -572,6 +626,14 @@ describe("vault approval gates (real /approve path)", () => {
       expect(row.actionPayload).toMatchObject({
         executionToken: expect.not.stringMatching(/^crashed-owner$/),
         recentBlockhash: "11111111111111111111111111111111",
+      });
+      const [approval] = await getDb()
+        .select()
+        .from(approvalQueue)
+        .where(eq(approvalQueue.txId, "tx-crashed-approved-solana"));
+      expect(approval).toMatchObject({
+        resolvedByType: "user",
+        resolvedById: TAKEOVER_ACTOR_ID,
       });
     } finally {
       releaseWinner();

--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -27,7 +27,7 @@ import {
   externalCustodyIdentityDigest,
   Vault,
 } from "@stwd/vault";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
 import { executionPayloadDigestForEvmSign } from "../services/execution-authorization";
@@ -161,23 +161,24 @@ describe("vault EVM execution gateway", () => {
     }
   });
 
-  it("preserves the legacy Solana sign path without minting an EVM authorization", async () => {
+  it("governs the Solana sign path without minting an EVM authorization", async () => {
     const beforeRows = await getDb().select().from(executionAuthorizationNonces);
     const signSpy = spyOn(Vault.prototype, "signTransaction").mockImplementation(
-      async (request, options) => {
+      async (_request, options) => {
+        const [claimed] = await getDb()
+          .select()
+          .from(transactions)
+          .where(and(eq(transactions.agentId, AGENT_ID), eq(transactions.status, "approved")))
+          .limit(1);
+        expect(claimed?.actionPayload).toMatchObject({
+          recoveryType: "solana_transaction",
+          executionToken: expect.any(String),
+          executionDigest: expect.any(String),
+        });
         await getDb()
-          .insert(transactions)
-          .values({
-            id: options.txId,
-            agentId: request.agentId,
-            status: "signed",
-            toAddress: request.to,
-            value: request.value,
-            data: request.data,
-            chainId: request.chainId,
-            actionPayload: { type: "transaction", broadcast: false },
-            policyResults: options.policyResults ?? [],
-          });
+          .update(transactions)
+          .set({ status: "signed", signedAt: new Date() })
+          .where(eq(transactions.id, options.txId));
         return "solana-signed";
       },
     );

--- a/packages/api/src/__tests__/vault-unsafe-signing-hardening.test.ts
+++ b/packages/api/src/__tests__/vault-unsafe-signing-hardening.test.ts
@@ -128,7 +128,7 @@ describe("vault unsafe signing hardening", () => {
     const routeBody = vaultSource.slice(routeStart, routeEnd);
     const guard = routeBody.indexOf("nativeTransferGasAccountingGuard");
     const policyEvaluation = routeBody.indexOf("policyEngine.evaluate");
-    const signCall = routeBody.indexOf("vault.signTransaction(signRequest");
+    const signCall = routeBody.indexOf(".signTransactionAuthorized(signRequest");
 
     expect(guard).toBeGreaterThanOrEqual(0);
     expect(policyEvaluation).toBeGreaterThan(guard);

--- a/packages/api/src/__tests__/wallet-actions.test.ts
+++ b/packages/api/src/__tests__/wallet-actions.test.ts
@@ -753,7 +753,7 @@ describe("wallet transfer actions", () => {
       });
       throw new ExternalBroadcastOutcomeUnknownError(signature);
     };
-    const request = (value = "123", referenceId = "durable-spl-reference") =>
+    const request = (value = "123", referenceId?: string) =>
       app.request(`/vault/${SOLANA_AGENT_ID}/actions/transfer`, {
         method: "POST",
         headers: { "content-type": "application/json", "Idempotency-Key": "durable-spl" },
@@ -775,6 +775,10 @@ describe("wallet transfer actions", () => {
         ok: false,
         data: { txHash: signature, reconciliationRequired: true },
       });
+      await getDb()
+        .update(policies)
+        .set({ enabled: false })
+        .where(eq(policies.agentId, SOLANA_AGENT_ID));
       const replay = await request();
       expect(replay.status).toBe(202);
       expect(signCalls).toBe(1);
@@ -798,6 +802,10 @@ describe("wallet transfer actions", () => {
         recentBlockhash: "11111111111111111111111111111111",
       });
     } finally {
+      await getDb()
+        .update(policies)
+        .set({ enabled: true })
+        .where(eq(policies.agentId, SOLANA_AGENT_ID));
       context.vault.buildSolanaSplTransferTransaction = originalBuild;
       context.vault.signSolanaTransaction = originalSign;
     }

--- a/packages/api/src/__tests__/wallet-actions.test.ts
+++ b/packages/api/src/__tests__/wallet-actions.test.ts
@@ -753,7 +753,7 @@ describe("wallet transfer actions", () => {
       });
       throw new ExternalBroadcastOutcomeUnknownError(signature);
     };
-    const request = (value = "123") =>
+    const request = (value = "123", referenceId = "durable-spl-reference") =>
       app.request(`/vault/${SOLANA_AGENT_ID}/actions/transfer`, {
         method: "POST",
         headers: { "content-type": "application/json", "Idempotency-Key": "durable-spl" },
@@ -763,6 +763,7 @@ describe("wallet transfer actions", () => {
           value,
           chainId: 101,
           broadcast: true,
+          referenceId,
         }),
       });
 
@@ -779,6 +780,8 @@ describe("wallet transfer actions", () => {
       expect(signCalls).toBe(1);
       const mismatch = await request("124");
       expect(mismatch.status).toBe(409);
+      const referenceMismatch = await request("123", "durable-spl-other-reference");
+      expect(referenceMismatch.status).toBe(409);
       expect(signCalls).toBe(1);
 
       const [row] = await getDb()

--- a/packages/api/src/__tests__/wallet-actions.test.ts
+++ b/packages/api/src/__tests__/wallet-actions.test.ts
@@ -20,6 +20,8 @@ const BLOCKED_SOLANA = "8J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg";
 const SOLANA_MINT = "So11111111111111111111111111111111111111112";
 const ORIGINAL_REDIS_URL = process.env.REDIS_URL;
 const ORIGINAL_REDIS_REQUIRED = process.env.REDIS_REQUIRED;
+const SERIALIZED_SPL_TRANSFER =
+  "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAIF6UPMZDHYTBaZ84s4PYnN/eY1HN26Qb0JbdXSFq+/tZZh2lmTgEh2HN5KGa6apfFlq4jJQUkI4Gb/A5au2FTWSwR4o/Pr5Ke0sw7ZpMZJP/G4jcxjJ16HXZc5252A2hpABpuIV/6rgYT7aH9jRhjANdrEOdwa6ztVmKDwAAAAAAEG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQQEAgMBAAoMewAAAAAAAAAJ";
 
 function expectedErc20TransferCalldata(recipient: string, amount: string) {
   return `0xa9059cbb${recipient.toLowerCase().replace(/^0x/, "").padStart(64, "0")}${BigInt(amount).toString(16).padStart(64, "0")}`;
@@ -650,7 +652,7 @@ describe("wallet transfer actions", () => {
       expect(request.value).toBe("123");
       expect(request.chainId).toBe(101);
       return {
-        transaction: "base64-spl-transfer-transaction",
+        transaction: SERIALIZED_SPL_TRANSFER,
         sourceTokenAccount: "source-token-account",
         destinationTokenAccount: "destination-token-account",
         mint: SOLANA_MINT,
@@ -661,7 +663,7 @@ describe("wallet transfer actions", () => {
     context.vault.signSolanaTransaction = async (request) => {
       expect(request.agentId).toBe(SOLANA_AGENT_ID);
       expect(request.tenantId).toBe(TENANT_ID);
-      expect(request.transaction).toBe("base64-spl-transfer-transaction");
+      expect(request.transaction).toBe(SERIALIZED_SPL_TRANSFER);
       expect(request.chainId).toBe(101);
       expect(request.broadcast).toBe(false);
       expect(request.expectedTo).toBeUndefined();
@@ -714,9 +716,9 @@ describe("wallet transfer actions", () => {
       expect(tx.status).toBe("signed");
       expect(tx.toAddress).toBe(ALLOWED_SOLANA);
       expect(tx.value).toBe("123");
-      expect(tx.data).toBe("base64-spl-transfer-transaction");
+      expect(tx.data).toBe(SERIALIZED_SPL_TRANSFER);
       expect(tx.chainId).toBe(101);
-      expect(tx.actionPayload).toEqual({
+      expect(tx.actionPayload).toMatchObject({
         type: "transfer",
         token: SOLANA_MINT,
         recipient: ALLOWED_SOLANA,
@@ -737,14 +739,28 @@ describe("wallet transfer actions", () => {
     const signature =
       "4oL4p7QvN3UH7V5wMGZgW5PuzEk4A9LXLHk9RxAoKjDKuLbQBsfXN8kEvKfj5K1oEJa8wFF6RVp2h7pP9w2f51ZV";
     let signCalls = 0;
-    context.vault.buildSolanaSplTransferTransaction = async () => ({
-      transaction: "base64-durable-spl-transfer",
-      sourceTokenAccount: "source-token-account",
-      destinationTokenAccount: "destination-token-account",
-      mint: SOLANA_MINT,
-      tokenProgram: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-      decimals: 9,
+    let buildCalls = 0;
+    let signalBuildStarted!: () => void;
+    let releaseBuild!: () => void;
+    const buildStarted = new Promise<void>((resolve) => {
+      signalBuildStarted = resolve;
     });
+    const buildRelease = new Promise<void>((resolve) => {
+      releaseBuild = resolve;
+    });
+    context.vault.buildSolanaSplTransferTransaction = async () => {
+      buildCalls += 1;
+      signalBuildStarted();
+      await buildRelease;
+      return {
+        transaction: SERIALIZED_SPL_TRANSFER,
+        sourceTokenAccount: "source-token-account",
+        destinationTokenAccount: "destination-token-account",
+        mint: SOLANA_MINT,
+        tokenProgram: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+        decimals: 9,
+      };
+    };
     context.vault.signSolanaTransaction = async (request) => {
       signCalls += 1;
       await request.onBroadcastPrepared?.({
@@ -753,7 +769,7 @@ describe("wallet transfer actions", () => {
       });
       throw new ExternalBroadcastOutcomeUnknownError(signature);
     };
-    const request = (value = "123", referenceId?: string) =>
+    const request = (value = "123", referenceId?: string, sponsor = false) =>
       app.request(`/vault/${SOLANA_AGENT_ID}/actions/transfer`, {
         method: "POST",
         headers: { "content-type": "application/json", "Idempotency-Key": "durable-spl" },
@@ -764,13 +780,21 @@ describe("wallet transfer actions", () => {
           chainId: 101,
           broadcast: true,
           referenceId,
+          sponsor,
         }),
       });
 
     try {
-      const first = await request();
+      const firstPromise = request();
+      await buildStarted;
+      const concurrentReplayPromise = request();
+      await Bun.sleep(25);
+      expect(buildCalls).toBe(1);
+      releaseBuild();
+      const [first, concurrentReplay] = await Promise.all([firstPromise, concurrentReplayPromise]);
       const firstBody = await first.json();
       expect(first.status, JSON.stringify(firstBody)).toBe(202);
+      expect(concurrentReplay.status).toBe(202);
       expect(firstBody).toMatchObject({
         ok: false,
         data: { txHash: signature, reconciliationRequired: true },
@@ -782,11 +806,15 @@ describe("wallet transfer actions", () => {
       const replay = await request();
       expect(replay.status).toBe(202);
       expect(signCalls).toBe(1);
+      expect(buildCalls).toBe(1);
       const mismatch = await request("124");
       expect(mismatch.status).toBe(409);
       const referenceMismatch = await request("123", "durable-spl-other-reference");
       expect(referenceMismatch.status).toBe(409);
+      const sponsorshipMismatch = await request("123", undefined, true);
+      expect(sponsorshipMismatch.status).toBe(409);
       expect(signCalls).toBe(1);
+      expect(buildCalls).toBe(1);
 
       const [row] = await getDb()
         .select()
@@ -866,7 +894,7 @@ describe("wallet transfer actions", () => {
     const originalSignSolanaTransaction = context.vault.signSolanaTransaction.bind(context.vault);
 
     context.vault.buildSolanaSplTransferTransaction = async () => ({
-      transaction: "base64-spl-transfer-transaction-without-mint-policy",
+      transaction: SERIALIZED_SPL_TRANSFER,
       sourceTokenAccount: "source-token-account",
       destinationTokenAccount: "destination-token-account",
       mint: SOLANA_MINT,

--- a/packages/api/src/__tests__/wallet-actions.test.ts
+++ b/packages/api/src/__tests__/wallet-actions.test.ts
@@ -839,6 +839,83 @@ describe("wallet transfer actions", () => {
     }
   });
 
+  it("replays pending and rejected Solana transfers before mutable gates", async () => {
+    const context = await import("../services/context");
+    const originalBuild = context.vault.buildSolanaSplTransferTransaction.bind(context.vault);
+    const originalSign = context.vault.signSolanaTransaction.bind(context.vault);
+    let buildCalls = 0;
+    context.vault.buildSolanaSplTransferTransaction = async () => {
+      buildCalls += 1;
+      return {
+        transaction: SERIALIZED_SPL_TRANSFER,
+        sourceTokenAccount: "source-token-account",
+        destinationTokenAccount: "destination-token-account",
+        mint: SOLANA_MINT,
+        tokenProgram: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+        decimals: 9,
+      };
+    };
+    context.vault.signSolanaTransaction = async () => {
+      throw new Error("pending/rejected Solana transfer must not reach signing");
+    };
+    const request = (agentId: string, key: string, value = "123") =>
+      app.request(`/vault/${agentId}/actions/transfer`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "Idempotency-Key": key },
+        body: JSON.stringify({
+          to: ALLOWED_SOLANA,
+          token: SOLANA_MINT,
+          value,
+          chainId: 101,
+          broadcast: true,
+        }),
+      });
+
+    try {
+      await getDb()
+        .update(policies)
+        .set({ config: { threshold: "1" } })
+        .where(eq(policies.id, "solana-auto-approve-threshold"));
+      expect((await request(SOLANA_AGENT_ID, "pending-solana-transfer")).status).toBe(202);
+      await getDb()
+        .update(policies)
+        .set({ enabled: false })
+        .where(eq(policies.agentId, SOLANA_AGENT_ID));
+      expect((await request(SOLANA_AGENT_ID, "pending-solana-transfer")).status).toBe(202);
+      expect((await request(SOLANA_AGENT_ID, "pending-solana-transfer", "124")).status).toBe(409);
+
+      expect((await request(SOLANA_AGENT_WITHOUT_MINT_ID, "rejected-solana-transfer")).status).toBe(
+        403,
+      );
+      await getDb()
+        .update(policies)
+        .set({ enabled: false })
+        .where(eq(policies.agentId, SOLANA_AGENT_WITHOUT_MINT_ID));
+      expect((await request(SOLANA_AGENT_WITHOUT_MINT_ID, "rejected-solana-transfer")).status).toBe(
+        403,
+      );
+      expect(
+        (await request(SOLANA_AGENT_WITHOUT_MINT_ID, "rejected-solana-transfer", "124")).status,
+      ).toBe(409);
+      expect(buildCalls).toBe(2);
+    } finally {
+      await getDb()
+        .update(policies)
+        .set({ enabled: true })
+        .where(eq(policies.agentId, SOLANA_AGENT_ID));
+      await getDb()
+        .update(policies)
+        .set({ config: { threshold: "999" } })
+        .where(eq(policies.id, "solana-auto-approve-threshold"));
+      await getDb()
+        .update(policies)
+        .set({ enabled: true })
+        .where(eq(policies.agentId, SOLANA_AGENT_WITHOUT_MINT_ID));
+      context.vault.buildSolanaSplTransferTransaction = originalBuild;
+      context.vault.signSolanaTransaction = originalSign;
+    }
+  });
+
   it("checkpoints native SOL before its lower-level broadcast and preserves the route payload", async () => {
     const context = await import("../services/context");
     const originalSign = context.vault.signTransaction.bind(context.vault);

--- a/packages/api/src/middleware/redis-enforcement.ts
+++ b/packages/api/src/middleware/redis-enforcement.ts
@@ -228,6 +228,8 @@ export async function recordVaultSpend(
     eventId?: string;
     occurredAt?: Date | number;
     throwOnError?: boolean;
+    /** SPL/token mint. When present, native-price fallback is forbidden. */
+    tokenAddress?: string;
   } = {},
 ): Promise<void> {
   if (!isRedisAvailable()) {
@@ -253,10 +255,24 @@ export async function recordVaultSpend(
 
   // Convert native wei → USD using the oracle. weiToUsd does bigint-safe scaling
   // (no Number(BigInt) precision loss) and applies the per-chain native price.
-  const usdValue = await priceOracle.weiToUsd(valueWei, chainId);
+  const tokenAddress =
+    options.tokenAddress && options.tokenAddress !== "native" ? options.tokenAddress : undefined;
+  const usdValue = await priceOracle.weiToUsd(valueWei, chainId, tokenAddress);
 
   if (usdValue !== null && usdValue > 0) {
     await recordAgentSpend(agentId, tenantId, usdValue, `chain:${chainId}`, options);
+    return;
+  }
+
+  // A native conservative-price floor cannot value SPL base units: decimals
+  // and market price are mint-specific. Keep the durable recovery effect
+  // pending so a retry can succeed after oracle support/availability returns.
+  if (tokenAddress) {
+    if (options.throwOnError) {
+      throw new Error(
+        `exact token valuation unavailable for chain ${chainId} token ${tokenAddress}`,
+      );
+    }
     return;
   }
 

--- a/packages/api/src/middleware/redis-enforcement.ts
+++ b/packages/api/src/middleware/redis-enforcement.ts
@@ -121,6 +121,17 @@ export function nativePriceFallbackUsd(): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 10_000;
 }
 
+export function conservativeNativeSpendUsd(valueBaseUnits: bigint, chainId: number): number {
+  const decimals = getNativeDecimalsStrict(chainId);
+  if (decimals === null) {
+    throw new Error(`Native-token decimals are not configured for chain ${chainId}`);
+  }
+  const divisor = 10n ** BigInt(decimals);
+  const tokenAmount =
+    Number(valueBaseUnits / divisor) + Number(valueBaseUnits % divisor) / Number(divisor);
+  return tokenAmount * nativePriceFallbackUsd();
+}
+
 /**
  * Run Redis-backed rate limit checks before signing.
  *
@@ -255,14 +266,12 @@ export async function recordVaultSpend(
   // the spend with a deliberately HIGH conservative native-price floor so the spend still
   // counts against the same `chain:${chainId}` USD cap and can trip it. Over-counting during
   // an oracle outage is the safe direction; the priced path above is unaffected.
-  const decimals = getNativeDecimalsStrict(chainId);
-  if (decimals === null) {
-    if (options.throwOnError) throw new Error(`unknown native decimals for chain ${chainId}`);
+  let conservativeUsd: number;
+  try {
+    conservativeUsd = conservativeNativeSpendUsd(wei, chainId);
+  } catch (error) {
+    if (options.throwOnError) throw error;
     return;
   }
-  const divisor = 10n ** BigInt(decimals);
-  const tokenAmount = Number(wei / divisor) + Number(wei % divisor) / Number(divisor);
-  const fallbackNativePriceUsd = nativePriceFallbackUsd();
-  const conservativeUsd = tokenAmount * fallbackNativePriceUsd;
   await recordAgentSpend(agentId, tenantId, conservativeUsd, `chain:${chainId}`, options);
 }

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -3747,7 +3747,10 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
         if (!signRequest.data) {
           throw new Error("SPL transfer transaction was not built");
         }
-        if (!solanaExecutionToken)
+        // Sponsored actions are pre-staged before the durable reservation so
+        // sponsored_gas_events can satisfy its transaction FK. Reuse that row
+        // for SPL execution instead of inserting the same action id twice.
+        if (!solanaRecoveryBinding && !sponsoredTransferStaged)
           await db.insert(transactions).values({
             id: actionId,
             agentId,

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -3453,6 +3453,14 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
         sponsorship: sponsorshipPayload,
       }),
       ...(parsedSolanaTransferApproval ?? {}),
+      ...(solanaRecoveryBinding
+        ? {
+            recoveryType: "solana_transaction",
+            recoveryActionType: "transfer",
+            idempotencyKeyDigest: solanaRecoveryBinding.idempotencyKeyDigest,
+            requestDigest: solanaRecoveryBinding.requestDigest,
+          }
+        : {}),
     };
     const policySet = await getScopedPolicySet(tenantId, agentId, c.get("agentPolicyIds"));
     const conditionSets = await loadConditionSetsForPolicies(tenantId, policySet);
@@ -3719,7 +3727,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           // SEC-163: SPL token transfers carry no vault-layer envelope (the
           // byte-level check only models native SOL transfers); the edge
           // policy evaluation above approved this transfer.
-          allowBlindSign: true,
+          allowParsedSign: true,
           ...(solanaExecutionToken
             ? {
                 onBroadcastPrepared: (checkpoint) =>
@@ -4158,6 +4166,15 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         ok: false,
         error:
           "This pending Solana approval predates signing-mode binding and cannot be replayed. Resubmit the transaction.",
+      },
+      409,
+    );
+  }
+  if (isQueuedSolanaSplTransfer && queuedSolanaSigningMode !== "parsed") {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "Approved SPL transfers require a parsed signing-mode binding",
       },
       409,
     );
@@ -9089,6 +9106,29 @@ function solanaTransferReplayResponse(
   c: Context<{ Variables: AppVariables }>,
   row: SolanaRecoveryRow,
 ): Response {
+  if (row.status === "pending") {
+    return c.json<ApiResponse>(
+      {
+        ok: true,
+        data: transferActionResponseFromTransaction(
+          row as unknown as typeof transactions.$inferSelect,
+        ),
+      },
+      202,
+    );
+  }
+  if (row.status === "rejected") {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "Transfer rejected by policy",
+        data: transferActionResponseFromTransaction(
+          row as unknown as typeof transactions.$inferSelect,
+        ),
+      },
+      403,
+    );
+  }
   if (row.status === "approved") {
     return c.json<ApiResponse>(
       {

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -4414,6 +4414,8 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         );
       }
 
+      const requiresSolanaExecutionClaim =
+        isSolana && (shouldBroadcast || transferPayload?.token === "native");
       const claimResult = isApprovedSolanaResume
         ? await db
             .select({ id: approvalQueue.id })
@@ -4426,23 +4428,35 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
               ),
             )
             .limit(1)
-        : await db
-            .update(approvalQueue)
-            .set({
-              status: "approved",
-              resolvedAt,
-              resolvedBy: `${approverPrincipal.type}:${approverPrincipal.id}`,
-              resolvedByType: approverPrincipal.type,
-              resolvedById: approverPrincipal.id,
-            })
-            .where(
-              and(
-                eq(approvalQueue.txId, txId),
-                eq(approvalQueue.agentId, agentId),
-                eq(approvalQueue.status, "pending"),
-              ),
-            )
-            .returning();
+        : requiresSolanaExecutionClaim
+          ? await db
+              .select({ id: approvalQueue.id })
+              .from(approvalQueue)
+              .where(
+                and(
+                  eq(approvalQueue.txId, txId),
+                  eq(approvalQueue.agentId, agentId),
+                  eq(approvalQueue.status, "pending"),
+                ),
+              )
+              .limit(1)
+          : await db
+              .update(approvalQueue)
+              .set({
+                status: "approved",
+                resolvedAt,
+                resolvedBy: `${approverPrincipal.type}:${approverPrincipal.id}`,
+                resolvedByType: approverPrincipal.type,
+                resolvedById: approverPrincipal.id,
+              })
+              .where(
+                and(
+                  eq(approvalQueue.txId, txId),
+                  eq(approvalQueue.agentId, agentId),
+                  eq(approvalQueue.status, "pending"),
+                ),
+              )
+              .returning();
 
       if (claimResult.length === 0) {
         return c.json<ApiResponse>(
@@ -4495,10 +4509,11 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           return c.json<ApiResponse>({ ok: false, error: reservationError }, 403);
         }
       }
-      if (isSolana && (shouldBroadcast || transferPayload?.token === "native")) {
+      if (requiresSolanaExecutionClaim) {
         const claimed = await claimApprovedSolanaExecution(transactionRow, {
           takeover: isApprovedSolanaResume,
           resolver: approverPrincipal,
+          approvePendingQueue: isFreshApproval ? { resolvedAt } : undefined,
         });
         approvedSolanaExecutionToken = claimed.executionToken;
         approvedSolanaActionPayload = claimed.actionPayload;
@@ -9032,7 +9047,11 @@ async function assertApprovedSolanaExecutionClaim(expected: {
 
 export async function claimApprovedSolanaExecution(
   row: typeof transactions.$inferSelect,
-  options: { takeover: boolean; resolver: ApprovalPrincipal },
+  options: {
+    takeover: boolean;
+    resolver: ApprovalPrincipal;
+    approvePendingQueue?: { resolvedAt: Date };
+  },
 ): Promise<{ executionToken: string; actionPayload: Record<string, unknown> }> {
   const prior = readSolanaRecoveryMetadata(row.actionPayload);
   const stableActionPayload = Object.fromEntries(
@@ -9148,6 +9167,25 @@ export async function claimApprovedSolanaExecution(
         )
         .returning({ id: approvalQueue.id });
       if (!transferred) throw new SolanaExecutionLeaseConflictError();
+    } else if (options.approvePendingQueue) {
+      const [approved] = await tx
+        .update(approvalQueue)
+        .set({
+          status: "approved",
+          resolvedAt: options.approvePendingQueue.resolvedAt,
+          resolvedBy: `${options.resolver.type}:${options.resolver.id}`,
+          resolvedByType: options.resolver.type,
+          resolvedById: options.resolver.id,
+        })
+        .where(
+          and(
+            eq(approvalQueue.txId, row.id),
+            eq(approvalQueue.agentId, row.agentId),
+            eq(approvalQueue.status, "pending"),
+          ),
+        )
+        .returning({ id: approvalQueue.id });
+      if (!approved) throw new SolanaExecutionLeaseConflictError();
     }
 
     return { executionToken, actionPayload };

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -3224,6 +3224,82 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
       400,
     );
   }
+  const idempotencyResponse = requireBroadcastActionIdempotency(
+    c,
+    transfer.broadcast,
+    "Broadcast transfer actions",
+  );
+  if (idempotencyResponse) return idempotencyResponse;
+  const solanaRecoveryBinding =
+    isSolanaActionChain(transfer.chainId) && transfer.broadcast
+      ? createSolanaTransferRecoveryBinding(c, {
+          tenantId,
+          agentId,
+          chainId: transfer.chainId,
+          to: transfer.to,
+          token: transfer.token,
+          value: transfer.value,
+          referenceId: transfer.referenceId,
+        })
+      : null;
+  const findExistingTransferAction = async () => {
+    const [byIdempotencyKey, byReferenceId] = await Promise.all([
+      solanaRecoveryBinding
+        ? db
+            .select()
+            .from(transactions)
+            .where(
+              and(
+                eq(transactions.id, solanaRecoveryBinding.txId),
+                eq(transactions.agentId, agentId),
+                eq(transactions.actionType, "transfer"),
+              ),
+            )
+            .limit(1)
+            .then((rows) => rows[0] ?? null)
+        : Promise.resolve(null),
+      findActionByReferenceId(agentId, "transfer", transfer.referenceId),
+    ]);
+    if (byIdempotencyKey && byReferenceId && byIdempotencyKey.id !== byReferenceId.id) {
+      return { conflict: true as const };
+    }
+    const existing = byIdempotencyKey ?? byReferenceId;
+    if (existing && solanaRecoveryBinding) {
+      const metadata = readSolanaRecoveryMetadata(existing.actionPayload);
+      if (
+        existing.id !== solanaRecoveryBinding.txId ||
+        metadata.idempotencyKeyDigest !== solanaRecoveryBinding.idempotencyKeyDigest ||
+        metadata.requestDigest !== solanaRecoveryBinding.requestDigest
+      ) {
+        return { conflict: true as const };
+      }
+    }
+    return { existing };
+  };
+  const existingLookup = await findExistingTransferAction();
+  if ("conflict" in existingLookup) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Idempotency-Key and referenceId identify different requests" },
+      409,
+    );
+  }
+  const existingAction = existingLookup.existing;
+  if (existingAction) {
+    if (solanaRecoveryBinding) {
+      return solanaLostOwnershipResponse(c, existingAction.id, agentId, "transfer");
+    }
+    return c.json<ApiResponse>({
+      ok: existingAction.status !== "rejected" && existingAction.status !== "failed",
+      error:
+        existingAction.status === "rejected"
+          ? "Transfer rejected by policy"
+          : existingAction.status === "failed"
+            ? "Transfer failed"
+            : undefined,
+      data: transferActionResponseFromTransaction(existingAction),
+    });
+  }
+
   const sponsorship = await resolveGasSponsorshipRequest({
     tenantId,
     agentId,
@@ -3248,53 +3324,6 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
       : transfer.sponsor
         ? { requested: true, sponsored: false }
         : undefined;
-  const idempotencyResponse = requireBroadcastActionIdempotency(
-    c,
-    transfer.broadcast,
-    "Broadcast transfer actions",
-  );
-  if (idempotencyResponse) return idempotencyResponse;
-  const solanaRecoveryBinding =
-    isSolanaActionChain(transfer.chainId) && transfer.broadcast
-      ? createSolanaTransferRecoveryBinding(c, {
-          tenantId,
-          agentId,
-          chainId: transfer.chainId,
-          to: transfer.to,
-          token: transfer.token,
-          value: transfer.value,
-          referenceId: transfer.referenceId,
-        })
-      : null;
-  const existingAction = await findActionByReferenceId(agentId, "transfer", transfer.referenceId);
-  if (existingAction) {
-    if (solanaRecoveryBinding) {
-      const metadata = readSolanaRecoveryMetadata(existingAction.actionPayload);
-      if (
-        metadata.idempotencyKeyDigest !== solanaRecoveryBinding.idempotencyKeyDigest ||
-        metadata.requestDigest !== solanaRecoveryBinding.requestDigest
-      ) {
-        return c.json<ApiResponse>(
-          {
-            ok: false,
-            error: "Idempotency-Key was already used for a different Solana transaction",
-          },
-          409,
-        );
-      }
-      return solanaLostOwnershipResponse(c, existingAction.id, agentId, "transfer");
-    }
-    return c.json<ApiResponse>({
-      ok: existingAction.status !== "rejected" && existingAction.status !== "failed",
-      error:
-        existingAction.status === "rejected"
-          ? "Transfer rejected by policy"
-          : existingAction.status === "failed"
-            ? "Transfer failed"
-            : undefined,
-      data: transferActionResponseFromTransaction(existingAction),
-    });
-  }
 
   const isTokenTransfer = transfer.token !== "native";
   const isSolanaTransfer = isSolanaActionChain(transfer.chainId);
@@ -3371,26 +3400,16 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
   }
 
   return withAgentSpendLock(agentId, async () => {
-    const lockedExistingAction = await findActionByReferenceId(
-      agentId,
-      "transfer",
-      transfer.referenceId,
-    );
+    const lockedLookup = await findExistingTransferAction();
+    if ("conflict" in lockedLookup) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Idempotency-Key and referenceId identify different requests" },
+        409,
+      );
+    }
+    const lockedExistingAction = lockedLookup.existing;
     if (lockedExistingAction) {
       if (solanaRecoveryBinding) {
-        const metadata = readSolanaRecoveryMetadata(lockedExistingAction.actionPayload);
-        if (
-          metadata.idempotencyKeyDigest !== solanaRecoveryBinding.idempotencyKeyDigest ||
-          metadata.requestDigest !== solanaRecoveryBinding.requestDigest
-        ) {
-          return c.json<ApiResponse>(
-            {
-              ok: false,
-              error: "Idempotency-Key was already used for a different Solana transaction",
-            },
-            409,
-          );
-        }
         return solanaLostOwnershipResponse(c, lockedExistingAction.id, agentId, "transfer");
       }
       return c.json<ApiResponse>({
@@ -4094,6 +4113,36 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       409,
     );
   }
+  if (isSolana && queuedSolanaSigningMode === "parsed") {
+    if (!transactionRow.data) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Approved parsed Solana transaction blob is unavailable" },
+        409,
+      );
+    }
+    try {
+      assertQueuedParsedSolanaIntent({
+        tenantId,
+        agentId,
+        transaction: transactionRow.data,
+        chainId: transactionRow.chainId,
+        toAddress: transactionRow.toAddress,
+        value: transactionRow.value,
+        metadata: approvalRecoveryMetadata,
+      });
+    } catch (error) {
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Approved parsed Solana transaction failed policy revalidation",
+        },
+        409,
+      );
+    }
+  }
   if (
     isSolana &&
     pendingApproval.status === "approved" &&
@@ -4637,9 +4686,11 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
             transaction: transactionRow.data,
             chainId: transactionRow.chainId,
             broadcast: shouldBroadcast,
-            ...(isSolanaTokenTransfer || queuedSolanaSigningMode !== null
-              ? { allowBlindSign: true }
-              : { expectedTo: transactionRow.toAddress, expectedValue: transactionRow.value }),
+            ...(isSolanaTokenTransfer || queuedSolanaSigningMode === "parsed"
+              ? { allowParsedSign: true }
+              : queuedSolanaSigningMode === "blind"
+                ? { allowBlindSign: true }
+                : { expectedTo: transactionRow.toAddress, expectedValue: transactionRow.value }),
             onBroadcastPrepared: checkpoint,
           });
           txHash = result.signature;
@@ -8663,6 +8714,48 @@ function solanaParsedEffects(
       amount: transfer.amount,
     })),
   };
+}
+
+function assertQueuedParsedSolanaIntent(input: {
+  tenantId: string;
+  agentId: string;
+  transaction: string;
+  chainId: number;
+  toAddress: string | null;
+  value: string | null;
+  metadata: Record<string, unknown>;
+}): void {
+  const summary = parseSolanaTransaction(input.transaction);
+  assertSolanaPriorityFeeWithinCap(summary);
+  const derived = deriveSolanaPolicyFields(summary);
+  if (!derived.fullyParsed || !input.toAddress || input.value === null) {
+    throw new SolanaExecutionLeaseConflictError(
+      "Approved parsed Solana transaction is no longer fully policy-verifiable",
+    );
+  }
+  const parsedEffects = solanaParsedEffects(derived);
+  const expectedDigest = solanaCallerIntentDigest({
+    route: "sign-solana",
+    tenantId: input.tenantId,
+    agentId: input.agentId,
+    chainId: input.chainId,
+    broadcast: input.metadata.broadcast !== false,
+    signingMode: "parsed",
+    to: input.toAddress,
+    value: input.value,
+    messageDigest: normalizedSolanaMessageDigest(input.transaction),
+    parsedEffects,
+  });
+  if (
+    input.metadata.blindSigned !== false ||
+    canonicalJsonStringify(input.metadata.parsedEffects) !==
+      canonicalJsonStringify(parsedEffects) ||
+    input.metadata.requestDigest !== expectedDigest
+  ) {
+    throw new SolanaExecutionLeaseConflictError(
+      "Approved parsed Solana transaction no longer matches its reviewed policy effects",
+    );
+  }
 }
 
 function createSolanaTransferRecoveryBinding(

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -1963,9 +1963,24 @@ async function requireSignerPermission(
   return { ok: true, auth: { authMode: "signer", signerId: signer.id } };
 }
 
+const pgliteAgentSpendQueues = new Map<string, Promise<void>>();
+
 async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
   if (process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true") {
-    return fn();
+    const predecessor = pgliteAgentSpendQueues.get(agentId) ?? Promise.resolve();
+    let release!: () => void;
+    const owned = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = predecessor.catch(() => undefined).then(() => owned);
+    pgliteAgentSpendQueues.set(agentId, tail);
+    await predecessor.catch(() => undefined);
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (pgliteAgentSpendQueues.get(agentId) === tail) pgliteAgentSpendQueues.delete(agentId);
+    }
   }
   return db.transaction(async (tx) => {
     await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${agentId}, 0))`);
@@ -3240,6 +3255,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           token: transfer.token,
           value: transfer.value,
           referenceId: transfer.referenceId,
+          sponsor: transfer.sponsor,
         })
       : null;
   const findExistingTransferAction = async () => {
@@ -3300,105 +3316,6 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
     });
   }
 
-  const sponsorship = await resolveGasSponsorshipRequest({
-    tenantId,
-    agentId,
-    chainId: transfer.chainId,
-    caip2: toCaip2(transfer.chainId),
-    sponsor: transfer.sponsor,
-  });
-  if (sponsorship.requested && !sponsorship.sponsored) {
-    const status: 403 | 501 | 503 =
-      sponsorship.status === 501 ? 501 : sponsorship.status === 503 ? 503 : 403;
-    return c.json<ApiResponse>({ ok: false, error: sponsorship.error }, status);
-  }
-  const sponsorshipPayload =
-    sponsorship.requested && sponsorship.sponsored
-      ? {
-          requested: true,
-          sponsored: true,
-          provider: sponsorship.provider,
-          mode: sponsorship.mode,
-          estimatedUsd: sponsorship.estimatedUsd,
-        }
-      : transfer.sponsor
-        ? { requested: true, sponsored: false }
-        : undefined;
-
-  const isTokenTransfer = transfer.token !== "native";
-  const isSolanaTransfer = isSolanaActionChain(transfer.chainId);
-  const isSolanaTokenTransfer = isSolanaTransfer && isTokenTransfer;
-  let solanaTokenTransaction:
-    | Awaited<ReturnType<typeof vault.buildSolanaSplTransferTransaction>>
-    | undefined;
-  if (!isTokenTransfer) {
-    const gasGuard = await nativeTransferGasAccountingGuard(
-      c,
-      transfer.to,
-      transfer.chainId,
-      undefined,
-    );
-    if (gasGuard) return gasGuard;
-  } else if (isSolanaTokenTransfer) {
-    try {
-      solanaTokenTransaction = await vault.buildSolanaSplTransferTransaction({
-        tenantId,
-        agentId,
-        to: transfer.to,
-        token: transfer.token,
-        value: transfer.value,
-        chainId: transfer.chainId,
-      });
-    } catch (error) {
-      return c.json<ApiResponse>(
-        { ok: false, error: sanitizeErrorMessage(error) || "Failed to build SPL transfer" },
-        422,
-      );
-    }
-  }
-  const signRequest: SignRequest = {
-    tenantId,
-    agentId,
-    to: isTokenTransfer && !isSolanaTokenTransfer ? transfer.token : transfer.to,
-    value: isTokenTransfer && !isSolanaTokenTransfer ? "0" : transfer.value,
-    data: isTokenTransfer
-      ? isSolanaTokenTransfer
-        ? solanaTokenTransaction?.transaction
-        : encodeErc20TransferCalldata(transfer.to, transfer.value)
-      : undefined,
-    chainId: transfer.chainId,
-    gasLimit: isTokenTransfer && !isSolanaTokenTransfer ? "65000" : undefined,
-    broadcast: transfer.broadcast,
-  };
-  const baseTransferActionPayload = transferActionPayload({
-    token: transfer.token,
-    recipient: transfer.to,
-    amount: transfer.value,
-    broadcast: transfer.broadcast,
-    referenceId: transfer.referenceId,
-    sponsorship: sponsorshipPayload,
-  });
-  const policySet = await getScopedPolicySet(tenantId, agentId, c.get("agentPolicyIds"));
-  const conditionSets = await loadConditionSetsForPolicies(tenantId, policySet);
-
-  const rateLimitResult = await enforceRateLimit(agentId, policySet);
-  if (!rateLimitResult.allowed) {
-    if (rateLimitResult.headers) {
-      for (const [key, value] of Object.entries(rateLimitResult.headers)) {
-        c.header(key, value);
-      }
-    }
-    return c.json<ApiResponse>(
-      { ok: false, error: rateLimitResult.reason || "Rate limit exceeded" },
-      429,
-    );
-  }
-  if (rateLimitResult.headers) {
-    for (const [key, value] of Object.entries(rateLimitResult.headers)) {
-      c.header(key, value);
-    }
-  }
-
   return withAgentSpendLock(agentId, async () => {
     const lockedLookup = await findExistingTransferAction();
     if ("conflict" in lockedLookup) {
@@ -3422,6 +3339,140 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
               : undefined,
         data: transferActionResponseFromTransaction(lockedExistingAction),
       });
+    }
+
+    const sponsorship = await resolveGasSponsorshipRequest({
+      tenantId,
+      agentId,
+      chainId: transfer.chainId,
+      caip2: toCaip2(transfer.chainId),
+      sponsor: transfer.sponsor,
+    });
+    if (sponsorship.requested && !sponsorship.sponsored) {
+      const status: 403 | 501 | 503 =
+        sponsorship.status === 501 ? 501 : sponsorship.status === 503 ? 503 : 403;
+      return c.json<ApiResponse>({ ok: false, error: sponsorship.error }, status);
+    }
+    const sponsorshipPayload =
+      sponsorship.requested && sponsorship.sponsored
+        ? {
+            requested: true,
+            sponsored: true,
+            provider: sponsorship.provider,
+            mode: sponsorship.mode,
+            estimatedUsd: sponsorship.estimatedUsd,
+          }
+        : transfer.sponsor
+          ? { requested: true, sponsored: false }
+          : undefined;
+
+    const isTokenTransfer = transfer.token !== "native";
+    const isSolanaTransfer = isSolanaActionChain(transfer.chainId);
+    const isSolanaTokenTransfer = isSolanaTransfer && isTokenTransfer;
+    let solanaTokenTransaction:
+      | Awaited<ReturnType<typeof vault.buildSolanaSplTransferTransaction>>
+      | undefined;
+    if (!isTokenTransfer) {
+      const gasGuard = await nativeTransferGasAccountingGuard(
+        c,
+        transfer.to,
+        transfer.chainId,
+        undefined,
+      );
+      if (gasGuard) return gasGuard;
+    } else if (isSolanaTokenTransfer) {
+      try {
+        solanaTokenTransaction = await vault.buildSolanaSplTransferTransaction({
+          tenantId,
+          agentId,
+          to: transfer.to,
+          token: transfer.token,
+          value: transfer.value,
+          chainId: transfer.chainId,
+        });
+      } catch (error) {
+        return c.json<ApiResponse>(
+          { ok: false, error: sanitizeErrorMessage(error) || "Failed to build SPL transfer" },
+          422,
+        );
+      }
+    }
+    const signRequest: SignRequest = {
+      tenantId,
+      agentId,
+      to: isTokenTransfer && !isSolanaTokenTransfer ? transfer.token : transfer.to,
+      value: isTokenTransfer && !isSolanaTokenTransfer ? "0" : transfer.value,
+      data: isTokenTransfer
+        ? isSolanaTokenTransfer
+          ? solanaTokenTransaction?.transaction
+          : encodeErc20TransferCalldata(transfer.to, transfer.value)
+        : undefined,
+      chainId: transfer.chainId,
+      gasLimit: isTokenTransfer && !isSolanaTokenTransfer ? "65000" : undefined,
+      broadcast: transfer.broadcast,
+    };
+    const parsedSolanaTransferApproval =
+      isSolanaTokenTransfer && signRequest.data
+        ? (() => {
+            const derived = deriveSolanaPolicyFields(parseSolanaTransaction(signRequest.data!));
+            if (!derived.fullyParsed) {
+              throw new SolanaExecutionLeaseConflictError(
+                "Built SPL transfer is not fully policy-verifiable",
+              );
+            }
+            const parsedEffects = solanaParsedEffects(derived);
+            return {
+              signingMode: "parsed" as const,
+              blindSigned: false,
+              parsedEffects,
+              reviewedRequestDigest: solanaCallerIntentDigest({
+                route: "transfer",
+                tenantId,
+                agentId,
+                chainId: transfer.chainId,
+                broadcast: transfer.broadcast,
+                signingMode: "spl",
+                to: transfer.to,
+                value: transfer.value,
+                token: transfer.token,
+                referenceId: transfer.referenceId,
+                sponsor: transfer.sponsor,
+                messageDigest: normalizedSolanaMessageDigest(signRequest.data),
+                parsedEffects,
+              }),
+            };
+          })()
+        : null;
+    const baseTransferActionPayload = {
+      ...transferActionPayload({
+        token: transfer.token,
+        recipient: transfer.to,
+        amount: transfer.value,
+        broadcast: transfer.broadcast,
+        referenceId: transfer.referenceId,
+        sponsorship: sponsorshipPayload,
+      }),
+      ...(parsedSolanaTransferApproval ?? {}),
+    };
+    const policySet = await getScopedPolicySet(tenantId, agentId, c.get("agentPolicyIds"));
+    const conditionSets = await loadConditionSetsForPolicies(tenantId, policySet);
+
+    const rateLimitResult = await enforceRateLimit(agentId, policySet);
+    if (!rateLimitResult.allowed) {
+      if (rateLimitResult.headers) {
+        for (const [key, value] of Object.entries(rateLimitResult.headers)) {
+          c.header(key, value);
+        }
+      }
+      return c.json<ApiResponse>(
+        { ok: false, error: rateLimitResult.reason || "Rate limit exceeded" },
+        429,
+      );
+    }
+    if (rateLimitResult.headers) {
+      for (const [key, value] of Object.entries(rateLimitResult.headers)) {
+        c.header(key, value);
+      }
     }
 
     const stats = await getTransactionStats(agentId, signRequest.chainId);
@@ -3460,14 +3511,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
         data: signRequest.data,
         chainId: signRequest.chainId,
         actionType: "transfer",
-        actionPayload: transferActionPayload({
-          token: transfer.token,
-          recipient: transfer.to,
-          amount: transfer.value,
-          broadcast: signRequest.broadcast !== false,
-          referenceId: transfer.referenceId,
-          sponsorship: sponsorshipPayload,
-        }),
+        actionPayload: baseTransferActionPayload,
         policyResults: evaluation.results,
       });
       if (evaluation.requiresManualApproval) {
@@ -3576,7 +3620,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           toAddress: transfer.to,
           value: transfer.value,
           broadcastRequested: true,
-          blindSigned: isSolanaTokenTransfer,
+          blindSigned: false,
           policyResults: evaluation.results,
           binding: solanaRecoveryBinding,
           actionType: "transfer",
@@ -4099,9 +4143,14 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
     approvalRecoveryMetadata.signingMode === "blind"
       ? approvalRecoveryMetadata.signingMode
       : null;
+  const isQueuedSolanaSplTransfer =
+    isSolana &&
+    transactionRow.actionType === "transfer" &&
+    typeof approvalRecoveryMetadata.token === "string" &&
+    approvalRecoveryMetadata.token !== "native";
   if (
     isSolana &&
-    transactionRow.actionType === "solana_transaction" &&
+    (transactionRow.actionType === "solana_transaction" || isQueuedSolanaSplTransfer) &&
     queuedSolanaSigningMode === null
   ) {
     return c.json<ApiResponse>(
@@ -4128,6 +4177,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         chainId: transactionRow.chainId,
         toAddress: transactionRow.toAddress,
         value: transactionRow.value,
+        actionType: transactionRow.actionType,
         metadata: approvalRecoveryMetadata,
       });
     } catch (error) {
@@ -8687,6 +8737,7 @@ type SolanaCallerIntent = {
   value: string;
   token?: string;
   referenceId?: string;
+  sponsor?: boolean;
   messageDigest?: string;
   parsedEffects?: {
     movesNativeSol: boolean;
@@ -8723,6 +8774,7 @@ function assertQueuedParsedSolanaIntent(input: {
   chainId: number;
   toAddress: string | null;
   value: string | null;
+  actionType: string | null;
   metadata: Record<string, unknown>;
 }): void {
   const summary = parseSolanaTransaction(input.transaction);
@@ -8734,15 +8786,34 @@ function assertQueuedParsedSolanaIntent(input: {
     );
   }
   const parsedEffects = solanaParsedEffects(derived);
+  const isTransfer = input.actionType === "transfer";
+  const token =
+    isTransfer && typeof input.metadata.token === "string" ? input.metadata.token : null;
+  if (isTransfer && (!token || token === "native")) {
+    throw new SolanaExecutionLeaseConflictError(
+      "Approved parsed Solana transfer has no reviewed token binding",
+    );
+  }
   const expectedDigest = solanaCallerIntentDigest({
-    route: "sign-solana",
+    route: isTransfer ? "transfer" : "sign-solana",
     tenantId: input.tenantId,
     agentId: input.agentId,
     chainId: input.chainId,
     broadcast: input.metadata.broadcast !== false,
-    signingMode: "parsed",
+    signingMode: isTransfer ? "spl" : "parsed",
     to: input.toAddress,
     value: input.value,
+    ...(isTransfer
+      ? {
+          token: token!,
+          referenceId:
+            typeof input.metadata.referenceId === "string" ? input.metadata.referenceId : undefined,
+          sponsor:
+            input.metadata.sponsorship !== null &&
+            typeof input.metadata.sponsorship === "object" &&
+            (input.metadata.sponsorship as Record<string, unknown>).requested === true,
+        }
+      : {}),
     messageDigest: normalizedSolanaMessageDigest(input.transaction),
     parsedEffects,
   });
@@ -8750,7 +8821,8 @@ function assertQueuedParsedSolanaIntent(input: {
     input.metadata.blindSigned !== false ||
     canonicalJsonStringify(input.metadata.parsedEffects) !==
       canonicalJsonStringify(parsedEffects) ||
-    input.metadata.requestDigest !== expectedDigest
+    (isTransfer ? input.metadata.reviewedRequestDigest : input.metadata.requestDigest) !==
+      expectedDigest
   ) {
     throw new SolanaExecutionLeaseConflictError(
       "Approved parsed Solana transaction no longer matches its reviewed policy effects",
@@ -8768,6 +8840,7 @@ function createSolanaTransferRecoveryBinding(
     token: string;
     value: string;
     referenceId?: string;
+    sponsor?: boolean;
   },
 ): SolanaRecoveryBinding {
   const key = c.req.header("Idempotency-Key");
@@ -8782,6 +8855,7 @@ function createSolanaTransferRecoveryBinding(
       broadcast: true,
       chainId: input.chainId,
       referenceId: input.referenceId,
+      sponsor: input.sponsor,
       signingMode: input.token === "native" ? "native" : "spl",
       tenantId: input.tenantId,
       to: input.to,
@@ -10207,7 +10281,8 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
       // authoritative policy check for ALL transaction shapes, so we only pass the
       // legacy envelope for the single-SystemProgram-transfer case (where it adds a
       // redundant byte-level assertion). For token / multi-instruction transactions
-      // the parser already verified the effects against policy above.
+      // the parser already verified the effects against policy above and the
+      // parsed-mode flag keeps that authority distinct from unsafe blind signing.
       const isSingleNativeTransfer =
         derived.movesNativeSol &&
         derived.summary.tokenTransfers.length === 0 &&
@@ -10242,7 +10317,7 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         // the caller attests via allowBlindSign instead.
         ...(isSingleNativeTransfer
           ? { expectedTo: toAddress, expectedValue: txValue }
-          : { allowBlindSign: true }),
+          : { allowParsedSign: true }),
         onBroadcastPrepared: (checkpoint) =>
           checkpointSolanaBroadcastSubmission(txId, agentId, ownerToken, checkpoint),
       });

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -17,6 +17,7 @@ import {
   randomBytes,
 } from "node:crypto";
 import {
+  agents,
   executionAuthorizationNonces,
   tenantConfigs as tenantConfigsTable,
   users,
@@ -43,7 +44,11 @@ import {
   ENTRY_POINT_V07,
   type ExportPrivateKeyResult,
   ExternalBroadcastOutcomeUnknownError,
+  executionClaimDigestForGovernedSolanaParsedSign,
   executionPayloadDigestForGovernedSolanaNativeSign,
+  executionPayloadDigestForGovernedSolanaParsedSign,
+  type GovernedSolanaParsedEffects,
+  type GovernedSolanaParsedExecutionClaim,
   GovernedVault,
   GovernedVaultError,
   getUserOperationHash,
@@ -3483,6 +3488,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
         : {}),
     };
     const policySet = await getScopedPolicySet(tenantId, agentId, c.get("agentPolicyIds"));
+    const transferPolicyRevisionHash = policyRevisionHashForPolicySet(policySet);
     const conditionSets = await loadConditionSetsForPolicies(tenantId, policySet);
 
     const rateLimitResult = await enforceRateLimit(agentId, policySet);
@@ -3639,20 +3645,36 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
 
     let solanaExecutionToken: string | null = null;
     let storedTransferActionPayload: Record<string, unknown> = baseTransferActionPayload;
-    if (solanaRecoveryBinding) {
+    const solanaSigningBinding = isSolanaTokenTransfer
+      ? (solanaRecoveryBinding ?? {
+          txId: actionId,
+          requestDigest: parsedSolanaTransferApproval?.reviewedRequestDigest,
+        })
+      : solanaRecoveryBinding;
+    if (solanaSigningBinding) {
       try {
         const staged = await stageSolanaRecoveryAnchor({
+          tenantId,
           agentId,
           transaction: signRequest.data ?? "",
           chainId: transfer.chainId,
           toAddress: transfer.to,
           value: transfer.value,
-          broadcastRequested: true,
+          broadcastRequested: transfer.broadcast,
           blindSigned: false,
           policyResults: evaluation.results,
-          binding: solanaRecoveryBinding,
+          binding: solanaSigningBinding,
           actionType: "transfer",
           actionPayload: baseTransferActionPayload,
+          ...(isSolanaTokenTransfer && parsedSolanaTransferApproval
+            ? {
+                parsedAuthorization: {
+                  messageDigest: normalizedSolanaMessageDigest(signRequest.data!),
+                  parsedEffects: parsedSolanaTransferApproval.parsedEffects,
+                  policyRevisionHash: transferPolicyRevisionHash,
+                },
+              }
+            : {}),
         });
         if (!staged.executionToken) {
           return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
@@ -3725,7 +3747,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
         if (!signRequest.data) {
           throw new Error("SPL transfer transaction was not built");
         }
-        if (!solanaRecoveryBinding)
+        if (!solanaExecutionToken)
           await db.insert(transactions).values({
             id: actionId,
             agentId,
@@ -3738,28 +3760,61 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
             actionPayload: storedTransferActionPayload,
             policyResults: evaluation.results,
           });
-        const signed = await vault.signSolanaTransaction({
-          agentId,
-          tenantId,
-          transaction: signRequest.data,
-          chainId: transfer.chainId,
-          broadcast: transfer.broadcast,
-          // SEC-163: SPL token transfers carry no vault-layer envelope (the
-          // byte-level check only models native SOL transfers); the edge
-          // policy evaluation above approved this transfer.
-          allowParsedSign: true,
-          ...(solanaExecutionToken
-            ? {
-                onBroadcastPrepared: (checkpoint) =>
-                  checkpointSolanaBroadcastSubmission(
-                    actionId,
-                    agentId,
-                    solanaExecutionToken,
-                    checkpoint,
-                  ),
-              }
-            : {}),
-        });
+        if (!solanaExecutionToken || !parsedSolanaTransferApproval) {
+          throw new SolanaExecutionLeaseConflictError(
+            "SPL transfer lacks a durable parsed Solana execution claim",
+          );
+        }
+        const messageDigest = normalizedSolanaMessageDigest(signRequest.data);
+        const executionPayloadDigest = executionPayloadDigestForGovernedSolanaParsedSign(
+          {
+            agentId,
+            tenantId,
+            transaction: signRequest.data,
+            chainId: transfer.chainId,
+            broadcast: transfer.broadcast,
+          },
+          {
+            messageDigest,
+            parsedEffects: parsedSolanaTransferApproval.parsedEffects,
+            policyRevisionHash: transferPolicyRevisionHash,
+          },
+        );
+        const signed = await new GovernedVault(vault, async () => {
+          throw new GovernedVaultError(
+            "EVM execution authorization is unavailable on the Solana gateway",
+            "unsupported_chain_family",
+          );
+        }).signSolanaParsedTransactionAuthorized(
+          {
+            agentId,
+            tenantId,
+            transaction: signRequest.data,
+            chainId: transfer.chainId,
+            broadcast: transfer.broadcast,
+            onBroadcastPrepared: (checkpoint) =>
+              checkpointSolanaBroadcastSubmission(
+                actionId,
+                agentId,
+                solanaExecutionToken!,
+                checkpoint,
+              ),
+          },
+          {
+            txId: actionId,
+            executionToken: solanaExecutionToken,
+            executionClaimDigest: executionClaimDigestForGovernedSolanaParsedSign({
+              executionPayloadDigest,
+              executionToken: solanaExecutionToken,
+              txId: actionId,
+            }),
+            executionPayloadDigest,
+            messageDigest,
+            parsedEffects: parsedSolanaTransferApproval.parsedEffects,
+            policyRevisionHash: transferPolicyRevisionHash,
+            consumeExecutionClaim: consumeParsedSolanaExecutionClaim,
+          },
+        );
         result = signed.signature;
       } else {
         result = await vault.signTransaction(signRequest, {
@@ -3783,6 +3838,18 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
       const txStatus = transfer.broadcast ? "broadcast" : "signed";
       completedResult = result;
       completedStatus = txStatus;
+      if (
+        isSolanaTokenTransfer &&
+        solanaExecutionToken &&
+        !(await finalizeSolanaRecoveryAnchor(actionId, agentId, solanaExecutionToken, {
+          signature: result,
+          broadcast: transfer.broadcast,
+          chainId: transfer.chainId,
+          caip2: toCaip2(transfer.chainId),
+        }))
+      ) {
+        return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
+      }
       const signedTx = transfer.broadcast ? undefined : result;
       const updatedTransfer = await db
         .update(transactions)
@@ -3800,8 +3867,10 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
             eq(transactions.agentId, agentId),
             solanaExecutionToken
               ? and(
-                  eq(transactions.status, "broadcast"),
-                  eq(transactions.txHash, result),
+                  eq(transactions.status, txStatus),
+                  transfer.broadcast
+                    ? eq(transactions.txHash, result)
+                    : sql`${transactions.txHash} is null`,
                   sql`${transactions.actionPayload}->>'executionToken' = ${solanaExecutionToken}`,
                 )
               : undefined,
@@ -3970,7 +4039,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           }),
         });
       }
-      if (solanaRecoveryBinding) {
+      if (solanaExecutionToken) {
         if (!(await markSolanaRecoveryAnchorFailed(actionId, agentId, solanaExecutionToken))) {
           return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
         }
@@ -4176,6 +4245,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
     transactionRow.actionType === "transfer" &&
     typeof approvalRecoveryMetadata.token === "string" &&
     approvalRecoveryMetadata.token !== "native";
+  let queuedParsedSolanaEffects: GovernedSolanaParsedEffects | null = null;
   if (
     isSolana &&
     (transactionRow.actionType === "solana_transaction" || isQueuedSolanaSplTransfer) &&
@@ -4207,7 +4277,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       );
     }
     try {
-      assertQueuedParsedSolanaIntent({
+      queuedParsedSolanaEffects = assertQueuedParsedSolanaIntent({
         tenantId,
         agentId,
         transaction: transactionRow.data,
@@ -4703,6 +4773,18 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           takeover: isApprovedSolanaResume,
           resolver: approverPrincipal,
           approvePendingQueue: isFreshApproval ? { resolvedAt } : undefined,
+          ...(queuedSolanaSigningMode === "parsed" &&
+          transactionRow.data &&
+          queuedParsedSolanaEffects
+            ? {
+                parsedAuthorization: {
+                  tenantId,
+                  messageDigest: normalizedSolanaMessageDigest(transactionRow.data),
+                  parsedEffects: queuedParsedSolanaEffects,
+                  policyRevisionHash: currentExecutionPolicyRevisionHash,
+                },
+              }
+            : {}),
         });
         approvedSolanaExecutionToken = claimed.executionToken;
         approvedSolanaActionPayload = claimed.actionPayload;
@@ -4718,8 +4800,6 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       let txHash: string;
 
       if (isSolana) {
-        const isSolanaTokenTransfer =
-          transferPayload !== null && transferPayload.token !== "native";
         const checkpoint = approvedSolanaExecutionToken
           ? (prepared: { signature: string; recentBlockhash: string }) =>
               checkpointSolanaBroadcastSubmission(
@@ -4767,19 +4847,74 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           if (!transactionRow.data) {
             throw new Error("Solana transaction blob not found; cannot replay approval");
           }
-          const result = await vault.signSolanaTransaction({
-            agentId,
-            tenantId,
-            transaction: transactionRow.data,
-            chainId: transactionRow.chainId,
-            broadcast: shouldBroadcast,
-            ...(isSolanaTokenTransfer || queuedSolanaSigningMode === "parsed"
-              ? { allowParsedSign: true }
-              : queuedSolanaSigningMode === "blind"
-                ? { allowBlindSign: true }
-                : { expectedTo: transactionRow.toAddress, expectedValue: transactionRow.value }),
-            onBroadcastPrepared: checkpoint,
-          });
+          const result =
+            queuedSolanaSigningMode === "parsed"
+              ? await (async () => {
+                  if (!approvedSolanaExecutionToken || !queuedParsedSolanaEffects) {
+                    throw new SolanaExecutionLeaseConflictError(
+                      "Approved parsed Solana transaction lacks a durable execution claim",
+                    );
+                  }
+                  const messageDigest = normalizedSolanaMessageDigest(transactionRow.data!);
+                  const executionPayloadDigest = executionPayloadDigestForGovernedSolanaParsedSign(
+                    {
+                      agentId,
+                      tenantId,
+                      transaction: transactionRow.data!,
+                      chainId: transactionRow.chainId,
+                      broadcast: shouldBroadcast,
+                      onBroadcastPrepared: checkpoint,
+                    },
+                    {
+                      messageDigest,
+                      parsedEffects: queuedParsedSolanaEffects,
+                      policyRevisionHash: currentExecutionPolicyRevisionHash,
+                    },
+                  );
+                  return new GovernedVault(vault, async () => {
+                    throw new GovernedVaultError(
+                      "EVM execution authorization is unavailable on the Solana gateway",
+                      "unsupported_chain_family",
+                    );
+                  }).signSolanaParsedTransactionAuthorized(
+                    {
+                      agentId,
+                      tenantId,
+                      transaction: transactionRow.data!,
+                      chainId: transactionRow.chainId,
+                      broadcast: shouldBroadcast,
+                      onBroadcastPrepared: checkpoint,
+                    },
+                    {
+                      txId,
+                      executionToken: approvedSolanaExecutionToken,
+                      executionClaimDigest: executionClaimDigestForGovernedSolanaParsedSign({
+                        executionPayloadDigest,
+                        executionToken: approvedSolanaExecutionToken,
+                        txId,
+                      }),
+                      executionPayloadDigest,
+                      messageDigest,
+                      parsedEffects: queuedParsedSolanaEffects,
+                      policyRevisionHash: currentExecutionPolicyRevisionHash,
+                      consumeExecutionClaim: consumeParsedSolanaExecutionClaim,
+                    },
+                  );
+                })()
+              : await vault.signSolanaTransaction({
+                  agentId,
+                  tenantId,
+                  transaction: transactionRow.data,
+                  chainId: transactionRow.chainId,
+                  broadcast: shouldBroadcast,
+                  ...(queuedSolanaSigningMode === "blind"
+                    ? { allowBlindSign: true }
+                    : {
+                        expectedTo: transactionRow.toAddress,
+                        expectedValue: transactionRow.value,
+                      }),
+                  onBroadcastPrepared: checkpoint,
+                });
           txHash = result.signature;
           if (shouldBroadcast && approvedSolanaExecutionToken) {
             const finalized = await finalizeSolanaRecoveryAnchor(
@@ -8776,11 +8911,7 @@ type SolanaCallerIntent = {
   referenceId?: string;
   sponsor?: boolean;
   messageDigest?: string;
-  parsedEffects?: {
-    movesNativeSol: boolean;
-    programIds: string[];
-    tokenTransfers: Array<{ mint?: string; destination: string; amount: string }>;
-  };
+  parsedEffects?: GovernedSolanaParsedEffects;
 };
 
 function solanaCallerIntentDigest(intent: SolanaCallerIntent): string {
@@ -8790,9 +8921,7 @@ function solanaCallerIntentDigest(intent: SolanaCallerIntent): string {
   return sha256(canonicalJsonStringify(intent));
 }
 
-function solanaParsedEffects(
-  derived: DerivedSolanaPolicyFields,
-): SolanaCallerIntent["parsedEffects"] {
+function solanaParsedEffects(derived: DerivedSolanaPolicyFields): GovernedSolanaParsedEffects {
   return {
     movesNativeSol: derived.movesNativeSol,
     programIds: derived.programIds,
@@ -8813,7 +8942,7 @@ function assertQueuedParsedSolanaIntent(input: {
   value: string | null;
   actionType: string | null;
   metadata: Record<string, unknown>;
-}): void {
+}): GovernedSolanaParsedEffects {
   const summary = parseSolanaTransaction(input.transaction);
   assertSolanaPriorityFeeWithinCap(summary);
   const derived = deriveSolanaPolicyFields(summary);
@@ -8865,6 +8994,7 @@ function assertQueuedParsedSolanaIntent(input: {
       "Approved parsed Solana transaction no longer matches its reviewed policy effects",
     );
   }
+  return parsedEffects;
 }
 
 function createSolanaTransferRecoveryBinding(
@@ -9185,6 +9315,7 @@ function solanaTransferReplayResponse(
 }
 
 async function stageSolanaRecoveryAnchor(input: {
+  tenantId?: string;
   agentId: string;
   transaction?: string;
   chainId: number;
@@ -9196,9 +9327,43 @@ async function stageSolanaRecoveryAnchor(input: {
   binding: SolanaRecoveryBinding;
   actionType?: string;
   actionPayload?: Record<string, unknown>;
+  parsedAuthorization?: {
+    messageDigest: string;
+    parsedEffects: GovernedSolanaParsedEffects;
+    policyRevisionHash: string;
+  };
 }): Promise<{ row: SolanaRecoveryRow; executionToken: string | null }> {
   const executionToken = crypto.randomUUID();
   const attemptLeaseUntil = new Date(Date.now() + SOLANA_SIGNING_ATTEMPT_LEASE_MS).toISOString();
+  let parsedAuthorizationPayload: Record<string, unknown> = {};
+  if (input.parsedAuthorization) {
+    if (!input.tenantId || !input.transaction) {
+      throw new SolanaExecutionLeaseConflictError(
+        "Parsed Solana execution staging requires tenant and transaction bindings",
+      );
+    }
+    const executionPayloadDigest = executionPayloadDigestForGovernedSolanaParsedSign(
+      {
+        agentId: input.agentId,
+        tenantId: input.tenantId,
+        transaction: input.transaction,
+        chainId: input.chainId,
+        broadcast: input.broadcastRequested,
+      },
+      input.parsedAuthorization,
+    );
+    parsedAuthorizationPayload = {
+      messageDigest: input.parsedAuthorization.messageDigest,
+      parsedEffects: input.parsedAuthorization.parsedEffects,
+      policyRevisionHash: input.parsedAuthorization.policyRevisionHash,
+      parsedExecutionPayloadDigest: executionPayloadDigest,
+      parsedExecutionClaimDigest: executionClaimDigestForGovernedSolanaParsedSign({
+        executionPayloadDigest,
+        executionToken,
+        txId: input.binding.txId,
+      }),
+    };
+  }
   const inserted = await db
     .insert(transactions)
     .values({
@@ -9222,6 +9387,7 @@ async function stageSolanaRecoveryAnchor(input: {
         requestDigest: input.binding.requestDigest,
         executionToken,
         attemptLeaseUntil,
+        ...parsedAuthorizationPayload,
       },
       policyResults: input.policyResults,
     })
@@ -9250,6 +9416,9 @@ async function stageSolanaRecoveryAnchor(input: {
   if (existing.status !== "approved") {
     return { row: existing as SolanaRecoveryRow, executionToken: null };
   }
+  if (input.parsedAuthorization && metadata.parsedClaimConsumedAt !== undefined) {
+    return { row: existing as SolanaRecoveryRow, executionToken: null };
+  }
 
   const priorLeaseUntil =
     typeof metadata.attemptLeaseUntil === "string"
@@ -9266,7 +9435,12 @@ async function stageSolanaRecoveryAnchor(input: {
   const [takenOver] = await db
     .update(transactions)
     .set({
-      actionPayload: { ...metadata, executionToken, attemptLeaseUntil },
+      actionPayload: {
+        ...metadata,
+        executionToken,
+        attemptLeaseUntil,
+        ...parsedAuthorizationPayload,
+      },
     })
     .where(
       and(
@@ -9285,6 +9459,68 @@ async function stageSolanaRecoveryAnchor(input: {
     .where(eq(transactions.id, input.binding.txId))
     .limit(1);
   return { row: (winner ?? existing) as SolanaRecoveryRow, executionToken: null };
+}
+
+async function consumeParsedSolanaExecutionClaim(
+  expected: GovernedSolanaParsedExecutionClaim,
+): Promise<void> {
+  const [row] = await db
+    .select({ transaction: transactions })
+    .from(transactions)
+    .innerJoin(
+      agents,
+      and(eq(agents.id, transactions.agentId), eq(agents.tenantId, expected.tenantId)),
+    )
+    .where(and(eq(transactions.id, expected.txId), eq(transactions.agentId, expected.agentId)))
+    .limit(1);
+  const claimedTransaction = row?.transaction;
+  if (
+    !claimedTransaction ||
+    !claimedTransaction.data ||
+    claimedTransaction.chainId !== expected.chainId
+  ) {
+    throw new SolanaExecutionLeaseConflictError("Parsed Solana execution claim is unavailable");
+  }
+  const metadata = readSolanaRecoveryMetadata(claimedTransaction.actionPayload);
+  if (
+    normalizedSolanaMessageDigest(claimedTransaction.data) !== expected.messageDigest ||
+    metadata.messageDigest !== expected.messageDigest ||
+    metadata.policyRevisionHash !== expected.policyRevisionHash ||
+    metadata.parsedExecutionPayloadDigest !== expected.executionPayloadDigest ||
+    metadata.parsedExecutionClaimDigest !== expected.executionClaimDigest ||
+    canonicalJsonStringify(metadata.parsedEffects) !==
+      canonicalJsonStringify(expected.parsedEffects) ||
+    metadata.broadcast !== expected.broadcast
+  ) {
+    throw new SolanaExecutionLeaseConflictError(
+      "Parsed Solana execution claim no longer matches its reviewed authority",
+    );
+  }
+
+  const [consumed] = await db
+    .update(transactions)
+    .set({
+      actionPayload: {
+        ...metadata,
+        parsedClaimConsumedAt: new Date().toISOString(),
+      },
+    })
+    .where(
+      and(
+        eq(transactions.id, expected.txId),
+        eq(transactions.agentId, expected.agentId),
+        sql`${transactions.status} in ('approved', 'pending')`,
+        sql`${transactions.actionPayload}->>'executionToken' = ${expected.executionToken}`,
+        sql`${transactions.actionPayload}->>'parsedExecutionClaimDigest' = ${expected.executionClaimDigest}`,
+        sql`${transactions.actionPayload}->>'parsedClaimConsumedAt' is null`,
+      ),
+    )
+    .returning({ id: transactions.id });
+  if (!consumed) {
+    throw new SolanaExecutionLeaseConflictError(
+      "Parsed Solana execution claim was already consumed or ownership changed",
+    );
+  }
 }
 
 async function checkpointSolanaBroadcastSubmission(
@@ -9363,6 +9599,12 @@ export async function claimApprovedSolanaExecution(
     takeover: boolean;
     resolver: ApprovalPrincipal;
     approvePendingQueue?: { resolvedAt: Date };
+    parsedAuthorization?: {
+      tenantId: string;
+      messageDigest: string;
+      parsedEffects: GovernedSolanaParsedEffects;
+      policyRevisionHash: string;
+    };
   },
 ): Promise<{ executionToken: string; actionPayload: Record<string, unknown> }> {
   const prior = readSolanaRecoveryMetadata(row.actionPayload);
@@ -9435,6 +9677,35 @@ export async function claimApprovedSolanaExecution(
     throw new SolanaExecutionLeaseConflictError();
   }
   const executionToken = crypto.randomUUID();
+  let parsedAuthorizationPayload: Record<string, unknown> = {};
+  if (options.parsedAuthorization) {
+    if (!row.data || prior.parsedClaimConsumedAt !== undefined) {
+      throw new SolanaExecutionLeaseConflictError(
+        "Approved parsed Solana authority is unavailable or was already consumed",
+      );
+    }
+    const executionPayloadDigest = executionPayloadDigestForGovernedSolanaParsedSign(
+      {
+        agentId: row.agentId,
+        tenantId: options.parsedAuthorization.tenantId,
+        transaction: row.data,
+        chainId: row.chainId,
+        broadcast: prior.broadcast !== false,
+      },
+      options.parsedAuthorization,
+    );
+    parsedAuthorizationPayload = {
+      messageDigest: options.parsedAuthorization.messageDigest,
+      parsedEffects: options.parsedAuthorization.parsedEffects,
+      policyRevisionHash: options.parsedAuthorization.policyRevisionHash,
+      parsedExecutionPayloadDigest: executionPayloadDigest,
+      parsedExecutionClaimDigest: executionClaimDigestForGovernedSolanaParsedSign({
+        executionPayloadDigest,
+        executionToken,
+        txId: row.id,
+      }),
+    };
+  }
   const actionPayload = {
     ...prior,
     recoveryType: "solana_transaction",
@@ -9443,6 +9714,7 @@ export async function claimApprovedSolanaExecution(
     executionDigest,
     executionToken,
     attemptLeaseUntil: new Date(Date.now() + SOLANA_SIGNING_ATTEMPT_LEASE_MS).toISOString(),
+    ...parsedAuthorizationPayload,
   };
   return db.transaction(async (tx) => {
     const [claimed] = await tx
@@ -10403,6 +10675,7 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         derived.to !== undefined;
 
       const staged = await stageSolanaRecoveryAnchor({
+        tenantId,
         agentId,
         transaction: body.transaction,
         chainId,
@@ -10412,27 +10685,78 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         blindSigned: false,
         policyResults: evaluation.results,
         binding,
+        ...(!isSingleNativeTransfer
+          ? {
+              parsedAuthorization: {
+                messageDigest: normalizedSolanaMessageDigest(body.transaction),
+                parsedEffects: solanaParsedEffects(derived),
+                policyRevisionHash: policyRevisionHashForPolicySet(policySet),
+              },
+            }
+          : {}),
       });
       if (!staged.executionToken) {
         return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
       }
       const ownerToken = staged.executionToken;
       executionToken = ownerToken;
-      const result = await vault.signSolanaTransaction({
-        agentId,
-        tenantId,
-        transaction: body.transaction,
-        chainId,
-        broadcast: body.broadcast,
-        // SEC-163: non-single-transfer shapes carry no vault-layer envelope —
-        // the instruction-parser policy check above approved the effects, so
-        // the caller attests via allowBlindSign instead.
-        ...(isSingleNativeTransfer
-          ? { expectedTo: toAddress, expectedValue: txValue }
-          : { allowParsedSign: true }),
-        onBroadcastPrepared: (checkpoint) =>
-          checkpointSolanaBroadcastSubmission(txId, agentId, ownerToken, checkpoint),
-      });
+      const result = isSingleNativeTransfer
+        ? await vault.signSolanaTransaction({
+            agentId,
+            tenantId,
+            transaction: body.transaction,
+            chainId,
+            broadcast: body.broadcast,
+            expectedTo: toAddress,
+            expectedValue: txValue,
+            onBroadcastPrepared: (checkpoint) =>
+              checkpointSolanaBroadcastSubmission(txId, agentId, ownerToken, checkpoint),
+          })
+        : await (async () => {
+            const parsedEffects = solanaParsedEffects(derived);
+            const messageDigest = normalizedSolanaMessageDigest(body.transaction);
+            const policyRevisionHash = policyRevisionHashForPolicySet(policySet);
+            const executionPayloadDigest = executionPayloadDigestForGovernedSolanaParsedSign(
+              {
+                agentId,
+                tenantId,
+                transaction: body.transaction,
+                chainId,
+                broadcast: body.broadcast,
+              },
+              { messageDigest, parsedEffects, policyRevisionHash },
+            );
+            return new GovernedVault(vault, async () => {
+              throw new GovernedVaultError(
+                "EVM execution authorization is unavailable on the Solana gateway",
+                "unsupported_chain_family",
+              );
+            }).signSolanaParsedTransactionAuthorized(
+              {
+                agentId,
+                tenantId,
+                transaction: body.transaction,
+                chainId,
+                broadcast: body.broadcast,
+                onBroadcastPrepared: (checkpoint) =>
+                  checkpointSolanaBroadcastSubmission(txId, agentId, ownerToken, checkpoint),
+              },
+              {
+                txId,
+                executionToken: ownerToken,
+                executionClaimDigest: executionClaimDigestForGovernedSolanaParsedSign({
+                  executionPayloadDigest,
+                  executionToken: ownerToken,
+                  txId,
+                }),
+                executionPayloadDigest,
+                messageDigest,
+                parsedEffects,
+                policyRevisionHash,
+                consumeExecutionClaim: consumeParsedSolanaExecutionClaim,
+              },
+            );
+          })();
       completedResult = { txId, ...result };
 
       if (!(await finalizeSolanaRecoveryAnchor(txId, agentId, ownerToken, result))) {

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -3254,8 +3254,36 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
     "Broadcast transfer actions",
   );
   if (idempotencyResponse) return idempotencyResponse;
+  const solanaRecoveryBinding =
+    isSolanaActionChain(transfer.chainId) && transfer.broadcast
+      ? createSolanaTransferRecoveryBinding(c, {
+          tenantId,
+          agentId,
+          chainId: transfer.chainId,
+          to: transfer.to,
+          token: transfer.token,
+          value: transfer.value,
+          referenceId: transfer.referenceId,
+        })
+      : null;
   const existingAction = await findActionByReferenceId(agentId, "transfer", transfer.referenceId);
   if (existingAction) {
+    if (solanaRecoveryBinding) {
+      const metadata = readSolanaRecoveryMetadata(existingAction.actionPayload);
+      if (
+        metadata.idempotencyKeyDigest !== solanaRecoveryBinding.idempotencyKeyDigest ||
+        metadata.requestDigest !== solanaRecoveryBinding.requestDigest
+      ) {
+        return c.json<ApiResponse>(
+          {
+            ok: false,
+            error: "Idempotency-Key was already used for a different Solana transaction",
+          },
+          409,
+        );
+      }
+      return solanaLostOwnershipResponse(c, existingAction.id, agentId, "transfer");
+    }
     return c.json<ApiResponse>({
       ok: existingAction.status !== "rejected" && existingAction.status !== "failed",
       error:
@@ -3321,18 +3349,6 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
     referenceId: transfer.referenceId,
     sponsorship: sponsorshipPayload,
   });
-  const solanaRecoveryBinding =
-    isSolanaTransfer && transfer.broadcast
-      ? createSolanaTransferRecoveryBinding(c, {
-          tenantId,
-          agentId,
-          chainId: transfer.chainId,
-          to: transfer.to,
-          token: transfer.token,
-          value: transfer.value,
-          referenceId: transfer.referenceId,
-        })
-      : null;
   const policySet = await getScopedPolicySet(tenantId, agentId, c.get("agentPolicyIds"));
   const conditionSets = await loadConditionSetsForPolicies(tenantId, policySet);
 
@@ -3361,6 +3377,22 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
       transfer.referenceId,
     );
     if (lockedExistingAction) {
+      if (solanaRecoveryBinding) {
+        const metadata = readSolanaRecoveryMetadata(lockedExistingAction.actionPayload);
+        if (
+          metadata.idempotencyKeyDigest !== solanaRecoveryBinding.idempotencyKeyDigest ||
+          metadata.requestDigest !== solanaRecoveryBinding.requestDigest
+        ) {
+          return c.json<ApiResponse>(
+            {
+              ok: false,
+              error: "Idempotency-Key was already used for a different Solana transaction",
+            },
+            409,
+          );
+        }
+        return solanaLostOwnershipResponse(c, lockedExistingAction.id, agentId, "transfer");
+      }
       return c.json<ApiResponse>({
         ok: lockedExistingAction.status !== "rejected" && lockedExistingAction.status !== "failed",
         error:
@@ -4043,6 +4075,25 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
 
   const isSolana = transactionRow.chainId === 101 || transactionRow.chainId === 102;
   const approvalRecoveryMetadata = readSolanaRecoveryMetadata(transactionRow.actionPayload);
+  const queuedSolanaSigningMode =
+    approvalRecoveryMetadata.signingMode === "parsed" ||
+    approvalRecoveryMetadata.signingMode === "blind"
+      ? approvalRecoveryMetadata.signingMode
+      : null;
+  if (
+    isSolana &&
+    transactionRow.actionType === "solana_transaction" &&
+    queuedSolanaSigningMode === null
+  ) {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error:
+          "This pending Solana approval predates signing-mode binding and cannot be replayed. Resubmit the transaction.",
+      },
+      409,
+    );
+  }
   if (
     isSolana &&
     pendingApproval.status === "approved" &&
@@ -4167,9 +4218,11 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         ? transferPayload.broadcast
         : sendCallsPayload
           ? sendCallsPayload.broadcast
-          : transactionPayload
-            ? transactionPayload.broadcast
-            : true;
+          : isSolana && typeof approvalRecoveryMetadata.broadcast === "boolean"
+            ? approvalRecoveryMetadata.broadcast
+            : transactionPayload
+              ? transactionPayload.broadcast
+              : true;
       const shouldBroadcast = requestedBroadcast !== false;
       const approvalSignRequest: SignRequest = {
         ...toSignRequest(transactionRow),
@@ -4584,7 +4637,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
             transaction: transactionRow.data,
             chainId: transactionRow.chainId,
             broadcast: shouldBroadcast,
-            ...(isSolanaTokenTransfer
+            ...(isSolanaTokenTransfer || queuedSolanaSigningMode !== null
               ? { allowBlindSign: true }
               : { expectedTo: transactionRow.toAddress, expectedValue: transactionRow.value }),
             onBroadcastPrepared: checkpoint,
@@ -8304,7 +8357,20 @@ async function signSolanaBlind(
     if (!evaluation.approved) {
       const txId = crypto.randomUUID();
       const manual = evaluation.requiresManualApproval;
-      await db.insert(transactions).values({
+      const queuedBinding = manual
+        ? createSolanaRecoveryBinding(c, {
+            routeFamily: "sign-solana",
+            tenantId,
+            agentId,
+            transaction: args.transaction,
+            chainId,
+            toAddress,
+            value: txValue,
+            broadcastRequested: shouldBroadcast,
+            blindSigned: true,
+          })
+        : null;
+      const transactionValues: typeof transactions.$inferInsert = {
         id: txId,
         agentId,
         status: manual ? "pending" : "rejected",
@@ -8313,11 +8379,30 @@ async function signSolanaBlind(
         data: manual ? args.transaction : undefined,
         chainId,
         policyResults: evaluation.results,
-      });
+        actionType: manual ? "solana_transaction" : undefined,
+        actionPayload: manual
+          ? {
+              type: "solana_transaction",
+              recoveryType: "solana_transaction",
+              recoveryActionType: "solana_transaction",
+              broadcast: shouldBroadcast,
+              signingMode: "blind",
+              blindSigned: true,
+              unparsedReason: args.unparsedReason,
+              idempotencyKeyDigest: queuedBinding?.idempotencyKeyDigest,
+              requestDigest: queuedBinding?.requestDigest,
+            }
+          : undefined,
+      };
       if (manual) {
-        await db
-          .insert(approvalQueue)
-          .values(approvalQueueValues(c, agentId, txId, signerAuthorization.auth));
+        await db.transaction(async (tx) => {
+          await tx.insert(transactions).values(transactionValues);
+          await tx
+            .insert(approvalQueue)
+            .values(approvalQueueValues(c, agentId, txId, signerAuthorization.auth));
+        });
+      } else {
+        await db.insert(transactions).values(transactionValues);
       }
       await writeVaultAudit(c, {
         tenantId,
@@ -9881,6 +9966,18 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
       const txId = crypto.randomUUID();
 
       if (evaluation.requiresManualApproval) {
+        const queuedBinding = createSolanaRecoveryBinding(c, {
+          routeFamily: "sign-solana",
+          tenantId,
+          agentId,
+          transaction: body.transaction,
+          chainId,
+          toAddress,
+          value: txValue,
+          broadcastRequested: shouldBroadcast,
+          blindSigned: false,
+          parsedEffects: solanaParsedEffects(derived),
+        });
         await db.transaction(async (tx) => {
           await tx.insert(transactions).values({
             id: txId,
@@ -9891,6 +9988,18 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
             data: body.transaction,
             chainId,
             policyResults: evaluation.results,
+            actionType: "solana_transaction",
+            actionPayload: {
+              type: "solana_transaction",
+              recoveryType: "solana_transaction",
+              recoveryActionType: "solana_transaction",
+              broadcast: shouldBroadcast,
+              signingMode: "parsed",
+              blindSigned: false,
+              parsedEffects: solanaParsedEffects(derived),
+              idempotencyKeyDigest: queuedBinding.idempotencyKeyDigest,
+              requestDigest: queuedBinding.requestDigest,
+            },
           });
           await tx
             .insert(approvalQueue)

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -43,11 +43,13 @@ import {
   ENTRY_POINT_V07,
   type ExportPrivateKeyResult,
   ExternalBroadcastOutcomeUnknownError,
+  executionPayloadDigestForGovernedSolanaNativeSign,
   GovernedVault,
   GovernedVaultError,
   getUserOperationHash,
   isVaultSigningFrozenError,
   MoneroNotConfiguredError,
+  normalizedSolanaMessageDigest,
   packUserOperation,
   parseMoneroWalletScope,
   parseSolanaTransaction,
@@ -2368,20 +2370,22 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
       }
     }
 
-    const solanaNativeBinding =
-      !isEvmSignRequest && shouldBroadcast
-        ? createSolanaRecoveryBinding(c, {
-            routeFamily: "sign",
-            tenantId,
-            agentId,
-            transaction: signRequest.data ?? "",
-            chainId: resolvedChainId,
-            toAddress: signRequest.to,
-            value: signRequest.value,
-            broadcastRequested: true,
-            blindSigned: false,
-          })
-        : null;
+    const solanaNativeBinding = !isEvmSignRequest
+      ? createSolanaRecoveryBinding(c, {
+          routeFamily: "sign",
+          tenantId,
+          agentId,
+          transaction: signRequest.data ?? "",
+          chainId: resolvedChainId,
+          toAddress: signRequest.to,
+          value: signRequest.value,
+          broadcastRequested: shouldBroadcast,
+          blindSigned: false,
+        })
+      : null;
+    const solanaNativeExecutionDigest = !isEvmSignRequest
+      ? executionPayloadDigestForGovernedSolanaNativeSign(signRequest)
+      : null;
     const executionTxId = solanaNativeBinding?.txId ?? crypto.randomUUID();
     let solanaNativeExecutionToken: string | null = null;
     try {
@@ -2439,22 +2443,25 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
       if (solanaNativeBinding) {
         const staged = await stageSolanaRecoveryAnchor({
           agentId,
-          transaction: signRequest.data ?? "",
+          transaction: signRequest.data,
           chainId: resolvedChainId,
           toAddress: signRequest.to,
           value: signRequest.value,
-          broadcastRequested: true,
+          broadcastRequested: shouldBroadcast,
           blindSigned: false,
           policyResults: evaluation.results,
           binding: solanaNativeBinding,
           actionType: "transaction",
-          actionPayload: transactionActionPayload({
-            broadcast: true,
-            nonce: signRequest.nonce,
-            gasLimit: signRequest.gasLimit,
-            venue: signRequest.venue,
-            walletAddress: signRequest.walletAddress,
-          }),
+          actionPayload: {
+            ...transactionActionPayload({
+              broadcast: shouldBroadcast,
+              nonce: signRequest.nonce,
+              gasLimit: signRequest.gasLimit,
+              venue: signRequest.venue,
+              walletAddress: signRequest.walletAddress,
+            }),
+            executionDigest: solanaNativeExecutionDigest,
+          },
         });
         if (!staged.executionToken) {
           return solanaLostOwnershipResponse(c, txId, agentId, "sign");
@@ -2539,22 +2546,30 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
                   "invariant: primary EVM sign reached raw signer without gateway authorization",
                 );
               }
-              return vault.signTransaction(signRequest, {
+              if (!solanaNativeExecutionToken || !solanaNativeExecutionDigest) {
+                throw new SolanaExecutionLeaseConflictError(
+                  "Direct Solana native signing lacks a durable execution claim",
+                );
+              }
+              const executionToken = solanaNativeExecutionToken;
+              return new GovernedVault(vault, async () => {
+                throw new GovernedVaultError(
+                  "EVM execution authorization is unavailable on the Solana gateway",
+                  "unsupported_chain_family",
+                );
+              }).signSolanaNativeTransferAuthorized(signRequest, {
                 txId,
                 policyResults: evaluation.results,
                 status: txStatus,
-                ...(solanaNativeExecutionToken
-                  ? {
-                      solanaRecoveryExecutionToken: solanaNativeExecutionToken,
-                      onSolanaBroadcastPrepared: (checkpoint) =>
-                        checkpointSolanaBroadcastSubmission(
-                          txId,
-                          agentId,
-                          solanaNativeExecutionToken!,
-                          checkpoint,
-                        ),
-                    }
-                  : {}),
+                executionToken,
+                executionClaimDigest: solanaNativeExecutionDigest,
+                executionPayloadDigest: solanaNativeExecutionDigest,
+                consumeExecutionClaim: assertApprovedSolanaExecutionClaim,
+                solanaRecoveryExecutionToken: shouldBroadcast ? executionToken : undefined,
+                onSolanaBroadcastPrepared: shouldBroadcast
+                  ? (checkpoint) =>
+                      checkpointSolanaBroadcastSubmission(txId, agentId, executionToken, checkpoint)
+                  : undefined,
               });
             })();
 
@@ -2574,8 +2589,10 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
             eq(transactions.agentId, agentId),
             solanaNativeExecutionToken
               ? and(
-                  eq(transactions.status, "broadcast"),
-                  eq(transactions.txHash, result),
+                  eq(transactions.status, shouldBroadcast ? "broadcast" : "signed"),
+                  shouldBroadcast
+                    ? eq(transactions.txHash, result)
+                    : sql`${transactions.txHash} is null`,
                   sql`${transactions.actionPayload}->>'executionToken' = ${solanaNativeExecutionToken}`,
                 )
               : undefined,
@@ -2589,17 +2606,8 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
         throw new Error("Transaction success write was not applied");
       }
 
-      if (solanaNativeExecutionToken) {
-        if (
-          !(await completeSolanaRecoveryEffects({
-            tenantId,
-            agentId,
-            txId,
-            signature: result,
-          }))
-        ) {
-          return solanaLostOwnershipResponse(c, txId, agentId, "sign");
-        }
+      if (solanaNativeExecutionToken && shouldBroadcast) {
+        await tryCompleteSolanaRecoveryEffects({ tenantId, agentId, txId, signature: result });
       } else {
         // ── Record spend in Redis (fire-and-forget) ──────────────────────────────
         recordVaultSpend(agentId, tenantId, signRequest.value, resolvedChainId).catch((err) =>
@@ -2693,17 +2701,15 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
             solanaNativeExecutionToken,
             e.transactionHash,
           );
-          if (
-            !preserved ||
-            !(await completeSolanaRecoveryEffects({
-              tenantId,
-              agentId,
-              txId: executionTxId,
-              signature: e.transactionHash,
-            }))
-          ) {
+          if (!preserved) {
             return solanaLostOwnershipResponse(c, executionTxId, agentId, "sign");
           }
+          await tryCompleteSolanaRecoveryEffects({
+            tenantId,
+            agentId,
+            txId: executionTxId,
+            signature: e.transactionHash,
+          });
           return outcomeUnknown;
         }
         // This is also the fallback for a failed Vault.recordSignedTransaction
@@ -3324,7 +3330,6 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           to: transfer.to,
           token: transfer.token,
           value: transfer.value,
-          transaction: signRequest.data,
           referenceId: transfer.referenceId,
         })
       : null;
@@ -3688,16 +3693,12 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
       }
 
       if (solanaExecutionToken && transfer.broadcast) {
-        if (
-          !(await completeSolanaRecoveryEffects({
-            tenantId,
-            agentId,
-            txId: actionId,
-            signature: result,
-          }))
-        ) {
-          return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
-        }
+        await tryCompleteSolanaRecoveryEffects({
+          tenantId,
+          agentId,
+          txId: actionId,
+          signature: result,
+        });
       } else {
         if (transfer.broadcast) {
           recordVaultSpend(agentId, tenantId, signRequest.value, signRequest.chainId).catch((err) =>
@@ -3776,17 +3777,15 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           solanaExecutionToken,
           e.transactionHash,
         );
-        if (
-          !preserved ||
-          !(await completeSolanaRecoveryEffects({
-            tenantId,
-            agentId,
-            txId: actionId,
-            signature: e.transactionHash,
-          }))
-        ) {
+        if (!preserved) {
           return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
         }
+        await tryCompleteSolanaRecoveryEffects({
+          tenantId,
+          agentId,
+          txId: actionId,
+          signature: e.transactionHash,
+        });
         return externalBroadcastOutcomeUnknownResponse(c, e, actionId) as Response;
       }
       if (solanaRecoveryBinding && e instanceof SolanaBroadcastNotSubmittedError) {
@@ -3811,16 +3810,12 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
       if (frozen) return frozen;
       if (completedResult && completedStatus) {
         if (solanaExecutionToken && transfer.broadcast) {
-          if (
-            !(await completeSolanaRecoveryEffects({
-              tenantId,
-              agentId,
-              txId: actionId,
-              signature: completedResult,
-            }))
-          ) {
-            return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
-          }
+          await tryCompleteSolanaRecoveryEffects({
+            tenantId,
+            agentId,
+            txId: actionId,
+            signature: completedResult,
+          });
         } else {
           await db
             .update(transactions)
@@ -4057,9 +4052,6 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
   ) {
     return solanaLostOwnershipResponse(c, txId, agentId, "approval");
   }
-  const sameResolver =
-    pendingApproval.resolvedByType === approverPrincipal.type &&
-    pendingApproval.resolvedById === approverPrincipal.id;
   const leaseUntil =
     typeof approvalRecoveryMetadata.attemptLeaseUntil === "string"
       ? Date.parse(approvalRecoveryMetadata.attemptLeaseUntil)
@@ -4069,7 +4061,6 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
   const isApprovedSolanaResume =
     isSolana &&
     pendingApproval.status === "approved" &&
-    sameResolver &&
     approvalRecoveryMetadata.recoveryType === "solana_transaction" &&
     approvalRecoveryMetadata.recoveryActionType === (transactionRow.actionType ?? "transaction") &&
     (transactionRow.status === "pending" ||
@@ -4432,8 +4423,6 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
                 eq(approvalQueue.txId, txId),
                 eq(approvalQueue.agentId, agentId),
                 eq(approvalQueue.status, "approved"),
-                eq(approvalQueue.resolvedByType, approverPrincipal.type),
-                eq(approvalQueue.resolvedById, approverPrincipal.id),
               ),
             )
             .limit(1)
@@ -4506,9 +4495,10 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           return c.json<ApiResponse>({ ok: false, error: reservationError }, 403);
         }
       }
-      if (isSolana && shouldBroadcast) {
+      if (isSolana && (shouldBroadcast || transferPayload?.token === "native")) {
         const claimed = await claimApprovedSolanaExecution(transactionRow, {
           takeover: isApprovedSolanaResume,
+          resolver: approverPrincipal,
         });
         approvedSolanaExecutionToken = claimed.executionToken;
         approvedSolanaActionPayload = claimed.actionPayload;
@@ -4536,13 +4526,39 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
               )
           : undefined;
         if (transferPayload?.token === "native" && !transactionRow.data) {
-          txHash = await vault.signTransaction(approvalSignRequest, {
-            txId,
-            policyResults: currentEvaluation.results,
-            status: shouldBroadcast ? "broadcast" : "signed",
-            onSolanaBroadcastPrepared: checkpoint,
-            solanaRecoveryExecutionToken: approvedSolanaExecutionToken ?? undefined,
+          const executionClaimDigest = approvedSolanaActionPayload?.executionDigest;
+          if (
+            !approvedSolanaExecutionToken ||
+            typeof executionClaimDigest !== "string" ||
+            executionClaimDigest.length === 0
+          ) {
+            throw new SolanaExecutionLeaseConflictError(
+              "Approved Solana native transfer lacks a durable execution claim",
+            );
+          }
+          const executionPayloadDigest =
+            executionPayloadDigestForGovernedSolanaNativeSign(approvalSignRequest);
+          const executionToken = approvedSolanaExecutionToken;
+          const governedSolanaVault = new GovernedVault(vault, async () => {
+            throw new GovernedVaultError(
+              "EVM execution authorization is unavailable on the Solana gateway",
+              "unsupported_chain_family",
+            );
           });
+          txHash = await governedSolanaVault.signSolanaNativeTransferAuthorized(
+            approvalSignRequest,
+            {
+              txId,
+              policyResults: currentEvaluation.results,
+              status: shouldBroadcast ? "broadcast" : "signed",
+              executionToken,
+              executionClaimDigest,
+              executionPayloadDigest,
+              consumeExecutionClaim: assertApprovedSolanaExecutionClaim,
+              onSolanaBroadcastPrepared: checkpoint,
+              solanaRecoveryExecutionToken: shouldBroadcast ? executionToken : undefined,
+            },
+          );
         } else {
           if (!transactionRow.data) {
             throw new Error("Solana transaction blob not found; cannot replay approval");
@@ -4719,8 +4735,10 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
             eq(transactions.agentId, agentId),
             approvedSolanaExecutionToken
               ? and(
-                  eq(transactions.status, "broadcast"),
-                  eq(transactions.txHash, txHash),
+                  eq(transactions.status, shouldBroadcast ? "broadcast" : "signed"),
+                  shouldBroadcast
+                    ? eq(transactions.txHash, txHash)
+                    : sql`${transactions.txHash} is null`,
                   sql`${transactions.actionPayload}->>'executionToken' = ${approvedSolanaExecutionToken}`,
                 )
               : undefined,
@@ -4732,16 +4750,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       }
 
       if (approvedSolanaExecutionToken && shouldBroadcast) {
-        if (
-          !(await completeSolanaRecoveryEffects({
-            tenantId,
-            agentId,
-            txId,
-            signature: txHash,
-          }))
-        ) {
-          return solanaLostOwnershipResponse(c, txId, agentId, "approval");
-        }
+        await tryCompleteSolanaRecoveryEffects({ tenantId, agentId, txId, signature: txHash });
       } else {
         if (!isSolana && shouldBroadcast) {
           recordVaultSpend(agentId, tenantId, transactionRow.value, transactionRow.chainId).catch(
@@ -4970,16 +4979,12 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       const outcomeUnknown = externalBroadcastOutcomeUnknownResponse(c, e, txId);
       if (outcomeUnknown) {
         if (approvedSolanaExecutionToken && completedTxHash) {
-          if (
-            !(await completeSolanaRecoveryEffects({
-              tenantId,
-              agentId,
-              txId,
-              signature: completedTxHash,
-            }))
-          ) {
-            return solanaLostOwnershipResponse(c, txId, agentId, "approval");
-          }
+          await tryCompleteSolanaRecoveryEffects({
+            tenantId,
+            agentId,
+            txId,
+            signature: completedTxHash,
+          });
           return outcomeUnknown;
         }
         recordVaultSpend(agentId, tenantId, transactionRow.value, transactionRow.chainId).catch(
@@ -5022,16 +5027,13 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         console.error(
           `[${requestId}] Approved transaction ${txId} broadcast before bookkeeping failed; returning broadcast result to prevent duplicate retry`,
         );
-        if (
-          approvedSolanaExecutionToken &&
-          !(await completeSolanaRecoveryEffects({
+        if (approvedSolanaExecutionToken) {
+          await tryCompleteSolanaRecoveryEffects({
             tenantId,
             agentId,
             txId,
             signature: completedTxHash,
-          }))
-        ) {
-          return solanaLostOwnershipResponse(c, txId, agentId, "approval");
+          });
         }
         return c.json<ApiResponse<{ txId: string; txHash: string }>>({
           ok: true,
@@ -8387,16 +8389,13 @@ async function signSolanaBlind(
       if (!(await finalizeSolanaRecoveryAnchor(txId, agentId, ownerToken, result))) {
         return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
       }
-      if (
-        result.broadcast &&
-        !(await completeSolanaRecoveryEffects({
+      if (result.broadcast) {
+        await tryCompleteSolanaRecoveryEffects({
           tenantId,
           agentId,
           txId,
           signature: result.signature,
-        }))
-      ) {
-        return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
+        });
       }
       if (!result.broadcast) {
         recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
@@ -8440,16 +8439,12 @@ async function signSolanaBlind(
         console.error(
           `[${requestId}] Solana blind sign completed before bookkeeping failed for agent ${agentId}, tx ${txId}; returning completed result to prevent duplicate retry`,
         );
-        if (
-          !(await completeSolanaRecoveryEffects({
-            tenantId,
-            agentId,
-            txId,
-            signature: completedResult.signature,
-          }))
-        ) {
-          return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
-        }
+        await tryCompleteSolanaRecoveryEffects({
+          tenantId,
+          agentId,
+          txId,
+          signature: completedResult.signature,
+        });
         setNoStoreHeaders(c);
         return c.json<
           ApiResponse<{
@@ -8485,17 +8480,15 @@ async function signSolanaBlind(
           executionToken,
           e.transactionHash,
         );
-        if (
-          !preserved ||
-          !(await completeSolanaRecoveryEffects({
-            tenantId,
-            agentId,
-            txId,
-            signature: e.transactionHash,
-          }))
-        ) {
+        if (!preserved) {
           return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
         }
+        await tryCompleteSolanaRecoveryEffects({
+          tenantId,
+          agentId,
+          txId,
+          signature: e.transactionHash,
+        });
         return externalBroadcastOutcomeUnknownResponse(c, e, txId) as Response;
       }
       if (
@@ -8532,6 +8525,46 @@ type SolanaRecoveryBinding = {
   requestDigest?: string;
 };
 
+type SolanaCallerIntent = {
+  route: "transfer" | "sign" | "sign-solana";
+  tenantId: string;
+  agentId: string;
+  chainId: number;
+  broadcast: boolean;
+  signingMode: "native" | "spl" | "parsed" | "blind";
+  to: string;
+  value: string;
+  token?: string;
+  referenceId?: string;
+  messageDigest?: string;
+  parsedEffects?: {
+    movesNativeSol: boolean;
+    programIds: string[];
+    tokenTransfers: Array<{ mint?: string; destination: string; amount: string }>;
+  };
+};
+
+function solanaCallerIntentDigest(intent: SolanaCallerIntent): string {
+  // Bind every caller-controlled message byte except signatures and the recent
+  // blockhash. A blockhash refresh is the same request, while memo, compute-
+  // budget, account, program, and instruction changes are distinct requests.
+  return sha256(canonicalJsonStringify(intent));
+}
+
+function solanaParsedEffects(
+  derived: DerivedSolanaPolicyFields,
+): SolanaCallerIntent["parsedEffects"] {
+  return {
+    movesNativeSol: derived.movesNativeSol,
+    programIds: derived.programIds,
+    tokenTransfers: derived.summary.tokenTransfers.map((transfer) => ({
+      mint: transfer.mint,
+      destination: transfer.destination,
+      amount: transfer.amount,
+    })),
+  };
+}
+
 function createSolanaTransferRecoveryBinding(
   c: Context<{ Variables: AppVariables }>,
   input: {
@@ -8541,7 +8574,6 @@ function createSolanaTransferRecoveryBinding(
     to: string;
     token: string;
     value: string;
-    transaction?: string;
     referenceId?: string;
   },
 ): SolanaRecoveryBinding {
@@ -8551,19 +8583,18 @@ function createSolanaTransferRecoveryBinding(
   return {
     txId: `solana_transfer_${sha256(scope).slice(0, 47)}`,
     idempotencyKeyDigest: sha256(scope),
-    requestDigest: sha256(
-      canonicalJsonStringify({
-        agentId: input.agentId,
-        broadcast: true,
-        chainId: input.chainId,
-        referenceId: input.referenceId,
-        tenantId: input.tenantId,
-        to: input.to,
-        token: input.token,
-        transaction: input.transaction,
-        value: input.value,
-      }),
-    ),
+    requestDigest: solanaCallerIntentDigest({
+      route: "transfer",
+      agentId: input.agentId,
+      broadcast: true,
+      chainId: input.chainId,
+      referenceId: input.referenceId,
+      signingMode: input.token === "native" ? "native" : "spl",
+      tenantId: input.tenantId,
+      to: input.to,
+      token: input.token,
+      value: input.value,
+    }),
   };
 }
 
@@ -8599,28 +8630,30 @@ function createSolanaRecoveryBinding(
     value: string;
     broadcastRequested: boolean;
     blindSigned: boolean;
+    parsedEffects?: SolanaCallerIntent["parsedEffects"];
   },
 ): SolanaRecoveryBinding {
-  if (!input.broadcastRequested) return { txId: crypto.randomUUID() };
+  const requestDigest = solanaCallerIntentDigest({
+    route: input.routeFamily,
+    agentId: input.agentId,
+    broadcast: input.broadcastRequested,
+    chainId: input.chainId,
+    signingMode: input.blindSigned ? "blind" : "parsed",
+    tenantId: input.tenantId,
+    to: input.toAddress,
+    value: input.value,
+    parsedEffects: input.parsedEffects,
+    messageDigest:
+      input.routeFamily === "sign" ? undefined : normalizedSolanaMessageDigest(input.transaction),
+  });
+  if (!input.broadcastRequested) return { txId: crypto.randomUUID(), requestDigest };
   const key = c.req.header("Idempotency-Key");
   if (!key) throw new Error("Idempotency-Key is required for Solana broadcast");
   const scope = `${input.tenantId}\0${input.agentId}\0${input.routeFamily}\0${key}`;
   return {
     txId: `solana_${sha256(scope).slice(0, 56)}`,
     idempotencyKeyDigest: sha256(scope),
-    requestDigest: sha256(
-      canonicalJsonStringify({
-        agentId: input.agentId,
-        routeFamily: input.routeFamily,
-        blindSigned: input.blindSigned,
-        broadcast: true,
-        chainId: input.chainId,
-        tenantId: input.tenantId,
-        toAddress: input.toAddress,
-        transaction: input.transaction,
-        value: input.value,
-      }),
-    ),
+    requestDigest,
   };
 }
 
@@ -8772,22 +8805,12 @@ async function solanaLostOwnershipResponse(
     row.txHash &&
     (row.status === "outcome_unknown" || row.status === "broadcast" || row.status === "confirmed")
   ) {
-    const completed = await completeSolanaRecoveryEffects({
+    await tryCompleteSolanaRecoveryEffects({
       tenantId: c.get("tenantId"),
       agentId,
       txId,
       signature: row.txHash,
     });
-    if (!completed) {
-      return c.json<ApiResponse>(
-        {
-          ok: false,
-          error: "Solana recovery accounting is being completed; retry",
-          data: { txId, status: row.status },
-        },
-        409,
-      );
-    }
   }
   if (routeFamily === "approval") return solanaApprovalReplayResponse(c, row);
   if (routeFamily === "transfer") return solanaTransferReplayResponse(c, row);
@@ -8836,7 +8859,7 @@ function solanaTransferReplayResponse(
 
 async function stageSolanaRecoveryAnchor(input: {
   agentId: string;
-  transaction: string;
+  transaction?: string;
   chainId: number;
   toAddress: string;
   value: string;
@@ -8973,28 +8996,61 @@ async function checkpointSolanaBroadcastSubmission(
   }
 }
 
-async function claimApprovedSolanaExecution(
+async function assertApprovedSolanaExecutionClaim(expected: {
+  tenantId: string;
+  agentId: string;
+  txId: string;
+  executionToken: string;
+  executionClaimDigest: string;
+  payloadDigest: string;
+}): Promise<void> {
+  const [row] = await db
+    .select()
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.id, expected.txId),
+        eq(transactions.agentId, expected.agentId),
+        sql`${transactions.status} in ('approved', 'pending')`,
+        sql`${transactions.actionPayload}->>'executionToken' = ${expected.executionToken}`,
+        sql`${transactions.actionPayload}->>'executionDigest' = ${expected.executionClaimDigest}`,
+      ),
+    )
+    .limit(1);
+  if (!row) throw new SolanaExecutionLeaseConflictError();
+  const storedPayloadDigest = executionPayloadDigestForGovernedSolanaNativeSign({
+    ...toSignRequest(row),
+    tenantId: expected.tenantId,
+    broadcast: readSolanaRecoveryMetadata(row.actionPayload).broadcast !== false,
+  });
+  if (storedPayloadDigest !== expected.payloadDigest) {
+    throw new SolanaExecutionLeaseConflictError(
+      "Approved Solana native transfer changed after execution was claimed",
+    );
+  }
+}
+
+export async function claimApprovedSolanaExecution(
   row: typeof transactions.$inferSelect,
-  options: { takeover: boolean },
+  options: { takeover: boolean; resolver: ApprovalPrincipal },
 ): Promise<{ executionToken: string; actionPayload: Record<string, unknown> }> {
   const prior = readSolanaRecoveryMetadata(row.actionPayload);
-  const requestDigest = sha256(
+  const stableActionPayload = Object.fromEntries(
+    Object.entries(prior).filter(
+      ([key]) =>
+        ![
+          "attemptLeaseUntil",
+          "executionToken",
+          "recoveryAnchor",
+          "recoveryActionType",
+          "recoveryType",
+          "executionDigest",
+        ].includes(key),
+    ),
+  );
+  const executionDigest = sha256(
     canonicalJsonStringify({
-      actionPayload: options.takeover
-        ? Object.fromEntries(
-            Object.entries(prior).filter(
-              ([key]) =>
-                ![
-                  "attemptLeaseUntil",
-                  "executionToken",
-                  "recoveryAnchor",
-                  "recoveryActionType",
-                  "recoveryType",
-                  "requestDigest",
-                ].includes(key),
-            ),
-          )
-        : row.actionPayload,
+      actionPayload: stableActionPayload,
       actionType: row.actionType,
       agentId: row.agentId,
       chainId: row.chainId,
@@ -9007,11 +9063,37 @@ async function claimApprovedSolanaExecution(
   const priorToken = typeof prior.executionToken === "string" ? prior.executionToken : null;
   const priorLeaseUntil =
     typeof prior.attemptLeaseUntil === "string" ? Date.parse(prior.attemptLeaseUntil) : Number.NaN;
-  if (options.takeover && priorToken) {
+  if (options.takeover) {
+    const legacyExecutionDigest = sha256(
+      canonicalJsonStringify({
+        actionPayload: Object.fromEntries(
+          Object.entries(prior).filter(
+            ([key]) =>
+              ![
+                "attemptLeaseUntil",
+                "executionToken",
+                "recoveryAnchor",
+                "recoveryActionType",
+                "recoveryType",
+                "requestDigest",
+              ].includes(key),
+          ),
+        ),
+        actionType: row.actionType,
+        agentId: row.agentId,
+        chainId: row.chainId,
+        data: row.data,
+        id: row.id,
+        toAddress: row.toAddress,
+        value: row.value,
+      }),
+    );
     if (
       prior.recoveryType !== "solana_transaction" ||
       prior.recoveryActionType !== (row.actionType ?? "transaction") ||
-      prior.requestDigest !== requestDigest ||
+      (prior.executionDigest !== undefined
+        ? prior.executionDigest !== executionDigest
+        : prior.requestDigest !== legacyExecutionDigest) ||
       !priorToken ||
       !Number.isFinite(priorLeaseUntil) ||
       priorLeaseUntil > Date.now()
@@ -9027,26 +9109,49 @@ async function claimApprovedSolanaExecution(
     recoveryType: "solana_transaction",
     recoveryActionType: row.actionType ?? "transaction",
     recoveryAnchor: true,
-    requestDigest,
+    executionDigest,
     executionToken,
     attemptLeaseUntil: new Date(Date.now() + SOLANA_SIGNING_ATTEMPT_LEASE_MS).toISOString(),
   };
-  const [claimed] = await db
-    .update(transactions)
-    .set({ status: "approved", actionPayload })
-    .where(
-      and(
-        eq(transactions.id, row.id),
-        eq(transactions.agentId, row.agentId),
-        eq(transactions.status, row.status),
-        priorToken
-          ? sql`${transactions.actionPayload}->>'executionToken' = ${priorToken}`
-          : sql`${transactions.actionPayload}->>'executionToken' is null`,
-      ),
-    )
-    .returning({ id: transactions.id });
-  if (!claimed) throw new SolanaExecutionLeaseConflictError();
-  return { executionToken, actionPayload };
+  return db.transaction(async (tx) => {
+    const [claimed] = await tx
+      .update(transactions)
+      .set({ status: "approved", actionPayload })
+      .where(
+        and(
+          eq(transactions.id, row.id),
+          eq(transactions.agentId, row.agentId),
+          eq(transactions.status, row.status),
+          priorToken
+            ? sql`${transactions.actionPayload}->>'executionToken' = ${priorToken}`
+            : sql`${transactions.actionPayload}->>'executionToken' is null`,
+        ),
+      )
+      .returning({ id: transactions.id });
+    if (!claimed) throw new SolanaExecutionLeaseConflictError();
+
+    if (options.takeover) {
+      const [transferred] = await tx
+        .update(approvalQueue)
+        .set({
+          resolvedAt: new Date(),
+          resolvedBy: `${options.resolver.type}:${options.resolver.id}`,
+          resolvedByType: options.resolver.type,
+          resolvedById: options.resolver.id,
+        })
+        .where(
+          and(
+            eq(approvalQueue.txId, row.id),
+            eq(approvalQueue.agentId, row.agentId),
+            eq(approvalQueue.status, "approved"),
+          ),
+        )
+        .returning({ id: approvalQueue.id });
+      if (!transferred) throw new SolanaExecutionLeaseConflictError();
+    }
+
+    return { executionToken, actionPayload };
+  });
 }
 
 class SolanaApprovalResetCasLostError extends Error {}
@@ -9304,6 +9409,27 @@ async function markSolanaBroadcastNotSubmitted(
     });
     return true;
   });
+}
+
+async function tryCompleteSolanaRecoveryEffects(input: {
+  tenantId: string;
+  agentId: string;
+  txId: string;
+  signature: string;
+}): Promise<boolean> {
+  try {
+    return await completeSolanaRecoveryEffects(input);
+  } catch (error) {
+    // The broadcast/result is already durably anchored. Never turn a
+    // telemetry/accounting outage into a retryable signing response: leave the
+    // effects claim pending so a replay or reconciliation can finish it once
+    // the dependency recovers.
+    console.error(
+      `[vault] Deferred Solana recovery effects for ${input.txId}`,
+      redactedThrownDiagnostics(error),
+    );
+    return false;
+  }
 }
 
 async function completeSolanaRecoveryEffects(input: {
@@ -9824,6 +9950,7 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
       value: txValue,
       broadcastRequested: shouldBroadcast,
       blindSigned: false,
+      parsedEffects: solanaParsedEffects(derived),
     });
     const { txId } = binding;
     let executionToken: string | null = null;
@@ -9885,16 +10012,13 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
       }
 
-      if (
-        result.broadcast &&
-        !(await completeSolanaRecoveryEffects({
+      if (result.broadcast) {
+        await tryCompleteSolanaRecoveryEffects({
           tenantId,
           agentId,
           txId,
           signature: result.signature,
-        }))
-      ) {
-        return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
+        });
       }
       if (!result.broadcast) {
         recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
@@ -9949,16 +10073,12 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
         console.error(
           `[${requestId}] Solana sign completed before bookkeeping failed for agent ${agentId}, tx ${txId}; returning completed result to prevent duplicate retry`,
         );
-        if (
-          !(await completeSolanaRecoveryEffects({
-            tenantId,
-            agentId,
-            txId,
-            signature: completedResult.signature,
-          }))
-        ) {
-          return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
-        }
+        await tryCompleteSolanaRecoveryEffects({
+          tenantId,
+          agentId,
+          txId,
+          signature: completedResult.signature,
+        });
         setNoStoreHeaders(c);
         return c.json<
           ApiResponse<{
@@ -9995,17 +10115,15 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
           executionToken,
           e.transactionHash,
         );
-        if (
-          !preserved ||
-          !(await completeSolanaRecoveryEffects({
-            tenantId,
-            agentId,
-            txId,
-            signature: e.transactionHash,
-          }))
-        ) {
+        if (!preserved) {
           return solanaLostOwnershipResponse(c, txId, agentId, "sign-solana");
         }
+        await tryCompleteSolanaRecoveryEffects({
+          tenantId,
+          agentId,
+          txId,
+          signature: e.transactionHash,
+        });
         return externalBroadcastOutcomeUnknownResponse(c, e, txId) as Response;
       }
       if (

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -9843,16 +9843,24 @@ async function completeSolanaRecoveryEffects(input: {
       throw new Error("Configured Redis accounting backend is unavailable");
     }
     const occurredAt = row.signedAt ?? row.createdAt;
+    const transferPayload = getTransferActionPayload(row.actionPayload);
+    const tokenAddress =
+      transferPayload?.token && transferPayload.token !== "native"
+        ? transferPayload.token
+        : undefined;
     if (isRedisAvailable()) {
       await recordVaultSpend(input.agentId, input.tenantId, row.value, row.chainId, {
         eventId: `solana:${input.txId}:${input.signature}`,
         occurredAt,
         throwOnError: true,
+        tokenAddress,
       });
       await recordAggregationEvent({
         eventId: `solana:${input.txId}:${input.signature}`,
         agentId: input.agentId,
-        valueRaw: row.value,
+        // Aggregation value_sum is native-base-unit denominated. Preserve
+        // counts for SPL transfers without folding token units into lamports.
+        valueRaw: tokenAddress ? "0" : row.value,
         to: row.toAddress,
         chainId: row.chainId,
         timestamp: occurredAt.getTime(),
@@ -9892,7 +9900,6 @@ async function completeSolanaRecoveryEffects(input: {
         },
       );
     }
-    const transferPayload = getTransferActionPayload(row.actionPayload);
     if (transferPayload) {
       await recordSponsoredActionIfNeeded({
         sponsorship: transferPayload.sponsorship,
@@ -10605,6 +10612,25 @@ vaultRoutes.post("/:agentId/transactions/:txId/reconcile-solana", async (c) => {
   ) {
     return c.json<ApiResponse>({ ok: false, error: "Solana transaction not found" }, 404);
   }
+  if ((row.status === "broadcast" || row.status === "confirmed") && isNonEmptyString(row.txHash)) {
+    if (
+      !(await completeSolanaRecoveryEffects({
+        tenantId,
+        agentId,
+        txId,
+        signature: row.txHash,
+      }))
+    ) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Solana recovery accounting is being completed; retry" },
+        409,
+      );
+    }
+    return c.json<ApiResponse>({
+      ok: true,
+      data: { txId, signature: row.txHash, status: row.status },
+    });
+  }
   if (row.status !== "outcome_unknown") {
     return c.json<ApiResponse>(
       { ok: false, error: "Only outcome_unknown Solana transactions can be reconciled" },
@@ -10680,6 +10706,26 @@ vaultRoutes.post("/:agentId/transactions/:txId/reconcile-solana", async (c) => {
     },
   );
   if (!transitioned) {
+    const [winner] = await db
+      .select({ status: transactions.status, txHash: transactions.txHash })
+      .from(transactions)
+      .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)))
+      .limit(1);
+    if (
+      winner?.txHash === signature &&
+      (winner.status === "broadcast" || winner.status === "confirmed")
+    ) {
+      if (!(await completeSolanaRecoveryEffects({ tenantId, agentId, txId, signature }))) {
+        return c.json<ApiResponse>(
+          { ok: false, error: "Solana recovery accounting is being completed; retry" },
+          409,
+        );
+      }
+      return c.json<ApiResponse>({
+        ok: true,
+        data: { txId, signature, status: winner.status },
+      });
+    }
     return c.json<ApiResponse>({ ok: false, error: "Transaction state changed; retry" }, 409);
   }
   if (

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -1964,28 +1964,48 @@ async function requireSignerPermission(
 }
 
 const pgliteAgentSpendQueues = new Map<string, Promise<void>>();
+let solanaRecoveryEffectsClaimHookForTests:
+  | ((input: { txId: string; status: string; claimToken: string }) => Promise<void>)
+  | null = null;
+
+export function __setSolanaRecoveryEffectsClaimHookForTests(
+  hook: typeof solanaRecoveryEffectsClaimHookForTests,
+): () => void {
+  const previous = solanaRecoveryEffectsClaimHookForTests;
+  solanaRecoveryEffectsClaimHookForTests = hook;
+  return () => {
+    solanaRecoveryEffectsClaimHookForTests = previous;
+  };
+}
 
 async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
   if (process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true") {
-    const predecessor = pgliteAgentSpendQueues.get(agentId) ?? Promise.resolve();
-    let release!: () => void;
-    const owned = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const tail = predecessor.catch(() => undefined).then(() => owned);
-    pgliteAgentSpendQueues.set(agentId, tail);
-    await predecessor.catch(() => undefined);
-    try {
-      return await fn();
-    } finally {
-      release();
-      if (pgliteAgentSpendQueues.get(agentId) === tail) pgliteAgentSpendQueues.delete(agentId);
-    }
+    return fn();
   }
   return db.transaction(async (tx) => {
     await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${agentId}, 0))`);
     return fn();
   });
+}
+
+async function withAgentTransferSpendLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
+  if (process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true") {
+    return withAgentSpendLock(agentId, fn);
+  }
+  const predecessor = pgliteAgentSpendQueues.get(agentId) ?? Promise.resolve();
+  let release!: () => void;
+  const owned = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const tail = predecessor.catch(() => undefined).then(() => owned);
+  pgliteAgentSpendQueues.set(agentId, tail);
+  await predecessor.catch(() => undefined);
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (pgliteAgentSpendQueues.get(agentId) === tail) pgliteAgentSpendQueues.delete(agentId);
+  }
 }
 
 async function nativeTransferGasAccountingGuard(
@@ -3316,7 +3336,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
     });
   }
 
-  return withAgentSpendLock(agentId, async () => {
+  return withAgentTransferSpendLock(agentId, async () => {
     const lockedLookup = await findExistingTransferAction();
     if ("conflict" in lockedLookup) {
       return c.json<ApiResponse>(
@@ -9800,6 +9820,10 @@ async function completeSolanaRecoveryEffects(input: {
         sql`(
           coalesce(${transactions.actionPayload}->>'recoveryEffectsState', 'pending') = 'pending'
           or (
+            ${transactions.actionPayload}->>'recoveryEffectsState' = 'accounted_unknown'
+            and ${row.status} in ('broadcast', 'confirmed')
+          )
+          or (
             ${transactions.actionPayload}->>'recoveryEffectsState' = 'processing'
             and coalesce(${transactions.actionPayload}->>'recoveryEffectsLeaseUntil', '') <= ${claimableBefore}
           )
@@ -9810,6 +9834,11 @@ async function completeSolanaRecoveryEffects(input: {
   if (!claimed) return false;
 
   try {
+    await solanaRecoveryEffectsClaimHookForTests?.({
+      txId: input.txId,
+      status: row.status,
+      claimToken,
+    });
     if (isRedisConfigured() && !isRedisAvailable()) {
       throw new Error("Configured Redis accounting backend is unavailable");
     }
@@ -9828,6 +9857,40 @@ async function completeSolanaRecoveryEffects(input: {
         chainId: row.chainId,
         timestamp: occurredAt.getTime(),
       });
+    }
+    if (row.status === "outcome_unknown") {
+      return await withTenantAuditedTransaction(
+        input.tenantId,
+        async (rawTx, appendRequiredAudit) => {
+          const tx = rawTx as typeof db;
+          const [accounted] = await tx
+            .update(transactions)
+            .set({
+              actionPayload: sql`jsonb_set(jsonb_set(coalesce(${transactions.actionPayload}, '{}'::jsonb), '{recoveryEffectsState}', '"accounted_unknown"'::jsonb), '{recoveryAmbiguousAccountingAt}', ${JSON.stringify(new Date().toISOString())}::jsonb) - 'recoveryEffectsToken' - 'recoveryEffectsLeaseUntil'`,
+            })
+            .where(
+              and(
+                eq(transactions.id, input.txId),
+                eq(transactions.agentId, input.agentId),
+                eq(transactions.txHash, input.signature),
+                eq(transactions.status, "outcome_unknown"),
+                sql`${transactions.actionPayload}->>'recoveryEffectsToken' = ${claimToken}`,
+              ),
+            )
+            .returning({ id: transactions.id });
+          if (!accounted) return false;
+          await appendRequiredAudit({
+            tenantId: input.tenantId,
+            actorType: "system",
+            actorId: "solana-recovery",
+            action: "vault.sign.solana.outcome_unknown_accounted",
+            resourceType: "transaction",
+            resourceId: input.txId,
+            metadata: { signature: input.signature, status: row.status },
+          });
+          return true;
+        },
+      );
     }
     const transferPayload = getTransferActionPayload(row.actionPayload);
     if (transferPayload) {
@@ -9875,6 +9938,7 @@ async function completeSolanaRecoveryEffects(input: {
               eq(transactions.id, input.txId),
               eq(transactions.agentId, input.agentId),
               eq(transactions.txHash, input.signature),
+              eq(transactions.status, row.status),
               sql`${transactions.actionPayload}->>'recoveryEffectsToken' = ${claimToken}`,
             ),
           )
@@ -9903,6 +9967,7 @@ async function completeSolanaRecoveryEffects(input: {
       .where(
         and(
           eq(transactions.id, input.txId),
+          eq(transactions.status, row.status),
           sql`${transactions.actionPayload}->>'recoveryEffectsToken' = ${claimToken}`,
         ),
       );
@@ -10580,11 +10645,7 @@ vaultRoutes.post("/:agentId/transactions/:txId/reconcile-solana", async (c) => {
         .set({
           status: nextStatus,
           confirmedAt: nextStatus === "confirmed" ? new Date() : row.confirmedAt,
-          actionPayload: {
-            ...metadata,
-            reconciledAt: new Date().toISOString(),
-            reconciliationResult: nextStatus,
-          },
+          actionPayload: sql`jsonb_set(jsonb_set(coalesce(${transactions.actionPayload}, '{}'::jsonb), '{reconciledAt}', ${JSON.stringify(new Date().toISOString())}::jsonb), '{reconciliationResult}', ${JSON.stringify(nextStatus)}::jsonb)`,
         })
         .where(
           and(
@@ -10592,6 +10653,10 @@ vaultRoutes.post("/:agentId/transactions/:txId/reconcile-solana", async (c) => {
             eq(transactions.agentId, agentId),
             eq(transactions.status, "outcome_unknown"),
             eq(transactions.txHash, signature),
+            sql`(
+              coalesce(${transactions.actionPayload}->>'recoveryEffectsState', 'pending') <> 'processing'
+              or coalesce(${transactions.actionPayload}->>'recoveryEffectsLeaseUntil', '') <= ${new Date().toISOString()}
+            )`,
           ),
         )
         .returning({ id: transactions.id });

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -660,14 +660,25 @@ export async function getTransactionStats(agentId: string, chainId?: number) {
         coalesce(
           sum(
             case
-              when ${transactions.createdAt} >= ${oneDayAgoStr}::timestamptz${chainFilter} then (${transactions.value})::numeric
+              when ${transactions.createdAt} >= ${oneDayAgoStr}::timestamptz${chainFilter}
+                and not (
+                  coalesce(${transactions.actionPayload}->>'type', '') = 'transfer'
+                  and coalesce(${transactions.actionPayload}->>'token', 'native') <> 'native'
+                )
+              then (${transactions.value})::numeric
               else 0
             end
           ),
           0
         )::text
       `,
-      spentThisWeek: sql<string>`coalesce(sum((${transactions.value})::numeric) filter (where true${chainFilter}), 0)::text`,
+      spentThisWeek: sql<string>`coalesce(sum((${transactions.value})::numeric) filter (
+        where true${chainFilter}
+          and not (
+            coalesce(${transactions.actionPayload}->>'type', '') = 'transfer'
+            and coalesce(${transactions.actionPayload}->>'token', 'native') <> 'native'
+          )
+      ), 0)::text`,
       additionalUsdSpentTodayMicros: sql<string>`
         coalesce((
           select sum((${operatorTransferReservations.amountBaseUnits})::numeric)

--- a/packages/shared/src/__tests__/tokens-venues-price.test.ts
+++ b/packages/shared/src/__tests__/tokens-venues-price.test.ts
@@ -11,6 +11,7 @@ import {
   VENUE_IDS,
   VENUE_METADATA,
   WRAPPED_SOL_ON_SOLANA,
+  WRAPPED_SOL_ON_SOLANA_DEVNET,
 } from "../index";
 
 const originalFetch = globalThis.fetch;
@@ -56,8 +57,11 @@ describe("token helpers", () => {
 
   it("registers wrapped SOL for exact SPL valuation without losing native lookup", () => {
     expect(getKnownToken(101, WRAPPED_SOL_ON_SOLANA.address)).toBe(WRAPPED_SOL_ON_SOLANA);
+    expect(getKnownToken(102, WRAPPED_SOL_ON_SOLANA.address)).toBe(WRAPPED_SOL_ON_SOLANA_DEVNET);
     expect(getTokenDecimals(101, WRAPPED_SOL_ON_SOLANA.address)).toBe(9);
+    expect(getTokenDecimals(102, WRAPPED_SOL_ON_SOLANA.address)).toBe(9);
     expect(getWrappedNativeAddress(101)).toBe(WRAPPED_SOL_ON_SOLANA.address);
+    expect(getWrappedNativeAddress(102)).toBe(WRAPPED_SOL_ON_SOLANA.address);
   });
 
   it("exposes wrapped native addresses only for configured chains", () => {
@@ -171,7 +175,7 @@ describe("createPriceOracle", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("values wrapped SOL token base units with the registered 9 decimals", async () => {
+  it("values wrapped SOL token base units with 9 decimals on both convention chains", async () => {
     globalThis.fetch = mock(
       async () =>
         new Response(
@@ -183,9 +187,12 @@ describe("createPriceOracle", () => {
     ) as unknown as typeof fetch;
 
     const oracle = createPriceOracle({ cacheTtlMs: 0 });
-    await expect(
-      oracle.weiToUsd("1500000000", 101, WRAPPED_SOL_ON_SOLANA.address),
-    ).resolves.toBe(300);
+    await expect(oracle.weiToUsd("1500000000", 101, WRAPPED_SOL_ON_SOLANA.address)).resolves.toBe(
+      300,
+    );
+    await expect(oracle.weiToUsd("500000000", 102, WRAPPED_SOL_ON_SOLANA.address)).resolves.toBe(
+      100,
+    );
   });
 
   it("keeps case-distinct Solana mint prices isolated in the cache", async () => {

--- a/packages/shared/src/__tests__/tokens-venues-price.test.ts
+++ b/packages/shared/src/__tests__/tokens-venues-price.test.ts
@@ -10,6 +10,7 @@ import {
   MONERO_ON_SOLANA,
   VENUE_IDS,
   VENUE_METADATA,
+  WRAPPED_SOL_ON_SOLANA,
 } from "../index";
 
 const originalFetch = globalThis.fetch;
@@ -51,6 +52,12 @@ describe("token helpers", () => {
     expect(getKnownToken(101, MONERO_ON_SOLANA.address)).toBe(MONERO_ON_SOLANA);
     expect(getTokenDecimals(101, MONERO_ON_SOLANA.address)).toBe(12);
     expect(getKnownToken(101, MONERO_ON_SOLANA.address.toLowerCase())).toBeUndefined();
+  });
+
+  it("registers wrapped SOL for exact SPL valuation without losing native lookup", () => {
+    expect(getKnownToken(101, WRAPPED_SOL_ON_SOLANA.address)).toBe(WRAPPED_SOL_ON_SOLANA);
+    expect(getTokenDecimals(101, WRAPPED_SOL_ON_SOLANA.address)).toBe(9);
+    expect(getWrappedNativeAddress(101)).toBe(WRAPPED_SOL_ON_SOLANA.address);
   });
 
   it("exposes wrapped native addresses only for configured chains", () => {
@@ -162,6 +169,23 @@ describe("createPriceOracle", () => {
     await expect(oracle.weiToUsd("1000000000", 101)).resolves.toBe(200);
     await expect(oracle.weiToUsd("500000000", 102)).resolves.toBe(100);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("values wrapped SOL token base units with the registered 9 decimals", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            pairs: [{ chainId: "solana", priceUsd: "200", liquidity: { usd: 50_000 } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    ) as unknown as typeof fetch;
+
+    const oracle = createPriceOracle({ cacheTtlMs: 0 });
+    await expect(
+      oracle.weiToUsd("1500000000", 101, WRAPPED_SOL_ON_SOLANA.address),
+    ).resolves.toBe(300);
   });
 
   it("keeps case-distinct Solana mint prices isolated in the cache", async () => {

--- a/packages/shared/src/__tests__/tokens-venues-price.test.ts
+++ b/packages/shared/src/__tests__/tokens-venues-price.test.ts
@@ -55,7 +55,8 @@ describe("token helpers", () => {
 
   it("exposes wrapped native addresses only for configured chains", () => {
     expect(getWrappedNativeAddress(8453)).toBe("0x4200000000000000000000000000000000000006");
-    expect(getWrappedNativeAddress(101)).toBeUndefined();
+    expect(getWrappedNativeAddress(101)).toBe("So11111111111111111111111111111111111111112");
+    expect(getWrappedNativeAddress(102)).toBe("So11111111111111111111111111111111111111112");
   });
 });
 
@@ -143,6 +144,24 @@ describe("createPriceOracle", () => {
     await expect(oracle.weiToUsd("2000000000000", 101, MONERO_ON_SOLANA.address)).resolves.toBe(
       651,
     );
+  });
+
+  it("values native SOL on both convention chains through the canonical wrapped mint", async () => {
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      expect(String(input)).toEndWith("/So11111111111111111111111111111111111111112");
+      return new Response(
+        JSON.stringify({
+          pairs: [{ chainId: "solana", priceUsd: "200", liquidity: { usd: 50_000 } }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const oracle = createPriceOracle({ cacheTtlMs: 0 });
+    await expect(oracle.weiToUsd("1000000000", 101)).resolves.toBe(200);
+    await expect(oracle.weiToUsd("500000000", 102)).resolves.toBe(100);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("keeps case-distinct Solana mint prices isolated in the cache", async () => {

--- a/packages/shared/src/price-oracle.ts
+++ b/packages/shared/src/price-oracle.ts
@@ -175,6 +175,7 @@ export function createPriceOracle(options?: { cacheTtlMs?: number }): PriceOracl
       case 43114:
         return "avalanche";
       case 101:
+      case 102:
         return "solana";
       default:
         return null;

--- a/packages/shared/src/security-surface.ts
+++ b/packages/shared/src/security-surface.ts
@@ -366,8 +366,15 @@ export const SECURITY_SURFACE_OPERATIONS = [
     id: "wallet.solana_transaction.sign",
     kind: "wallet-signing",
     capability: "sign_solana_transaction",
-    vaultMethods: ["signSolanaTransaction"],
+    vaultMethods: ["signSolanaTransaction", "signTransaction"],
     routes: [
+      {
+        file: "packages/api/src/routes/vault.ts",
+        method: "POST",
+        path: "/:agentId/sign",
+        notes:
+          "Solana native branch consumes a durable execution claim through GovernedVault before raw signing",
+      },
       { file: "packages/api/src/routes/vault.ts", method: "POST", path: "/:agentId/sign-solana" },
       {
         file: "packages/api/src/routes/vault.ts",
@@ -379,7 +386,8 @@ export const SECURITY_SURFACE_OPERATIONS = [
         file: "packages/api/src/routes/vault.ts",
         method: "POST",
         path: "/:agentId/approve/:txId",
-        notes: "Solana approval execution branch",
+        notes:
+          "Solana approval execution branch; native transfers consume a durable execution claim through GovernedVault immediately before raw signing",
       },
     ],
     auth: ["agent access", "delegated sign_transaction"],
@@ -552,27 +560,13 @@ export interface RawEvmSignCallSite {
  * entry without removing the call also fails.
  */
 export const RAW_EVM_SIGN_INVENTORY = [
-  // ── packages/api/src/routes/vault.ts (4 raw calls) ──
-  {
-    file: "packages/api/src/routes/vault.ts",
-    marker: "invariant: primary EVM sign reached raw signer without gateway authorization",
-    classification: "migrated-invariant-guarded",
-    reason:
-      "Primary /sign Solana-only fallback. An isEvmSignRequest invariant guard throws immediately above it, so no EVM request can reach raw signing.",
-  },
+  // ── packages/api/src/routes/vault.ts (2 raw calls) ──
   {
     file: "packages/api/src/routes/vault.ts",
     marker: "/:agentId/actions/transfer",
     classification: "legacy",
     reason:
       "Transfer action EVM sign; separate non-migrated surface. One-for-one with LEGACY_EVM_SIGN_CALL_SITES.",
-  },
-  {
-    file: "packages/api/src/routes/vault.ts",
-    marker: 'transferPayload?.token === "native" && !transactionRow.data',
-    classification: "migrated-invariant-guarded",
-    reason:
-      "Approved native-SOL replay. The enclosing isSolana branch prevents every EVM approval from reaching this raw signer.",
   },
   {
     file: "packages/api/src/routes/vault.ts",

--- a/packages/shared/src/tokens.ts
+++ b/packages/shared/src/tokens.ts
@@ -79,6 +79,8 @@ export const WRAPPED_NATIVE: Record<number, string> = {
   42161: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1", // WETH (Arbitrum)
   10: "0x4200000000000000000000000000000000000006", // WETH (Optimism)
   43114: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7", // WAVAX
+  101: "So11111111111111111111111111111111111111112", // wrapped SOL (mainnet)
+  102: "So11111111111111111111111111111111111111112", // wrapped SOL (devnet convention)
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/packages/shared/src/tokens.ts
+++ b/packages/shared/src/tokens.ts
@@ -33,7 +33,19 @@ export const MONERO_ON_SOLANA: TokenInfo = Object.freeze({
   website: "https://wxmr.io",
 });
 
-export const KNOWN_TOKENS: readonly TokenInfo[] = Object.freeze([MONERO_ON_SOLANA]);
+export const WRAPPED_SOL_ON_SOLANA: TokenInfo = Object.freeze({
+  address: "So11111111111111111111111111111111111111112",
+  symbol: "wSOL",
+  decimals: 9,
+  chainId: 101,
+  name: "Wrapped SOL",
+  website: "https://solana.com",
+});
+
+export const KNOWN_TOKENS: readonly TokenInfo[] = Object.freeze([
+  MONERO_ON_SOLANA,
+  WRAPPED_SOL_ON_SOLANA,
+]);
 
 /**
  * Return exact token metadata when Steward knows the asset. Solana addresses

--- a/packages/shared/src/tokens.ts
+++ b/packages/shared/src/tokens.ts
@@ -42,9 +42,15 @@ export const WRAPPED_SOL_ON_SOLANA: TokenInfo = Object.freeze({
   website: "https://solana.com",
 });
 
+export const WRAPPED_SOL_ON_SOLANA_DEVNET: TokenInfo = Object.freeze({
+  ...WRAPPED_SOL_ON_SOLANA,
+  chainId: 102,
+});
+
 export const KNOWN_TOKENS: readonly TokenInfo[] = Object.freeze([
   MONERO_ON_SOLANA,
   WRAPPED_SOL_ON_SOLANA,
+  WRAPPED_SOL_ON_SOLANA_DEVNET,
 ]);
 
 /**

--- a/packages/vault/src/__tests__/blind-sign-gate.test.ts
+++ b/packages/vault/src/__tests__/blind-sign-gate.test.ts
@@ -80,7 +80,28 @@ describe("Vault blind-sign gate (SEC-163)", () => {
         transaction: tx,
         broadcast: false,
       }),
-    ).rejects.toThrow(/allowBlindSign/);
+    ).rejects.toThrow(/governed execution grant/);
+  });
+
+  test("signSolanaTransaction rejects a caller-forged parsed execution object", async () => {
+    const feePayer = await createSolanaAgent(vault);
+    const tx = nativeTransfer(feePayer, PublicKey.unique(), 1_000);
+    const forged = {
+      tenantId: TENANT_ID,
+      agentId: AGENT_ID,
+      transaction: tx,
+      broadcast: false,
+      governedParsedSign: {
+        tenantId: TENANT_ID,
+        agentId: AGENT_ID,
+        chainId: 101,
+        broadcast: false,
+        messageDigest: "attacker-controlled",
+        executionPayloadDigest: "attacker-controlled",
+      },
+    } as unknown as Parameters<Vault["signSolanaTransaction"]>[0];
+
+    await expect(vault.signSolanaTransaction(forged)).rejects.toThrow(/governed execution grant/);
   });
 
   test("signSolanaTransaction signs an envelope-less request with allowBlindSign: true", async () => {

--- a/packages/vault/src/__tests__/governed-vault.test.ts
+++ b/packages/vault/src/__tests__/governed-vault.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { ExecutionAuthorization, SignRequest } from "@stwd/shared";
 import {
   executionPayloadDigestForGovernedEvmSign,
+  executionPayloadDigestForGovernedSolanaNativeSign,
   GovernedVault,
   GovernedVaultError,
 } from "../governed-vault";
@@ -34,6 +35,92 @@ const authorization: ExecutionAuthorization = {
 };
 
 describe("GovernedVault", () => {
+  it("consumes a durable Solana claim immediately before native raw signing", async () => {
+    const calls: string[] = [];
+    const solanaRequest: SignRequest = {
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      to: "7J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg",
+      value: "1000000000",
+      chainId: 101,
+      broadcast: true,
+    };
+    const rawVault = {
+      async signTransaction() {
+        calls.push("raw-sign");
+        return "solana-signature";
+      },
+    } as unknown as Vault;
+    const governed = new GovernedVault(rawVault, async () => {
+      throw new Error("EVM callback must not be used");
+    });
+    const digest = executionPayloadDigestForGovernedSolanaNativeSign(solanaRequest);
+
+    const result = await governed.signSolanaNativeTransferAuthorized(solanaRequest, {
+      txId: "solana-tx-1",
+      executionToken: "claim-token",
+      executionClaimDigest: "claim-digest",
+      executionPayloadDigest: digest,
+      consumeExecutionClaim: async (expected) => {
+        expect(expected).toMatchObject({
+          txId: "solana-tx-1",
+          executionToken: "claim-token",
+          executionClaimDigest: "claim-digest",
+          payloadDigest: digest,
+        });
+        calls.push("consume-claim");
+      },
+    });
+
+    expect(result).toBe("solana-signature");
+    expect(calls).toEqual(["consume-claim", "raw-sign"]);
+  });
+
+  it("never raw-signs Solana when the durable claim rejects or intent changes", async () => {
+    let rawCalls = 0;
+    const solanaRequest: SignRequest = {
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      to: "7J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg",
+      value: "1",
+      chainId: 101,
+      broadcast: true,
+    };
+    const rawVault = {
+      async signTransaction() {
+        rawCalls += 1;
+        return "never";
+      },
+    } as unknown as Vault;
+    const governed = new GovernedVault(rawVault, async () => {});
+    const digest = executionPayloadDigestForGovernedSolanaNativeSign(solanaRequest);
+
+    await expect(
+      governed.signSolanaNativeTransferAuthorized(
+        { ...solanaRequest, value: "2" },
+        {
+          txId: "solana-tx-2",
+          executionToken: "claim-token",
+          executionClaimDigest: "claim-digest",
+          executionPayloadDigest: digest,
+          consumeExecutionClaim: async () => {},
+        },
+      ),
+    ).rejects.toThrow("does not match");
+    await expect(
+      governed.signSolanaNativeTransferAuthorized(solanaRequest, {
+        txId: "solana-tx-2",
+        executionToken: "claim-token",
+        executionClaimDigest: "claim-digest",
+        executionPayloadDigest: digest,
+        consumeExecutionClaim: async () => {
+          throw new Error("stale claim");
+        },
+      }),
+    ).rejects.toThrow("stale claim");
+    expect(rawCalls).toBe(0);
+  });
+
   it("consumes execution authorization immediately before raw signTransaction", async () => {
     const calls: string[] = [];
     const rawVault = {

--- a/packages/vault/src/__tests__/governed-vault.test.ts
+++ b/packages/vault/src/__tests__/governed-vault.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import type { ExecutionAuthorization, SignRequest } from "@stwd/shared";
 import {
+  executionClaimDigestForGovernedSolanaParsedSign,
   executionPayloadDigestForGovernedEvmSign,
   executionPayloadDigestForGovernedSolanaNativeSign,
+  executionPayloadDigestForGovernedSolanaParsedSign,
   GovernedVault,
   GovernedVaultError,
 } from "../governed-vault";
+import { normalizedSolanaMessageDigest } from "../solana";
 import type { SignTransactionOptions, Vault } from "../vault";
 
 const request: SignRequest = {
@@ -35,6 +38,140 @@ const authorization: ExecutionAuthorization = {
 };
 
 describe("GovernedVault", () => {
+  it("consumes the complete parsed Solana claim before entering the raw custody signer", async () => {
+    const calls: string[] = [];
+    const transaction = "opaque-parsed-solana-transaction";
+    const parsedRequest = {
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      transaction,
+      chainId: 101,
+      broadcast: false,
+    } as const;
+    const parsedEffects = {
+      movesNativeSol: false,
+      programIds: ["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"],
+      tokenTransfers: [{ mint: "mint-1", destination: "destination-1", amount: "7" }],
+    };
+    const messageDigest = normalizedSolanaMessageDigest(transaction);
+    const policyRevisionHash = "policy-revision-1";
+    const executionPayloadDigest = executionPayloadDigestForGovernedSolanaParsedSign(
+      parsedRequest,
+      { messageDigest, parsedEffects, policyRevisionHash },
+    );
+    const executionClaimDigest = executionClaimDigestForGovernedSolanaParsedSign({
+      executionPayloadDigest,
+      executionToken: "lease-token-1",
+      txId: "tx-parsed-1",
+    });
+    const rawVault = {
+      async signSolanaTransaction(rawRequest: Record<string, unknown>) {
+        expect(rawRequest.allowBlindSign).toBeUndefined();
+        expect(rawRequest.governedParsedSign).toBeDefined();
+        calls.push("raw-sign");
+        return { signature: "signed", broadcast: false, chainId: 101 };
+      },
+    } as unknown as Vault;
+    const governed = new GovernedVault(rawVault, async () => {});
+
+    const result = await governed.signSolanaParsedTransactionAuthorized(parsedRequest, {
+      txId: "tx-parsed-1",
+      executionToken: "lease-token-1",
+      executionClaimDigest,
+      executionPayloadDigest,
+      messageDigest,
+      parsedEffects,
+      policyRevisionHash,
+      consumeExecutionClaim: async (expected) => {
+        expect(expected).toEqual({
+          tenantId: "tenant-1",
+          agentId: "agent-1",
+          txId: "tx-parsed-1",
+          executionToken: "lease-token-1",
+          executionClaimDigest,
+          executionPayloadDigest,
+          messageDigest,
+          parsedEffects,
+          policyRevisionHash,
+          chainId: 101,
+          broadcast: false,
+        });
+        calls.push("consume-claim");
+      },
+    });
+
+    expect(result.signature).toBe("signed");
+    expect(calls).toEqual(["consume-claim", "raw-sign"]);
+  });
+
+  it("never enters raw parsed Solana signing for stale, mutated, or replayed authority", async () => {
+    let rawCalls = 0;
+    const transaction = "opaque-parsed-solana-transaction";
+    const parsedRequest = {
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      transaction,
+      chainId: 101,
+      broadcast: true,
+    } as const;
+    const parsedEffects = {
+      movesNativeSol: false,
+      programIds: ["program-1"],
+      tokenTransfers: [{ destination: "destination-1", amount: "7" }],
+    };
+    const messageDigest = normalizedSolanaMessageDigest(transaction);
+    const executionPayloadDigest = executionPayloadDigestForGovernedSolanaParsedSign(
+      parsedRequest,
+      { messageDigest, parsedEffects, policyRevisionHash: "policy-1" },
+    );
+    const options = {
+      txId: "tx-parsed-2",
+      executionToken: "lease-token-2",
+      executionClaimDigest: executionClaimDigestForGovernedSolanaParsedSign({
+        executionPayloadDigest,
+        executionToken: "lease-token-2",
+        txId: "tx-parsed-2",
+      }),
+      executionPayloadDigest,
+      messageDigest,
+      parsedEffects,
+      policyRevisionHash: "policy-1",
+      consumeExecutionClaim: async () => {
+        throw new Error("claim already consumed");
+      },
+    };
+    const rawVault = {
+      async signSolanaTransaction() {
+        rawCalls += 1;
+        return { signature: "never", broadcast: true, chainId: 101 };
+      },
+    } as unknown as Vault;
+    const governed = new GovernedVault(rawVault, async () => {});
+
+    await expect(
+      governed.signSolanaParsedTransactionAuthorized(parsedRequest, options),
+    ).rejects.toThrow("claim already consumed");
+    await expect(
+      governed.signSolanaParsedTransactionAuthorized(
+        { ...parsedRequest, transaction: "mutated-transaction" },
+        options,
+      ),
+    ).rejects.toThrow("does not match");
+    await expect(
+      governed.signSolanaParsedTransactionAuthorized(parsedRequest, {
+        ...options,
+        parsedEffects: { ...parsedEffects, programIds: ["program-2"] },
+      }),
+    ).rejects.toThrow("does not match");
+    await expect(
+      governed.signSolanaParsedTransactionAuthorized(parsedRequest, {
+        ...options,
+        policyRevisionHash: "policy-2",
+      }),
+    ).rejects.toThrow("does not match");
+    expect(rawCalls).toBe(0);
+  });
+
   it("consumes a durable Solana claim immediately before native raw signing", async () => {
     const calls: string[] = [];
     const solanaRequest: SignRequest = {

--- a/packages/vault/src/__tests__/solana-intent-digest.test.ts
+++ b/packages/vault/src/__tests__/solana-intent-digest.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import {
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import { normalizedSolanaMessageDigest } from "../solana";
+
+const PAYER = Keypair.fromSeed(new Uint8Array(32).fill(1));
+const RECIPIENT = Keypair.fromSeed(new Uint8Array(32).fill(2)).publicKey;
+const MEMO_PROGRAM = new PublicKey("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
+
+function serializedIntent(input: {
+  blockhashByte: number;
+  computeUnits: number;
+  memo: string;
+}): string {
+  const transaction = new Transaction({
+    feePayer: PAYER.publicKey,
+    recentBlockhash: new PublicKey(new Uint8Array(32).fill(input.blockhashByte)).toBase58(),
+  }).add(
+    ComputeBudgetProgram.setComputeUnitLimit({ units: input.computeUnits }),
+    SystemProgram.transfer({ fromPubkey: PAYER.publicKey, toPubkey: RECIPIENT, lamports: 42 }),
+    new TransactionInstruction({
+      data: Buffer.from(input.memo),
+      keys: [],
+      programId: MEMO_PROGRAM,
+    }),
+  );
+  transaction.partialSign(PAYER);
+  return Buffer.from(transaction.serialize()).toString("base64");
+}
+
+describe("normalized Solana message digest", () => {
+  it("excludes signatures and the recent blockhash but binds memo and compute-budget bytes", () => {
+    const original = serializedIntent({ blockhashByte: 7, computeUnits: 250_000, memo: "pay-42" });
+    const refreshed = serializedIntent({
+      blockhashByte: 8,
+      computeUnits: 250_000,
+      memo: "pay-42",
+    });
+    const changedMemo = serializedIntent({
+      blockhashByte: 7,
+      computeUnits: 250_000,
+      memo: "pay-43",
+    });
+    const changedBudget = serializedIntent({
+      blockhashByte: 7,
+      computeUnits: 300_000,
+      memo: "pay-42",
+    });
+
+    const changedSignature = Uint8Array.from(Buffer.from(original, "base64"));
+    changedSignature[1] ^= 0xff;
+
+    expect(normalizedSolanaMessageDigest(refreshed)).toBe(normalizedSolanaMessageDigest(original));
+    expect(normalizedSolanaMessageDigest(Buffer.from(changedSignature).toString("base64"))).toBe(
+      normalizedSolanaMessageDigest(original),
+    );
+    expect(normalizedSolanaMessageDigest(changedMemo)).not.toBe(
+      normalizedSolanaMessageDigest(original),
+    );
+    expect(normalizedSolanaMessageDigest(changedBudget)).not.toBe(
+      normalizedSolanaMessageDigest(original),
+    );
+  });
+});

--- a/packages/vault/src/governed-solana-signing.ts
+++ b/packages/vault/src/governed-solana-signing.ts
@@ -1,0 +1,51 @@
+import { normalizedSolanaMessageDigest } from "./solana";
+
+const governedParsedSolanaGrant = Symbol("governed-parsed-solana-signing-grant");
+
+export type GovernedParsedSolanaSigningGrant = {
+  readonly [governedParsedSolanaGrant]: true;
+  readonly agentId: string;
+  readonly broadcast: boolean;
+  readonly chainId: number;
+  readonly executionPayloadDigest: string;
+  readonly messageDigest: string;
+  readonly tenantId: string;
+};
+
+export function createGovernedParsedSolanaSigningGrant(input: {
+  agentId: string;
+  broadcast: boolean;
+  chainId: number;
+  executionPayloadDigest: string;
+  messageDigest: string;
+  tenantId: string;
+}): GovernedParsedSolanaSigningGrant {
+  return Object.freeze({
+    [governedParsedSolanaGrant]: true as const,
+    ...input,
+  });
+}
+
+export function assertGovernedParsedSolanaSigningGrant(
+  grant: GovernedParsedSolanaSigningGrant | undefined,
+  request: {
+    agentId: string;
+    broadcast?: boolean;
+    chainId?: number;
+    tenantId: string;
+    transaction: string;
+  },
+): void {
+  if (
+    !grant ||
+    grant[governedParsedSolanaGrant] !== true ||
+    grant.tenantId !== request.tenantId ||
+    grant.agentId !== request.agentId ||
+    grant.chainId !== (request.chainId ?? 101) ||
+    grant.broadcast !== (request.broadcast !== false) ||
+    !grant.executionPayloadDigest ||
+    grant.messageDigest !== normalizedSolanaMessageDigest(request.transaction)
+  ) {
+    throw new Error("Parsed Solana signing requires a matching governed execution grant");
+  }
+}

--- a/packages/vault/src/governed-vault.ts
+++ b/packages/vault/src/governed-vault.ts
@@ -4,7 +4,10 @@ import {
   type ExecutionAuthorization,
   normalizeEvmExecutionPayload,
   type SignRequest,
+  type SignSolanaTransactionRequest,
 } from "@stwd/shared";
+import { createGovernedParsedSolanaSigningGrant } from "./governed-solana-signing";
+import { normalizedSolanaMessageDigest } from "./solana";
 import type { SignTransactionOptions, Vault } from "./vault";
 
 export type ExecutionAuthorizationConsumeCallback = (
@@ -51,6 +54,105 @@ export interface GovernedSolanaNativeSignOptions extends SignTransactionOptions 
     executionClaimDigest: string;
     payloadDigest: string;
   }) => Promise<void>;
+}
+
+export interface GovernedSolanaParsedEffects {
+  movesNativeSol: boolean;
+  programIds: string[];
+  tokenTransfers: Array<{ mint?: string; destination: string; amount: string }>;
+}
+
+export type GovernedSolanaParsedSignRequest = Omit<
+  SignSolanaTransactionRequest,
+  "allowBlindSign" | "expectedTo" | "expectedValue"
+> & {
+  allowBlindSign?: never;
+  expectedTo?: never;
+  expectedValue?: never;
+};
+
+export interface GovernedSolanaParsedExecutionClaim {
+  tenantId: string;
+  agentId: string;
+  txId: string;
+  executionToken: string;
+  executionClaimDigest: string;
+  executionPayloadDigest: string;
+  messageDigest: string;
+  parsedEffects: GovernedSolanaParsedEffects;
+  policyRevisionHash: string;
+  chainId: number;
+  broadcast: boolean;
+}
+
+export interface GovernedSolanaParsedSignOptions {
+  txId: string;
+  executionToken: string;
+  executionClaimDigest: string;
+  executionPayloadDigest: string;
+  messageDigest: string;
+  parsedEffects: GovernedSolanaParsedEffects;
+  policyRevisionHash: string;
+  consumeExecutionClaim: (expected: GovernedSolanaParsedExecutionClaim) => Promise<void>;
+}
+
+export function executionPayloadDigestForGovernedSolanaParsedSign(
+  request: GovernedSolanaParsedSignRequest,
+  input: {
+    messageDigest: string;
+    parsedEffects: GovernedSolanaParsedEffects;
+    policyRevisionHash: string;
+  },
+): string {
+  const chainId = request.chainId ?? 101;
+  if (chainId !== 101 && chainId !== 102) {
+    throw new GovernedVaultError(
+      "Governed parsed Solana signing requires a Solana chain",
+      "unsupported_chain_family",
+    );
+  }
+  const actualMessageDigest = normalizedSolanaMessageDigest(request.transaction);
+  if (!input.messageDigest || input.messageDigest !== actualMessageDigest) {
+    throw new GovernedVaultError(
+      "Parsed Solana message digest does not match the serialized transaction",
+      "payload_digest_mismatch",
+    );
+  }
+  if (!input.policyRevisionHash) {
+    throw new GovernedVaultError(
+      "Parsed Solana signing requires a policy revision",
+      "missing_authorization",
+    );
+  }
+  return createHash("sha256")
+    .update(
+      canonicalJsonStringify({
+        agentId: request.agentId,
+        broadcast: request.broadcast !== false,
+        chainId,
+        messageDigest: actualMessageDigest,
+        parsedEffects: input.parsedEffects,
+        policyRevisionHash: input.policyRevisionHash,
+        tenantId: request.tenantId,
+      }),
+    )
+    .digest("hex");
+}
+
+export function executionClaimDigestForGovernedSolanaParsedSign(input: {
+  executionPayloadDigest: string;
+  executionToken: string;
+  txId: string;
+}): string {
+  return createHash("sha256")
+    .update(
+      canonicalJsonStringify({
+        executionPayloadDigest: input.executionPayloadDigest,
+        executionToken: input.executionToken,
+        txId: input.txId,
+      }),
+    )
+    .digest("hex");
 }
 
 export function executionPayloadDigestForGovernedSolanaNativeSign(request: SignRequest): string {
@@ -208,5 +310,72 @@ export class GovernedVault {
       ...rawOptions
     } = options;
     return this.rawVault.signTransaction(request, rawOptions);
+  }
+
+  async signSolanaParsedTransactionAuthorized(
+    request: GovernedSolanaParsedSignRequest,
+    options: GovernedSolanaParsedSignOptions,
+  ): ReturnType<Vault["signSolanaTransaction"]> {
+    if (!options.txId || !options.executionToken || !options.executionClaimDigest) {
+      throw new GovernedVaultError(
+        "A durable parsed Solana execution claim is required",
+        "missing_authorization",
+      );
+    }
+    const executionPayloadDigest = executionPayloadDigestForGovernedSolanaParsedSign(request, {
+      messageDigest: options.messageDigest,
+      parsedEffects: options.parsedEffects,
+      policyRevisionHash: options.policyRevisionHash,
+    });
+    if (
+      !options.executionPayloadDigest ||
+      options.executionPayloadDigest !== executionPayloadDigest ||
+      options.executionClaimDigest !==
+        executionClaimDigestForGovernedSolanaParsedSign({
+          executionPayloadDigest,
+          executionToken: options.executionToken,
+          txId: options.txId,
+        })
+    ) {
+      throw new GovernedVaultError(
+        "Parsed Solana execution digest does not match the governed request",
+        "payload_digest_mismatch",
+      );
+    }
+
+    const expected: GovernedSolanaParsedExecutionClaim = {
+      tenantId: request.tenantId,
+      agentId: request.agentId,
+      txId: options.txId,
+      executionToken: options.executionToken,
+      executionClaimDigest: options.executionClaimDigest,
+      executionPayloadDigest,
+      messageDigest: options.messageDigest,
+      parsedEffects: options.parsedEffects,
+      policyRevisionHash: options.policyRevisionHash,
+      chainId: request.chainId ?? 101,
+      broadcast: request.broadcast !== false,
+    };
+    try {
+      await options.consumeExecutionClaim(expected);
+    } catch (error) {
+      if (error instanceof GovernedVaultError) throw error;
+      throw new GovernedVaultError(
+        error instanceof Error ? error.message : "Parsed Solana execution claim was rejected",
+        "authorization_rejected",
+      );
+    }
+
+    return this.rawVault.signSolanaTransaction({
+      ...request,
+      governedParsedSign: createGovernedParsedSolanaSigningGrant({
+        agentId: request.agentId,
+        broadcast: request.broadcast !== false,
+        chainId: request.chainId ?? 101,
+        executionPayloadDigest,
+        messageDigest: options.messageDigest,
+        tenantId: request.tenantId,
+      }),
+    });
   }
 }

--- a/packages/vault/src/governed-vault.ts
+++ b/packages/vault/src/governed-vault.ts
@@ -39,6 +39,43 @@ export interface GovernedSignTransactionOptions extends SignTransactionOptions {
   executionPayloadDigest?: string;
 }
 
+export interface GovernedSolanaNativeSignOptions extends SignTransactionOptions {
+  executionToken: string;
+  executionClaimDigest: string;
+  executionPayloadDigest: string;
+  consumeExecutionClaim: (expected: {
+    tenantId: string;
+    agentId: string;
+    txId: string;
+    executionToken: string;
+    executionClaimDigest: string;
+    payloadDigest: string;
+  }) => Promise<void>;
+}
+
+export function executionPayloadDigestForGovernedSolanaNativeSign(request: SignRequest): string {
+  const chainId = request.chainId ?? 101;
+  if (chainId !== 101 && chainId !== 102) {
+    throw new GovernedVaultError(
+      "Governed Solana native signing requires a Solana chain",
+      "unsupported_chain_family",
+    );
+  }
+  return createHash("sha256")
+    .update(
+      canonicalJsonStringify({
+        agentId: request.agentId,
+        broadcast: request.broadcast !== false,
+        chainId,
+        data: request.data ?? null,
+        tenantId: request.tenantId,
+        to: request.to,
+        value: request.value,
+      }),
+    )
+    .digest("hex");
+}
+
 /**
  * Digest binds the normalized transaction INTENT (caller-controlled,
  * policy-relevant fields) via the SINGLE shared canonicalizer/normalizer in
@@ -127,5 +164,49 @@ export class GovernedVault {
       expectedBackend: options.executionAuthorization.backend as "local-vault" | "external-custody",
       expectedBackendIdentityDigest: options.executionAuthorization.backendIdentityDigest,
     });
+  }
+
+  async signSolanaNativeTransferAuthorized(
+    request: SignRequest,
+    options: GovernedSolanaNativeSignOptions,
+  ): Promise<string> {
+    if (!options.txId || !options.executionToken || !options.executionClaimDigest) {
+      throw new GovernedVaultError(
+        "A durable Solana execution claim is required",
+        "missing_authorization",
+      );
+    }
+    const payloadDigest = executionPayloadDigestForGovernedSolanaNativeSign(request);
+    if (!options.executionPayloadDigest || options.executionPayloadDigest !== payloadDigest) {
+      throw new GovernedVaultError(
+        "Solana execution payload digest does not match the governed request",
+        "payload_digest_mismatch",
+      );
+    }
+    try {
+      await options.consumeExecutionClaim({
+        tenantId: request.tenantId,
+        agentId: request.agentId,
+        txId: options.txId,
+        executionToken: options.executionToken,
+        executionClaimDigest: options.executionClaimDigest,
+        payloadDigest,
+      });
+    } catch (error) {
+      if (error instanceof GovernedVaultError) throw error;
+      throw new GovernedVaultError(
+        error instanceof Error ? error.message : "Solana execution claim was rejected",
+        "authorization_rejected",
+      );
+    }
+
+    const {
+      consumeExecutionClaim: _consume,
+      executionClaimDigest: _claimDigest,
+      executionPayloadDigest: _payloadDigest,
+      executionToken: _token,
+      ...rawOptions
+    } = options;
+    return this.rawVault.signTransaction(request, rawOptions);
   }
 }

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -65,9 +65,15 @@ export type {
   ExecutionAuthorizationConsumeCallback,
   GovernedSignTransactionOptions,
   GovernedSolanaNativeSignOptions,
+  GovernedSolanaParsedEffects,
+  GovernedSolanaParsedExecutionClaim,
+  GovernedSolanaParsedSignOptions,
+  GovernedSolanaParsedSignRequest,
 } from "./governed-vault";
 export {
+  executionClaimDigestForGovernedSolanaParsedSign,
   executionPayloadDigestForGovernedSolanaNativeSign,
+  executionPayloadDigestForGovernedSolanaParsedSign,
   GovernedVault,
   GovernedVaultError,
 } from "./governed-vault";

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -64,8 +64,13 @@ export { runExternalKeyCustodyV1Conformance } from "./external-key-custody-confo
 export type {
   ExecutionAuthorizationConsumeCallback,
   GovernedSignTransactionOptions,
+  GovernedSolanaNativeSignOptions,
 } from "./governed-vault";
-export { GovernedVault, GovernedVaultError } from "./governed-vault";
+export {
+  executionPayloadDigestForGovernedSolanaNativeSign,
+  GovernedVault,
+  GovernedVaultError,
+} from "./governed-vault";
 export type { BitcoinAddressType, BitcoinNetwork, DerivedBitcoinKey } from "./hd-wallet";
 export {
   deriveBitcoinKey,
@@ -174,6 +179,7 @@ export {
   getSolanaBalance,
   getSplTokenBalances,
   isValidSolanaPublicKey,
+  normalizedSolanaMessageDigest,
   restoreSolanaKeypair,
   signSolanaMessage,
   signSolanaTransaction,

--- a/packages/vault/src/secret-vault.ts
+++ b/packages/vault/src/secret-vault.ts
@@ -48,6 +48,10 @@ import {
 } from "./secret-route-authority";
 import { validateSecretRouteConfig } from "./secret-route-validator";
 
+function isPGLiteRuntime(): boolean {
+  return process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true";
+}
+
 export interface SecretMetadata {
   id: string;
   tenantId: string;
@@ -380,7 +384,7 @@ export class SecretVault {
     tenantId: string,
     name: string,
   ): Promise<Secret[]> {
-    if (process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true") {
+    if (!isPGLiteRuntime()) {
       await tx.execute(
         sql`SELECT pg_advisory_xact_lock(hashtextextended(${`steward_secret_${tenantId}:${name}`}, 0))`,
       );

--- a/packages/vault/src/solana.ts
+++ b/packages/vault/src/solana.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { createPrivateKey, sign as cryptoSign } from "node:crypto";
+import { createHash, createPrivateKey, sign as cryptoSign } from "node:crypto";
 import {
   ComputeBudgetProgram,
   Connection,
@@ -70,6 +70,63 @@ function transactionToBase64(tx: Transaction): string {
       String.fromCharCode(b),
     ).join(""),
   );
+}
+
+function readSolanaShortVec(bytes: Uint8Array, offset: number): [number, number] {
+  let value = 0;
+  let shift = 0;
+  let cursor = offset;
+  for (let index = 0; index < 5; index += 1) {
+    const byte = bytes[cursor];
+    if (byte === undefined) throw new Error("Solana transaction has a truncated shortvec");
+    cursor += 1;
+    value |= (byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) return [value, cursor];
+    shift += 7;
+  }
+  throw new Error("Solana transaction has an oversized shortvec");
+}
+
+/**
+ * Hash the complete caller-controlled Solana message while deliberately
+ * excluding only transaction signatures and the recent blockhash. A refreshed
+ * blockhash therefore preserves idempotency, but changing a memo, compute-budget
+ * instruction, account, program, or instruction byte produces a new digest.
+ */
+export function normalizedSolanaMessageDigest(transaction: string): string {
+  let bytes: Uint8Array;
+  try {
+    const decoded = atob(transaction);
+    bytes = Uint8Array.from(decoded, (character) => character.charCodeAt(0));
+  } catch {
+    return createHash("sha256").update("opaque-solana-text\0").update(transaction).digest("hex");
+  }
+  try {
+    const [signatureCount, messageOffset] = readSolanaShortVec(bytes, 0);
+    const messageStart = messageOffset + signatureCount * 64;
+    if (messageStart >= bytes.length) throw new Error("Solana transaction message is missing");
+
+    let cursor = messageStart;
+    if ((bytes[cursor] & 0x80) !== 0) cursor += 1;
+    cursor += 3; // message header
+    const [accountCount, accountsOffset] = readSolanaShortVec(bytes, cursor);
+    const recentBlockhashOffset = accountsOffset + accountCount * 32;
+    if (recentBlockhashOffset + 32 > bytes.length) {
+      throw new Error("Solana transaction recent blockhash is missing");
+    }
+
+    const normalizedMessage = bytes.slice(messageStart);
+    normalizedMessage.fill(
+      0,
+      recentBlockhashOffset - messageStart,
+      recentBlockhashOffset - messageStart + 32,
+    );
+    return createHash("sha256").update(normalizedMessage).digest("hex");
+  } catch {
+    // Unsafe blind-sign mode can deliberately carry bytes the parser cannot
+    // interpret. Bind those bytes exactly rather than weakening idempotency.
+    return createHash("sha256").update("opaque-solana-bytes\0").update(bytes).digest("hex");
+  }
 }
 
 // ─── Key Generation ────────────────────────────────────────────────────────

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -68,6 +68,10 @@ import {
   normalizeExternalKeyHandleRegistration,
   SolanaBroadcastNotSubmittedError,
 } from "./external-key-custody";
+import {
+  assertGovernedParsedSolanaSigningGrant,
+  type GovernedParsedSolanaSigningGrant,
+} from "./governed-solana-signing";
 import { deriveBitcoinKey, deriveEvmKey, deriveSolanaKey, generateMnemonic } from "./hd-wallet";
 import { type EncryptedKey, KeyStore } from "./keystore";
 import { backendFromKeyStore, type KeystoreBackend } from "./keystore-backend";
@@ -3096,7 +3100,9 @@ export class Vault {
    * Works for both multi-wallet agents (new) and legacy Solana-only agents.
    */
   async signSolanaTransaction(
-    request: SignSolanaTransactionRequest & { allowParsedSign?: boolean },
+    request: SignSolanaTransactionRequest & {
+      governedParsedSign?: GovernedParsedSolanaSigningGrant;
+    },
   ): Promise<{
     signature: string;
     broadcast: boolean;
@@ -3128,12 +3134,12 @@ export class Vault {
     // so the caller must explicitly attest that its own edge policy evaluation
     // approved the transaction. Checked after the signing freeze (a freeze
     // must still report as a freeze) and before any key material is touched.
+    if ((request.expectedTo === undefined) !== (request.expectedValue === undefined)) {
+      throw new Error("Solana transaction policy envelope requires expectedTo and expectedValue");
+    }
     if (request.expectedTo === undefined && request.expectedValue === undefined) {
-      if (request.allowBlindSign !== true && request.allowParsedSign !== true) {
-        throw new Error(
-          "Solana transaction signing without a policy envelope requires allowParsedSign: true " +
-            "or allowBlindSign: true from the caller",
-        );
+      if (request.allowBlindSign !== true) {
+        assertGovernedParsedSolanaSigningGrant(request.governedParsedSign, request);
       }
       if (request.allowBlindSign === true) {
         console.warn(

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -3095,7 +3095,9 @@ export class Vault {
    *
    * Works for both multi-wallet agents (new) and legacy Solana-only agents.
    */
-  async signSolanaTransaction(request: SignSolanaTransactionRequest): Promise<{
+  async signSolanaTransaction(
+    request: SignSolanaTransactionRequest & { allowParsedSign?: boolean },
+  ): Promise<{
     signature: string;
     broadcast: boolean;
     chainId: number;
@@ -3127,15 +3129,17 @@ export class Vault {
     // approved the transaction. Checked after the signing freeze (a freeze
     // must still report as a freeze) and before any key material is touched.
     if (request.expectedTo === undefined && request.expectedValue === undefined) {
-      if (request.allowBlindSign !== true) {
+      if (request.allowBlindSign !== true && request.allowParsedSign !== true) {
         throw new Error(
-          "Solana transaction signing without a policy envelope requires allowBlindSign: true " +
-            "(caller attestation that edge policy approved the transaction)",
+          "Solana transaction signing without a policy envelope requires allowParsedSign: true " +
+            "or allowBlindSign: true from the caller",
         );
       }
-      console.warn(
-        `[Vault] BLIND Solana sign (no policy envelope, caller-attested): tenant=${request.tenantId} agent=${request.agentId} chainId=${request.chainId ?? 101} broadcast=${request.broadcast !== false}`,
-      );
+      if (request.allowBlindSign === true) {
+        console.warn(
+          `[Vault] BLIND Solana sign (no policy envelope, caller-attested): tenant=${request.tenantId} agent=${request.agentId} chainId=${request.chainId ?? 101} broadcast=${request.broadcast !== false}`,
+        );
+      }
     }
 
     // Resolve Solana key: prefer encryptedChainKeys (multi-wallet), fall back to


### PR DESCRIPTION
Supersedes #799 with a clean replay on current develop. Preserves durable authorization, replay, accounting, governed parsed-signing claims, sponsored SPL anchor reuse, and explicit PGlite lineage locks.\n\nVerified: Solana recovery anchor 10/10; parser policy 17/17; governed vault and authority inventory 15/15; shared, vault, and API builds.