### PR TITLE
fix(api): isolate auth authority per Worker request

### DIFF
--- a/packages/api/src/__tests__/auth-runtime-authority.test.ts
+++ b/packages/api/src/__tests__/auth-runtime-authority.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import {
+  _getPasskeyAuthForTests,
+  assertAuthStoresAreSafe,
+  authCallbackBaseUrl,
+  getAllowedSiweDomains,
+  getConfiguredOidcClientSecret,
+  parseOAuthRedirectAllowlistEnv,
+  resolvePasskeyRuntimeAuthority,
+} from "../routes/auth";
+
+describe("auth Worker runtime authority", () => {
+  it("isolates passkey configuration and cached authenticators across overlapping bindings", async () => {
+    const authorityA = {
+      PASSKEY_RP_ID: "a.example",
+      PASSKEY_RP_NAME: "Tenant A",
+      PASSKEY_ORIGIN: "https://a.example",
+      PASSKEY_ALLOWED_ORIGINS: "https://a.example,https://www.a.example",
+    };
+    const authorityB = {
+      PASSKEY_RP_ID: "b.example",
+      PASSKEY_RP_NAME: "Tenant B",
+      PASSKEY_ORIGIN: "https://b.example",
+      PASSKEY_ALLOWED_ORIGINS: "https://b.example",
+    };
+    let releaseA!: () => void;
+    const holdA = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    let startedA!: () => void;
+    const didStartA = new Promise<void>((resolve) => {
+      startedA = resolve;
+    });
+
+    const pendingA = withRuntimeEnvironment(authorityA, async () => {
+      const first = _getPasskeyAuthForTests(authorityA.PASSKEY_ORIGIN);
+      startedA();
+      await holdA;
+      return {
+        authority: resolvePasskeyRuntimeAuthority(),
+        first,
+        second: _getPasskeyAuthForTests(authorityA.PASSKEY_ORIGIN),
+      };
+    });
+    await didStartA;
+    const observedB = await withRuntimeEnvironment(authorityB, async () => {
+      await Promise.resolve();
+      return {
+        authority: resolvePasskeyRuntimeAuthority(),
+        auth: _getPasskeyAuthForTests(authorityB.PASSKEY_ORIGIN),
+      };
+    });
+    releaseA();
+    const observedA = await pendingA;
+
+    expect(observedA.authority).toEqual({
+      defaultRpID: "a.example",
+      defaultOrigin: "https://a.example",
+      rpName: "Tenant A",
+      allowedOrigins: ["https://a.example", "https://www.a.example"],
+    });
+    expect(observedB.authority).toEqual({
+      defaultRpID: "b.example",
+      defaultOrigin: "https://b.example",
+      rpName: "Tenant B",
+      allowedOrigins: ["https://b.example"],
+    });
+    expect(observedA.first).toBe(observedA.second);
+    expect(observedA.first).not.toBe(observedB.auth);
+    expect(withRuntimeEnvironment({}, resolvePasskeyRuntimeAuthority)).toEqual({
+      defaultRpID: "steward.fi",
+      defaultOrigin: "https://steward.fi",
+      rpName: "Steward",
+      allowedOrigins: ["https://steward.fi"],
+    });
+  });
+
+  it("isolates SIWE domains, OAuth redirects, and dynamic provider secrets", async () => {
+    const dynamicSecretName = "STEWARD_TENANT_OIDC_SECRET_RUNTIME_AUTHORITY";
+    const read = async () => {
+      await Promise.resolve();
+      return {
+        siwe: getAllowedSiweDomains(),
+        redirects: parseOAuthRedirectAllowlistEnv(),
+        secret: getConfiguredOidcClientSecret(dynamicSecretName),
+      };
+    };
+    const [a, b, missing] = await Promise.all([
+      withRuntimeEnvironment(
+        {
+          SIWE_ALLOWED_DOMAINS: "a.example,www.a.example",
+          STEWARD_OAUTH_ALLOWED_REDIRECTS: "https://a.example/callback",
+          [dynamicSecretName]: "secret-a",
+        },
+        read,
+      ),
+      withRuntimeEnvironment(
+        {
+          APP_URL: "https://b.example/app",
+          STEWARD_OAUTH_REDIRECT_ALLOWLIST: "https://b.example/callback",
+          [dynamicSecretName]: "secret-b",
+        },
+        read,
+      ),
+      withRuntimeEnvironment({}, read),
+    ]);
+
+    expect(a).toEqual({
+      siwe: ["a.example", "www.a.example"],
+      redirects: ["https://a.example/callback"],
+      secret: "secret-a",
+    });
+    expect(b).toEqual({
+      siwe: ["b.example"],
+      redirects: ["https://b.example/callback"],
+      secret: "secret-b",
+    });
+    expect(missing).toEqual({ siwe: ["steward.fi"], redirects: [], secret: undefined });
+  });
+
+  it("fails closed for missing production callback and durable-store authority", () => {
+    const context = {
+      req: { header: (name: string) => (name === "host" ? "hostile.example" : undefined) },
+    };
+    expect(() =>
+      withRuntimeEnvironment({ NODE_ENV: "production" }, () =>
+        authCallbackBaseUrl(context as never),
+      ),
+    ).toThrow("APP_URL is required");
+    expect(
+      withRuntimeEnvironment({ NODE_ENV: "development" }, () =>
+        authCallbackBaseUrl(context as never),
+      ),
+    ).toBe("https://hostile.example");
+
+    const memoryStores = {
+      challenge: "memory",
+      token: "memory",
+      siweNonce: "memory",
+      mfa: "memory",
+      importSession: "memory",
+    } as const;
+    expect(() =>
+      withRuntimeEnvironment({ STEWARD_RUNTIME: "workers" }, () =>
+        assertAuthStoresAreSafe(memoryStores),
+      ),
+    ).toThrow("Durable auth storage is required");
+    expect(() =>
+      withRuntimeEnvironment(
+        { STEWARD_RUNTIME: "workers", STEWARD_ALLOW_MEMORY_AUTH_STORES: "true" },
+        () => assertAuthStoresAreSafe(memoryStores),
+      ),
+    ).not.toThrow();
+    expect(() =>
+      withRuntimeEnvironment({}, () => assertAuthStoresAreSafe(memoryStores)),
+    ).not.toThrow();
+  });
+});

--- a/packages/api/src/__tests__/worker-runtime-env-inventory.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-env-inventory.test.ts
@@ -36,7 +36,32 @@ const migratedRuntimeAuthorityKeys = [
   "STEWARD_IDEMPOTENCY_MAX_ENTRIES",
   "STEWARD_IDEMPOTENCY_METRICS_TTL_MS",
   "STEWARD_IDEMPOTENCY_TTL_MS",
+  "APP_URL",
+  "PASSKEY_ALLOWED_ORIGINS",
+  "PASSKEY_ORIGIN",
+  "PASSKEY_RP_ID",
+  "PASSKEY_RP_NAME",
+  "SIWE_ALLOWED_DOMAINS",
+  "STEWARD_ALLOW_UNBOUND_OAUTH_PROVIDER_CODE_EXCHANGE",
+  "STEWARD_OAUTH_ALLOWED_REDIRECTS",
+  "STEWARD_OAUTH_REDIRECT_ALLOWLIST",
 ] as const;
+
+const pendingAuthRouteReaders = [
+  "EMAIL_AUTH_REDIRECT_BASE_URL",
+  "FARCASTER_LOGIN_ENABLED",
+  "NODE_ENV",
+  "SMS_PROVIDER",
+  "STEWARD_DB_MODE",
+  "STEWARD_ENABLE_PROD_TEST_ACCOUNT_TOKEN",
+  "STEWARD_PGLITE_MEMORY",
+  "TELEGRAM_BOT_TOKEN",
+  "TOTP_ISSUER",
+  "TWILIO_ACCOUNT_SID",
+  "TWILIO_AUTH_TOKEN",
+  "TWILIO_FROM",
+  "WHATSAPP_OTP_ENABLED",
+];
 
 describe("Worker runtime environment static inventory", () => {
   it("rejects unclassified direct process.env readers in security middleware", () => {
@@ -67,5 +92,11 @@ describe("Worker runtime environment static inventory", () => {
       }
     }
     expect(violations).toEqual([]);
+  });
+
+  it("pins the remaining auth-route mutable-global compatibility inventory", () => {
+    const authSource = readFileSync(join(srcRoot, "routes", "auth.ts"), "utf8");
+    expect(directEnvironmentKeys(authSource)).toEqual(pendingAuthRouteReaders);
+    expect(authSource).not.toMatch(/process\.env\s*\[/);
   });
 });

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -2768,16 +2768,24 @@ async function ensureUserTenantLink(
   role: string = "member",
 ): Promise<void> {
   await withVerifiedAuthTenant(tenantId, userId, async () => {
+    // Migration 0123 enforces that a canonical personal tenant has exactly
+    // one owner and no member-shaped alias. BEFORE triggers run even when a
+    // duplicate insert would later be suppressed by ON CONFLICT, so derive
+    // the only valid role before attempting the idempotent write.
+    const membershipRole = tenantId === `personal-${userId}` ? "owner" : role;
     if (tenantId === "default") {
-      if (role !== "member" && role !== GUEST_TENANT_ROLE) {
+      if (membershipRole !== "member" && membershipRole !== GUEST_TENANT_ROLE) {
         throw new Error("Default tenant membership role is not permitted");
       }
       await getDb().execute(
-        sql`SELECT steward_bootstrap.ensure_default_membership(${userId}::uuid, ${role})`,
+        sql`SELECT steward_bootstrap.ensure_default_membership(${userId}::uuid, ${membershipRole})`,
       );
       return;
     }
-    await getDb().insert(userTenants).values({ userId, tenantId, role }).onConflictDoNothing();
+    await getDb()
+      .insert(userTenants)
+      .values({ userId, tenantId, role: membershipRole })
+      .onConflictDoNothing();
   });
 }
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1454,9 +1454,9 @@ export async function initAuthStores(usePostgres = false): Promise<void> {
   initUserLinkChallengeStores(challengeBackend);
 
   // Reset singletons so they pick up the new stores on next use
-  _passkeyAuth = null;
+  _passkeyAuthByRequest = new WeakMap();
   _phoneAuth = null;
-  _passkeyAuthByOrigin.clear();
+  _passkeyAuthWithoutRequest.clear();
   _emailAuthByRequest = new WeakMap();
 }
 
@@ -1591,7 +1591,7 @@ async function markOidcIdTokenUsedOnce(
 }
 
 function isUnsafeUnboundOAuthProviderCodeExchangeAllowed(): boolean {
-  return process.env.STEWARD_ALLOW_UNBOUND_OAUTH_PROVIDER_CODE_EXCHANGE === "true";
+  return runtimeEnvironmentValue("STEWARD_ALLOW_UNBOUND_OAUTH_PROVIDER_CODE_EXCHANGE") === "true";
 }
 
 function isValidPkceCodeVerifier(value: string): boolean {
@@ -1642,8 +1642,14 @@ export function getAuthStoreSources(): AuthStoreSources {
  */
 export function assertAuthStoresAreSafe(sources: AuthStoreSources = getAuthStoreSources()): void {
   const requiresDurableStores =
-    process.env.NODE_ENV === "production" || process.env.STEWARD_RUNTIME === "workers";
-  if (!requiresDurableStores || process.env.STEWARD_ALLOW_MEMORY_AUTH_STORES === "true") return;
+    runtimeEnvironmentValue("NODE_ENV") === "production" ||
+    runtimeEnvironmentValue("STEWARD_RUNTIME") === "workers";
+  if (
+    !requiresDurableStores ||
+    runtimeEnvironmentValue("STEWARD_ALLOW_MEMORY_AUTH_STORES") === "true"
+  ) {
+    return;
+  }
 
   const memoryStores = Object.entries(sources)
     .filter(([, source]) => source === "memory")
@@ -1671,8 +1677,43 @@ export function decryptImportSessionJson<T>(value: string): T {
   return JSON.parse(getOAuthKeyStore().decrypt(encrypted)) as T;
 }
 
-let _passkeyAuth: PasskeyAuth | null = null;
-const _passkeyAuthByOrigin = new Map<string, PasskeyAuth>();
+let _passkeyAuthByRequest = new WeakMap<object, Map<string, PasskeyAuth>>();
+const _passkeyAuthWithoutRequest = new Map<string, PasskeyAuth>();
+
+export type PasskeyRuntimeAuthority = Readonly<{
+  defaultRpID: string;
+  defaultOrigin: string;
+  rpName: string;
+  allowedOrigins: readonly string[];
+}>;
+
+/** Resolve WebAuthn authority from the active immutable request binding. */
+export function resolvePasskeyRuntimeAuthority(): PasskeyRuntimeAuthority {
+  const defaultRpID = runtimeEnvironmentValue("PASSKEY_RP_ID") || "steward.fi";
+  const defaultOrigin = runtimeEnvironmentValue("PASSKEY_ORIGIN") || "https://steward.fi";
+  const rpName = runtimeEnvironmentValue("PASSKEY_RP_NAME") || "Steward";
+  const allowedOrigins = (runtimeEnvironmentValue("PASSKEY_ALLOWED_ORIGINS") || defaultOrigin)
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+  return Object.freeze({
+    defaultRpID,
+    defaultOrigin,
+    rpName,
+    allowedOrigins: Object.freeze(allowedOrigins),
+  });
+}
+
+function passkeyAuthCache(): Map<string, PasskeyAuth> {
+  const identity = runtimeEnvironmentIdentity();
+  if (!identity) return _passkeyAuthWithoutRequest;
+  let cache = _passkeyAuthByRequest.get(identity);
+  if (!cache) {
+    cache = new Map();
+    _passkeyAuthByRequest.set(identity, cache);
+  }
+  return cache;
+}
 
 /**
  * Get PasskeyAuth for a specific origin (multi-tenant passkey support).
@@ -1719,25 +1760,21 @@ function resolveRpID(requestHostname: string, allowedOrigins: string[], fallback
 }
 
 function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
-  const defaultRpID = process.env.PASSKEY_RP_ID || "steward.fi";
-  const defaultOrigin = process.env.PASSKEY_ORIGIN || "https://steward.fi";
-  const rpName = process.env.PASSKEY_RP_NAME || "Steward";
+  const { defaultRpID, defaultOrigin, rpName, allowedOrigins } = resolvePasskeyRuntimeAuthority();
+  const cache = passkeyAuthCache();
 
   // If no origin provided, use the default singleton
   if (!requestOrigin) {
-    if (!_passkeyAuth) {
-      const origins = (process.env.PASSKEY_ALLOWED_ORIGINS || defaultOrigin)
-        .split(",")
-        .map((o) => o.trim())
-        .filter(Boolean);
-      _passkeyAuth = new PasskeyAuth({
-        rpName,
-        rpID: defaultRpID,
-        origin: origins.length > 1 ? origins : defaultOrigin,
-        challengeStore: getChallengeStore(),
-      });
-    }
-    return _passkeyAuth;
+    const cached = cache.get("default:configuration");
+    if (cached) return cached;
+    const auth = new PasskeyAuth({
+      rpName,
+      rpID: defaultRpID,
+      origin: allowedOrigins.length > 1 ? [...allowedOrigins] : defaultOrigin,
+      challengeStore: getChallengeStore(),
+    });
+    cache.set("default:configuration", auth);
+    return auth;
   }
 
   // Parse origin to get hostname
@@ -1749,10 +1786,7 @@ function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
   }
 
   // Validate against allowed origins
-  const allowed = (process.env.PASSKEY_ALLOWED_ORIGINS || defaultOrigin)
-    .split(",")
-    .map((o) => o.trim())
-    .filter(Boolean);
+  const allowed = [...allowedOrigins];
   if (!allowed.includes(requestOrigin) && requestHostname !== defaultRpID) {
     return getPasskeyAuth(); // not in allowed list, use default
   }
@@ -1763,7 +1797,8 @@ function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
   const rpID = resolveRpID(requestHostname, allowed, defaultRpID);
 
   // Cache per rpID
-  const cached = _passkeyAuthByOrigin.get(rpID);
+  const cacheKey = `rp:${rpID}`;
+  const cached = cache.get(cacheKey);
   if (cached) return cached;
 
   // Origin list passed to PasskeyAuth covers all variants the browser may
@@ -1776,8 +1811,13 @@ function getPasskeyAuth(requestOrigin?: string): PasskeyAuth {
     origin: acceptedOrigins,
     challengeStore: getChallengeStore(),
   });
-  _passkeyAuthByOrigin.set(rpID, auth);
+  cache.set(cacheKey, auth);
   return auth;
+}
+
+/** Test seam for verifying request-bound PasskeyAuth generation isolation. */
+export function _getPasskeyAuthForTests(requestOrigin?: string): PasskeyAuth {
+  return getPasskeyAuth(requestOrigin);
 }
 
 // ─── EmailAuth cache ──────────────────────────────────────────────────────────
@@ -2562,8 +2602,8 @@ function ethereumWalletTenantId(address: string): string {
   return `eth:${address.toLowerCase()}`;
 }
 
-function getAllowedSiweDomains(): string[] {
-  const raw = process.env.SIWE_ALLOWED_DOMAINS?.trim();
+export function getAllowedSiweDomains(): string[] {
+  const raw = runtimeEnvironmentValue("SIWE_ALLOWED_DOMAINS")?.trim();
   if (raw) {
     const domains = raw
       .split(",")
@@ -2572,7 +2612,7 @@ function getAllowedSiweDomains(): string[] {
     if (domains.length > 0) return domains;
   }
 
-  const appUrl = process.env.APP_URL?.trim() || "https://steward.fi";
+  const appUrl = runtimeEnvironmentValue("APP_URL")?.trim() || "https://steward.fi";
   try {
     return [new URL(appUrl).host.toLowerCase()];
   } catch {
@@ -10816,10 +10856,10 @@ async function provisionOAuthUser(opts: {
  * APP_URL is mandatory in production so a forged Host/X-Forwarded-Proto header
  * cannot influence the provider redirect_uri.
  */
-function authCallbackBaseUrl(c: Context): string {
-  const configured = process.env.APP_URL?.trim();
+export function authCallbackBaseUrl(c: Context): string {
+  const configured = runtimeEnvironmentValue("APP_URL")?.trim();
   if (configured) return configured.replace(/\/$/, "");
-  if (process.env.NODE_ENV === "production") {
+  if (runtimeEnvironmentValue("NODE_ENV") === "production") {
     throw new Error("APP_URL is required for OAuth/OIDC callback URLs in production");
   }
   return `${c.req.header("x-forwarded-proto") ?? "https"}://${c.req.header("host") ?? "localhost"}`;
@@ -10955,7 +10995,7 @@ async function exchangeOidcAuthorizationCode(opts: {
     if (!isAllowedOidcClientSecretEnvForTenant(provider.clientSecretEnv, tenantId)) {
       throw new Error("OIDC client secret env is outside the allowed tenant namespace");
     }
-    const secret = process.env[provider.clientSecretEnv];
+    const secret = getConfiguredOidcClientSecret(provider.clientSecretEnv);
     if (!secret) throw new Error(`OIDC client secret env ${provider.clientSecretEnv} is not set`);
     body.set("client_secret", secret);
   }
@@ -11004,16 +11044,21 @@ async function exchangeOidcAuthorizationCode(opts: {
   return payload.id_token.trim();
 }
 
+/** Read an allowlisted tenant OIDC secret from the active request binding. */
+export function getConfiguredOidcClientSecret(envName: string): string | undefined {
+  return runtimeEnvironmentValue(envName);
+}
+
 const OAUTH_REDIRECT_ALLOWLIST_ENV_KEYS = [
   "STEWARD_OAUTH_ALLOWED_REDIRECTS",
   "STEWARD_OAUTH_REDIRECT_ALLOWLIST",
 ] as const;
 
-function parseOAuthRedirectAllowlistEnv(): string[] {
+export function parseOAuthRedirectAllowlistEnv(): string[] {
   const entries = new Set<string>();
 
   for (const envName of OAUTH_REDIRECT_ALLOWLIST_ENV_KEYS) {
-    const raw = process.env[envName];
+    const raw = runtimeEnvironmentValue(envName);
     if (!raw) continue;
 
     for (const entry of raw.split(",")) {

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -81,6 +81,7 @@ import {
   type SignRequest,
   type TenantAuthAbuseConfig,
 } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import {
   applyUserWalletDefaults,
   generateMnemonic,
@@ -2172,7 +2173,7 @@ function farcasterProviderAccountId(address: string): string {
 }
 
 function userFarcasterAllowedDomains(): string[] | undefined {
-  const raw = process.env.SIWE_ALLOWED_DOMAINS?.trim();
+  const raw = runtimeEnvironmentValue("SIWE_ALLOWED_DOMAINS")?.trim();
   if (!raw) return undefined;
   const domains = raw
     .split(",")

--- a/packages/api/src/services/saml-sso-config.ts
+++ b/packages/api/src/services/saml-sso-config.ts
@@ -1,4 +1,5 @@
 import type { TenantSamlSsoConfig, TenantSamlSsoUpdate } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { validateWebhookUrl } from "./webhook-url";
 
 const MAX_CERTS = 5;
@@ -79,7 +80,10 @@ export function buildSamlServiceProviderUrls(tenantId: string): {
   acsUrl: string;
   metadataUrl: string;
 } {
-  const appUrl = (process.env.APP_URL?.trim() || "https://steward.fi").replace(/\/$/, "");
+  const appUrl = (runtimeEnvironmentValue("APP_URL")?.trim() || "https://steward.fi").replace(
+    /\/$/,
+    "",
+  );
   const encodedTenant = encodeURIComponent(tenantId);
   const metadataUrl = `${appUrl}/auth/saml/${encodedTenant}/metadata`;
   return {


### PR DESCRIPTION
Advances #770 with a bounded Worker-reachable authentication tranche.

- resolves passkey RP/origin/name allowlists from the immutable request binding and scopes PasskeyAuth memoization to the opaque request identity
- moves SIWE domain and APP_URL authority, OAuth callback/redirect policy, unsafe unbound-exchange opt-in, and durable auth-store posture off mutable process globals
- reads allowlisted tenant OIDC client secrets from the active request binding
- pins the remaining auth.ts process.env compatibility inventory and forbids dynamic process.env bracket reads
- adds hostile overlapping A/B/missing tests for passkey cache generations, SIWE/OAuth policy, dynamic provider secrets, callback fail-closed posture, and durable stores
- corrects the post-0123 auth lifecycle boundary: canonical personal-<userId> links derive the required owner role before BEFORE-trigger validation, instead of retrying an existing owner row as member and relying on ON CONFLICT

Exact-head evidence (f800a6af8b07d187db5def7af94983b631d66142 on 03bfb3d780f35276fdb2da5895401f6603836c71):
- mounted auth nonce/Apple callback: 5/5
- authority + static guard: 6/6
- OAuth nonce exchange: 18/18
- tenant OIDC config: 4/4
- passkey enumeration: 2/2 (pre-final-rebase; unchanged paths)
- tenant SAML config: 3/3 (pre-final-rebase; unchanged paths)
- durable auth-store/readiness: 15/15 (pre-final-rebase; unchanged paths)
- Biome and diff check clean
- API tsc reaches only current-develop vault.ts baseline errors (findActionByIdempotency and idempotencyKeyDigest)

Root cause verified before correction: migration 0123 added steward_guard_personal_membership_write. OAuth provisioning first created the canonical owner row, then ensureUserTenantLink retried personal-<same-user> with role=member. PostgreSQL BEFORE triggers run before ON CONFLICT DO NOTHING, producing SQLSTATE 23514 Reserved tenant membership is immutable. The helper now derives owner only when tenantId exactly equals personal-${userId}; other tenants retain the requested role.

The Postgres-only OAuth redirect integration requires a real CI DATABASE_URL and was not claimed locally.