### PR TITLE
fix(trading): bind Hyperliquid signatures to fenced wallet

### DIFF
--- a/packages/plugin-trading/src/__tests__/operator-recovery.test.ts
+++ b/packages/plugin-trading/src/__tests__/operator-recovery.test.ts
@@ -27,6 +27,7 @@ import { and, asc, eq, inArray } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 import { verifyAuditChain } from "../../../api/src/services/audit";
+import type { StewardAppContext } from "../context";
 
 const PLATFORM_KEY = "stw_platform_test_operator_key";
 setDefaultTimeout(30_000);
@@ -50,6 +51,9 @@ const submitSendAssetCalls: unknown[] = [];
 let signSendAssetError: Error | undefined;
 let submitSendAssetError: Error | undefined;
 let closeAllPause: Promise<void> | null = null;
+const adapterVaultClients: Array<{
+  signTypedData: (input: Record<string, unknown>) => Promise<string>;
+}> = [];
 
 mock.module("@stwd/policy-engine", () => ({
   aggregationLookupFromMap: () => undefined,
@@ -66,7 +70,11 @@ class MockHyperliquidAdapter {
     public vault: unknown,
     public agentId: string,
     public walletAddress: string,
-  ) {}
+  ) {
+    adapterVaultClients.push(
+      vault as { signTypedData: (input: Record<string, unknown>) => Promise<string> },
+    );
+  }
 
   async closeAllPositions() {
     closeAllCalls.push(Date.now());
@@ -221,7 +229,7 @@ async function seedAgent(opts: {
  * plus the unauthenticated/wrong-key rejections, which is what production
  * operator recovery uses).
  */
-async function buildApp() {
+async function buildApp(ctxOverrides: Partial<StewardAppContext> = {}) {
   const { isValidPlatformKey } = await import("@stwd/auth");
   const { createOperatorRecoveryRoutes } = await import("../routes/operator-recovery");
   const { testCtx } = await import("./_ctx");
@@ -239,7 +247,7 @@ async function buildApp() {
     c.set("authType", "platform");
     return next();
   });
-  app.route("/v1/trade", createOperatorRecoveryRoutes(testCtx()));
+  app.route("/v1/trade", createOperatorRecoveryRoutes({ ...testCtx(), ...ctxOverrides }));
   return app;
 }
 
@@ -740,6 +748,52 @@ describe("operator recovery leverage", () => {
     expect(body.data.leverage).toBe(3);
     expect(body.data.isCross).toBe(false);
     expect(updateLeverageCalls).toEqual([{ coin: "xyz:SPCX", leverage: 3, isCross: false }]);
+  });
+
+  it("binds operator-recovery signatures to the resolved venue wallet", async () => {
+    const tenantId = `tenant-lev-wallet-${Date.now()}`;
+    const agentId = `agent-lev-wallet-${Date.now()}`;
+    await seedAgent({ tenantId, agentId });
+    adapterVaultClients.length = 0;
+    const signedInputs: Array<Record<string, unknown>> = [];
+    const app = await buildApp({
+      vault: {
+        getWallet: async () => ({
+          address: "0x00000000000000000000000000000000000000bb",
+        }),
+        signTypedData: async (input: Record<string, unknown>) => {
+          signedInputs.push(input);
+          return `0x${"1".repeat(128)}1b`;
+        },
+      } as unknown as StewardAppContext["vault"],
+    });
+    const res = await app.request("/v1/trade/hyperliquid/leverage", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Steward-Platform-Key": PLATFORM_KEY,
+        "X-Steward-Tenant": tenantId,
+        "Idempotency-Key": crypto.randomUUID(),
+      },
+      body: JSON.stringify({ agentId, coin: "BTC", leverage: 2, isCross: false }),
+    });
+    expect(res.status).toBe(200);
+    expect(adapterVaultClients).toHaveLength(1);
+
+    await adapterVaultClients[0]!.signTypedData({
+      agentId,
+      domain: { name: "Hyperliquid", version: "1", chainId: 42161 },
+      types: { Action: [{ name: "nonce", type: "uint64" }] },
+      primaryType: "Action",
+      value: { nonce: 1 },
+    });
+    expect(signedInputs).toHaveLength(1);
+    expect(signedInputs[0]).toMatchObject({
+      agentId,
+      tenantId,
+      venue: "hyperliquid",
+      expectedWalletAddress: "0x00000000000000000000000000000000000000bb",
+    });
   });
 });
 

--- a/packages/plugin-trading/src/__tests__/trade-venue-submit-fence.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-venue-submit-fence.test.ts
@@ -57,6 +57,7 @@ import {
 import { agents, auditEvents, closeDb, getDb, tenants, tradeSessions } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { TradeSessionManager } from "@stwd/trade-sessions";
+import { Vault } from "@stwd/vault";
 import { HyperliquidAdapter } from "@stwd/venue-hyperliquid";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
@@ -82,6 +83,7 @@ let updateLeverageSpy: ReturnType<typeof spyOn> | undefined;
 let fenceSpy: ReturnType<typeof spyOn> | undefined;
 let createTradeRoutesForTest: typeof import("../routes/trade").createTradeRoutes;
 let sharedTestContext: StewardAppContext;
+let vaultTypedSignSpy: ReturnType<typeof spyOn> | undefined;
 
 async function seedSession(
   allowedAssets: string[] = ["BTC"],
@@ -200,9 +202,35 @@ describe("Hyperliquid venue-submit spend-fence (real /hyperliquid/order path)", 
     signSpy?.mockRestore();
     submitSpy?.mockRestore();
     updateLeverageSpy?.mockRestore();
+    vaultTypedSignSpy?.mockRestore();
     signSpy = undefined;
     submitSpy = undefined;
     updateLeverageSpy = undefined;
+    vaultTypedSignSpy = undefined;
+  });
+
+  it("binds every Hyperliquid signature to the fenced session wallet", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession();
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+    vaultTypedSignSpy = spyOn(Vault.prototype, "signTypedData").mockResolvedValue(
+      `0x${"1".repeat(128)}1b`,
+    );
+    submitSpy = spyOn(HyperliquidAdapter.prototype, "submitOrder").mockResolvedValue({
+      orderId: "hl-wallet-bound",
+      status: "filled",
+      filledQty: 1,
+      avgPrice: 10,
+    } as Awaited<ReturnType<HyperliquidAdapter["submitOrder"]>>);
+
+    const response = await postOrder(app, sessionId, crypto.randomUUID());
+    expect(response.status).toBe(200);
+    expect(vaultTypedSignSpy).toHaveBeenCalledTimes(1);
+    expect(vaultTypedSignSpy!.mock.calls[0]?.[0]).toMatchObject({
+      agentId,
+      tenantId,
+      venue: "hyperliquid",
+      expectedWalletAddress: "0x0000000000000000000000000000000000000001",
+    });
   });
 
   it("releases spend and cancels (no submitted audit) when the venue rejects the order", async () => {

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -883,7 +883,12 @@ export function createOperatorRecoveryRoutes(
   function buildAdapter(tenantId: string, agentId: string, walletAddress: string) {
     const vaultClient = {
       signTypedData: (input: Omit<Parameters<typeof vault.signTypedData>[0], "tenantId">) =>
-        vault.signTypedData({ ...input, tenantId, venue: "hyperliquid" as const }),
+        vault.signTypedData({
+          ...input,
+          tenantId,
+          venue: "hyperliquid" as const,
+          expectedWalletAddress: walletAddress,
+        }),
     };
     return new HyperliquidAdapter(vaultClient, agentId, walletAddress);
   }

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -1159,7 +1159,12 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         if (storedSession?.agentId === agentId && storedSession.venue === "hyperliquid") {
           const vaultClient = {
             signTypedData: (input: Omit<Parameters<typeof vault.signTypedData>[0], "tenantId">) =>
-              vault.signTypedData({ ...input, tenantId, venue: "hyperliquid" }),
+              vault.signTypedData({
+                ...input,
+                tenantId,
+                venue: "hyperliquid",
+                expectedWalletAddress: storedSession.walletId,
+              }),
           };
           const adapter = new HyperliquidAdapter(vaultClient, agentId, storedSession.walletId);
           try {
@@ -1402,7 +1407,6 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       );
     }
 
-    const walletAddress = session.walletId;
     const manager = getSessionManager();
     const fenced = await manager.withActiveSubmissionFence(
       { tenantId, id: session.id },
@@ -1420,6 +1424,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           await idempotency.store?.(envelope);
           return envelope;
         }
+        const walletAddress = activeSession.walletId;
 
         const reserved = await getSessionManager().incrementSpend({
           tenantId,
@@ -1448,7 +1453,12 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
 
         const vaultClient = {
           signTypedData: (input: Omit<Parameters<typeof vault.signTypedData>[0], "tenantId">) =>
-            vault.signTypedData({ ...input, tenantId, venue: "hyperliquid" }),
+            vault.signTypedData({
+              ...input,
+              tenantId,
+              venue: "hyperliquid",
+              expectedWalletAddress: walletAddress,
+            }),
         };
         const adapter = new HyperliquidAdapter(vaultClient, agentId, walletAddress);
         if (builderPerp) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -639,6 +639,13 @@ export interface SignTypedDataRequest {
    * otherwise it resolves the unscoped wallet.
    */
   venue?: VenueId;
+  /**
+   * Optional fail-closed assertion for a wallet identity authorized before the
+   * custody boundary. The vault never uses this value to select a key: under
+   * the custody-transition lock it resolves the current scoped wallet and key,
+   * then requires both to derive this address before signing.
+   */
+  expectedWalletAddress?: string;
   domain: TypedDataDomain;
   types: Record<string, TypedDataField[]>;
   primaryType: string;

--- a/packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts
+++ b/packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts
@@ -11,12 +11,13 @@ import {
   isNull,
   tenants,
 } from "@stwd/db";
-import { generatePrivateKey } from "viem/accounts";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import type {
   ExternalKeyCustodyProvider,
   ExternalKeyHandleImportRequest,
   ExternalKeyHandleRegistration,
 } from "../external-key-custody";
+import { KeyStore } from "../keystore";
 import { Vault } from "../vault";
 
 setDefaultTimeout(120_000);
@@ -35,6 +36,7 @@ const agentId = `custody-race-agent-${suffix}`;
 const restoreFirstAgentId = `custody-race-restore-first-${suffix}`;
 const externalBeforeImportAgentId = `race-external-first-${suffix}`;
 const importBeforeExternalAgentId = `race-local-first-${suffix}`;
+const typedDataRotationAgentId = `typed-data-rotation-${suffix}`;
 const blocker = databaseUrl ? createPostgresClient(databaseUrl) : null;
 const inspector = databaseUrl ? createPostgresClient(databaseUrl) : null;
 
@@ -427,5 +429,81 @@ suite("custody transitions across real PostgreSQL connections", () => {
         (wallet) => (wallet.metadata as Record<string, unknown> | null)?.custody === "external",
       ),
     ).toBe(false);
+  });
+
+  test("a queued typed-data signature revalidates the venue wallet after a concurrent rotation", async () => {
+    if (!blocker || !inspector) throw new Error("real PostgreSQL clients are unavailable");
+    const venue = "hyperliquid";
+    const vault = new Vault({ masterPassword: MASTER_PASSWORD });
+    await vault.createAgent(tenantId, typedDataRotationAgentId, "Typed Data Rotation Agent");
+    const original = await vault.provisionVenueWallet({
+      tenantId,
+      agentId: typedDataRotationAgentId,
+      venue,
+      chainFamily: "evm",
+      approvedAddresses: [],
+    });
+
+    const replacementPrivateKey = generatePrivateKey();
+    const replacementAddress = privateKeyToAccount(replacementPrivateKey).address;
+    const replacement = new KeyStore(MASTER_PASSWORD).encrypt(replacementPrivateKey, {
+      tenantId,
+      agentId: typedDataRotationAgentId,
+      chainFamily: "evm",
+      venue,
+    });
+    const lockKey = JSON.stringify([
+      "vault-custody-v1",
+      tenantId,
+      typedDataRotationAgentId,
+      "evm",
+      venue,
+    ]);
+    let signingResult!: Promise<
+      { status: "fulfilled"; value: string } | { status: "rejected"; reason: unknown }
+    >;
+
+    await blocker.begin(async (tx) => {
+      await tx`select pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`;
+      signingResult = vault
+        .signTypedData({
+          tenantId,
+          agentId: typedDataRotationAgentId,
+          venue,
+          expectedWalletAddress: original.address,
+          domain: { name: "Steward wallet rotation", version: "1", chainId: 8453 },
+          types: { Rotation: [{ name: "session", type: "string" }] },
+          primaryType: "Rotation",
+          value: { session: "authorized-before-rotation" },
+        })
+        .then(
+          (value) => ({ status: "fulfilled" as const, value }),
+          (reason: unknown) => ({ status: "rejected" as const, reason }),
+        );
+      await waitForBlockedAdvisoryConnections(lockKey, 1);
+      await tx`
+        update encrypted_chain_keys
+        set ciphertext = ${replacement.ciphertext}, iv = ${replacement.iv},
+            tag = ${replacement.tag}, salt = ${replacement.salt}
+        where agent_id = ${typedDataRotationAgentId}
+          and chain_family = 'evm'
+          and venue = ${venue}
+      `;
+      await tx`
+        update agent_wallets
+        set address = ${replacementAddress}
+        where agent_id = ${typedDataRotationAgentId}
+          and chain_family = 'evm'
+          and venue = ${venue}
+      `;
+    });
+
+    const result = await signingResult;
+    expect(result.status).toBe("rejected");
+    if (result.status === "rejected") {
+      expect(String(result.reason)).toContain(
+        "Typed-data signer no longer matches the authorized wallet",
+      );
+    }
   });
 });

--- a/packages/vault/src/__tests__/venue-wallet-key-roundtrip.test.ts
+++ b/packages/vault/src/__tests__/venue-wallet-key-roundtrip.test.ts
@@ -98,6 +98,50 @@ describe("provisionVenueWallet key round-trip (AAD context regression)", () => {
         .where(and(eq(agentWallets.agentId, "agent1"), eq(agentWallets.venue, venue)));
       expect(walletRow?.chainFamily).toBe(chainFamily);
 
+      if (chainFamily === "evm") {
+        const typedData = {
+          agentId: "agent1",
+          tenantId: TENANT_ID,
+          venue,
+          domain: { name: "Steward wallet binding", version: "1", chainId: 8453 },
+          types: { Binding: [{ name: "session", type: "string" }] },
+          primaryType: "Binding",
+          value: { session: "session-before-wallet-rotation" },
+        };
+        const signature = await vault.signTypedData({
+          ...typedData,
+          expectedWalletAddress: walletRow!.address,
+        });
+        expect(signature).toMatch(/^0x[0-9a-f]{130}$/i);
+
+        await expect(vault.signTypedData(typedData)).rejects.toThrow(
+          "Hyperliquid typed-data signing requires an authorized wallet assertion",
+        );
+
+        await expect(
+          vault.signTypedData({
+            ...typedData,
+            expectedWalletAddress: "0x2222222222222222222222222222222222222222",
+          }),
+        ).rejects.toThrow("Typed-data signer no longer matches the authorized wallet");
+
+        await getDb()
+          .delete(agentWallets)
+          .where(
+            and(
+              eq(agentWallets.agentId, "agent1"),
+              eq(agentWallets.chainFamily, "evm"),
+              eq(agentWallets.venue, venue),
+            ),
+          );
+        await expect(
+          vault.signTypedData({
+            ...typedData,
+            expectedWalletAddress: walletRow!.address,
+          }),
+        ).rejects.toThrow("Typed-data signer no longer matches the authorized wallet");
+      }
+
       // AAD genuinely binds the venue: a different or absent venue must NOT decrypt.
       expect(() => keyStore.decrypt(enc, { ...ctx, venue: "polymarket" })).toThrow();
       expect(() =>

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -3041,19 +3041,14 @@ export class Vault {
   async signTypedData(request: SignTypedDataRequest): Promise<string> {
     const db = getDb();
 
-    // Verify agent exists for this tenant
-    const [agentRow] = await db
-      .select({ walletAddress: agents.walletAddress })
-      .from(agents)
-      .where(and(eq(agents.id, request.agentId), eq(agents.tenantId, request.tenantId)));
-
-    if (!agentRow) {
-      throw new Error(`Agent ${request.agentId} not found for tenant ${request.tenantId}`);
+    if (request.venue === "hyperliquid" && !request.expectedWalletAddress) {
+      throw new Error("Hyperliquid typed-data signing requires an authorized wallet assertion");
     }
 
-    if (detectChainType(agentRow.walletAddress) === "solana") {
-      throw new Error("EIP-712 typed data signing is not supported for Solana wallets");
-    }
+    // These guards use their established stores/connections. Run them before
+    // opening the custody-lock transaction so single-connection PGlite cannot
+    // self-deadlock; the locked key/address revalidation below remains the
+    // authoritative protection against a concurrent local wallet rotation.
     await assertVaultSigningActive({
       tenantId: request.tenantId,
       agentId: request.agentId,
@@ -3062,76 +3057,114 @@ export class Vault {
     });
     await this.assertLocalSigningScopeIsNotExternal(request.agentId, "evm", request.venue ?? null);
 
-    // Resolve signing key: prefer encryptedChainKeys (multi-wallet), scoped by
-    // venue when requested, then fall back to legacy encryptedKeys only for
-    // legacy NULL-venue requests.
-    let secretKey: string;
-    const [chainKey] = await db
-      .select()
-      .from(encryptedChainKeys)
-      .where(
-        and(
-          eq(encryptedChainKeys.agentId, request.agentId),
-          eq(encryptedChainKeys.chainFamily, "evm"),
-          request.venue
-            ? eq(encryptedChainKeys.venue, request.venue)
-            : isNull(encryptedChainKeys.venue),
-        ),
-      );
+    const signWithCurrentKey = async (queryDb: Pick<typeof db, "select">): Promise<string> => {
+      // Re-check tenant ownership after taking the custody lock. A request that
+      // raced an agent/custody transition must use the post-lock state.
+      const [agentRow] = await queryDb
+        .select({ walletAddress: agents.walletAddress })
+        .from(agents)
+        .where(and(eq(agents.id, request.agentId), eq(agents.tenantId, request.tenantId)));
 
-    if (chainKey) {
-      secretKey = await this.keyStore.decrypt(
-        {
-          ciphertext: chainKey.ciphertext,
-          iv: chainKey.iv,
-          tag: chainKey.tag,
-          salt: chainKey.salt,
-        },
-        {
+      if (!agentRow) {
+        throw new Error(`Agent ${request.agentId} not found for tenant ${request.tenantId}`);
+      }
+      if (detectChainType(agentRow.walletAddress) === "solana") {
+        throw new Error("EIP-712 typed data signing is not supported for Solana wallets");
+      }
+      const venue = request.venue ?? null;
+      const [walletRow] = await queryDb
+        .select({ address: agentWallets.address })
+        .from(agentWallets)
+        .where(
+          and(
+            eq(agentWallets.agentId, request.agentId),
+            eq(agentWallets.chainFamily, "evm"),
+            venue ? eq(agentWallets.venue, venue) : isNull(agentWallets.venue),
+          ),
+        );
+      // Resolve signing key: prefer encryptedChainKeys (multi-wallet), scoped by
+      // venue when requested, then fall back to legacy encryptedKeys only for
+      // legacy NULL-venue requests.
+      let secretKey: string;
+      const [chainKey] = await queryDb
+        .select()
+        .from(encryptedChainKeys)
+        .where(
+          and(
+            eq(encryptedChainKeys.agentId, request.agentId),
+            eq(encryptedChainKeys.chainFamily, "evm"),
+            request.venue
+              ? eq(encryptedChainKeys.venue, request.venue)
+              : isNull(encryptedChainKeys.venue),
+          ),
+        );
+
+      if (chainKey) {
+        secretKey = await this.keyStore.decrypt(
+          {
+            ciphertext: chainKey.ciphertext,
+            iv: chainKey.iv,
+            tag: chainKey.tag,
+            salt: chainKey.salt,
+          },
+          {
+            tenantId: request.tenantId,
+            agentId: request.agentId,
+            chainFamily: "evm",
+            venue: request.venue ?? null,
+          },
+        );
+      } else {
+        if (request.venue) {
+          throw new Error(
+            `No signing key found for agent ${request.agentId} on venue ${request.venue}`,
+          );
+        }
+        const [legacyKey] = await queryDb
+          .select()
+          .from(encryptedKeys)
+          .where(eq(encryptedKeys.agentId, request.agentId));
+        if (!legacyKey) {
+          throw new Error(`No signing key found for agent ${request.agentId}`);
+        }
+        secretKey = await this.keyStore.decrypt(legacyKey as EncryptedKey, {
           tenantId: request.tenantId,
           agentId: request.agentId,
           chainFamily: "evm",
-          venue: request.venue ?? null,
+          venue: null,
+        });
+      }
+
+      const account = privateKeyToAccount(secretKey as `0x${string}`);
+      if (
+        request.expectedWalletAddress &&
+        (walletRow?.address.toLowerCase() !== request.expectedWalletAddress.toLowerCase() ||
+          account.address.toLowerCase() !== request.expectedWalletAddress.toLowerCase())
+      ) {
+        throw new Error("Typed-data signer no longer matches the authorized wallet");
+      }
+
+      return account.signTypedData({
+        domain: {
+          name: request.domain.name,
+          version: request.domain.version,
+          chainId: request.domain.chainId,
+          verifyingContract: request.domain.verifyingContract as `0x${string}` | undefined,
+          salt: request.domain.salt as `0x${string}` | undefined,
         },
-      );
-    } else {
-      if (request.venue) {
-        throw new Error(
-          `No signing key found for agent ${request.agentId} on venue ${request.venue}`,
-        );
-      }
-      // Fallback: legacy encrypted_keys table
-      const [legacyKey] = await db
-        .select()
-        .from(encryptedKeys)
-        .where(eq(encryptedKeys.agentId, request.agentId));
-      if (!legacyKey) {
-        throw new Error(`No signing key found for agent ${request.agentId}`);
-      }
-      secretKey = await this.keyStore.decrypt(legacyKey as EncryptedKey, {
-        tenantId: request.tenantId,
-        agentId: request.agentId,
-        chainFamily: "evm",
-        venue: null,
+        types: request.types as Record<string, Array<{ name: string; type: string }>>,
+        primaryType: request.primaryType,
+        message: request.value,
       });
-    }
+    };
 
-    const account = privateKeyToAccount(secretKey as `0x${string}`);
-
-    const signature = await account.signTypedData({
-      domain: {
-        name: request.domain.name,
-        version: request.domain.version,
-        chainId: request.domain.chainId,
-        verifyingContract: request.domain.verifyingContract as `0x${string}` | undefined,
-        salt: request.domain.salt as `0x${string}` | undefined,
-      },
-      types: request.types as Record<string, Array<{ name: string; type: string }>>,
-      primaryType: request.primaryType,
-      message: request.value,
+    if (!usesCustodyAdvisoryLock()) return signWithCurrentKey(db);
+    return db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${custodyTransitionLockKey(request.tenantId, request.agentId, "evm", request.venue ?? null)}, 0))`,
+      );
+      return signWithCurrentKey(tx);
     });
-
-    return signature;
   }
 
   /**


### PR DESCRIPTION
## Summary
- carry the durable Hyperliquid session/recovery wallet into every typed-data signing adapter as a fail-closed assertion
- require that assertion at the Vault boundary, then resolve the current venue address and key under the custody advisory lock and reject any mismatch
- cover normal fenced submission, durable replay construction, operator recovery, missing/mismatched/deleted wallet state, and concurrent replacement-key rotation

## Verification
- `bun test packages/plugin-trading/src/__tests__/trade-venue-submit-fence.test.ts packages/plugin-trading/src/__tests__/operator-recovery.test.ts packages/vault/src/__tests__/venue-wallet-key-roundtrip.test.ts` (36 pass)
- `DATABASE_URL=<fresh local PostgreSQL> bun test packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts` (5 pass; includes two-connection queued-signature/rotation race)
- `bun run --cwd packages/shared build`
- `bun run --cwd packages/vault build`
- `bun run --cwd packages/plugin-trading build`
- changed-file `bunx @biomejs/biome check ...` (8 files clean)
- `git diff origin/develop...HEAD --check`

Closes #870
