### PR TITLE
fix(worker): bind simulator RPC authority to requests

### DIFF
--- a/packages/api/src/__tests__/evm-simulator-runtime-authority.test.ts
+++ b/packages/api/src/__tests__/evm-simulator-runtime-authority.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { createEnvEvmSimulator, type EvmSimulationRequest } from "../services/evm-simulator";
+
+const originalFetch = globalThis.fetch;
+const request: EvmSimulationRequest = {
+  chainId: 8453,
+  from: "0x1111111111111111111111111111111111111111",
+  to: "0x2222222222222222222222222222222222222222",
+  value: "1",
+  data: "0x12345678",
+  intentHash: "simulator-runtime-authority",
+};
+
+function rpcResponse(method: string): Response {
+  return Response.json({ jsonrpc: "2.0", id: 1, result: method === "eth_call" ? "0x" : "0x5208" });
+}
+
+describe("request-local EVM simulator authority", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("reuses one composed simulator across A -> B while removal fails closed", async () => {
+    const simulator = createEnvEvmSimulator();
+    const calls: string[] = [];
+    globalThis.fetch = (async (input, init) => {
+      calls.push(String(input));
+      const method = JSON.parse(String(init?.body)).method as string;
+      return rpcResponse(method);
+    }) as typeof fetch;
+
+    const resultA = await withRuntimeEnvironment(
+      { STEWARD_EVM_RPC_URL_8453: "https://rpc-a.example" },
+      () => simulator.simulate(request),
+    );
+    const resultB = await withRuntimeEnvironment(
+      { STEWARD_EVM_RPC_URLS_JSON: '{"8453":"https://rpc-b.example"}' },
+      () => simulator.simulate(request),
+    );
+    const removed = await withRuntimeEnvironment({}, () => simulator.simulate(request));
+
+    expect(resultA).toEqual({ ok: true, gasEstimate: "0x5208" });
+    expect(resultB).toEqual({ ok: true, gasEstimate: "0x5208" });
+    expect(removed).toEqual({ ok: false, revertReason: "evm simulator rpc not configured" });
+    expect(withRuntimeEnvironment({}, () => simulator.isConfigured?.(request.chainId))).toBe(false);
+    expect(calls).toEqual([
+      "https://rpc-a.example",
+      "https://rpc-a.example",
+      "https://rpc-b.example",
+      "https://rpc-b.example",
+    ]);
+  });
+
+  it("pins overlapping requests to their own immutable RPC binding", async () => {
+    const simulator = createEnvEvmSimulator();
+    const calls: Array<{ url: string; method: string }> = [];
+    let releaseA!: () => void;
+    let markAStarted!: () => void;
+    const aStarted = new Promise<void>((resolve) => {
+      markAStarted = resolve;
+    });
+    const aReleased = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+
+    globalThis.fetch = (async (input, init) => {
+      const url = String(input);
+      const method = JSON.parse(String(init?.body)).method as string;
+      calls.push({ url, method });
+      if (url === "https://rpc-a.example" && method === "eth_call") {
+        markAStarted();
+        await aReleased;
+      }
+      return rpcResponse(method);
+    }) as typeof fetch;
+
+    const requestA = withRuntimeEnvironment(
+      { STEWARD_EVM_RPC_URL_8453: "https://rpc-a.example" },
+      () => simulator.simulate(request),
+    );
+    await aStarted;
+    const resultB = await withRuntimeEnvironment(
+      { STEWARD_EVM_RPC_URL_8453: "https://rpc-b.example" },
+      () => simulator.simulate(request),
+    );
+    releaseA();
+    const resultA = await requestA;
+
+    expect(resultA).toEqual({ ok: true, gasEstimate: "0x5208" });
+    expect(resultB).toEqual({ ok: true, gasEstimate: "0x5208" });
+    expect(calls).toEqual([
+      { url: "https://rpc-a.example", method: "eth_call" },
+      { url: "https://rpc-b.example", method: "eth_call" },
+      { url: "https://rpc-b.example", method: "eth_estimateGas" },
+      { url: "https://rpc-a.example", method: "eth_estimateGas" },
+    ]);
+  });
+});

--- a/packages/api/src/services/evm-simulator.ts
+++ b/packages/api/src/services/evm-simulator.ts
@@ -1,3 +1,5 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
 export interface EvmSimulationRequest {
   chainId: number;
   from: string;
@@ -14,6 +16,8 @@ export interface EvmSimulationResult {
 }
 
 export interface EvmSimulator {
+  /** Request-local availability check for the requested chain. */
+  isConfigured?(chainId: number): boolean;
   simulate(request: EvmSimulationRequest): Promise<EvmSimulationResult>;
 }
 
@@ -40,6 +44,14 @@ function rpcUrlForChain(chainId: number, env: Record<string, string | undefined>
   return parseRpcUrls(env.STEWARD_EVM_RPC_URLS_JSON)[String(chainId)] ?? null;
 }
 
+function runtimeRpcUrlForChain(chainId: number): string | null {
+  const keyed = runtimeEnvironmentValue(`STEWARD_EVM_RPC_URL_${chainId}`)?.trim();
+  if (keyed && /^https?:\/\//.test(keyed)) return keyed;
+  return (
+    parseRpcUrls(runtimeEnvironmentValue("STEWARD_EVM_RPC_URLS_JSON"))[String(chainId)] ?? null
+  );
+}
+
 async function rpcCall(url: string, method: string, params: unknown[]): Promise<unknown> {
   const response = await fetch(url, {
     method: "POST",
@@ -58,7 +70,15 @@ function hexWei(decimal: string): `0x${string}` {
 }
 
 export class JsonRpcEvmSimulator implements EvmSimulator {
-  constructor(private readonly env: Record<string, string | undefined> = process.env) {}
+  private readonly env: Readonly<Record<string, string | undefined>>;
+
+  constructor(env: Record<string, string | undefined> = process.env) {
+    this.env = Object.freeze({ ...env });
+  }
+
+  isConfigured(chainId: number): boolean {
+    return rpcUrlForChain(chainId, this.env) !== null;
+  }
 
   async simulate(request: EvmSimulationRequest): Promise<EvmSimulationResult> {
     const url = rpcUrlForChain(request.chainId, this.env);
@@ -84,9 +104,43 @@ export class JsonRpcEvmSimulator implements EvmSimulator {
   }
 }
 
-export function createEnvEvmSimulator(): EvmSimulator | null {
-  const hasJson =
-    Object.keys(parseRpcUrls(process.env.STEWARD_EVM_RPC_URLS_JSON)).length > 0 ||
-    Object.keys(process.env).some((key) => /^STEWARD_EVM_RPC_URL_\d+$/.test(key));
-  return hasJson ? new JsonRpcEvmSimulator() : null;
+class RuntimeEnvironmentEvmSimulator implements EvmSimulator {
+  isConfigured(chainId: number): boolean {
+    return runtimeRpcUrlForChain(chainId) !== null;
+  }
+
+  async simulate(request: EvmSimulationRequest): Promise<EvmSimulationResult> {
+    // Resolve once, synchronously, from the immutable request environment. Both
+    // RPC calls stay pinned to this URL even when another Worker request runs
+    // concurrently with a different binding generation.
+    const url = runtimeRpcUrlForChain(request.chainId);
+    if (!url) return { ok: false, revertReason: "evm simulator rpc not configured" };
+
+    const tx = {
+      from: request.from,
+      to: request.to,
+      value: hexWei(request.value),
+      data: request.data,
+    };
+
+    try {
+      await rpcCall(url, "eth_call", [tx, "latest"]);
+      const gas = await rpcCall(url, "eth_estimateGas", [tx]);
+      return { ok: true, gasEstimate: typeof gas === "string" ? gas : undefined };
+    } catch (error) {
+      return {
+        ok: false,
+        revertReason: error instanceof Error ? error.message : "evm simulation failed",
+      };
+    }
+  }
+}
+
+/**
+ * Return a stable simulator facade whose authority is resolved per invocation.
+ * The composed Worker app may cache this object across isolate requests; it
+ * never caches or consults a prior request's RPC bindings.
+ */
+export function createEnvEvmSimulator(): EvmSimulator {
+  return new RuntimeEnvironmentEvmSimulator();
 }

--- a/packages/plugin-trading/src/context.ts
+++ b/packages/plugin-trading/src/context.ts
@@ -67,6 +67,7 @@ export interface EvmSimulationResult {
 }
 
 export interface EvmSimulator {
+  isConfigured?(chainId: number): boolean;
   simulate(request: EvmSimulationRequest): Promise<EvmSimulationResult>;
 }
 

--- a/packages/plugin-trading/src/routes/evm-swap.ts
+++ b/packages/plugin-trading/src/routes/evm-swap.ts
@@ -459,7 +459,12 @@ export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: A
         };
       };
 
-      if (!ctx.evmSimulator) return reject(503, "EVM simulator is not configured");
+      if (
+        !ctx.evmSimulator ||
+        (ctx.evmSimulator.isConfigured && !ctx.evmSimulator.isConfigured(parsed.data.chainId))
+      ) {
+        return reject(503, "EVM simulator is not configured");
+      }
       const owner = await resolveEvmWallet(ctx, agent, parsed.data.chainId);
       if (!owner || !isEvmAddress(owner)) return reject(403, "Agent EVM wallet not found");
 


### PR DESCRIPTION
## Summary
- replace the first-request `process.env` EVM simulator snapshot with a stable facade that resolves RPC authority from the immutable request runtime environment
- pin each simulation's RPC URL before asynchronous work, so overlapping Worker requests cannot switch either RPC call to another binding generation
- make configured-chain checks request-local, including fail-closed behavior when a reused isolate loses the binding
- snapshot explicitly constructed `JsonRpcEvmSimulator` environments instead of retaining mutable records

## Verification
- `bun test packages/api/src/__tests__/evm-simulator-runtime-authority.test.ts packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts` (16 pass; sequential A -> B -> removed and suspended-A/overlapping-B included)
- `bun run --cwd packages/plugin-trading build`
- changed-file `bunx @biomejs/biome check ...` (4 files clean)
- `git diff origin/develop...HEAD --check`

## Current develop build note
- `bun run --cwd packages/api build` reaches two pre-existing errors in unchanged `packages/api/src/routes/vault.ts`: missing `findActionByIdempotency` and an unsupported `idempotencyKeyDigest` property. This PR has no diff in that file; the changed API simulator source reports no type error.

Closes #764