### PR TITLE
fix(ci): restore current-tip migration and browser gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,12 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install Chromium
-        run: bunx playwright install --with-deps chromium
+        working-directory: web
+        run: bun run playwright install --with-deps chromium
+
+      - name: Verify Chromium launch
+        working-directory: web
+        run: bun -e 'import { chromium } from "@playwright/test"; const browser = await chromium.launch(); await browser.close();'
 
       - name: Build workspace dependencies
         run: bunx turbo run build --filter=@stwd/react --filter=@stwd/sdk --filter=@stwd/shared

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -163,7 +163,11 @@ jobs:
 
       - name: Install Chromium
         working-directory: web
-        run: bunx playwright install --with-deps chromium
+        run: bun run playwright install --with-deps chromium
+
+      - name: Verify Chromium launch
+        working-directory: web
+        run: bun -e 'import { chromium } from "@playwright/test"; const browser = await chromium.launch(); await browser.close();'
 
       - name: Axe scan and keyboard-only approval flows
         working-directory: web
@@ -504,7 +508,12 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install Chromium
-        run: bunx playwright install --with-deps chromium
+        working-directory: web
+        run: bun run playwright install --with-deps chromium
+
+      - name: Verify Chromium launch
+        working-directory: web
+        run: bun -e 'import { chromium } from "@playwright/test"; const browser = await chromium.launch(); await browser.close();'
 
       - name: Build workspace dependencies
         run: bunx turbo run build --filter=@stwd/react --filter=@stwd/sdk --filter=@stwd/shared

--- a/packages/db/src/__tests__/migration-ledger-integrity.test.ts
+++ b/packages/db/src/__tests__/migration-ledger-integrity.test.ts
@@ -66,6 +66,10 @@ describe("core migration ledger integrity", () => {
     expect(source).toContain('name: "capability_grants_agent_fence"');
     expect(source).toContain('tag: "0003_tenant_rls_policies"');
     expect(source).toContain('kind: "policy"');
+    expect(source).toContain('tag: "0004_capability_rate_limit_buckets"');
+    expect(source).toContain('name: "capability_rate_limit_buckets"');
+    expect(source).toContain('name: "capability_rate_limit_bucket_agent_fence()"');
+    expect(source).toContain('name: "capability_rate_limit_bucket_agent_fence"');
     expect(source).toContain("schema does not match its applied migration prefix");
   });
 

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -369,6 +369,7 @@ async function assertExactMigrationObjectInventory(db: MigrationQueryExecutor): 
         ('public', 'capabilities', 'r'),
         ('public', 'capability_grants', 'r'),
         ('public', 'capability_invocations', 'r'),
+        ('public', 'capability_rate_limit_buckets', 'r'),
         ('public', 'example_log', 'r'),
         ('public', 'example_log_id_seq', 'S')
     ),
@@ -392,6 +393,7 @@ async function assertExactMigrationObjectInventory(db: MigrationQueryExecutor): 
         ('public', 'steward_reject_upstream_lease_evidence_mutation()'),
         ('public', 'capability_grants_agent_fence()'),
         ('public', 'capability_grants_guard_agent_delete()'),
+        ('public', 'capability_rate_limit_bucket_agent_fence()'),
         ('steward_rls', 'tenant_id()'),
         ('steward_rls', 'user_id()'),
         ('steward_bootstrap', 'agent_subject(p_agent_id text, p_tenant_id text, p_jti text)'),
@@ -642,6 +644,34 @@ async function assertBundledPluginLedgerIntegrity(db: MigrationQueryExecutor): P
               kind: "policy",
               schema: "public",
               table: "capability_invocations",
+              name: "steward_tenant_isolation",
+            },
+          ],
+        },
+        {
+          tag: "0004_capability_rate_limit_buckets",
+          effects: [
+            {
+              kind: "relation",
+              schema: "public",
+              name: "capability_rate_limit_buckets",
+              relationKind: "r",
+            },
+            {
+              kind: "routine",
+              schema: "public",
+              name: "capability_rate_limit_bucket_agent_fence()",
+            },
+            {
+              kind: "trigger",
+              schema: "public",
+              table: "capability_rate_limit_buckets",
+              name: "capability_rate_limit_bucket_agent_fence",
+            },
+            {
+              kind: "policy",
+              schema: "public",
+              table: "capability_rate_limit_buckets",
               name: "steward_tenant_isolation",
             },
           ],

--- a/scripts/__tests__/check-ci-test-inventory.test.ts
+++ b/scripts/__tests__/check-ci-test-inventory.test.ts
@@ -35,7 +35,13 @@ describe("CI test inventory", () => {
       for (const workflow of ["pr.yml", "ci.yml"]) {
         writeFileSync(
           join(root, ".github/workflows", workflow),
-          "run: bun test src e2e/wallets/wallet-e2e-contract.test.ts\n",
+          [
+            "run: bun test --isolate src e2e/wallets/wallet-e2e-contract.test.ts",
+            "working-directory: web",
+            "        run: bun run playwright install --with-deps chromium",
+            "working-directory: web",
+            "        run: bun -e 'import { chromium } from \"@playwright/test\"; const browser = await chromium.launch(); await browser.close();'",
+          ].join("\n"),
         );
       }
       writeFileSync(
@@ -54,6 +60,43 @@ describe("CI test inventory", () => {
         writeFileSync(join(root, "web/e2e/wallets", path), "");
       }
       expect(() => assertWalletE2EInventory(root)).not.toThrow();
+      writeFileSync(
+        join(root, ".github/workflows", "pr.yml"),
+        "run: bun test src e2e/wallets/wallet-e2e-contract.test.ts\n",
+      );
+      expect(() => assertWalletE2EInventory(root)).toThrow(
+        ".github/workflows/pr.yml does not explicitly execute the isolated wallet E2E contract",
+      );
+      writeFileSync(
+        join(root, ".github/workflows", "pr.yml"),
+        [
+          "run: bun test --isolate src e2e/wallets/wallet-e2e-contract.test.ts",
+          "working-directory: web",
+          "        run: bun run playwright install --with-deps chromium",
+          "working-directory: web",
+          "        run: bun -e 'import { chromium } from \"@playwright/test\"; const browser = await chromium.launch(); await browser.close();'",
+        ].join("\n"),
+      );
+      const ciWorkflowPath = join(root, ".github/workflows", "ci.yml");
+      const validCiWorkflow = readFileSync(ciWorkflowPath, "utf8");
+      writeFileSync(
+        ciWorkflowPath,
+        validCiWorkflow.replace(
+          "bun run playwright install --with-deps chromium",
+          "bunx playwright install --with-deps chromium",
+        ),
+      );
+      expect(() => assertWalletE2EInventory(root)).toThrow(
+        ".github/workflows/ci.yml uses an unpinned Playwright CLI",
+      );
+      writeFileSync(
+        ciWorkflowPath,
+        validCiWorkflow.replace("const browser = await chromium.launch()", "const browser = null"),
+      );
+      expect(() => assertWalletE2EInventory(root)).toThrow(
+        ".github/workflows/ci.yml does not verify the workspace Chromium launch",
+      );
+      writeFileSync(ciWorkflowPath, validCiWorkflow);
       rmSync(join(root, "web/e2e/wallets/phantom-siws.spec.ts"));
       expect(() => assertWalletE2EInventory(root)).toThrow(
         "wallet E2E inventory is missing web/e2e/wallets/phantom-siws.spec.ts",

--- a/scripts/check-ci-test-inventory.ts
+++ b/scripts/check-ci-test-inventory.ts
@@ -4,6 +4,10 @@ import { dirname, resolve } from "node:path";
 const WORKFLOWS = [".github/workflows/pr.yml", ".github/workflows/ci.yml"] as const;
 const NON_WORKSPACE_MATRIX_ENTRIES = ["scripts/__tests__"] as const;
 const WALLET_CONTRACT = "web/e2e/wallets/wallet-e2e-contract.test.ts";
+const WALLET_CONTRACT_COMMAND = "bun test --isolate src e2e/wallets/wallet-e2e-contract.test.ts";
+const CHROMIUM_INSTALL_COMMAND = "bun run playwright install --with-deps chromium";
+const CHROMIUM_LAUNCH_ASSERTION =
+  "bun -e 'import { chromium } from \"@playwright/test\"; const browser = await chromium.launch(); await browser.close();'";
 const WALLET_SPECS = [
   "web/e2e/wallets/metamask-siwe.spec.ts",
   "web/e2e/wallets/phantom-siws.spec.ts",
@@ -365,8 +369,19 @@ export function assertWalletE2EInventory(rootDir: string): void {
   }
   for (const workflowPath of WORKFLOWS) {
     const workflow = readFileSync(resolve(rootDir, workflowPath), "utf8");
-    if (!workflow.includes("bun test src e2e/wallets/wallet-e2e-contract.test.ts")) {
-      throw new Error(`${workflowPath} does not explicitly execute the wallet E2E contract`);
+    if (!workflow.includes(WALLET_CONTRACT_COMMAND)) {
+      throw new Error(
+        `${workflowPath} does not explicitly execute the isolated wallet E2E contract`,
+      );
+    }
+    if (workflow.includes("bunx playwright")) {
+      throw new Error(`${workflowPath} uses an unpinned Playwright CLI`);
+    }
+    if (!workflow.includes(`working-directory: web\n        run: ${CHROMIUM_INSTALL_COMMAND}`)) {
+      throw new Error(`${workflowPath} does not install Chromium through the web workspace CLI`);
+    }
+    if (!workflow.includes(`working-directory: web\n        run: ${CHROMIUM_LAUNCH_ASSERTION}`)) {
+      throw new Error(`${workflowPath} does not verify the workspace Chromium launch`);
     }
   }
 


### PR DESCRIPTION
## Summary\n- restore fresh-Postgres migration preflight for plugin-capabilities 0004\n- bind Chromium installation and launch checks to the web workspace Playwright runtime\n- require the isolated wallet contract command in both CI workflows and inventory checks\n\n## Verification\n- CI inventory: 14/14, 53 assertions\n- migration ledger: 12/12, 39 assertions\n- shared and DB builds\n- Biome and diff-check\n- Playwright 1.61.1 / matching Chromium launch\n- fresh PostgreSQL 16: 96 core migrations, 5 capability migrations, exact 0004 table/routine/trigger/policy/RLS/FORCE RLS, idempotent core rerun\n\nThis repairs the exact failures on current develop.