### PR TITLE
fix(api): bind remaining middleware authority per request

### DIFF
--- a/packages/api/src/__tests__/idempotency-middleware.test.ts
+++ b/packages/api/src/__tests__/idempotency-middleware.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { Hono } from "hono";
 import {
   getTenantIdempotencyMetrics,
   idempotencyMiddleware,
   MemoryIdempotencyStore,
+  RedisIdempotencyStore,
   resetIdempotencyMetricsForTests,
+  resolveIdempotencyRuntimeAuthority,
 } from "../middleware/idempotency";
 import type { AppVariables } from "../services/context";
 
@@ -57,6 +60,93 @@ function makeApp() {
 }
 
 describe("idempotencyMiddleware", () => {
+  it("isolates idempotency authority across missing, sequential, and overlapping bindings", async () => {
+    const missing = withRuntimeEnvironment({}, resolveIdempotencyRuntimeAuthority);
+    expect(missing).toMatchObject({
+      ttlMs: 86_400_000,
+      metricsTtlSeconds: 604_800,
+      maxEntries: 10_000,
+      allowMemoryFallback: true,
+    });
+
+    const authorityA = {
+      NODE_ENV: "development",
+      STEWARD_IDEMPOTENCY_TTL_MS: "11000",
+      STEWARD_IDEMPOTENCY_METRICS_TTL_MS: "22000",
+      STEWARD_IDEMPOTENCY_MAX_ENTRIES: "33",
+    };
+    const authorityB = {
+      NODE_ENV: "production",
+      STEWARD_IDEMPOTENCY_TTL_MS: "44000",
+      STEWARD_IDEMPOTENCY_METRICS_TTL_MS: "55000",
+      STEWARD_IDEMPOTENCY_MAX_ENTRIES: "66",
+    };
+    let releaseA!: () => void;
+    const holdA = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    let startedA!: () => void;
+    const didStartA = new Promise<void>((resolve) => {
+      startedA = resolve;
+    });
+    const pendingA = withRuntimeEnvironment(authorityA, async () => {
+      startedA();
+      await holdA;
+      return resolveIdempotencyRuntimeAuthority();
+    });
+    await didStartA;
+    const observedB = await withRuntimeEnvironment(authorityB, async () => {
+      await Promise.resolve();
+      return resolveIdempotencyRuntimeAuthority();
+    });
+    releaseA();
+    const observedA = await pendingA;
+
+    expect(observedA).toEqual({
+      ttlMs: 11_000,
+      metricsTtlSeconds: 22,
+      maxEntries: 33,
+      allowMemoryFallback: true,
+    });
+    expect(observedB).toEqual({
+      ttlMs: 44_000,
+      metricsTtlSeconds: 55,
+      maxEntries: 66,
+      allowMemoryFallback: false,
+    });
+  });
+
+  it("isolates real fallback capacity generations and fails closed without production Redis", async () => {
+    const store = new RedisIdempotencyStore();
+    const entry = (suffix: number) => ({
+      fingerprint: `fingerprint-${suffix}`,
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await withRuntimeEnvironment(
+      { NODE_ENV: "development", STEWARD_IDEMPOTENCY_MAX_ENTRIES: "1" },
+      async () => {
+        await store.reserve?.("a-1", entry(1));
+        await store.reserve?.("a-2", entry(2));
+        expect(await store.get("a-1")).toBeUndefined();
+        expect((await store.get("a-2"))?.fingerprint).toBe("fingerprint-2");
+      },
+    );
+    await withRuntimeEnvironment(
+      { NODE_ENV: "development", STEWARD_IDEMPOTENCY_MAX_ENTRIES: "2" },
+      async () => {
+        await store.reserve?.("b-1", entry(3));
+        await store.reserve?.("b-2", entry(4));
+        expect((await store.get("b-1"))?.fingerprint).toBe("fingerprint-3");
+        expect((await store.get("b-2"))?.fingerprint).toBe("fingerprint-4");
+      },
+    );
+    await expect(
+      withRuntimeEnvironment({ NODE_ENV: "production" }, () => store.get("a-2")),
+    ).rejects.toThrow("Durable idempotency store unavailable");
+  });
+
   it("records tenant-scoped privacy-preserving counters", async () => {
     resetIdempotencyMetricsForTests();
     const { app } = makeApp();

--- a/packages/api/src/__tests__/redis-enforcement.test.ts
+++ b/packages/api/src/__tests__/redis-enforcement.test.ts
@@ -169,6 +169,38 @@ describe("extractSpendLimitPolicy", () => {
 // ─── Graceful degradation tests (no Redis) ───────────────────────────────────
 
 describe("enforceRateLimit (no Redis)", () => {
+  it("isolates production fail-closed posture across hostile Worker bindings", async () => {
+    const policies: PolicyRule[] = [
+      {
+        id: "runtime-rate-limit",
+        type: "rate-limit",
+        enabled: true,
+        config: { maxTxPerHour: 10, maxTxPerDay: 20 },
+      },
+    ];
+    const [development, production, missing] = await Promise.all([
+      withRuntimeEnvironment({ NODE_ENV: "development" }, async () => {
+        await Promise.resolve();
+        return enforceRateLimit("agent-development", policies);
+      }),
+      withRuntimeEnvironment({ NODE_ENV: "production" }, async () => {
+        await Promise.resolve();
+        return enforceRateLimit("agent-production", policies);
+      }),
+      withRuntimeEnvironment({}, async () => {
+        await Promise.resolve();
+        return enforceRateLimit("agent-missing", policies);
+      }),
+    ]);
+
+    expect(development.allowed).toBe(true);
+    expect(missing.allowed).toBe(true);
+    expect(production).toMatchObject({
+      allowed: false,
+      reason: "Rate limit enforcement is unavailable",
+    });
+  });
+
   it("allows requests when Redis is not available", async () => {
     const policies: PolicyRule[] = [
       {

--- a/packages/api/src/__tests__/tenant-cors-development.test.ts
+++ b/packages/api/src/__tests__/tenant-cors-development.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
 import { Hono } from "hono";
 
 let databaseReads = 0;
@@ -26,18 +27,19 @@ describe("tenant CORS development wildcard", () => {
   });
 
   test("does not consult tenant storage for an explicit development wildcard", async () => {
-    process.env.NODE_ENV = "development";
     databaseReads = 0;
     const app = new Hono();
     app.use("*", tenantCors);
 
-    const response = await app.request("/resource", {
-      method: "OPTIONS",
-      headers: {
-        Origin: "https://local-ui.example",
-        "Access-Control-Request-Method": "PATCH",
-      },
-    });
+    const response = await withRuntimeEnvironment({ NODE_ENV: "development" }, () =>
+      app.request("/resource", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://local-ui.example",
+          "Access-Control-Request-Method": "PATCH",
+        },
+      }),
+    );
 
     expect(response.status).toBe(204);
     expect(response.headers.get("access-control-allow-origin")).toBe("*");
@@ -45,21 +47,49 @@ describe("tenant CORS development wildcard", () => {
   });
 
   test("keeps production fail closed when origin storage is unavailable", async () => {
-    process.env.NODE_ENV = "production";
     databaseReads = 0;
     const app = new Hono();
     app.use("*", tenantCors);
 
-    const response = await app.request("/resource", {
-      method: "OPTIONS",
-      headers: {
-        Origin: "https://console.example.com",
-        "Access-Control-Request-Method": "PATCH",
-      },
-    });
+    const response = await withRuntimeEnvironment({ NODE_ENV: "production" }, () =>
+      app.request("/resource", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://console.example.com",
+          "Access-Control-Request-Method": "PATCH",
+        },
+      }),
+    );
 
     expect(response.status).toBe(403);
     expect(response.headers.get("access-control-allow-origin")).toBeNull();
     expect(databaseReads).toBe(1);
+  });
+
+  test("isolates overlapping development, production, and missing bindings", async () => {
+    databaseReads = 0;
+    const request = () => {
+      const app = new Hono();
+      app.use("*", tenantCors);
+      return app.request("/resource", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://hostile-overlap.example",
+          "Access-Control-Request-Method": "PATCH",
+        },
+      });
+    };
+
+    const [development, production, missing] = await Promise.all([
+      withRuntimeEnvironment({ NODE_ENV: "development" }, request),
+      withRuntimeEnvironment({ NODE_ENV: "production" }, request),
+      withRuntimeEnvironment({}, request),
+    ]);
+
+    expect(development.status).toBe(204);
+    expect(development.headers.get("access-control-allow-origin")).toBe("*");
+    expect(production.status).toBe(403);
+    expect(missing.status).toBe(403);
+    expect(databaseReads).toBe(2);
   });
 });

--- a/packages/api/src/__tests__/worker-runtime-env-inventory.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-env-inventory.test.ts
@@ -20,21 +20,12 @@ function directEnvironmentKeys(source: string): string[] {
   return [...keys].sort();
 }
 
-// Exact remaining middleware inventory. These are follow-up #770 tranches;
-// pinning the file/key pairs makes any new mutable-global middleware authority
-// fail CI instead of silently expanding the compatibility bridge.
-const pendingMiddlewareReaders = {
-  "idempotency.ts": [
-    "NODE_ENV",
-    "STEWARD_IDEMPOTENCY_MAX_ENTRIES",
-    "STEWARD_IDEMPOTENCY_METRICS_TTL_MS",
-    "STEWARD_IDEMPOTENCY_TTL_MS",
-  ],
-  "redis-enforcement.ts": ["NODE_ENV"],
-  "tenant-cors.ts": ["NODE_ENV"],
-};
+// #770 has eliminated direct mutable-global authority from security middleware.
+// Keep the exact inventory empty so new readers fail CI instead of silently
+// expanding the compatibility bridge.
+const pendingMiddlewareReaders = {};
 
-const migratedRequestGuardKeys = [
+const migratedRuntimeAuthorityKeys = [
   "STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS",
   "STEWARD_REQUEST_EXPIRY_MAX_SKEW_MS",
   "STEWARD_REQUEST_SIGNING_SECRET",
@@ -42,6 +33,9 @@ const migratedRequestGuardKeys = [
   "STEWARD_REQUEST_TIMESTAMP_TTL_MS",
   "STEWARD_REQUIRE_AUTH_SIGNATURE",
   "STEWARD_REQUIRE_REQUEST_EXPIRY",
+  "STEWARD_IDEMPOTENCY_MAX_ENTRIES",
+  "STEWARD_IDEMPOTENCY_METRICS_TTL_MS",
+  "STEWARD_IDEMPOTENCY_TTL_MS",
 ] as const;
 
 describe("Worker runtime environment static inventory", () => {
@@ -58,12 +52,16 @@ describe("Worker runtime environment static inventory", () => {
     expect(actual).toEqual(pendingMiddlewareReaders);
   });
 
-  it("keeps the migrated request-guard authority off mutable process.env globally", () => {
+  it("keeps migrated runtime authority off mutable process.env globally", () => {
     const violations: string[] = [];
     for (const path of productionTypescriptFiles(srcRoot)) {
       const keys = directEnvironmentKeys(readFileSync(path, "utf8"));
       for (const key of keys) {
-        if (migratedRequestGuardKeys.includes(key as (typeof migratedRequestGuardKeys)[number])) {
+        if (
+          migratedRuntimeAuthorityKeys.includes(
+            key as (typeof migratedRuntimeAuthorityKeys)[number],
+          )
+        ) {
           violations.push(`${relative(srcRoot, path)}:${key}`);
         }
       }

--- a/packages/api/src/middleware/idempotency.ts
+++ b/packages/api/src/middleware/idempotency.ts
@@ -1,4 +1,5 @@
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { createMiddleware } from "hono/factory";
 import type { ApiResponse, AppVariables } from "../services/context";
 import { isRecentMfaTimestamp } from "../services/recent-mfa";
@@ -86,6 +87,30 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+export type IdempotencyRuntimeAuthority = Readonly<{
+  ttlMs: number;
+  metricsTtlSeconds: number;
+  maxEntries: number;
+  allowMemoryFallback: boolean;
+}>;
+
+/** Resolve idempotency policy from the active immutable request binding. */
+export function resolveIdempotencyRuntimeAuthority(): IdempotencyRuntimeAuthority {
+  const metricsTtlMs = parsePositiveInt(
+    runtimeEnvironmentValue("STEWARD_IDEMPOTENCY_METRICS_TTL_MS"),
+    DEFAULT_METRICS_TTL_MS,
+  );
+  return Object.freeze({
+    ttlMs: parsePositiveInt(runtimeEnvironmentValue("STEWARD_IDEMPOTENCY_TTL_MS"), DEFAULT_TTL_MS),
+    metricsTtlSeconds: Math.max(1, Math.ceil(metricsTtlMs / 1000)),
+    maxEntries: parsePositiveInt(
+      runtimeEnvironmentValue("STEWARD_IDEMPOTENCY_MAX_ENTRIES"),
+      DEFAULT_MAX_ENTRIES,
+    ),
+    allowMemoryFallback: runtimeEnvironmentValue("NODE_ENV") !== "production",
+  });
+}
+
 function emptyIdempotencyCounters(): IdempotencyMetricCounters {
   return {
     observed: 0,
@@ -119,11 +144,7 @@ function metricsRedisKey(tenantId: string): string {
 }
 
 function metricsTtlSeconds(): number {
-  const ttlMs = parsePositiveInt(
-    process.env.STEWARD_IDEMPOTENCY_METRICS_TTL_MS,
-    DEFAULT_METRICS_TTL_MS,
-  );
-  return Math.max(1, Math.ceil(ttlMs / 1000));
+  return resolveIdempotencyRuntimeAuthority().metricsTtlSeconds;
 }
 
 function tenantIdFromPath(pathname: string): string | null {
@@ -152,6 +173,10 @@ function recordIdempotencyMetric(
   counter: keyof IdempotencyMetricCounters,
   now = Date.now(),
 ) {
+  // Capture the active request binding before the fire-and-forget Redis write
+  // crosses an await boundary. A concurrent Worker request must not be able to
+  // substitute its metrics retention policy.
+  const metricRetentionSeconds = metricsTtlSeconds();
   let bucket = idempotencyMetricBuckets.get(tenantId);
   if (!bucket) {
     if (idempotencyMetricBuckets.size >= MAX_METRIC_TENANTS) {
@@ -167,13 +192,14 @@ function recordIdempotencyMetric(
   }
   bucket.counters[counter] += 1;
   bucket.lastSeenAt = now;
-  void recordIdempotencyMetricInRedis(tenantId, counter, now);
+  void recordIdempotencyMetricInRedis(tenantId, counter, now, metricRetentionSeconds);
 }
 
 async function recordIdempotencyMetricInRedis(
   tenantId: string,
   counter: keyof IdempotencyMetricCounters,
   now: number,
+  metricRetentionSeconds: number,
 ): Promise<void> {
   const redis = getRedisClient();
   if (!redis) return;
@@ -184,7 +210,7 @@ async function recordIdempotencyMetricInRedis(
     if (!existingWindow) pipeline.hset(key, "windowStartedAt", String(now));
     pipeline.hset(key, "lastSeenAt", String(now));
     pipeline.hincrby(key, counter, 1);
-    pipeline.expire(key, metricsTtlSeconds());
+    pipeline.expire(key, metricRetentionSeconds);
     await pipeline.exec();
   } catch (error) {
     console.error(
@@ -242,7 +268,7 @@ async function snapshotFromRedis(
 
 export async function getTenantIdempotencyMetrics(
   tenantId: string,
-  ttlMs = parsePositiveInt(process.env.STEWARD_IDEMPOTENCY_TTL_MS, DEFAULT_TTL_MS),
+  ttlMs = parsePositiveInt(runtimeEnvironmentValue("STEWARD_IDEMPOTENCY_TTL_MS"), DEFAULT_TTL_MS),
 ): Promise<TenantIdempotencyMetricsSnapshot> {
   const bucket = idempotencyMetricBuckets.get(tenantId);
   const now = Date.now();
@@ -407,20 +433,32 @@ export class MemoryIdempotencyStore implements IdempotencyStore {
 }
 
 export class RedisIdempotencyStore implements IdempotencyStore {
-  private readonly fallback = new MemoryIdempotencyStore(
-    parsePositiveInt(process.env.STEWARD_IDEMPOTENCY_MAX_ENTRIES, DEFAULT_MAX_ENTRIES),
-  );
+  private readonly fallbacks = new Map<number, MemoryIdempotencyStore>();
+
+  private fallback(): MemoryIdempotencyStore {
+    const { maxEntries } = resolveIdempotencyRuntimeAuthority();
+    const existing = this.fallbacks.get(maxEntries);
+    if (existing) return existing;
+    // Capacity is deployment authority rather than caller input, but keep the
+    // number of retained Worker binding generations bounded regardless.
+    if (this.fallbacks.size >= 8) {
+      throw new Error("Too many idempotency fallback capacity generations");
+    }
+    const fallback = new MemoryIdempotencyStore(maxEntries);
+    this.fallbacks.set(maxEntries, fallback);
+    return fallback;
+  }
 
   private client() {
     const redis = getRedisClient();
     if (redis) return redis;
-    if (process.env.NODE_ENV !== "production") return null;
+    if (resolveIdempotencyRuntimeAuthority().allowMemoryFallback) return null;
     throw new Error("Durable idempotency store unavailable");
   }
 
   async get(key: string): Promise<IdempotencyEntry | undefined> {
     const redis = this.client();
-    if (!redis) return this.fallback.get(key);
+    if (!redis) return this.fallback().get(key);
     return parseEntry(await redis.get(`idempotency:${key}`));
   }
 
@@ -436,7 +474,7 @@ export class RedisIdempotencyStore implements IdempotencyStore {
     entry: Omit<IdempotencyEntry, "status" | "response">,
   ): Promise<IdempotencyEntry | undefined> {
     const redis = this.client();
-    if (!redis) return this.fallback.reserve(key, entry);
+    if (!redis) return this.fallback().reserve(key, entry);
     const redisKey = `idempotency:${key}`;
     const value = serializeEntry({ ...entry, status: "processing" });
     const ttlMs = Math.max(1, entry.expiresAt - Date.now());
@@ -450,7 +488,7 @@ export class RedisIdempotencyStore implements IdempotencyStore {
     response?: NonNullable<IdempotencyEntry["response"]>,
   ): Promise<void> {
     const redis = this.client();
-    if (!redis) return this.fallback.setCompleted(key, response);
+    if (!redis) return this.fallback().setCompleted(key, response);
     const existing = await this.get(key);
     if (!existing) return;
     const ttlMs = Math.max(1, existing.expiresAt - Date.now());
@@ -464,7 +502,7 @@ export class RedisIdempotencyStore implements IdempotencyStore {
 
   async delete(key: string): Promise<void> {
     const redis = this.client();
-    if (!redis) return this.fallback.delete(key);
+    if (!redis) return this.fallback().delete(key);
     await redis.del(`idempotency:${key}`);
   }
 }
@@ -621,10 +659,11 @@ function hasReplaySafePublicContext(c: { req: { path: string } }) {
 
 export function idempotencyMiddleware(options?: { store?: IdempotencyStore; ttlMs?: number }) {
   const store = options?.store ?? defaultIdempotencyStore;
-  const ttlMs =
-    options?.ttlMs ?? parsePositiveInt(process.env.STEWARD_IDEMPOTENCY_TTL_MS, DEFAULT_TTL_MS);
 
   return createMiddleware<{ Variables: AppVariables }>(async (c, next) => {
+    // Resolve once from the immutable request snapshot, before any body/hash or
+    // store await. Explicit test/application options remain authoritative.
+    const ttlMs = options?.ttlMs ?? resolveIdempotencyRuntimeAuthority().ttlMs;
     if (!MUTATING_METHODS.has(c.req.method.toUpperCase())) return next();
 
     const key = c.req.header("Idempotency-Key");

--- a/packages/api/src/middleware/redis-enforcement.ts
+++ b/packages/api/src/middleware/redis-enforcement.ts
@@ -144,7 +144,9 @@ export async function enforceRateLimit(
   const rlParams = extractRateLimitPolicy(policies);
   if (!rlParams) return { allowed: true };
   if (!isRedisAvailable()) {
-    if (!isRedisConfigured() && process.env.NODE_ENV !== "production") return { allowed: true };
+    if (!isRedisConfigured() && runtimeEnvironmentValue("NODE_ENV") !== "production") {
+      return { allowed: true };
+    }
     return {
       allowed: false,
       reason: "Rate limit enforcement is unavailable",

--- a/packages/api/src/middleware/tenant-cors.ts
+++ b/packages/api/src/middleware/tenant-cors.ts
@@ -20,6 +20,7 @@ import {
   tenantConfigs as tenantConfigsTable,
 } from "@stwd/db";
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { and, eq } from "drizzle-orm";
 import type { Context, Next } from "hono";
 
@@ -147,7 +148,7 @@ const MAX_AGE = "86400";
  * environments all fail closed.
  */
 function devWildcardAllowed(): boolean {
-  const env = process.env.NODE_ENV;
+  const env = runtimeEnvironmentValue("NODE_ENV");
   return env === "development" || env === "test";
 }
 


### PR DESCRIPTION
Advances #770 with the next bounded Worker-security tranche.

- resolves idempotency TTL, metrics retention, fallback capacity, and durable-store posture from the active immutable request binding
- isolates bounded in-memory fallback generations by request-local capacity and fails closed without production Redis
- resolves Redis enforcement and tenant CORS production posture from request-local authority
- makes the middleware direct process.env inventory empty and pins migrated idempotency keys globally
- adds hostile A/B/missing/overlap coverage plus real fallback-capacity and production fail-closed checks

Exact-head evidence (23cc618a36e0d57076bf7e3b4f40ad900b2a491b):
- 63/63 focused and adjacent Redis/idempotency/CORS tests passed
- tenant-cors-preflight.test.ts: 3/3 passed in isolated process with --timeout 30000
- Biome changed files: clean
- git diff --check: clean
- API tsc reaches only the two pre-existing current-develop vault.ts errors: missing findActionByIdempotency and unsupported idempotencyKeyDigest (no changed-file diagnostics)