### PR TITLE
fix(api): isolate Worker security authority

### DIFF
--- a/packages/api/src/__tests__/auth-client-ip.test.ts
+++ b/packages/api/src/__tests__/auth-client-ip.test.ts
@@ -16,6 +16,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, mock } from "bun:
 import { hashSha256Hex } from "@stwd/auth";
 import { closeDb } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { Hono } from "hono";
 import { SOCKET_PEER_ENV_KEY } from "../services/runtime-gate";
 
@@ -149,6 +150,36 @@ function capturedKeys(endpoint: string): string[] {
 }
 
 describe("trustedClientIp", () => {
+  it("keeps hostile overlapping Worker trust snapshots request-local", async () => {
+    process.env.STEWARD_TRUST_CLOUDFLARE = "true";
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "10";
+    let releaseFirst!: () => void;
+    let firstReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      firstReady = resolve;
+    });
+    const barrier = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = withRuntimeEnvironment(
+      { STEWARD_RUNTIME: "workers", STEWARD_TRUST_CLOUDFLARE: "true" },
+      async () => {
+        firstReady();
+        await barrier;
+        return probeIp({ "cf-connecting-ip": "198.51.100.11", "x-forwarded-for": "203.0.113.1" });
+      },
+    );
+    await ready;
+    const second = await withRuntimeEnvironment(
+      { STEWARD_RUNTIME: "workers", STEWARD_TRUSTED_PROXY_HOPS: "1" },
+      () => probeIp({ "cf-connecting-ip": "198.51.100.22", "x-forwarded-for": "203.0.113.2" }),
+    );
+    releaseFirst();
+
+    expect(await first).toBe("198.51.100.11");
+    expect(second).toBe("203.0.113.2");
+  });
   it("trusts no forwarded header when no hops are configured (safe default)", async () => {
     delete process.env.STEWARD_TRUSTED_PROXY_HOPS;
     delete process.env.STEWARD_TRUST_PROXY_HEADERS;
@@ -558,6 +589,29 @@ describe("auth rate-limit keying (route harness)", () => {
     });
     expect(strict.status).toBe(429);
     expect(strict.headers.get("retry-after")).toBe("60");
+  });
+
+  it("uses request-local Worker outage posture despite a permissive process mirror", async () => {
+    process.env.NODE_ENV = "development";
+    process.env.STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL = "true";
+    process.env.STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX = "300";
+    process.env.REDIS_URL = "redis://ambient-soft-fail.invalid:6379";
+    await redisMiddleware.shutdownRedis();
+
+    const strict = await withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        NODE_ENV: "production",
+        REDIS_DRIVER: "ioredis",
+        REDIS_URL: "redis://request-local-outage.invalid:6379",
+        STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX: "0",
+      },
+      () => authRoutes.request("/nonce"),
+    );
+
+    expect(strict.status).toBe(429);
+    expect(strict.headers.get("retry-after")).toBe("60");
+    expect(rateLimitCalls).toHaveLength(0);
   });
 
   it("never-configured Redis in production stays hard fail-closed (valve does not apply)", async () => {

--- a/packages/api/src/__tests__/capability-rate-limit-readiness.test.ts
+++ b/packages/api/src/__tests__/capability-rate-limit-readiness.test.ts
@@ -1,8 +1,26 @@
 import { describe, expect, it } from "bun:test";
 import type { IoredisLike } from "@stwd/redis";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { checkCapabilityRateLimitReadiness } from "../services/capability-rate-limit-readiness";
 
 describe("capability rate-limit Redis readiness", () => {
+  it("uses the immutable request posture instead of an ambient production value", async () => {
+    const priorNodeEnvironment = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      await expect(
+        withRuntimeEnvironment({ NODE_ENV: "development" }, () =>
+          checkCapabilityRateLimitReadiness({
+            getRedisClient: () => null,
+            isRedisConfigured: () => false,
+          }),
+        ),
+      ).resolves.toEqual({ ok: true, source: "memory" });
+    } finally {
+      if (priorNodeEnvironment === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = priorNodeEnvironment;
+    }
+  });
   it("executes a bounded physical-generation reservation and cleans it up", async () => {
     const evaluatedKeys: string[] = [];
     const deletedKeys: string[] = [];

--- a/packages/api/src/__tests__/worker-security-authority.test.ts
+++ b/packages/api/src/__tests__/worker-security-authority.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { resolveJwksUrl } from "../middleware/agent-jwt";
+import { isHstsEnabled } from "../middleware/security-headers";
+
+const originalEnvironment = {
+  ELIZA_CLOUD_JWKS_URL: process.env.ELIZA_CLOUD_JWKS_URL,
+  STEWARD_HSTS_DISABLED: process.env.STEWARD_HSTS_DISABLED,
+};
+
+afterEach(() => {
+  for (const [name, value] of Object.entries(originalEnvironment)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+});
+
+describe("Worker request-local security authority", () => {
+  it("keeps overlapping agent JWKS authorities isolated from the process mirror", async () => {
+    process.env.ELIZA_CLOUD_JWKS_URL = "https://ambient.invalid/jwks";
+    let releaseFirst!: () => void;
+    let firstReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      firstReady = resolve;
+    });
+    const barrier = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        NODE_ENV: "production",
+        ELIZA_CLOUD_JWKS_URL: "https://first.invalid/jwks",
+      },
+      async () => {
+        firstReady();
+        await barrier;
+        return resolveJwksUrl();
+      },
+    );
+    await ready;
+    const second = withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        NODE_ENV: "production",
+        ELIZA_CLOUD_JWKS_URL: "https://second.invalid/jwks",
+      },
+      () => resolveJwksUrl(),
+    );
+    releaseFirst();
+
+    await expect(first).resolves.toBe("https://first.invalid/jwks");
+    expect(second).toBe("https://second.invalid/jwks");
+  });
+
+  it("never enables the development JWKS trust anchor on Workers", () => {
+    expect(() =>
+      withRuntimeEnvironment(
+        {
+          STEWARD_RUNTIME: "workers",
+          NODE_ENV: "development",
+          STEWARD_ALLOW_DEFAULT_ELIZA_JWKS: "true",
+        },
+        () => resolveJwksUrl(),
+      ),
+    ).toThrow("jwks-url-required");
+  });
+
+  it("binds HSTS posture to each Worker request snapshot", () => {
+    process.env.STEWARD_HSTS_DISABLED = "true";
+    expect(withRuntimeEnvironment({ STEWARD_HSTS_DISABLED: "false" }, isHstsEnabled)).toBe(true);
+    expect(withRuntimeEnvironment({ STEWARD_HSTS_DISABLED: "true" }, isHstsEnabled)).toBe(false);
+  });
+});

--- a/packages/api/src/middleware/agent-jwt.ts
+++ b/packages/api/src/middleware/agent-jwt.ts
@@ -1,4 +1,5 @@
 import type { VerifiedAgentPrincipal } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type { Context, Next } from "hono";
 import { errors, importJWK, type JWTPayload, jwtVerify } from "jose";
 import { recordAgentTokenExp } from "../services/agent-token-status";
@@ -51,12 +52,13 @@ function invalid(c: Context, reason: string, status: 401 = 401) {
  * ELIZA_CLOUD_JWKS_URL; outside production the hardcoded dev anchor requires
  * the STEWARD_ALLOW_DEFAULT_ELIZA_JWKS=true opt-in. Fails closed otherwise.
  */
-function resolveJwksUrl(): string {
-  const configured = process.env.ELIZA_CLOUD_JWKS_URL?.trim();
+export function resolveJwksUrl(): string {
+  const configured = runtimeEnvironmentValue("ELIZA_CLOUD_JWKS_URL")?.trim();
   if (configured) return configured;
   if (
-    process.env.NODE_ENV !== "production" &&
-    process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS === "true"
+    runtimeEnvironmentValue("STEWARD_RUNTIME") !== "workers" &&
+    runtimeEnvironmentValue("NODE_ENV") !== "production" &&
+    runtimeEnvironmentValue("STEWARD_ALLOW_DEFAULT_ELIZA_JWKS") === "true"
   ) {
     return DEFAULT_ELIZA_CLOUD_JWKS_URL;
   }

--- a/packages/api/src/middleware/security-headers.ts
+++ b/packages/api/src/middleware/security-headers.ts
@@ -7,6 +7,7 @@
  * private dev deploys without HTTPS.
  */
 
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type { MiddlewareHandler } from "hono";
 
 const STATIC_HEADERS: Record<string, string> = {
@@ -26,7 +27,7 @@ const STATIC_HEADERS: Record<string, string> = {
 const HSTS_VALUE = "max-age=63072000; includeSubDomains; preload";
 
 export function isHstsEnabled(): boolean {
-  return process.env.STEWARD_HSTS_DISABLED !== "true";
+  return runtimeEnvironmentValue("STEWARD_HSTS_DISABLED") !== "true";
 }
 
 function hostFromRequest(req: Request): string {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -261,9 +261,9 @@ function normalizeEmailDomain(value: unknown): string | null {
  * not preserved.
  */
 function trustedProxyHops(): number {
-  const raw = process.env.STEWARD_TRUSTED_PROXY_HOPS?.trim();
+  const raw = runtimeEnvironmentValue("STEWARD_TRUSTED_PROXY_HOPS")?.trim();
   if (raw === undefined || raw === "") {
-    return process.env.STEWARD_TRUST_PROXY_HEADERS === "true" ? 1 : 0;
+    return runtimeEnvironmentValue("STEWARD_TRUST_PROXY_HEADERS") === "true" ? 1 : 0;
   }
   // Canonical non-negative integer only: "1.5" must not truncate into trust.
   if (!/^\d+$/.test(raw)) return 0;
@@ -341,7 +341,7 @@ function logNoTrustedClientIpDiag(c: Context, hops: number): void {
  * never a shared "global" bucket, never open.
  */
 export function trustedClientIp(c: Context): string | undefined {
-  const trustCloudflare = process.env.STEWARD_TRUST_CLOUDFLARE === "true";
+  const trustCloudflare = runtimeEnvironmentValue("STEWARD_TRUST_CLOUDFLARE") === "true";
   if (trustCloudflare) {
     const cf = c.req.header("cf-connecting-ip")?.trim();
     if (cf && isIP(cf)) return cf;
@@ -437,7 +437,10 @@ function authRateLimitSubject(c: Context): { subject: string; coarse: boolean } 
   const peer = socketPeerFromEnv(c.env);
   if (peer && isIP(peer)) return { subject: `ip:${clientIpBucket(peer)}`, coarse: false };
   const now = Date.now();
-  if (process.env.NODE_ENV === "production" && now - coarseSubjectWarnedAt >= 60_000) {
+  if (
+    runtimeEnvironmentValue("NODE_ENV") === "production" &&
+    now - coarseSubjectWarnedAt >= 60_000
+  ) {
     coarseSubjectWarnedAt = now;
     console.warn(
       "[AuthRateLimit] No trusted client IP (set STEWARD_TRUSTED_PROXY_HOPS=2 on Railway); auth rate limits fall back to coarse per-host buckets instead of per-client budgets",
@@ -451,8 +454,8 @@ function authRateLimitSubject(c: Context): { subject: string; coarse: boolean } 
 
 function allowAuthRateLimitSoftFail(): boolean {
   return (
-    process.env.NODE_ENV !== "production" ||
-    process.env.STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL === "true"
+    runtimeEnvironmentValue("NODE_ENV") !== "production" ||
+    runtimeEnvironmentValue("STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL") === "true"
   );
 }
 
@@ -468,7 +471,7 @@ function allowAuthRateLimitSoftFail(): boolean {
  * isolate on Workers, which only tightens it).
  */
 function authRateLimitOutageValveMax(): number {
-  const raw = process.env.STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX;
+  const raw = runtimeEnvironmentValue("STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX");
   if (raw === undefined || raw === "") return 300;
   const parsed = Number.parseInt(raw, 10);
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : 300;

--- a/packages/api/src/services/capability-rate-limit-readiness.ts
+++ b/packages/api/src/services/capability-rate-limit-readiness.ts
@@ -1,6 +1,7 @@
 import { getDb } from "@stwd/db";
 import { checkRateLimit, type IoredisLike, rateLimitBucketKey } from "@stwd/redis";
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { sql } from "drizzle-orm";
 import { getRedisClient, isRedisConfigured } from "../middleware/redis";
 import { withAuthenticatedTenantDatabase } from "./context";
@@ -94,7 +95,8 @@ export async function checkCapabilityRateLimitReadiness(
       error: "Configured Redis capability rate-limit backend is unavailable",
     };
   }
-  if (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test") {
+  const nodeEnvironment = runtimeEnvironmentValue("NODE_ENV");
+  if (nodeEnvironment === "development" || nodeEnvironment === "test") {
     return { ok: true, source: "memory" };
   }
 

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -526,7 +526,7 @@ async function initializeWorker(env: Env): Promise<void> {
         dbUrl.includes("sslmode=verify-ca") ||
         dbUrl.includes("sslmode=verify-full"),
       hstsEnabled: isHstsEnabled(),
-      insecureDbAllowed: process.env.STEWARD_ALLOW_INSECURE_DB === "true",
+      insecureDbAllowed: env.STEWARD_ALLOW_INSECURE_DB === "true",
       runtime: "workers",
     },
   });

--- a/packages/plugin-capabilities/src/__tests__/manifest-routes.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/manifest-routes.test.ts
@@ -41,6 +41,9 @@ const GH_SPEC = {
 function buildCtx(db: unknown): StewardAppContext {
   return {
     db,
+    withCapabilityTenantDatabase(_tenantId, callback) {
+      return callback(db as StewardAppContext["db"]);
+    },
     getRedisClient() {
       return null;
     },


### PR DESCRIPTION
Closes #786.

This removes the remaining security-sensitive Worker reads from the mutable process.env compatibility mirror:
- agent JWKS URL and dev-anchor posture come from the immutable request snapshot; Workers can never enable the development default anchor
- Cloudflare/proxy-hop identity, auth soft-fail/outage-valve posture, HSTS, and capability readiness NODE_ENV are request-local
- Worker boot telemetry reads its invocation env directly
- hostile overlap/process-poison regressions prove one request cannot reinterpret another request's trust or outage posture

It also repairs the overlapping hosted plugin-capabilities regression: the Worker manifest test now supplies its required request-owned capability database authority, so it reaches the intended autonomous-recovery 503 instead of an unrelated rate-limit 429.

Exact head evidence:
- API security/readiness/global limiter/Worker boot suites: 61 passed across 5 files
- Worker manifest regression: 1 passed
- plugin-capabilities typecheck: passed
- CI test inventory: passed
- Biome and git diff --check: passed

Known current-develop build failures, unchanged and outside this PR: packages/api/src/routes/vault.ts:3752 references missing findActionByIdempotency, and :3969 supplies unsupported idempotencyKeyDigest. The API typecheck reaches only those two base errors; all #786-touched modules typecheck.

Please require independent exact-head review and terminal hosted checks before merge.