### PR TITLE
fix(db): restore shipped capabilities migration identity

### DIFF
--- a/packages/db/src/__tests__/migration-ledger-integrity.test.ts
+++ b/packages/db/src/__tests__/migration-ledger-integrity.test.ts
@@ -70,7 +70,25 @@ describe("core migration ledger integrity", () => {
     expect(source).toContain('name: "capability_rate_limit_buckets"');
     expect(source).toContain('name: "capability_rate_limit_bucket_agent_fence()"');
     expect(source).toContain('name: "capability_rate_limit_bucket_agent_fence"');
+    expect(source).toContain('tag: "0005_activated_rls_inheritance"');
     expect(source).toContain("schema does not match its applied migration prefix");
+  });
+
+  test("preserves the shipped capabilities tenant-policy identity", () => {
+    const pluginMigrations = new URL("../../../plugin-capabilities/drizzle/", import.meta.url);
+    const shippedPolicy = readFileSync(new URL("0003_tenant_rls_policies.sql", pluginMigrations));
+    expect(createHash("sha256").update(shippedPolicy).digest("hex")).toBe(
+      "0d45006776d6c932d36eeec87811b98b24e3d1fb388af6aafd8109b70ae1bc2b",
+    );
+    const pluginJournal = JSON.parse(
+      readFileSync(new URL("meta/_journal.json", pluginMigrations), "utf8"),
+    ) as { entries: JournalEntry[] };
+    expect(pluginJournal.entries.at(-2)?.tag).toBe("0004_capability_rate_limit_buckets");
+    expect(pluginJournal.entries.at(-1)).toMatchObject({
+      idx: 5,
+      tag: "0005_activated_rls_inheritance",
+      when: 1787250000001,
+    });
   });
 
   test("accepts a genuinely empty database before the first migration", () => {

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -758,6 +758,10 @@ async function assertBundledPluginLedgerIntegrity(db: MigrationQueryExecutor): P
             },
           ],
         },
+        {
+          tag: "0005_activated_rls_inheritance",
+          effects: [],
+        },
       ],
     },
     {

--- a/packages/db/src/plugin-migrate.ts
+++ b/packages/db/src/plugin-migrate.ts
@@ -45,6 +45,7 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import type { PluginMigrationSource } from "@stwd/shared";
+import { readMigrationFiles } from "drizzle-orm/migrator";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 
 import { createDb } from "./client";
@@ -283,11 +284,48 @@ export async function runPluginMigrations(
       // CRITICAL ISOLATION: migrationsTable scopes drizzle's applied-migrations
       // bookkeeping to the per-plugin table. The core's __drizzle_migrations is
       // NEVER touched by this call.
-      await migrateFn(db, {
-        migrationsFolder: source.migrationsFolder,
-        migrationsTable,
-        migrationsSchema: PLUGIN_MIGRATIONS_SCHEMA,
-      });
+      const [ledgerShape] =
+        ownsClient && useAdvisoryLock
+          ? await client.unsafe("SELECT to_regclass($1) IS NOT NULL AS ledger_exists", [
+              `${PLUGIN_MIGRATIONS_SCHEMA}.${migrationsTable}`,
+            ])
+          : [{ ledger_exists: false }];
+      if (ownsClient && ledgerShape?.ledger_exists) {
+        // Drizzle always issues CREATE SCHEMA IF NOT EXISTS before applying a
+        // plugin migration. PostgreSQL still requires database-level CREATE
+        // for that statement, even when the schema already exists. Activated
+        // deployments deliberately revoke that privilege from the migration
+        // role, so replay the checked-in suffix directly against the already-
+        // owned namespaced ledger instead.
+        const migrationFiles = readMigrationFiles({ migrationsFolder: source.migrationsFolder });
+        const ledgerRows = await client.unsafe(
+          `SELECT hash, created_at FROM ${PLUGIN_MIGRATIONS_SCHEMA}."${migrationsTable}" ORDER BY id ASC`,
+        );
+        if (ledgerRows.length > migrationFiles.length) {
+          throw new Error(`plugin migration "${source.id}" ledger is ahead of this build`);
+        }
+        for (const [index, row] of ledgerRows.entries()) {
+          const expected = migrationFiles[index];
+          if (row.hash !== expected?.hash || Number(row.created_at) !== expected.folderMillis) {
+            throw new Error(`plugin migration "${source.id}" ledger identity mismatch`);
+          }
+        }
+        await client.begin(async (transaction: any) => {
+          for (const migration of migrationFiles.slice(ledgerRows.length)) {
+            for (const statement of migration.sql) await transaction.unsafe(statement);
+            await transaction.unsafe(
+              `INSERT INTO ${PLUGIN_MIGRATIONS_SCHEMA}."${migrationsTable}" (hash, created_at) VALUES ($1, $2)`,
+              [migration.hash, migration.folderMillis],
+            );
+          }
+        });
+      } else {
+        await migrateFn(db, {
+          migrationsFolder: source.migrationsFolder,
+          migrationsTable,
+          migrationsSchema: PLUGIN_MIGRATIONS_SCHEMA,
+        });
+      }
     } finally {
       if (advisoryLockHeld && client && !overallTimedOut) {
         await client`SELECT pg_advisory_unlock(hashtextextended(${lockKey}, 0))`;

--- a/packages/plugin-capabilities/drizzle/0003_tenant_rls_policies.sql
+++ b/packages/plugin-capabilities/drizzle/0003_tenant_rls_policies.sql
@@ -1,62 +1,13 @@
--- SEC-169: capability authority is tenant-owned even though these relations
--- live in the plugin migration ledger. Install deny-by-default policies after
--- the core steward_rls.tenant_id() helper exists.
-DROP POLICY IF EXISTS steward_tenant_isolation ON public.capabilities;
---> statement-breakpoint
+-- Capabilities are tenant authority, so an enabled capabilities plugin must
+-- participate in the same exact RLS contract as the core schema.
 CREATE POLICY steward_tenant_isolation ON public.capabilities
-  FOR ALL
   USING (tenant_id = steward_rls.tenant_id())
   WITH CHECK (tenant_id = steward_rls.tenant_id());
---> statement-breakpoint
-DROP POLICY IF EXISTS steward_tenant_isolation ON public.capability_grants;
 --> statement-breakpoint
 CREATE POLICY steward_tenant_isolation ON public.capability_grants
-  FOR ALL
   USING (tenant_id = steward_rls.tenant_id())
   WITH CHECK (tenant_id = steward_rls.tenant_id());
---> statement-breakpoint
-DROP POLICY IF EXISTS steward_tenant_isolation ON public.capability_invocations;
 --> statement-breakpoint
 CREATE POLICY steward_tenant_isolation ON public.capability_invocations
-  FOR ALL
   USING (tenant_id = steward_rls.tenant_id())
   WITH CHECK (tenant_id = steward_rls.tenant_id());
---> statement-breakpoint
--- Plugin migrations may run either before the operator activates RLS or after
--- an already-activated deployment enables this plugin. Mirror the core state:
--- if the canonical agents table is forced, activate the new plugin relations
--- atomically and retain migration-role maintenance access.
-DO $$
-DECLARE
-  relation_name text;
-BEGIN
-  IF EXISTS (
-    SELECT 1
-    FROM pg_class c
-    JOIN pg_namespace n ON n.oid = c.relnamespace
-    WHERE n.nspname = 'public'
-      AND c.relname = 'agents'
-      AND c.relrowsecurity
-      AND c.relforcerowsecurity
-  ) THEN
-    FOREACH relation_name IN ARRAY ARRAY[
-      'capabilities',
-      'capability_grants',
-      'capability_invocations'
-    ]
-    LOOP
-      EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', relation_name);
-      EXECUTE format('ALTER TABLE public.%I FORCE ROW LEVEL SECURITY', relation_name);
-      EXECUTE format(
-        'DROP POLICY IF EXISTS steward_migration_maintenance ON public.%I',
-        relation_name
-      );
-      EXECUTE format(
-        'CREATE POLICY steward_migration_maintenance ON public.%I FOR ALL TO %I USING (true) WITH CHECK (true)',
-        relation_name,
-        current_user
-      );
-    END LOOP;
-  END IF;
-END
-$$;

--- a/packages/plugin-capabilities/drizzle/0005_activated_rls_inheritance.sql
+++ b/packages/plugin-capabilities/drizzle/0005_activated_rls_inheritance.sql
@@ -1,0 +1,38 @@
+-- A plugin can be enabled after the operator has already activated and forced
+-- RLS on the core schema. Inherit that state without rewriting the shipped
+-- tenant-policy migration identity.
+DO $$
+DECLARE
+  relation_name text;
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'agents'
+      AND c.relrowsecurity
+      AND c.relforcerowsecurity
+  ) THEN
+    FOREACH relation_name IN ARRAY ARRAY[
+      'capabilities',
+      'capability_grants',
+      'capability_invocations',
+      'capability_rate_limit_buckets'
+    ]
+    LOOP
+      EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', relation_name);
+      EXECUTE format('ALTER TABLE public.%I FORCE ROW LEVEL SECURITY', relation_name);
+      EXECUTE format(
+        'DROP POLICY IF EXISTS steward_migration_maintenance ON public.%I',
+        relation_name
+      );
+      EXECUTE format(
+        'CREATE POLICY steward_migration_maintenance ON public.%I FOR ALL TO %I USING (true) WITH CHECK (true)',
+        relation_name,
+        current_user
+      );
+    END LOOP;
+  END IF;
+END
+$$;

--- a/packages/plugin-capabilities/drizzle/meta/_journal.json
+++ b/packages/plugin-capabilities/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1787250000000,
       "tag": "0004_capability_rate_limit_buckets",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1787250000001,
+      "tag": "0005_activated_rls_inheritance",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- restore shipped capabilities migration 0003 byte-for-byte (SHA-256 `0d45006776d6c932d36eeec87811b98b24e3d1fb388af6aafd8109b70ae1bc2b`)
- move activated-RLS inheritance into strictly increasing plugin migration 0005, covering all four capability relations
- verify existing plugin ledgers before applying a pending suffix atomically without requiring revoked database-level CREATE privilege
- pin the shipped identity and new journal tip in regression coverage

## Exact-head evidence
- base: `f0ce51c86eb0d92e727b5108ec3133879a422887`
- head: `aaaad2b9245d666d7aec03642babe550d549b89b`
- exact pre-#881 real PostgreSQL: core applied only `0123_personal_lifecycle_invariants`; plugin applied only 0005
- second core run: already up to date; second plugin run: ledger remained 6 rows at `1787250000001`
- activated restricted migration role: existing-ledger suffix path applied 0005 without database CREATE and installed four migration-maintenance policies when core RLS was forced
- `bun test packages/db/src/__tests__/migration-ledger-integrity.test.ts packages/db/src/__tests__/plugin-migrate.test.ts`: 18 pass, 72 assertions
- `bun run --cwd packages/db build`: pass
- targeted Biome and `git diff --check`: pass

This PR does not alter core migration identities or protections.