### PR TITLE
fix(db): recover shipped migration collision at startup

### DIFF
--- a/packages/api/src/__tests__/startup-phase.test.ts
+++ b/packages/api/src/__tests__/startup-phase.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import {
   resolveStartupPhaseTimeoutMs,
   runStartupPhase,
@@ -6,6 +7,16 @@ import {
 } from "../startup-phase";
 
 describe("bounded pre-listen startup phases", () => {
+  test("keeps plugin migration discovery inside the bounded compose phase", () => {
+    const source = readFileSync(new URL("../index.ts", import.meta.url), "utf8");
+    const phaseStart = source.indexOf('runStartupPhase("compose"');
+    const phaseEnd = source.indexOf("}));", phaseStart);
+    const discovery = source.indexOf("getComposedPluginMigrationSources()", phaseStart);
+    expect(phaseStart).toBeGreaterThanOrEqual(0);
+    expect(discovery).toBeGreaterThan(phaseStart);
+    expect(discovery).toBeLessThanOrEqual(phaseEnd);
+  });
+
   test("uses an exact phase override and rejects invalid bounds", () => {
     expect(
       resolveStartupPhaseTimeoutMs("redis", {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -61,8 +61,10 @@ validateJwtSecretEnv();
 // composeApp() is async because plugin registration may be async + the trading
 // plugin is dynamically imported so the lean core graph never statically pulls
 // in the trading stack. top-level await is supported by the Bun entry.
-const app = await runStartupPhase("compose", () => composeApp());
-const pluginMigrationSources = await getComposedPluginMigrationSources();
+const { app, pluginMigrationSources } = await runStartupPhase("compose", async () => ({
+  app: await composeApp(),
+  pluginMigrationSources: await getComposedPluginMigrationSources(),
+}));
 const capabilitiesEnabled = resolveEnabledPlugins().has("capabilities");
 
 // ─── Shutdown guard ──────────────────────────────────────────────────────────

--- a/packages/db/src/__tests__/migration-ledger-integrity.test.ts
+++ b/packages/db/src/__tests__/migration-ledger-integrity.test.ts
@@ -43,7 +43,7 @@ describe("core migration ledger integrity", () => {
     const source = readFileSync(new URL("../migrate.ts", import.meta.url), "utf8");
     const inspect = source.indexOf("to_regclass('drizzle.__drizzle_migrations')");
     const validate = source.indexOf(
-      "assertCoreMigrationLedgerIntegrity(existingRows, journal, databaseShape)",
+      "assertCoreMigrationLedgerIntegrity(existingRows, journal, databaseShape, {",
     );
     const mutate = source.indexOf("await tx.execute(sql`CREATE SCHEMA drizzle`)");
     expect(inspect).toBeGreaterThan(0);
@@ -119,6 +119,27 @@ describe("core migration ledger integrity", () => {
     expect(() => assertCoreMigrationLedgerIntegrity(missing, journal, migratedDatabase)).toThrow(
       /missing 0111_tenant_rls_policy_install below its recorded cutoff/,
     );
+  });
+
+  test("admits only the shipped 0114/0118 timestamp collision to the repair transaction", () => {
+    const successor = journal.entries.findIndex(
+      (entry) => entry.tag === "0118_generic_intent_execution_delete_fence",
+    );
+    const predecessor = journal.entries.findIndex(
+      (entry) => entry.tag === "0114_durable_wallet_claim_account_audit",
+    );
+    expect(successor).toBeGreaterThan(predecessor);
+    expect(journal.entries[successor]?.when).toBe(journal.entries[predecessor]?.when);
+    const predecessorOnly = rows(journal.entries.slice(0, successor));
+
+    expect(() =>
+      assertCoreMigrationLedgerIntegrity(predecessorOnly, journal, migratedDatabase),
+    ).toThrow(/missing 0118_generic_intent_execution_delete_fence below its recorded cutoff/);
+    expect(() =>
+      assertCoreMigrationLedgerIntegrity(predecessorOnly, journal, migratedDatabase, {
+        allowShippedTimestampCollision: true,
+      }),
+    ).not.toThrow();
   });
 
   test("rejects wrong, shared, and ambiguous legacy database shapes", () => {

--- a/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-operator-postgres.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
 import postgres from "postgres";
 
 const describeWithPostgres = process.env.DATABASE_URL ? describe : describe.skip;
@@ -312,6 +313,65 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
         migrator_drizzle_create: true,
       });
 
+      const collisionSuccessor = "0118_generic_intent_execution_delete_fence";
+      const collisionHash = createHash("sha256")
+        .update(readFileSync(new URL(`../../drizzle/${collisionSuccessor}.sql`, import.meta.url)))
+        .digest("hex");
+      await db`DROP TRIGGER agents_active_intent_execution_fence ON public.agents`;
+      await db`DROP FUNCTION public.steward_guard_generic_intent_execution_delete()`;
+      await db`DROP INDEX public.webhook_deliveries_predecessor_idx`;
+      await db`
+        ALTER TABLE public.webhook_deliveries
+          DROP CONSTRAINT webhook_deliveries_predecessor_fk,
+          DROP COLUMN predecessor_delivery_id,
+          DROP COLUMN claim_token
+      `;
+      await db`DELETE FROM drizzle.__drizzle_migrations WHERE hash = ${collisionHash}`;
+
+      const collisionUpgrade = await runCommand(
+        ["bun", "run", "--cwd", "packages/api", "migrate"],
+        {
+          DATABASE_URL: migrationDatabaseUrl(),
+          STEWARD_PLUGINS: "capabilities",
+          STEWARD_ENABLE_TRADING: "false",
+          STEWARD_MASTER_PASSWORD: `restricted-migrator-master-${suffix}`,
+        },
+      );
+      expect(collisionUpgrade).toContain(collisionSuccessor);
+      const [collisionRecovered] = await db<
+        Array<{
+          ledger_rows: number;
+          trigger_exists: boolean;
+          predecessor_column_exists: boolean;
+          claim_column_exists: boolean;
+        }>
+      >`
+        SELECT
+          (SELECT count(*)::int FROM drizzle.__drizzle_migrations WHERE hash = ${collisionHash}) AS ledger_rows,
+          to_regclass('public.agents') IS NOT NULL AND EXISTS (
+            SELECT 1 FROM pg_trigger
+            WHERE tgrelid = 'public.agents'::regclass
+              AND tgname = 'agents_active_intent_execution_fence'
+              AND NOT tgisinternal
+          ) AS trigger_exists,
+          EXISTS (
+            SELECT 1 FROM pg_attribute
+            WHERE attrelid = 'public.webhook_deliveries'::regclass
+              AND attname = 'predecessor_delivery_id' AND NOT attisdropped
+          ) AS predecessor_column_exists,
+          EXISTS (
+            SELECT 1 FROM pg_attribute
+            WHERE attrelid = 'public.webhook_deliveries'::regclass
+              AND attname = 'claim_token' AND NOT attisdropped
+          ) AS claim_column_exists
+      `;
+      expect(collisionRecovered).toEqual({
+        ledger_rows: 1,
+        trigger_exists: true,
+        predecessor_column_exists: true,
+        claim_column_exists: true,
+      });
+
       const [installed] = await db<{ relations: number; policies: number }[]>`
         SELECT count(DISTINCT c.relname)::int AS relations, count(*)::int AS policies
         FROM pg_policy p
@@ -320,9 +380,9 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
         WHERE n.nspname = 'public'
       `;
       // Core contributes 71 policy-bearing relations/73 policies; the enabled
-      // capabilities plugin contributes its three independently journaled
+      // capabilities plugin contributes its four independently journaled
       // tenant-scoped relations and policies in the same restricted release.
-      expect(installed).toEqual({ relations: 74, policies: 76 });
+      expect(installed).toEqual({ relations: 75, policies: 77 });
 
       await runOperatorScript("rls-bootstrap.sql", true);
       await admin.unsafe(`ALTER ROLE ${appRole} PASSWORD '${appRolePassword}'`);
@@ -490,7 +550,7 @@ describeWithPostgres("SEC-169 operator lifecycle on the real Steward schema", ()
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = 'public' AND p.polname LIKE 'steward_%'
       `;
-      expect(activated).toEqual({ enabled: 74, forced: 74, maintenance: 74 });
+      expect(activated).toEqual({ enabled: 75, forced: 75, maintenance: 75 });
       const [maintenanceBoundary] = await db<{ wrong_role_count: number }[]>`
         SELECT count(*)::int AS wrong_role_count
         FROM pg_policy policy

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -105,7 +105,7 @@ export function assertCoreMigrationLedgerIntegrity(
   rows: readonly CoreMigrationLedgerRow[],
   journal: Journal,
   database: CoreMigrationDatabaseShape,
-  options: { requireComplete?: boolean } = {},
+  options: { requireComplete?: boolean; allowShippedTimestampCollision?: boolean } = {},
 ): void {
   if ((database.alwaysRejectedObjectCount ?? 0) > 0) {
     throw new Error(
@@ -194,10 +194,19 @@ export function assertCoreMigrationLedgerIntegrity(
     const greatestRecordedWhen = Math.max(
       ...recordedIndices.map((index) => journal.entries[index].when),
     );
+    const collisionPredecessor = expected.find(
+      (entry) => entry.tag === SHIPPED_COLLISION_PREDECESSOR_TAG,
+    );
     const silentlySkipped = expected.filter(
       (entry) =>
         entry.when <= greatestRecordedWhen &&
-        !recordedIdentities.has(`${entry.when}:${entry.hash}`),
+        !recordedIdentities.has(`${entry.when}:${entry.hash}`) &&
+        !(
+          options.allowShippedTimestampCollision === true &&
+          entry.tag === SHIPPED_COLLISION_SUCCESSOR_TAG &&
+          collisionPredecessor?.when === entry.when &&
+          recordedIdentities.has(`${collisionPredecessor.when}:${collisionPredecessor.hash}`)
+        ),
     );
     if (silentlySkipped.length > 0) {
       throw new Error(
@@ -210,6 +219,9 @@ export function assertCoreMigrationLedgerIntegrity(
     throw new Error("[migrate] Core migrator returned with an incomplete Steward journal");
   }
 }
+
+const SHIPPED_COLLISION_PREDECESSOR_TAG = "0114_durable_wallet_claim_account_audit";
+const SHIPPED_COLLISION_SUCCESSOR_TAG = "0118_generic_intent_execution_delete_fence";
 
 /**
  * The legacy `psql -f` deploy loop was retired when this migrator was
@@ -252,6 +264,39 @@ function hashMigration(tag: string): string {
   const crypto = require("node:crypto") as typeof import("node:crypto");
   const sql = readFileSync(`${MIGRATIONS_FOLDER}/${tag}.sql`, "utf-8");
   return crypto.createHash("sha256").update(sql).digest("hex");
+}
+
+async function recoverShippedTimestampCollision(
+  db: MigrationQueryExecutor,
+  rows: readonly CoreMigrationLedgerRow[],
+  journal: Journal,
+): Promise<boolean> {
+  const predecessor = journal.entries.find(
+    (entry) => entry.tag === SHIPPED_COLLISION_PREDECESSOR_TAG,
+  );
+  const successor = journal.entries.find((entry) => entry.tag === SHIPPED_COLLISION_SUCCESSOR_TAG);
+  if (!predecessor || !successor || predecessor.when !== successor.when) return false;
+
+  const hasPredecessor = rows.some(
+    (row) =>
+      row.hash === hashMigration(predecessor.tag) && Number(row.created_at) === predecessor.when,
+  );
+  const hasSuccessor = rows.some(
+    (row) => row.hash === hashMigration(successor.tag) && Number(row.created_at) === successor.when,
+  );
+  if (!hasPredecessor || hasSuccessor) return false;
+
+  const migrationSql = readFileSync(`${MIGRATIONS_FOLDER}/${successor.tag}.sql`, "utf8");
+  const statements = migrationSql
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+  for (const statement of statements) await db.execute(sql.raw(statement));
+  await db.execute(sql`
+    INSERT INTO drizzle.__drizzle_migrations (hash, created_at)
+    VALUES (${hashMigration(successor.tag)}, ${successor.when})
+  `);
+  return true;
 }
 
 type MigrationQueryExecutor = {
@@ -1389,7 +1434,9 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
           SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id ASC
         `) as CoreMigrationLedgerRow[];
       }
-      assertCoreMigrationLedgerIntegrity(existingRows, journal, databaseShape);
+      assertCoreMigrationLedgerIntegrity(existingRows, journal, databaseShape, {
+        allowShippedTimestampCollision: true,
+      });
       if (existingRows.length === journal.entries.length) {
         assertCoreMigrationLedgerIntegrity(existingRows, journal, databaseShape, {
           requireComplete: true,
@@ -1421,11 +1468,16 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
             ),
           );
         }
-        assertCoreMigrationLedgerIntegrity(transactionalRows, journal, {
-          ...databaseShape,
-          tenantsExists: Boolean(txTenantsExists[0]?.r),
-          coreLedgerExists: Boolean(txLedgerExists[0]?.r),
-        });
+        assertCoreMigrationLedgerIntegrity(
+          transactionalRows,
+          journal,
+          {
+            ...databaseShape,
+            tenantsExists: Boolean(txTenantsExists[0]?.r),
+            coreLedgerExists: Boolean(txLedgerExists[0]?.r),
+          },
+          { allowShippedTimestampCollision: true },
+        );
 
         // Only a verified empty/legacy Steward target may receive the ledger.
         // Avoid even idempotent CREATE statements once admin topology/the ledger
@@ -1483,6 +1535,15 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
         const beforeCount = queryRows<{ n: number }>(
           await tx.execute(sql`SELECT count(*)::int AS n FROM drizzle.__drizzle_migrations`),
         )[0].n;
+
+        if (await recoverShippedTimestampCollision(tx, transactionalRows, journal)) {
+          transactionalRows = queryRows<CoreMigrationLedgerRow>(
+            await tx.execute(
+              sql`SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id ASC`,
+            ),
+          );
+          assertCoreMigrationLedgerIntegrity(transactionalRows, journal, databaseShape);
+        }
 
         // The postgres-js migrator normally opens its own transaction. We are
         // already inside the ownership-check transaction, so give it the same


### PR DESCRIPTION
## Summary
- keep plugin migration discovery inside the bounded compose startup phase
- narrowly admit and transactionally recover the shipped 0114-present / 0118-missing equal-timestamp ledger state without changing either shipped identity
- prove restricted-role recovery restores the exact 0118 objects and ledger row
- update the existing restricted operator expectations for the fourth capabilities migration now shipped on develop

## Exact-head evidence
- base: `9a92acc25b6657f90885869359c7bfdf12f99bcd`
- head: `a2dd7b46f9488bd722899df617cb0afc6ec1fff0`
- `bun test packages/db/src/__tests__/migration-ledger-integrity.test.ts` — 13 pass, 43 assertions
- `bun test packages/api/src/__tests__/startup-phase.test.ts` — 5 pass, 11 assertions
- `bun run --cwd packages/shared build` — pass
- `bun run --cwd packages/db build` — pass
- targeted Biome and `git diff --check` — pass
- real-Postgres hostile-target half of the restricted operator suite passes; the lifecycle subprocess is locally harness-blocked by missing sparse-worktree runtime packages (`@node-saml/node-saml`) before migration execution. The checked-in test exercises the complete restricted upgrade in hosted/full dependency environments.

This intentionally does not alter shipped migration journal identities and contains no replacement for the already-merged 0004 inventory or 0119–0122 recovery chain.
