### PR TITLE
fix(readiness): exercise capability Redis authority

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "bun", "-e", "const r=await fetch('http://localhost:3200/health');process.exit(r.ok?0:1)"]
+      test: ["CMD", "bun", "-e", "const r=await fetch('http://localhost:3200/ready');process.exit(r.ok?0:1)"]
       interval: 30s
       timeout: 5s
       start_period: 15s

--- a/packages/api/src/__tests__/capability-rate-limit-readiness.test.ts
+++ b/packages/api/src/__tests__/capability-rate-limit-readiness.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import type { IoredisLike } from "@stwd/redis";
+import { checkCapabilityRateLimitReadiness } from "../services/capability-rate-limit-readiness";
+
+describe("capability rate-limit Redis readiness", () => {
+  it("executes a bounded physical-generation reservation and cleans it up", async () => {
+    const evaluatedKeys: string[] = [];
+    const deletedKeys: string[] = [];
+    const client = {
+      async eval(_script: string, _keyCount: number, ...args: Array<string | number>) {
+        evaluatedKeys.push(String(args[0]));
+        return [1, 1, "1000000", 1_000_000, 1_000];
+      },
+      async del(...keys: string[]) {
+        deletedKeys.push(...keys);
+        return keys.length;
+      },
+    } as unknown as IoredisLike;
+
+    await expect(
+      checkCapabilityRateLimitReadiness({
+        getRedisClient: () => client,
+        isRedisConfigured: () => true,
+      }),
+    ).resolves.toEqual({ ok: true, source: "redis" });
+
+    expect(evaluatedKeys).toHaveLength(1);
+    expect(evaluatedKeys[0]).toMatch(/^ratelimit:capability-readiness:[^:]+:policy:1000:1$/);
+    expect(deletedKeys).toEqual(evaluatedKeys);
+  });
+
+  it("reports not-ready when a stale cached client cannot execute the probe", async () => {
+    const deletedKeys: string[] = [];
+    const staleClient = {
+      async eval() {
+        throw new Error("connection closed");
+      },
+      async del(...keys: string[]) {
+        deletedKeys.push(...keys);
+        return keys.length;
+      },
+    } as unknown as IoredisLike;
+
+    const result = await checkCapabilityRateLimitReadiness({
+      getRedisClient: () => staleClient,
+      isRedisConfigured: () => true,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      source: "redis",
+      error: "Configured Redis capability rate-limit backend exercise failed",
+    });
+    expect(deletedKeys).toHaveLength(1);
+    expect(deletedKeys[0]).toEndWith(":policy:1000:1");
+  });
+
+  it("bounds a stalled cached client and still attempts isolated-key cleanup", async () => {
+    const deletedKeys: string[] = [];
+    const stalledClient = {
+      async eval() {
+        return await new Promise<never>(() => undefined);
+      },
+      async del(...keys: string[]) {
+        deletedKeys.push(...keys);
+        return keys.length;
+      },
+    } as unknown as IoredisLike;
+
+    const startedAt = performance.now();
+    const result = await checkCapabilityRateLimitReadiness({
+      getRedisClient: () => stalledClient,
+      isRedisConfigured: () => true,
+      redisProbeTimeoutMs: 10,
+    });
+
+    expect(performance.now() - startedAt).toBeLessThan(500);
+    expect(result).toEqual({
+      ok: false,
+      source: "redis",
+      error: "Configured Redis capability rate-limit backend exercise failed",
+    });
+    expect(deletedKeys).toHaveLength(1);
+    expect(deletedKeys[0]).toEndWith(":policy:1000:1");
+  });
+});

--- a/packages/api/src/services/capability-rate-limit-readiness.ts
+++ b/packages/api/src/services/capability-rate-limit-readiness.ts
@@ -1,4 +1,5 @@
 import { getDb } from "@stwd/db";
+import { checkRateLimit, type IoredisLike, rateLimitBucketKey } from "@stwd/redis";
 import { redactedThrownDiagnostics } from "@stwd/shared";
 import { sql } from "drizzle-orm";
 import { getRedisClient, isRedisConfigured } from "../middleware/redis";
@@ -11,6 +12,32 @@ export interface CapabilityRateLimitReadiness {
 }
 
 const READINESS_TENANT_ID = "steward-capability-rate-readiness";
+const REDIS_PROBE_WINDOW_MS = 1_000;
+const REDIS_PROBE_MAX_REQUESTS = 1;
+const REDIS_PROBE_TIMEOUT_MS = 1_000;
+
+interface CapabilityRateLimitReadinessOptions {
+  getRedisClient?: () => IoredisLike | null;
+  isRedisConfigured?: () => boolean;
+  redisProbeTimeoutMs?: number;
+}
+
+async function withinRedisProbeDeadline<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("capability Redis readiness timed out")),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
 
 function resultRows<T>(result: unknown): T[] {
   return (Array.isArray(result) ? result : ((result as { rows?: T[] } | null)?.rows ?? [])) as T[];
@@ -22,9 +49,45 @@ function resultRows<T>(result: unknown): T[] {
  * observe the exact forced-RLS policy, and exercise the real DML/trigger/function
  * authority in a rolled-back PL/pgSQL subtransaction that leaves no readiness
  * state behind. */
-export async function checkCapabilityRateLimitReadiness(): Promise<CapabilityRateLimitReadiness> {
-  if (getRedisClient()) return { ok: true, source: "redis" };
-  if (isRedisConfigured()) {
+export async function checkCapabilityRateLimitReadiness(
+  options: CapabilityRateLimitReadinessOptions = {},
+): Promise<CapabilityRateLimitReadiness> {
+  const redisClient = (options.getRedisClient ?? getRedisClient)();
+  if (redisClient) {
+    const logicalKey = `ratelimit:capability-readiness:${crypto.randomUUID()}`;
+    const physicalKey = rateLimitBucketKey(
+      logicalKey,
+      REDIS_PROBE_WINDOW_MS,
+      REDIS_PROBE_MAX_REQUESTS,
+    );
+    const timeoutMs = options.redisProbeTimeoutMs ?? REDIS_PROBE_TIMEOUT_MS;
+    let probeError: unknown;
+    try {
+      const result = await withinRedisProbeDeadline(
+        checkRateLimit(logicalKey, REDIS_PROBE_WINDOW_MS, REDIS_PROBE_MAX_REQUESTS, redisClient),
+        timeoutMs,
+      );
+      if (!result.allowed) throw new Error("capability Redis readiness reservation denied");
+    } catch (error) {
+      probeError = error;
+    }
+    try {
+      await withinRedisProbeDeadline(redisClient.del(physicalKey), timeoutMs);
+    } catch (error) {
+      probeError ??= error;
+    }
+    if (!probeError) return { ok: true, source: "redis" };
+    console.error(
+      "[steward:readiness] capability rate-limit Redis exercise failed",
+      redactedThrownDiagnostics(probeError),
+    );
+    return {
+      ok: false,
+      source: "redis",
+      error: "Configured Redis capability rate-limit backend exercise failed",
+    };
+  }
+  if ((options.isRedisConfigured ?? isRedisConfigured)()) {
     return {
       ok: false,
       source: "redis",

--- a/packages/plugin-capabilities/src/__tests__/rate-limit-redis.integration.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/rate-limit-redis.integration.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from "bun:test";
-import { disconnectRedis, getRedis } from "@stwd/redis";
+import { checkRateLimit, disconnectRedis, getRedis, rateLimitBucketKey } from "@stwd/redis";
 import type { StewardAppContext } from "../context";
 import { CAPABILITY_INVOKE_RATE_LIMIT, enforceCapabilityRateLimit } from "../rate-limit";
 
@@ -14,6 +14,17 @@ describeRedis("capability rate limiting with real Redis", () => {
     const tenantId = `redis-rate-tenant-${crypto.randomUUID()}`;
     const agentId = `redis-rate-agent-${crypto.randomUUID()}`;
     const key = `ratelimit:capability:invoke:${tenantId}:${agentId}:${CAPABILITY_INVOKE_RATE_LIMIT.windowMs}`;
+    const physicalKey = rateLimitBucketKey(
+      key,
+      CAPABILITY_INVOKE_RATE_LIMIT.windowMs,
+      CAPABILITY_INVOKE_RATE_LIMIT.maxRequests,
+    );
+    const alternateMax = CAPABILITY_INVOKE_RATE_LIMIT.maxRequests + 1;
+    const alternatePhysicalKey = rateLimitBucketKey(
+      key,
+      CAPABILITY_INVOKE_RATE_LIMIT.windowMs,
+      alternateMax,
+    );
     const context = (): Pick<StewardAppContext, "db" | "getRedisClient" | "isRedisConfigured"> => ({
       db: {} as StewardAppContext["db"],
       getRedisClient: () => getRedis(),
@@ -37,13 +48,19 @@ describeRedis("capability rate limiting with real Redis", () => {
         CAPABILITY_INVOKE_RATE_LIMIT.maxRequests,
       );
       expect(results.filter((result) => !result.allowed)).toHaveLength(1);
+      expect(await getRedis().zcard(physicalKey)).toBe(CAPABILITY_INVOKE_RATE_LIMIT.maxRequests);
+      expect(
+        await checkRateLimit(key, CAPABILITY_INVOKE_RATE_LIMIT.windowMs, alternateMax, getRedis()),
+      ).toMatchObject({ allowed: true, remaining: alternateMax - 1 });
+      expect(await getRedis().zcard(alternatePhysicalKey)).toBe(1);
+      expect(await getRedis().zcard(physicalKey)).toBe(CAPABILITY_INVOKE_RATE_LIMIT.maxRequests);
 
       await disconnectRedis();
       expect(
         await enforceCapabilityRateLimit(context(), "invoke", tenantId, agentId),
       ).toMatchObject({ allowed: false });
     } finally {
-      await getRedis().del(key);
+      await getRedis().del(physicalKey, alternatePhysicalKey);
     }
   });
 });

--- a/packages/proxy/src/__tests__/deploy-artifacts.test.ts
+++ b/packages/proxy/src/__tests__/deploy-artifacts.test.ts
@@ -145,6 +145,7 @@ describe("#101 deploy/docker-compose.yml proxy production env", () => {
     const api = compose.slice(apiStart, proxyStart);
     expect(api).toContain('REDIS_URL: "redis://redis:6379"');
     expect(api).toContain('STEWARD_ALLOW_INSECURE_REDIS: "true"');
+    expect(api).toContain("fetch('http://localhost:3200/ready')");
     expect(proxy).toContain('REDIS_URL: "redis://redis:6379"');
     expect(proxy).toContain('STEWARD_ALLOW_INSECURE_REDIS: "true"');
   });

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -56,6 +56,7 @@ export {
   checkRateLimit,
   getRateLimitStatus,
   type RateLimitResult,
+  rateLimitBucketKey,
 } from "./rate-limiter.js";
 export {
   checkSpendLimit,

--- a/packages/redis/src/rate-limiter.ts
+++ b/packages/redis/src/rate-limiter.ts
@@ -80,7 +80,7 @@ function validateRateLimitInput(key: string, windowMs: number, maxRequests: numb
  * reinterpret them). Keep the caller-facing key stable while fencing the
  * physical Redis key by both numeric policy inputs.
  */
-function durableBucketKey(key: string, windowMs: number, maxRequests: number): string {
+export function rateLimitBucketKey(key: string, windowMs: number, maxRequests: number): string {
   return `${key}:policy:${windowMs}:${maxRequests}`;
 }
 
@@ -114,7 +114,7 @@ export async function checkRateLimit(
   const res = (await redis.eval(
     RATE_LIMIT_LUA,
     1,
-    durableBucketKey(key, windowMs, maxRequests),
+    rateLimitBucketKey(key, windowMs, maxRequests),
     String(windowMs),
     String(maxRequests),
     member,
@@ -153,7 +153,7 @@ export async function getRateLimitStatus(
   const [count, _oldestScore, _serverNow, resetMs] = (await redis.eval(
     RATE_LIMIT_STATUS_LUA,
     1,
-    durableBucketKey(key, windowMs, maxRequests),
+    rateLimitBucketKey(key, windowMs, maxRequests),
     String(windowMs),
   )) as [number, string, number, number];
 


### PR DESCRIPTION
Post-merge corrective for #859.

This makes capability rate-limit readiness exercise the configured Redis authority with a bounded Redis TIME/Lua reservation on a UUID-isolated policy-generation key, then performs bounded cleanup. A cached client that is stale, disconnected, or stalled now reports not-ready. The root Compose API healthcheck now targets /ready. The real-Redis integration asserts distinct physical policy generations and deletes those exact keys.

#786 remains explicitly separate: this PR does not change the broader request-local Worker JWT/runtime configuration lane.

Exact published head validation:
- API readiness: 3 passed
- Redis limiter: 3 passed, 5 environment-gated skips
- capability limiter: 8 passed
- real Redis integration: 1 passed, 7 assertions; Redis DBSIZE=0 after cleanup
- deploy artifacts: 54 passed
- API, Redis, plugin-capabilities, and proxy builds/typechecks passed
- Biome and git diff --check passed

Please require independent exact-head review and hosted checks before merge.