### PR TITLE
fix(api): retire email authority cache on bounded deadline

### DIFF
--- a/packages/api/src/__tests__/platform-email-config.test.ts
+++ b/packages/api/src/__tests__/platform-email-config.test.ts
@@ -2,7 +2,9 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 
 import { __resetAuditHmacKeyCacheForTests, closeDb, getDb, tenantConfigs, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { eq } from "drizzle-orm";
+import { clearEmailAuthTenantCacheForTests, getEmailAuthForTenant } from "../routes/auth";
 
 const PLATFORM_KEY = "platform-email-config-key";
 const TENANT_ID = "platform-email-config-tenant";
@@ -135,6 +137,89 @@ describe("platform tenant email config routes", () => {
       .from(tenantConfigs)
       .where(eq(tenantConfigs.tenantId, TENANT_ID));
     expect(afterDelete?.emailConfig ?? null).toBeNull();
+  });
+
+  it("retires cached email authority only after the mounted outer transaction commits", async () => {
+    const { withAuthenticatedTenantDatabase } = await import("../services/context");
+    const dbHandle = getDb();
+    await dbHandle
+      .insert(tenantConfigs)
+      .values({ tenantId: TENANT_ID, emailConfig: { subjectOverride: "Committed authority" } })
+      .onConflictDoUpdate({
+        target: tenantConfigs.tenantId,
+        set: { emailConfig: { subjectOverride: "Committed authority" } },
+      });
+    clearEmailAuthTenantCacheForTests();
+
+    await withRuntimeEnvironment(
+      {
+        NODE_ENV: "test",
+        STEWARD_MASTER_PASSWORD: "platform-email-config-master-password",
+        STEWARD_AUDIT_HMAC_KEY: "platform-email-config-audit-key-with-enough-entropy",
+        STEWARD_PLATFORM_KEYS: PLATFORM_KEY,
+        STEWARD_PLATFORM_KEY_SCOPES: JSON.stringify({
+          [PLATFORM_KEY]: ["platform:tenant-email-config:write"],
+        }),
+        RESEND_API_KEY: "post-commit-resend-key",
+        EMAIL_FROM: "Post Commit <login@post-commit.example>",
+      },
+      async () => {
+        const original = await getEmailAuthForTenant(TENANT_ID);
+        expect((original as any).subjectOverride).toBe("Committed authority");
+
+        await expect(
+          withAuthenticatedTenantDatabase(
+            TENANT_ID,
+            "platform-key",
+            "rollback-cache-regression",
+            async () => {
+              const response = await platformRoutes.request(`/tenants/${TENANT_ID}/email-config`, {
+                method: "PATCH",
+                headers: {
+                  "Content-Type": "application/json",
+                  "X-Steward-Platform-Key": PLATFORM_KEY,
+                },
+                body: JSON.stringify({ subjectOverride: "Must roll back" }),
+              });
+              expect(response.status).toBe(200);
+              // The route's audited unit is only a savepoint here. Authority
+              // remains usable until its owning transaction commits.
+              expect(await getEmailAuthForTenant(TENANT_ID)).toBe(original);
+              throw new Error("force outer rollback");
+            },
+          ),
+        ).rejects.toThrow("force outer rollback");
+
+        expect(await getEmailAuthForTenant(TENANT_ID)).toBe(original);
+        const [rolledBack] = await dbHandle
+          .select({ emailConfig: tenantConfigs.emailConfig })
+          .from(tenantConfigs)
+          .where(eq(tenantConfigs.tenantId, TENANT_ID));
+        expect(rolledBack?.emailConfig?.subjectOverride).toBe("Committed authority");
+
+        await withAuthenticatedTenantDatabase(
+          TENANT_ID,
+          "platform-key",
+          "commit-cache-regression",
+          async () => {
+            const response = await platformRoutes.request(`/tenants/${TENANT_ID}/email-config`, {
+              method: "PATCH",
+              headers: {
+                "Content-Type": "application/json",
+                "X-Steward-Platform-Key": PLATFORM_KEY,
+              },
+              body: JSON.stringify({ subjectOverride: "Replacement authority" }),
+            });
+            expect(response.status).toBe(200);
+            expect(await getEmailAuthForTenant(TENANT_ID)).toBe(original);
+          },
+        );
+
+        const replacement = await getEmailAuthForTenant(TENANT_ID);
+        expect(replacement).not.toBe(original);
+        expect((replacement as any).subjectOverride).toBe("Replacement authority");
+      },
+    );
   });
 
   it("accepts a template-only PATCH (no apiKey) and merges over existing config", async () => {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1781,8 +1781,23 @@ const EMAIL_AUTH_REQUEST_CACHE_TTL_MS = 30_000;
 interface EmailAuthRequestCacheEntry {
   readonly createdAt: number;
   readonly pending: Promise<EmailAuth>;
+  readonly retirementTimer: ReturnType<typeof setTimeout>;
 }
 let _emailAuthByRequest = new WeakMap<object, Map<string, EmailAuthRequestCacheEntry>>();
+
+function retireEmailAuthCacheEntry(
+  tenants: Map<string, EmailAuthRequestCacheEntry>,
+  tenantId: string,
+  entry: EmailAuthRequestCacheEntry,
+): void {
+  if (tenants.get(tenantId) !== entry) return;
+  tenants.delete(tenantId);
+  clearTimeout(entry.retirementTimer);
+  void entry.pending.then(
+    (auth) => auth.disposeProvider(),
+    () => undefined,
+  );
+}
 
 function getEmailKeyStore(): KeyStore {
   return getConfiguredKeyStore(undefined, { allowDevSecretFallback: true });
@@ -2086,13 +2101,7 @@ export async function getEmailAuthForTenant(tenantId: string): Promise<EmailAuth
   if (cached && Date.now() - cached.createdAt < EMAIL_AUTH_REQUEST_CACHE_TTL_MS) {
     return cached.pending;
   }
-  if (cached) {
-    tenants?.delete(tenantId);
-    void cached.pending.then(
-      (auth) => auth.disposeProvider(),
-      () => undefined,
-    );
-  }
+  if (cached && tenants) retireEmailAuthCacheEntry(tenants, tenantId, cached);
 
   let entry: EmailAuthRequestCacheEntry;
   const pending = createEmailAuthForTenant(tenantId).catch((error) => {
@@ -2103,7 +2112,12 @@ export async function getEmailAuthForTenant(tenantId: string): Promise<EmailAuth
     tenants = new Map();
     _emailAuthByRequest.set(requestIdentity, tenants);
   }
-  entry = { createdAt: Date.now(), pending };
+  const retirementTimer = setTimeout(() => {
+    if (tenants) retireEmailAuthCacheEntry(tenants, tenantId, entry);
+  }, EMAIL_AUTH_REQUEST_CACHE_TTL_MS);
+  // A request-local cache deadline must not keep a Node/Bun process alive.
+  retirementTimer.unref?.();
+  entry = { createdAt: Date.now(), pending, retirementTimer };
   tenants.set(tenantId, entry);
   return pending;
 }
@@ -2113,11 +2127,7 @@ export function invalidateEmailAuthForTenant(tenantId: string): void {
   if (!identity) return;
   const tenants = _emailAuthByRequest.get(identity);
   const cached = tenants?.get(tenantId);
-  tenants?.delete(tenantId);
-  void cached?.pending.then(
-    (auth) => auth.disposeProvider(),
-    () => undefined,
-  );
+  if (cached && tenants) retireEmailAuthCacheEntry(tenants, tenantId, cached);
 }
 
 export function clearEmailAuthTenantCacheForTests(): void {
@@ -2136,7 +2146,7 @@ export function expireEmailAuthTenantCacheForTests(tenantId: string): void {
   if (!identity) return;
   const tenants = _emailAuthByRequest.get(identity);
   const cached = tenants?.get(tenantId);
-  if (cached) tenants?.set(tenantId, { ...cached, createdAt: 0 });
+  if (cached && tenants) retireEmailAuthCacheEntry(tenants, tenantId, cached);
 }
 
 export function clearOAuthTokenKeyStoreForTests(): void {


### PR DESCRIPTION
Closes #716

## Summary
- replace lazy email authority TTL eviction with an identity-checked, unref timed retirement
- dispose credential-bearing providers on deadline, invalidation, and replacement
- preserve outer-transaction commit fencing so rollback retains the prior authority

## Verification
- exact current develop 260ed8112 merged cleanly
- mounted email/platform suites: 22/22, 244 assertions
- API and Redis TypeScript builds pass
- changed-file Biome and diff-check pass