### PR TITLE
fix(sdk): use WebAuthn v13 browser call contract

### DIFF
--- a/packages/sdk/src/__tests__/auth-add-passkey.test.ts
+++ b/packages/sdk/src/__tests__/auth-add-passkey.test.ts
@@ -68,27 +68,31 @@ function restoreBrowserShim(): void {
   globalThis.window = originalWindow;
 }
 
+const startRegistration = mock(async () => ({
+  id: "credential-1",
+  rawId: "credential-1",
+  response: {
+    clientDataJSON: "client-data",
+    attestationObject: "attestation",
+  },
+  type: "public-key",
+}));
+
+const startAuthentication = mock(async () => ({
+  id: "credential-login",
+  rawId: "credential-login",
+  response: {
+    clientDataJSON: "client-data",
+    authenticatorData: "authenticator-data",
+    signature: "signature",
+    userHandle: "u-1",
+  },
+  type: "public-key",
+}));
+
 mock.module("@simplewebauthn/browser", () => ({
-  startRegistration: async () => ({
-    id: "credential-1",
-    rawId: "credential-1",
-    response: {
-      clientDataJSON: "client-data",
-      attestationObject: "attestation",
-    },
-    type: "public-key",
-  }),
-  startAuthentication: async () => ({
-    id: "credential-login",
-    rawId: "credential-login",
-    response: {
-      clientDataJSON: "client-data",
-      authenticatorData: "authenticator-data",
-      signature: "signature",
-      userHandle: "u-1",
-    },
-    type: "public-key",
-  }),
+  startRegistration,
+  startAuthentication,
 }));
 
 function fakeJwt(claims: Record<string, unknown> = {}): string {
@@ -126,6 +130,8 @@ function memoryStorage(): SessionStorage {
 
 beforeEach(() => {
   captured = [];
+  startRegistration.mockClear();
+  startAuthentication.mockClear();
   originalFetch = global.fetch;
   installFetch();
   installBrowserShim();
@@ -154,6 +160,7 @@ describe("StewardAuth.addPasskey", () => {
       id: "credential-1",
       type: "public-key",
     });
+    expect(startRegistration).toHaveBeenCalledWith({ optionsJSON: REG_OPTIONS });
 
     // And the resulting session reflects the verify payload.
     expect(result.token).toBe("test-jwt");
@@ -212,6 +219,13 @@ describe("StewardAuth.addPasskey", () => {
       challengeId: "login-challenge",
       response: { id: "credential-login", type: "public-key" },
     });
+    expect(startAuthentication).toHaveBeenCalledWith({
+      optionsJSON: {
+        challenge: "login-challenge",
+        challengeId: "login-challenge",
+        rpId: "api.example.test",
+      },
+    });
   });
 
   it("completes passkey MFA with bearer auth and stores the refreshed session", async () => {
@@ -261,6 +275,13 @@ describe("StewardAuth.addPasskey", () => {
     expect(captured[1]?.body).toMatchObject({
       challengeId: "mfa-challenge",
       response: { id: "credential-login", type: "public-key" },
+    });
+    expect(startAuthentication).toHaveBeenCalledWith({
+      optionsJSON: {
+        challenge: "mfa-challenge",
+        challengeId: "mfa-challenge",
+        rpId: "api.example.test",
+      },
     });
     expect(result.token).toBe(steppedUpToken);
     expect(storage.getItem("steward_session_token")).toBe(steppedUpToken);

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -924,9 +924,11 @@ export class StewardAuth {
     let authResponse: unknown;
     try {
       // Server-provided options; types are validated by the WebAuthn browser library.
-      authResponse = await lib.startAuthentication(
-        options as Parameters<SimpleWebAuthnBrowser["startAuthentication"]>[0],
-      );
+      authResponse = await lib.startAuthentication({
+        optionsJSON: options as Parameters<
+          SimpleWebAuthnBrowser["startAuthentication"]
+        >[0]["optionsJSON"],
+      });
     } catch (err) {
       throw new StewardApiError(
         `WebAuthn authentication cancelled or failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -985,9 +987,11 @@ export class StewardAuth {
     let regResponse: unknown;
     try {
       // Server-provided options; types are validated by the WebAuthn browser library.
-      regResponse = await lib.startRegistration(
-        regOptsRes.data as Parameters<SimpleWebAuthnBrowser["startRegistration"]>[0],
-      );
+      regResponse = await lib.startRegistration({
+        optionsJSON: regOptsRes.data as unknown as Parameters<
+          SimpleWebAuthnBrowser["startRegistration"]
+        >[0]["optionsJSON"],
+      });
     } catch (err) {
       throw new StewardApiError(
         `WebAuthn registration cancelled or failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -1736,9 +1740,11 @@ export class StewardAuth {
 
     let authResponse: unknown;
     try {
-      authResponse = await browserLib.startAuthentication(
-        optionsRes.data as Parameters<SimpleWebAuthnBrowser["startAuthentication"]>[0],
-      );
+      authResponse = await browserLib.startAuthentication({
+        optionsJSON: optionsRes.data as unknown as Parameters<
+          SimpleWebAuthnBrowser["startAuthentication"]
+        >[0]["optionsJSON"],
+      });
     } catch (err) {
       throw new StewardApiError(
         `WebAuthn authentication cancelled or failed: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## Summary

- pass server-issued WebAuthn JSON through the SimpleWebAuthn v13 `optionsJSON` wrapper
- fix all three SDK call sites: passkey login, registration, and MFA
- make the SDK mocks assert the production browser-library argument shape

Dependency audit: `@simplewebauthn/browser` resolves to v13.3.0, whose registration and authentication declarations both require `{ optionsJSON, ... }`. This does not change the API server or its privacy-preserving `allowCredentials` policy.

## Exact-head verification

- base: `6275484e2716fa7df5ba5a5d753330f0a4568566`
- head: `cf9e3bc494cc2d2be98860d4781faee0a660b7fa`
- full SDK suite: 293 tests, 1,300 assertions
- SDK TypeScript build
- Biome on both changed files
- `git diff --check origin/develop...HEAD`
- bidirectional mutation: all three call-shape assertions fail with the old direct-JSON calls and pass with this change