### PR TITLE
fix(worker): isolate request guard authority

### DIFF
--- a/packages/api/src/__tests__/request-guard-runtime-authority.test.ts
+++ b/packages/api/src/__tests__/request-guard-runtime-authority.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { Hono } from "hono";
+import {
+  authorizationSignature,
+  createAuthorizationSignature,
+} from "../middleware/authorization-signature";
+import { requestExpiry } from "../middleware/request-expiry";
+
+const PATH = "/vault/agent-1/sign";
+const BODY = JSON.stringify({ value: "1" });
+const SECRET_A = "request-authority-a-with-enough-entropy";
+const SECRET_B = "request-authority-b-with-enough-entropy";
+
+async function headers(secret: string, requestId: string) {
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const signature = await createAuthorizationSignature(
+    {
+      method: "POST",
+      url: `https://api.test${PATH}`,
+      timestamp,
+      idempotencyKey: requestId,
+      body: BODY,
+    },
+    secret,
+  );
+  return {
+    "content-type": "application/json",
+    "x-steward-request-timestamp": timestamp,
+    "idempotency-key": requestId,
+    "x-steward-signature": signature,
+  };
+}
+
+function makeApp(appSecretResolver?: (request: Request) => Promise<string[]>) {
+  const app = new Hono<{ Variables: { requestSignatureVerified?: boolean } }>();
+  app.use("*", requestExpiry());
+  app.use("*", authorizationSignature({ appSecretResolver }));
+  app.post(PATH, (c) => c.json({ ok: true, verified: c.get("requestSignatureVerified") }));
+  return app;
+}
+
+describe("request-local request-guard authority", () => {
+  it("observes sequential A -> B -> missing rotations without retaining A", async () => {
+    const app = makeApp(async () => []);
+    const requestAHeaders = await headers(SECRET_A, "guard-a");
+    const requestBHeaders = await headers(SECRET_B, "guard-b");
+
+    const responseA = await withRuntimeEnvironment(
+      {
+        NODE_ENV: "production",
+        STEWARD_REQUEST_SIGNING_SECRET: SECRET_A,
+        STEWARD_REQUIRE_REQUEST_EXPIRY: "true",
+      },
+      () => app.request(PATH, { method: "POST", headers: requestAHeaders, body: BODY }),
+    );
+    const staleAUnderB = await withRuntimeEnvironment(
+      {
+        NODE_ENV: "production",
+        STEWARD_REQUEST_SIGNING_SECRET: SECRET_B,
+        STEWARD_REQUIRE_REQUEST_EXPIRY: "true",
+      },
+      () => app.request(PATH, { method: "POST", headers: requestAHeaders, body: BODY }),
+    );
+    const responseB = await withRuntimeEnvironment(
+      {
+        NODE_ENV: "production",
+        STEWARD_REQUEST_SIGNING_SECRET: SECRET_B,
+        STEWARD_REQUIRE_REQUEST_EXPIRY: "true",
+      },
+      () => app.request(PATH, { method: "POST", headers: requestBHeaders, body: BODY }),
+    );
+    const missing = await withRuntimeEnvironment({ NODE_ENV: "production" }, () =>
+      app.request(PATH, { method: "POST", headers: requestAHeaders, body: BODY }),
+    );
+
+    expect(responseA.status).toBe(200);
+    expect(staleAUnderB.status).toBe(401);
+    expect(responseB.status).toBe(200);
+    expect(missing.status).toBe(500);
+    expect(await missing.json()).toEqual({
+      ok: false,
+      error: "Request signing is not configured",
+    });
+  });
+
+  it("pins suspended A while overlapping B uses only B", async () => {
+    let markAStarted!: () => void;
+    let releaseA!: () => void;
+    const aStarted = new Promise<void>((resolve) => {
+      markAStarted = resolve;
+    });
+    const aReleased = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    const app = makeApp(async (request) => {
+      if (request.headers.get("idempotency-key") === "guard-overlap-a") {
+        markAStarted();
+        await aReleased;
+      }
+      return [];
+    });
+    const requestAHeaders = await headers(SECRET_A, "guard-overlap-a");
+    const requestBHeaders = await headers(SECRET_B, "guard-overlap-b");
+
+    const pendingA = withRuntimeEnvironment(
+      { NODE_ENV: "production", STEWARD_REQUEST_SIGNING_SECRET: SECRET_A },
+      () => app.request(PATH, { method: "POST", headers: requestAHeaders, body: BODY }),
+    );
+    await aStarted;
+    const responseB = await withRuntimeEnvironment(
+      { NODE_ENV: "production", STEWARD_REQUEST_SIGNING_SECRET: SECRET_B },
+      () => app.request(PATH, { method: "POST", headers: requestBHeaders, body: BODY }),
+    );
+    releaseA();
+    const responseA = await pendingA;
+
+    expect(responseA.status).toBe(200);
+    expect(responseB.status).toBe(200);
+  });
+
+  it("resolves request-expiry requirement and windows from each request", async () => {
+    const now = 1_700_000_000_000;
+    const app = new Hono();
+    app.use("*", requestExpiry({ now: () => now }));
+    app.post(PATH, (c) => c.json({ ok: true }));
+
+    const optional = await withRuntimeEnvironment({ NODE_ENV: "development" }, () =>
+      app.request(PATH, { method: "POST" }),
+    );
+    const required = await withRuntimeEnvironment(
+      { NODE_ENV: "development", STEWARD_REQUIRE_REQUEST_EXPIRY: "true" },
+      () => app.request(PATH, { method: "POST" }),
+    );
+    const narrowWindow = await withRuntimeEnvironment(
+      {
+        NODE_ENV: "development",
+        STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS: "1",
+        STEWARD_REQUEST_TIMESTAMP_TTL_MS: "10",
+      },
+      () =>
+        app.request(PATH, {
+          method: "POST",
+          headers: { "X-Steward-Request-Timestamp": String(now - 1_000) },
+        }),
+    );
+
+    expect(optional.status).toBe(200);
+    expect(required.status).toBe(400);
+    expect(narrowWindow.status).toBe(408);
+  });
+});

--- a/packages/api/src/__tests__/worker-runtime-env-inventory.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-env-inventory.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const srcRoot = join(import.meta.dir, "..");
+
+function productionTypescriptFiles(directory: string): string[] {
+  return readdirSync(directory).flatMap((entry) => {
+    if (entry === "__tests__") return [];
+    const path = join(directory, entry);
+    if (statSync(path).isDirectory()) return productionTypescriptFiles(path);
+    return entry.endsWith(".ts") ? [path] : [];
+  });
+}
+
+function directEnvironmentKeys(source: string): string[] {
+  const keys = new Set<string>();
+  const pattern = /process\.env(?:\.([A-Z][A-Z0-9_]*)|\[\s*["']([A-Z][A-Z0-9_]*)["']\s*\])/g;
+  for (const match of source.matchAll(pattern)) keys.add(match[1] ?? match[2]!);
+  return [...keys].sort();
+}
+
+// Exact remaining middleware inventory. These are follow-up #770 tranches;
+// pinning the file/key pairs makes any new mutable-global middleware authority
+// fail CI instead of silently expanding the compatibility bridge.
+const pendingMiddlewareReaders = {
+  "idempotency.ts": [
+    "NODE_ENV",
+    "STEWARD_IDEMPOTENCY_MAX_ENTRIES",
+    "STEWARD_IDEMPOTENCY_METRICS_TTL_MS",
+    "STEWARD_IDEMPOTENCY_TTL_MS",
+  ],
+  "redis-enforcement.ts": ["NODE_ENV"],
+  "tenant-cors.ts": ["NODE_ENV"],
+};
+
+const migratedRequestGuardKeys = [
+  "STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS",
+  "STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS",
+  "STEWARD_REQUEST_SIGNING_SECRET",
+  "STEWARD_REQUEST_SIGNING_SECRETS",
+  "STEWARD_REQUEST_TIMESTAMP_TTL_MS",
+  "STEWARD_REQUIRE_AUTH_SIGNATURE",
+  "STEWARD_REQUIRE_REQUEST_EXPIRY",
+] as const;
+
+describe("Worker runtime environment static inventory", () => {
+  it("rejects unclassified direct process.env readers in security middleware", () => {
+    const middlewareRoot = join(srcRoot, "middleware");
+    const actual = Object.fromEntries(
+      productionTypescriptFiles(middlewareRoot)
+        .map((path) => [
+          relative(middlewareRoot, path),
+          directEnvironmentKeys(readFileSync(path, "utf8")),
+        ])
+        .filter(([, keys]) => keys.length > 0),
+    );
+    expect(actual).toEqual(pendingMiddlewareReaders);
+  });
+
+  it("keeps the migrated request-guard authority off mutable process.env globally", () => {
+    const violations: string[] = [];
+    for (const path of productionTypescriptFiles(srcRoot)) {
+      const keys = directEnvironmentKeys(readFileSync(path, "utf8"));
+      for (const key of keys) {
+        if (migratedRequestGuardKeys.includes(key as (typeof migratedRequestGuardKeys)[number])) {
+          violations.push(`${relative(srcRoot, path)}:${key}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -37,6 +37,7 @@
 
 import { platformAuthMiddleware } from "@stwd/auth";
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { authorizationSignature } from "./middleware/authorization-signature";
@@ -152,10 +153,17 @@ export function createApp(): Hono<{ Variables: AppVariables }> {
   // strict mode so browser/unsigned SDK clients keep working until an operator
   // has rolled out signing clients. Mounted in pre-idempotency setup so these
   // guards always run before the idempotency middleware.
-  app.use("*", requestExpiry({ required: process.env.STEWARD_REQUIRE_REQUEST_EXPIRY === "true" }));
   app.use(
     "*",
-    authorizationSignature({ required: process.env.STEWARD_REQUIRE_AUTH_SIGNATURE === "true" }),
+    requestExpiry({
+      required: () => runtimeEnvironmentValue("STEWARD_REQUIRE_REQUEST_EXPIRY") === "true",
+    }),
+  );
+  app.use(
+    "*",
+    authorizationSignature({
+      required: () => runtimeEnvironmentValue("STEWARD_REQUIRE_AUTH_SIGNATURE") === "true",
+    }),
   );
 
   // ─── Auth middleware per route group ────────────────────────────────────────

--- a/packages/api/src/middleware/authorization-signature.ts
+++ b/packages/api/src/middleware/authorization-signature.ts
@@ -8,6 +8,7 @@ import {
   tenantAppClients,
   tenantRequestSigningKeys,
 } from "@stwd/db";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type { EncryptedKey, KeyStore } from "@stwd/vault";
 import { and, eq } from "drizzle-orm";
 import type { Context } from "hono";
@@ -57,7 +58,7 @@ function parseHttpTime(value: string | undefined): number | null {
 }
 
 export type AuthorizationSignatureOptions = {
-  required?: boolean;
+  required?: boolean | (() => boolean);
   secrets?: string[];
   appSecretResolver?: (request: Request) => Promise<string[]> | string[];
   tenantKeyStoreFactory?: (
@@ -69,8 +70,8 @@ export type AuthorizationSignatureOptions = {
 
 function configuredSecrets(): string[] {
   const combined = [
-    process.env.STEWARD_REQUEST_SIGNING_SECRETS,
-    process.env.STEWARD_REQUEST_SIGNING_SECRET,
+    runtimeEnvironmentValue("STEWARD_REQUEST_SIGNING_SECRETS"),
+    runtimeEnvironmentValue("STEWARD_REQUEST_SIGNING_SECRET"),
   ]
     .filter(Boolean)
     .join(",");
@@ -810,28 +811,33 @@ export async function buildAuthorizationCanonicalString(
 }
 
 export function authorizationSignature(options?: AuthorizationSignatureOptions) {
-  const required =
-    options?.required ??
-    (process.env.STEWARD_REQUIRE_AUTH_SIGNATURE === "true" ||
-      process.env.NODE_ENV === "production");
-  const secrets = options?.secrets ?? configuredSecrets();
   const appSecretResolver = options?.appSecretResolver ?? appClientSecretSigningCandidates;
   const tenantKeyStoreFactory =
     options?.tenantKeyStoreFactory ??
     ((_masterPassword, _masterSalt, domain) => getConfiguredKeyStore(domain));
-  const maxClockSkewMs = parsePositiveInt(
-    process.env.STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS,
-    DEFAULT_MAX_CLOCK_SKEW_MS,
-  );
-  const timestampTtlMs = parsePositiveInt(
-    process.env.STEWARD_REQUEST_TIMESTAMP_TTL_MS,
-    DEFAULT_TIMESTAMP_TTL_MS,
-  );
 
   return createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
     if (!MUTATING_METHODS.has(c.req.method.toUpperCase()) || !isSensitivePath(c.req.path)) {
       return next();
     }
+
+    // Capture one immutable request-local authority tuple before any crypto,
+    // database, or app-secret resolver await can yield to another Worker request.
+    const required =
+      typeof options?.required === "function"
+        ? options.required()
+        : (options?.required ??
+          (runtimeEnvironmentValue("STEWARD_REQUIRE_AUTH_SIGNATURE") === "true" ||
+            runtimeEnvironmentValue("NODE_ENV") === "production"));
+    const secrets = options?.secrets ?? configuredSecrets();
+    const maxClockSkewMs = parsePositiveInt(
+      runtimeEnvironmentValue("STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS"),
+      DEFAULT_MAX_CLOCK_SKEW_MS,
+    );
+    const timestampTtlMs = parsePositiveInt(
+      runtimeEnvironmentValue("STEWARD_REQUEST_TIMESTAMP_TTL_MS"),
+      DEFAULT_TIMESTAMP_TTL_MS,
+    );
 
     const rawSignature = c.req.header("X-Steward-Signature");
     if (!rawSignature) {

--- a/packages/api/src/middleware/request-expiry.ts
+++ b/packages/api/src/middleware/request-expiry.ts
@@ -1,3 +1,4 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createMiddleware } from "hono/factory";
 import type { ApiResponse, AppVariables } from "../services/context";
 import { isSensitivePath } from "./sensitive-paths";
@@ -7,7 +8,7 @@ const DEFAULT_TIMESTAMP_TTL_MS = 5 * 60 * 1000;
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 export type RequestExpiryOptions = {
-  required?: boolean;
+  required?: boolean | (() => boolean);
   maxClockSkewMs?: number;
   timestampTtlMs?: number;
   now?: () => number;
@@ -34,23 +35,34 @@ function parseHttpTime(value: string | undefined): number | null {
 }
 
 export function requestExpiry(options?: RequestExpiryOptions) {
-  const required =
-    options?.required ??
-    (process.env.STEWARD_REQUIRE_REQUEST_EXPIRY === "true" ||
-      (process.env.NODE_ENV === "production" &&
-        process.env.STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS !== "true"));
-  const maxClockSkewMs =
-    options?.maxClockSkewMs ??
-    parsePositiveInt(process.env.STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS, DEFAULT_MAX_CLOCK_SKEW_MS);
-  const timestampTtlMs =
-    options?.timestampTtlMs ??
-    parsePositiveInt(process.env.STEWARD_REQUEST_TIMESTAMP_TTL_MS, DEFAULT_TIMESTAMP_TTL_MS);
   const now = options?.now ?? (() => Date.now());
 
   return createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
     if (!MUTATING_METHODS.has(c.req.method.toUpperCase()) || !isSensitivePath(c.req.path)) {
       return next();
     }
+
+    // Resolve the complete freshness authority inside the immutable request
+    // environment. The composed Worker app is cached across binding rotations.
+    const required =
+      typeof options?.required === "function"
+        ? options.required()
+        : (options?.required ??
+          (runtimeEnvironmentValue("STEWARD_REQUIRE_REQUEST_EXPIRY") === "true" ||
+            (runtimeEnvironmentValue("NODE_ENV") === "production" &&
+              runtimeEnvironmentValue("STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS") !== "true")));
+    const maxClockSkewMs =
+      options?.maxClockSkewMs ??
+      parsePositiveInt(
+        runtimeEnvironmentValue("STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS"),
+        DEFAULT_MAX_CLOCK_SKEW_MS,
+      );
+    const timestampTtlMs =
+      options?.timestampTtlMs ??
+      parsePositiveInt(
+        runtimeEnvironmentValue("STEWARD_REQUEST_TIMESTAMP_TTL_MS"),
+        DEFAULT_TIMESTAMP_TTL_MS,
+      );
 
     const expiresAtHeader = c.req.header("X-Steward-Request-Expires-At");
     const timestampHeader = c.req.header("X-Steward-Request-Timestamp");

--- a/packages/api/src/routes/tenant-config.ts
+++ b/packages/api/src/routes/tenant-config.ts
@@ -38,6 +38,7 @@ import type {
   TenantTestAccountConfig,
   TenantTheme,
 } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import type { EncryptedKey, KeyStore } from "@stwd/vault";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
@@ -448,8 +449,8 @@ function hasLocalhostUrl(value: string): boolean {
 
 function configuredRequestSigningSecrets(): string[] {
   return [
-    ...(process.env.STEWARD_REQUEST_SIGNING_SECRETS ?? "").split(","),
-    process.env.STEWARD_REQUEST_SIGNING_SECRET ?? "",
+    ...(runtimeEnvironmentValue("STEWARD_REQUEST_SIGNING_SECRETS") ?? "").split(","),
+    runtimeEnvironmentValue("STEWARD_REQUEST_SIGNING_SECRET") ?? "",
   ]
     .map((secret) => secret.trim())
     .filter(Boolean);
@@ -480,13 +481,15 @@ function buildTenantSecurityChecklist(
   appClientSecrets: TenantAppClientSecret[],
   requestSigningKeys: TenantRequestSigningKey[],
 ): TenantSecurityChecklist {
-  const production = process.env.NODE_ENV === "production";
+  const production = runtimeEnvironmentValue("NODE_ENV") === "production";
   // SEC-010: these mirror the ACTUAL enforcement posture of the mounted
   // guards (app.ts). Freshness/signature headers are always verified when
   // present; they are REQUIRED only via the explicit env opt-ins, so the
   // checklist must not claim production enforcement that does not exist.
-  const requestExpiryRequired = process.env.STEWARD_REQUIRE_REQUEST_EXPIRY === "true";
-  const authSignatureRequired = process.env.STEWARD_REQUIRE_AUTH_SIGNATURE === "true";
+  const requestExpiryRequired =
+    runtimeEnvironmentValue("STEWARD_REQUIRE_REQUEST_EXPIRY") === "true";
+  const authSignatureRequired =
+    runtimeEnvironmentValue("STEWARD_REQUIRE_AUTH_SIGNATURE") === "true";
   const signingSecrets = configuredRequestSigningSecrets();
   const appClientSigningSecrets = appClientSecrets.filter(
     (secret) =>


### PR DESCRIPTION
## Summary
- move request-signature roots, required mode, and freshness windows from mutable `process.env` into the immutable request runtime environment
- preserve the mounted app's explicit opt-in posture through request-local required-mode resolvers
- make the tenant security checklist report the same request-local signature/freshness authority enforced by the middleware
- add hostile sequential A -> B -> missing and suspended-A/overlapping-B coverage
- add a static inventory that pins every remaining direct middleware reader and globally rejects regressions for this migrated authority-key tranche

## Verification
- `DATABASE_URL=<local PostgreSQL> bun test packages/api/src/__tests__/request-guard-runtime-authority.test.ts packages/api/src/__tests__/worker-runtime-env-inventory.test.ts packages/api/src/__tests__/authorization-signature-middleware.test.ts packages/api/src/__tests__/request-expiry-middleware.test.ts packages/api/src/__tests__/request-guards-mounted.test.ts` (28 pass)
- changed-file `bunx @biomejs/biome check ...` (6 files clean)
- `git diff origin/develop...HEAD --check`

## Current develop build note
- `bun run --cwd packages/api build` reaches the same two pre-existing errors in unchanged `packages/api/src/routes/vault.ts`: missing `findActionByIdempotency` and unsupported `idempotencyKeyDigest`. This PR has no diff in that file.

Advances #770. The umbrella remains open for the inventoried idempotency, Redis-enforcement, tenant-CORS, auth/provider, and scheduler tranches.