### PR TITLE
fix(auth): bind login audits to tenant RLS

### DIFF
--- a/packages/api/src/__tests__/auth-login-audit-rls-boundary.test.ts
+++ b/packages/api/src/__tests__/auth-login-audit-rls-boundary.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+const source = await Bun.file(new URL("../routes/auth.ts", import.meta.url)).text();
+
+function sourceBetween(startMarker: string, endMarker: string): string {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start + 1);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe("auth login audit RLS boundary", () => {
+  test("binds every auth.login audit to the verified user tenant", () => {
+    const auditHelper = sourceBetween(
+      "async function writeAuthLoginAudit(",
+      "async function findOrCreateWalletTenant(",
+    );
+    expect(auditHelper).toContain("withVerifiedAuthTenant(tenantId, userId");
+    expect(auditHelper).toContain('action: "auth.login"');
+  });
+
+  test("routes shared OAuth/session finalization through the guarded audit helper", () => {
+    const responseBuilder = sourceBetween(
+      "async function buildAuthOrMfaResponse(",
+      "function authExchangeJson(",
+    );
+    expect(responseBuilder).toContain("await writeAuthLoginAudit(c, tenantId, userId, claims)");
+    expect(responseBuilder).not.toContain("await writeAuditEvent(");
+  });
+});

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -2486,20 +2486,22 @@ async function writeAuthLoginAudit(
   claims: Record<string, unknown> | undefined,
   metadata: Record<string, unknown> = {},
 ): Promise<void> {
-  await writeAuditEvent({
-    tenantId,
-    actorType: "user",
-    actorId: userId,
-    action: "auth.login",
-    resourceType: "session",
-    metadata: {
-      method: typeof claims?.authMethod === "string" ? claims.authMethod : "unknown",
-      ...metadata,
-    },
-    ipAddress: c.req.header("x-forwarded-for") ?? null,
-    userAgent: c.req.header("user-agent") ?? null,
-    requestId: c.req.header("x-request-id") ?? null,
-  });
+  await withVerifiedAuthTenant(tenantId, userId, () =>
+    writeAuditEvent({
+      tenantId,
+      actorType: "user",
+      actorId: userId,
+      action: "auth.login",
+      resourceType: "session",
+      metadata: {
+        method: typeof claims?.authMethod === "string" ? claims.authMethod : "unknown",
+        ...metadata,
+      },
+      ipAddress: c.req.header("x-forwarded-for") ?? null,
+      userAgent: c.req.header("user-agent") ?? null,
+      requestId: c.get("requestId") ?? c.req.header("x-request-id") ?? null,
+    }),
+  );
 }
 
 type WalletTenantResult = {
@@ -3289,19 +3291,7 @@ async function buildAuthOrMfaResponse(
   }
 
   if (c) {
-    await writeAuditEvent({
-      tenantId,
-      actorType: "user",
-      actorId: userId,
-      action: "auth.login",
-      resourceType: "session",
-      metadata: {
-        method: typeof claims.authMethod === "string" ? claims.authMethod : "unknown",
-      },
-      ipAddress: c.req.header("x-forwarded-for") ?? null,
-      userAgent: c.req.header("user-agent") ?? null,
-      requestId: c.get("requestId") ?? null,
-    });
+    await writeAuthLoginAudit(c, tenantId, userId, claims);
   }
   const token = await createSessionToken(address, tenantId, sessionClaims);
   const refreshToken = await createRefreshToken(userId, tenantId, sessionClaims);


### PR DESCRIPTION
## Summary

- run the shared `auth.login` audit write inside the verified user/tenant RLS transaction
- route OAuth/session finalization through that guarded helper instead of its unscoped duplicate
- preserve the request context ID and add a regression boundary test

## Live root-cause evidence

Hosted staging Google OAuth now clears Google callback validation, provisions the user/wallet, then fails with `oauth_account_provisioning_failed`. Replaying the exact deployed audit write against the staging application role produced PostgreSQL `42501`: `new row violates row-level security policy for table "audit_events"`. Running the same write in `withTenantRlsTransaction` succeeds.

## Validation

- `bun test packages/api/src/__tests__/auth-login-audit-rls-boundary.test.ts packages/api/src/__tests__/auth-oauth-callback-browser.test.ts packages/api/src/__tests__/auth-oauth-token-encryption.test.ts` — 23 pass, 0 fail
- post-rebase focused rerun — 19 pass, 0 fail
- Biome on both changed files — clean
- `git diff --check` — clean

`@stwd/api` full typecheck is independently blocked on current `develop` by existing `packages/api/src/routes/vault.ts` errors (`findActionByIdempotency` and `idempotencyKeyDigest`); this PR does not touch that file.

## Staging acceptance

After merge/deploy: complete a real Google login on `https://staging.eliza.app/login`, verify callback/session/redirect, then sign out and repeat to prove canonical account reuse.
