### PR TITLE
fix: recover valid closed-PR work and restore exact-head gates

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,5 @@
 # Build and push Docker image to GitHub Container Registry (GHCR)
-# Triggers on pushes to develop + main branches and version tags (v*)
+# Builds every pull request and publishes pushes to develop/main or version tags (v*).
 #   develop -> :develop image (auto-deployed to STAGING by deploy-staging.yml)
 #   main    -> :main image (promoted to PRODUCTION manually via deploy-railway.yml)
 #   v*      -> :<semver> image (tagged release for production)
@@ -11,13 +11,6 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [develop, main]
-    paths:
-      - "Dockerfile"
-      - ".dockerignore"
-      - "package.json"
-      - "bun.lock"
-      - "packages/**/package.json"
-      - ".github/workflows/docker.yml"
 
 # A branch tag is mutable. Do not let a slower build for an older push finish
 # after a newer build and overwrite `:develop` / `:main` with stale bytes.

--- a/packages/api/src/__tests__/fixtures/platform-user-metadata-concurrent-writer.ts
+++ b/packages/api/src/__tests__/fixtures/platform-user-metadata-concurrent-writer.ts
@@ -33,10 +33,13 @@ try {
   await withTenantAuditedTransactionOnDb(handle.db, "platform", async (txRaw, appendAudit) => {
     const tx = txRaw as typeof handle.db;
     await tx.execute(sql`SELECT id FROM users WHERE id = ${userId}::uuid FOR UPDATE`);
-    await tx.update(users).set({
-      customMetadata: { owner: "concurrent-winner" },
-      updatedAt: new Date(),
-    }).where(eq(users.id, userId));
+    await tx
+      .update(users)
+      .set({
+        customMetadata: { owner: "concurrent-winner" },
+        updatedAt: new Date(),
+      })
+      .where(eq(users.id, userId));
     await appendAudit({
       tenantId: "platform",
       actorType: "platform",

--- a/packages/api/src/__tests__/platform-user-metadata-audit-atomicity-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/platform-user-metadata-audit-atomicity-postgres.integration.test.ts
@@ -1,10 +1,5 @@
 import { expect, it, mock } from "bun:test";
-import {
-  __resetAuditHmacKeyCacheForTests,
-  auditEvents,
-  createDb,
-  users,
-} from "@stwd/db";
+import { __resetAuditHmacKeyCacheForTests, auditEvents, createDb, users } from "@stwd/db";
 import { and, eq, inArray } from "drizzle-orm";
 import { Hono } from "hono";
 import { correlationId } from "../middleware/correlation";
@@ -17,67 +12,70 @@ mock.module("../services/webhook-dispatch", () => ({
 const databaseUrl = process.env.DATABASE_URL;
 const realPostgresIt = databaseUrl && !process.env.STEWARD_PGLITE_MEMORY ? it : it.skip;
 
-realPostgresIt("restricted platform writers preserve the concurrent winner and fence webhooks on rollback", async () => {
-  dispatchWebhookMock.mockClear();
-  const suffix = crypto.randomUUID().replaceAll("-", "");
-  const platformKey = `platform-metadata-key-${suffix}`;
-  const failedRequestId = `failed-${suffix}`;
-  const successRequestId = `success-${suffix}`;
-  const triggerFunction = `fail_platform_metadata_audit_${suffix}`;
-  const triggerName = `fail_platform_metadata_audit_${suffix}`;
-  const platformRole = `steward_platform_722_${suffix.slice(0, 16)}`;
-  const platformPassword = `platform-metadata-password-${suffix}`;
-  const gateKey = Number.parseInt(suffix.slice(0, 12), 16);
-  const oldKeys = process.env.STEWARD_PLATFORM_KEYS;
-  const oldScopes = process.env.STEWARD_PLATFORM_KEY_SCOPES;
-  const oldAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
-  const oldPlatformDatabaseUrl = process.env.STEWARD_PLATFORM_DATABASE_URL;
-  const oldPlatformDatabaseRole = process.env.STEWARD_PLATFORM_DATABASE_ROLE;
-  process.env.STEWARD_PLATFORM_KEYS = platformKey;
-  process.env.STEWARD_PLATFORM_KEY_SCOPES = JSON.stringify({
-    [platformKey]: ["platform:read", "platform:write", "platform:user:write"],
-  });
-  process.env.STEWARD_AUDIT_HMAC_KEY = `platform-metadata-audit-key-${suffix}`;
-  __resetAuditHmacKeyCacheForTests();
+realPostgresIt(
+  "restricted platform writers preserve the concurrent winner and fence webhooks on rollback",
+  async () => {
+    dispatchWebhookMock.mockClear();
+    const suffix = crypto.randomUUID().replaceAll("-", "");
+    const platformKey = `platform-metadata-key-${suffix}`;
+    const failedRequestId = `failed-${suffix}`;
+    const successRequestId = `success-${suffix}`;
+    const triggerFunction = `fail_platform_metadata_audit_${suffix}`;
+    const triggerName = `fail_platform_metadata_audit_${suffix}`;
+    const platformRole = `steward_platform_722_${suffix.slice(0, 16)}`;
+    const platformPassword = `platform-metadata-password-${suffix}`;
+    const gateKey = Number.parseInt(suffix.slice(0, 12), 16);
+    const oldKeys = process.env.STEWARD_PLATFORM_KEYS;
+    const oldScopes = process.env.STEWARD_PLATFORM_KEY_SCOPES;
+    const oldAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+    const oldPlatformDatabaseUrl = process.env.STEWARD_PLATFORM_DATABASE_URL;
+    const oldPlatformDatabaseRole = process.env.STEWARD_PLATFORM_DATABASE_ROLE;
+    process.env.STEWARD_PLATFORM_KEYS = platformKey;
+    process.env.STEWARD_PLATFORM_KEY_SCOPES = JSON.stringify({
+      [platformKey]: ["platform:read", "platform:write", "platform:user:write"],
+    });
+    process.env.STEWARD_AUDIT_HMAC_KEY = `platform-metadata-audit-key-${suffix}`;
+    __resetAuditHmacKeyCacheForTests();
 
-  const admin = createDb(databaseUrl!);
-  const locker = await admin.client.reserve();
-  let gateLocked = false;
-  let roleCreated = false;
-  let userId: string | undefined;
-  try {
-    const [database] = await admin.client<{ name: string }[]>`SELECT current_database() AS name`;
-    if (!database) throw new Error("failed to resolve integration database name");
-    await admin.client.unsafe(
-      `CREATE ROLE ${quoteIdentifier(platformRole)} LOGIN PASSWORD '${platformPassword}' ` +
-        "NOSUPERUSER NOBYPASSRLS NOINHERIT",
-    );
-    roleCreated = true;
-    await admin.client.unsafe(
-      `GRANT CONNECT ON DATABASE ${quoteIdentifier(database.name)} TO ${quoteIdentifier(platformRole)}`,
-    );
-    await admin.client.unsafe(
-      `GRANT USAGE ON SCHEMA public TO ${quoteIdentifier(platformRole)}`,
-    );
-    await admin.client.unsafe(
-      `GRANT SELECT, UPDATE ON TABLE public.users TO ${quoteIdentifier(platformRole)}`,
-    );
-    await admin.client.unsafe(
-      `GRANT SELECT, INSERT, UPDATE ON TABLE public.audit_events, public.audit_chain_heads TO ${quoteIdentifier(platformRole)}`,
-    );
-    const platformUrl = new URL(databaseUrl!);
-    platformUrl.username = platformRole;
-    platformUrl.password = platformPassword;
-    process.env.STEWARD_PLATFORM_DATABASE_URL = platformUrl.toString();
-    process.env.STEWARD_PLATFORM_DATABASE_ROLE = platformRole;
+    const admin = createDb(databaseUrl!);
+    const locker = await admin.client.reserve();
+    let gateLocked = false;
+    let roleCreated = false;
+    let userId: string | undefined;
+    try {
+      const [database] = await admin.client<{ name: string }[]>`SELECT current_database() AS name`;
+      if (!database) throw new Error("failed to resolve integration database name");
+      await admin.client.unsafe(
+        `CREATE ROLE ${quoteIdentifier(platformRole)} LOGIN PASSWORD '${platformPassword}' ` +
+          "NOSUPERUSER NOBYPASSRLS NOINHERIT",
+      );
+      roleCreated = true;
+      await admin.client.unsafe(
+        `GRANT CONNECT ON DATABASE ${quoteIdentifier(database.name)} TO ${quoteIdentifier(platformRole)}`,
+      );
+      await admin.client.unsafe(`GRANT USAGE ON SCHEMA public TO ${quoteIdentifier(platformRole)}`);
+      await admin.client.unsafe(
+        `GRANT SELECT, UPDATE ON TABLE public.users TO ${quoteIdentifier(platformRole)}`,
+      );
+      await admin.client.unsafe(
+        `GRANT SELECT, INSERT, UPDATE ON TABLE public.audit_events, public.audit_chain_heads TO ${quoteIdentifier(platformRole)}`,
+      );
+      const platformUrl = new URL(databaseUrl!);
+      platformUrl.username = platformRole;
+      platformUrl.password = platformPassword;
+      process.env.STEWARD_PLATFORM_DATABASE_URL = platformUrl.toString();
+      process.env.STEWARD_PLATFORM_DATABASE_ROLE = platformRole;
 
-    const [created] = await admin.db.insert(users).values({
-      email: `platform-metadata-${suffix}@example.test`,
-      customMetadata: { owner: "initial" },
-    }).returning({ id: users.id });
-    if (!created) throw new Error("failed to seed platform metadata user");
-    userId = created.id;
-    await admin.client.unsafe(`create function "${triggerFunction}"() returns trigger language plpgsql as $$
+      const [created] = await admin.db
+        .insert(users)
+        .values({
+          email: `platform-metadata-${suffix}@example.test`,
+          customMetadata: { owner: "initial" },
+        })
+        .returning({ id: users.id });
+      if (!created) throw new Error("failed to seed platform metadata user");
+      userId = created.id;
+      await admin.client.unsafe(`create function "${triggerFunction}"() returns trigger language plpgsql as $$
       begin
         if new.request_id = '${failedRequestId}' and new.action = 'user.metadata.update' then
           perform pg_advisory_xact_lock(${gateKey});
@@ -85,83 +83,101 @@ realPostgresIt("restricted platform writers preserve the concurrent winner and f
         end if;
         return new;
       end $$`);
-    await admin.client.unsafe(`create trigger "${triggerName}" before insert on audit_events
+      await admin.client.unsafe(`create trigger "${triggerName}" before insert on audit_events
       for each row execute function "${triggerFunction}"()`);
-    await locker`select pg_advisory_lock(${gateKey})`;
-    gateLocked = true;
+      await locker`select pg_advisory_lock(${gateKey})`;
+      gateLocked = true;
 
-    const { platformRoutes } = await import("../routes/platform");
-    const app = new Hono();
-    app.use("*", correlationId);
-    app.route("/platform", platformRoutes);
-    app.onError((error, c) => c.json({ ok: false, error: error.message }, 500));
-    const failedRequest = app.request(`/platform/users/${userId}/metadata`, {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Request-Id": failedRequestId,
-        "X-Steward-Platform-Key": platformKey,
-      },
-      body: JSON.stringify({ customMetadata: { owner: "must-rollback" } }),
-    });
-    await waitForWaiters(admin, 1, "mounted platform route did not reach blocked audit");
-    expect(dispatchWebhookMock).not.toHaveBeenCalled();
+      const { platformRoutes } = await import("../routes/platform");
+      const app = new Hono();
+      app.use("*", correlationId);
+      app.route("/platform", platformRoutes);
+      app.onError((error, c) => c.json({ ok: false, error: error.message }, 500));
+      const failedRequest = app.request(`/platform/users/${userId}/metadata`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Request-Id": failedRequestId,
+          "X-Steward-Platform-Key": platformKey,
+        },
+        body: JSON.stringify({ customMetadata: { owner: "must-rollback" } }),
+      });
+      await waitForWaiters(admin, 1, "mounted platform route did not reach blocked audit");
+      expect(dispatchWebhookMock).not.toHaveBeenCalled();
 
-    const writer = Bun.spawn([
-      process.execPath,
-      new URL("./fixtures/platform-user-metadata-concurrent-writer.ts", import.meta.url).pathname,
-    ], {
-      cwd: new URL("../../../..", import.meta.url).pathname,
-      env: {
-        ...process.env,
-        DATABASE_URL: process.env.STEWARD_PLATFORM_DATABASE_URL,
-        TEST_USER_ID: userId,
-        TEST_REQUEST_ID: successRequestId,
-        TEST_EXPECTED_DATABASE_ROLE: platformRole,
-      },
-      stderr: "pipe",
-    });
-    await waitForWaiters(admin, 2, "concurrent metadata writer did not reach serialization lock");
-    await locker`select pg_advisory_unlock(${gateKey})`;
-    gateLocked = false;
+      const writer = Bun.spawn(
+        [
+          process.execPath,
+          new URL("./fixtures/platform-user-metadata-concurrent-writer.ts", import.meta.url)
+            .pathname,
+        ],
+        {
+          cwd: new URL("../../../..", import.meta.url).pathname,
+          env: {
+            ...process.env,
+            DATABASE_URL: process.env.STEWARD_PLATFORM_DATABASE_URL,
+            TEST_USER_ID: userId,
+            TEST_REQUEST_ID: successRequestId,
+            TEST_EXPECTED_DATABASE_ROLE: platformRole,
+          },
+          stderr: "pipe",
+        },
+      );
+      await waitForWaiters(admin, 2, "concurrent metadata writer did not reach serialization lock");
+      await locker`select pg_advisory_unlock(${gateKey})`;
+      gateLocked = false;
 
-    const [failedResponse, writerExit] = await Promise.all([failedRequest, writer.exited]);
-    if (writerExit !== 0) throw new Error(await new Response(writer.stderr).text());
-    expect(failedResponse.status).toBe(500);
-    expect(dispatchWebhookMock).not.toHaveBeenCalled();
-    const [stored] = await admin.db.select({ metadata: users.customMetadata })
-      .from(users).where(eq(users.id, userId));
-    expect(stored?.metadata).toEqual({ owner: "concurrent-winner" });
-    const events = await admin.db.select({ action: auditEvents.action, requestId: auditEvents.requestId })
-      .from(auditEvents).where(and(eq(auditEvents.resourceId, userId),
-        inArray(auditEvents.requestId, [failedRequestId, successRequestId])));
-    expect(events.filter((event) => event.requestId === failedRequestId)).toEqual([
-      { action: "user.metadata.update.authorized", requestId: failedRequestId },
-    ]);
-    expect(events.filter((event) => event.requestId === successRequestId)).toEqual([
-      { action: "user.metadata.update", requestId: successRequestId },
-    ]);
-  } finally {
-    if (gateLocked) await locker`select pg_advisory_unlock(${gateKey})`;
-    locker.release();
-    await admin.client.unsafe(`drop trigger if exists "${triggerName}" on audit_events`);
-    await admin.client.unsafe(`drop function if exists "${triggerFunction}"()`);
-    if (userId) await admin.db.delete(users).where(eq(users.id, userId));
-    if (roleCreated) {
-      await admin.client.unsafe(`DROP OWNED BY ${quoteIdentifier(platformRole)}`);
-      await admin.client.unsafe(`DROP ROLE ${quoteIdentifier(platformRole)}`);
+      const [failedResponse, writerExit] = await Promise.all([failedRequest, writer.exited]);
+      if (writerExit !== 0) throw new Error(await new Response(writer.stderr).text());
+      expect(failedResponse.status).toBe(500);
+      expect(dispatchWebhookMock).not.toHaveBeenCalled();
+      const [stored] = await admin.db
+        .select({ metadata: users.customMetadata })
+        .from(users)
+        .where(eq(users.id, userId));
+      expect(stored?.metadata).toEqual({ owner: "concurrent-winner" });
+      const events = await admin.db
+        .select({ action: auditEvents.action, requestId: auditEvents.requestId })
+        .from(auditEvents)
+        .where(
+          and(
+            eq(auditEvents.resourceId, userId),
+            inArray(auditEvents.requestId, [failedRequestId, successRequestId]),
+          ),
+        );
+      expect(events.filter((event) => event.requestId === failedRequestId)).toEqual([
+        { action: "user.metadata.update.authorized", requestId: failedRequestId },
+      ]);
+      expect(events.filter((event) => event.requestId === successRequestId)).toEqual([
+        { action: "user.metadata.update", requestId: successRequestId },
+      ]);
+    } finally {
+      if (gateLocked) await locker`select pg_advisory_unlock(${gateKey})`;
+      locker.release();
+      await admin.client.unsafe(`drop trigger if exists "${triggerName}" on audit_events`);
+      await admin.client.unsafe(`drop function if exists "${triggerFunction}"()`);
+      if (userId) await admin.db.delete(users).where(eq(users.id, userId));
+      if (roleCreated) {
+        await admin.client.unsafe(`DROP OWNED BY ${quoteIdentifier(platformRole)}`);
+        await admin.client.unsafe(`DROP ROLE ${quoteIdentifier(platformRole)}`);
+      }
+      await admin.client.end();
+      restore("STEWARD_PLATFORM_KEYS", oldKeys);
+      restore("STEWARD_PLATFORM_KEY_SCOPES", oldScopes);
+      restore("STEWARD_AUDIT_HMAC_KEY", oldAuditKey);
+      restore("STEWARD_PLATFORM_DATABASE_URL", oldPlatformDatabaseUrl);
+      restore("STEWARD_PLATFORM_DATABASE_ROLE", oldPlatformDatabaseRole);
+      __resetAuditHmacKeyCacheForTests();
     }
-    await admin.client.end();
-    restore("STEWARD_PLATFORM_KEYS", oldKeys);
-    restore("STEWARD_PLATFORM_KEY_SCOPES", oldScopes);
-    restore("STEWARD_AUDIT_HMAC_KEY", oldAuditKey);
-    restore("STEWARD_PLATFORM_DATABASE_URL", oldPlatformDatabaseUrl);
-    restore("STEWARD_PLATFORM_DATABASE_ROLE", oldPlatformDatabaseRole);
-    __resetAuditHmacKeyCacheForTests();
-  }
-}, 120_000);
+  },
+  120_000,
+);
 
-async function waitForWaiters(admin: ReturnType<typeof createDb>, minimum: number, message: string) {
+async function waitForWaiters(
+  admin: ReturnType<typeof createDb>,
+  minimum: number,
+  message: string,
+) {
   for (let attempt = 0; attempt < 200; attempt++) {
     const [row] = await admin.client<{ count: string }[]>`
       select count(*)::text as count from pg_stat_activity where wait_event = 'advisory'`;

--- a/packages/api/src/__tests__/solana-recovery-anchor.test.ts
+++ b/packages/api/src/__tests__/solana-recovery-anchor.test.ts
@@ -628,7 +628,6 @@ describe("Solana durable recovery anchors", () => {
   });
 
   it("never takes over an expired lease after its parsed claim entered raw custody", async () => {
-    const context = await import("../services/context");
     const originalSign = Vault.prototype.signSolanaTransaction;
     let signCalls = 0;
     let submittedCalls = 0;

--- a/packages/api/src/__tests__/tenant-policy-retirement.test.ts
+++ b/packages/api/src/__tests__/tenant-policy-retirement.test.ts
@@ -52,12 +52,16 @@ beforeAll(async () => {
   tenantConfigs = context.tenantConfigs;
   getPolicySet = context.getPolicySet;
 
-  await getDb().insert(tenants).values({
-    id: TENANT_ID,
-    name: "Tenant policy retirement",
-    apiKeyHash: `hash-${TENANT_ID}`,
-  });
-  await getDb().insert(users).values({ id: USER_ID, email: `${USER_ID}@example.test` });
+  await getDb()
+    .insert(tenants)
+    .values({
+      id: TENANT_ID,
+      name: "Tenant policy retirement",
+      apiKeyHash: `hash-${TENANT_ID}`,
+    });
+  await getDb()
+    .insert(users)
+    .values({ id: USER_ID, email: `${USER_ID}@example.test` });
   await getDb().insert(userTenants).values({ userId: USER_ID, tenantId: TENANT_ID, role: "owner" });
   const { createSessionToken } = await import("../routes/auth");
   sessionToken = await createSessionToken("0x0000000000000000000000000000000000000000", TENANT_ID, {
@@ -76,7 +80,9 @@ afterAll(async () => {
   await getDb().delete(policies).where(eq(policies.agentId, "missing-policy-agent"));
   await getDb().delete(userTenants).where(eq(userTenants.tenantId, TENANT_ID));
   await getDb().delete(users).where(eq(users.id, USER_ID));
-  await getDb().delete(tenants).where(inArray(tenants.id, [TENANT_ID, CREATE_ID]));
+  await getDb()
+    .delete(tenants)
+    .where(inArray(tenants.id, [TENANT_ID, CREATE_ID]));
   await closeDb();
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_AUDIT_HMAC_KEY;

--- a/packages/api/src/__tests__/tenant-webhook-deprecation.test.ts
+++ b/packages/api/src/__tests__/tenant-webhook-deprecation.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   __resetAuditHmacKeyCacheForTests,
   auditEvents,
@@ -11,8 +13,6 @@ import {
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { and, eq, inArray } from "drizzle-orm";
 import { Hono } from "hono";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import type { AppVariables } from "../services/context";
 
 const PLATFORM_KEY = "legacy-webhook-platform-key-with-enough-entropy";
@@ -161,6 +161,6 @@ describe("legacy tenant webhook deprecation", () => {
     expect(tenantDocs).toContain("returns HTTP 410 for both `webhookUrl`");
     expect(tenantDocs).toContain("The generated OpenAPI contract likewise");
     expect(tenantDocs).not.toContain("Update the default policies for a tenant");
-    expect(openApi).not.toContain('\"/tenants/{id}/webhook\"');
+    expect(openApi).not.toContain('"/tenants/{id}/webhook"');
   });
 });

--- a/packages/api/src/__tests__/wallet-actions.test.ts
+++ b/packages/api/src/__tests__/wallet-actions.test.ts
@@ -774,6 +774,13 @@ describe("wallet transfer actions", () => {
         signature: "base64-signed-spl-transfer-transaction",
         broadcast: false,
         chainId: request.chainId,
+        artifactSignature:
+          "3oL4p7QvN3UH7V5wMGZgW5PuzEk4A9LXLHk9RxAoKjDKuLbQBsfXN8kEvKfj5K1oEJa8wFF6RVp2h7pP9w2f51ZV",
+        signer: "11111111111111111111111111111111",
+        recentBlockhash: "11111111111111111111111111111111",
+        blockhashKind: "recent",
+        lastValidBlockHeight: 1_000,
+        rawIntentDigest: "a".repeat(64),
       };
     };
 

--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -14,8 +14,8 @@ import {
   withTenantTransactionDatabase,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import * as redisMiddleware from "../middleware/redis";
 import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import * as redisMiddleware from "../middleware/redis";
 import {
   __resetWorkerRlsReadinessForTests,
   __setWorkerInitForTests,

--- a/packages/api/src/routes/secrets.ts
+++ b/packages/api/src/routes/secrets.ts
@@ -17,7 +17,7 @@ import {
   tenantConfigs as tenantConfigsTable,
 } from "@stwd/db";
 import { type SecretVault, validateSecretRouteConfig } from "@stwd/vault";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import {
   type AuditEventInput,

--- a/packages/api/src/routes/tenants.ts
+++ b/packages/api/src/routes/tenants.ts
@@ -13,13 +13,11 @@ import {
 } from "@stwd/db";
 import { eq } from "drizzle-orm";
 import { type Context, Hono, type Next } from "hono";
-import { withTenantAuditedTransaction, writeAuditEvent } from "../services/audit";
+import { withTenantAuditedTransaction } from "../services/audit";
 import {
   type ApiResponse,
   type AppVariables,
   db,
-  findTenant,
-  getConditionSetReferenceValidationError,
   getTenantPayload,
   isNonEmptyString,
   isValidTenantId,

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -10246,6 +10246,7 @@ type SolanaRecoveryRow = {
   txHash: string | null;
   chainId: number;
   actionPayload: unknown;
+  signedArtifactEvidence?: unknown;
   actionType?: string | null;
 };
 
@@ -10275,6 +10276,9 @@ function solanaReplayResponse(
     ) as Response;
   }
   if ((row.status === "broadcast" || row.status === "confirmed") && row.txHash) {
+    const evidence = isSignedArtifactEvidence(row.signedArtifactEvidence)
+      ? row.signedArtifactEvidence
+      : null;
     return c.json<ApiResponse<SolanaSigningResult & { txId: string }>>({
       ok: true,
       data: {
@@ -10283,6 +10287,24 @@ function solanaReplayResponse(
         broadcast: true,
         chainId: row.chainId,
         caip2: toCaip2(row.chainId),
+        ...(evidence?.chainFamily === "solana"
+          ? {
+              artifactSignature: evidence.artifactSignature,
+              signer: evidence.signer,
+              recentBlockhash: evidence.recentBlockhash,
+              blockhashKind: evidence.blockhashKind,
+              ...(evidence.lastValidBlockHeight === undefined
+                ? {}
+                : { lastValidBlockHeight: evidence.lastValidBlockHeight }),
+              ...(evidence.durableNonceAccount === undefined
+                ? {}
+                : { durableNonceAccount: evidence.durableNonceAccount }),
+              ...(evidence.durableNonceAuthority === undefined
+                ? {}
+                : { durableNonceAuthority: evidence.durableNonceAuthority }),
+              rawIntentDigest: evidence.rawIntentDigest,
+            }
+          : {}),
       },
     });
   }

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -696,6 +696,8 @@ function transferActionPayload(input: {
   broadcast: boolean;
   referenceId?: string | null;
   sponsorship?: Record<string, unknown>;
+  idempotencyKeyDigest?: string;
+  requestDigest?: string;
 }) {
   return {
     type: "transfer",
@@ -705,6 +707,8 @@ function transferActionPayload(input: {
     broadcast: input.broadcast,
     ...(input.referenceId ? { referenceId: input.referenceId } : {}),
     ...(input.sponsorship ? { sponsorship: input.sponsorship } : {}),
+    ...(input.idempotencyKeyDigest ? { idempotencyKeyDigest: input.idempotencyKeyDigest } : {}),
+    ...(input.requestDigest ? { requestDigest: input.requestDigest } : {}),
   };
 }
 
@@ -872,6 +876,21 @@ async function findActionByReferenceId(
         eq(transactions.agentId, agentId),
         eq(transactions.actionType, actionType),
         sql`(${transactions.actionPayload}->>'referenceId' = ${referenceId} or ${transactions.actionPayload}->>'reference_id' = ${referenceId})`,
+      ),
+    )
+    .limit(1);
+  return existing ?? null;
+}
+
+async function findActionByIdempotency(agentId: string, actionType: string, keyDigest: string) {
+  const [existing] = await db
+    .select()
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.agentId, agentId),
+        eq(transactions.actionType, actionType),
+        sql`${transactions.actionPayload}->>'idempotencyKeyDigest' = ${keyDigest}`,
       ),
     )
     .limit(1);
@@ -4204,7 +4223,11 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
           policyResults: evaluation.results,
         },
       });
-      if (sponsorshipPayload?.sponsored === true && !solanaRecoveryBinding) {
+      if (
+        sponsorshipPayload?.sponsored === true &&
+        !solanaRecoveryBinding &&
+        !solanaExecutionToken
+      ) {
         await db.insert(transactions).values({
           id: actionId,
           agentId,
@@ -4266,14 +4289,14 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
             blockhashKind: "recent" | "durable_nonce" | "unknown";
           }
         | undefined;
+      let solanaSigningResult: SolanaSigningResult | null = null;
       if (isSolanaTokenTransfer) {
         if (!signRequest.data) {
           throw new Error("SPL transfer transaction was not built");
         }
-        // Sponsored actions are pre-staged before the durable reservation so
-        // sponsored_gas_events can satisfy its transaction FK. Reuse that row
-        // for SPL execution instead of inserting the same action id twice.
-        if (!solanaRecoveryBinding && !sponsoredTransferStaged)
+        // Parsed SPL execution is normally pre-staged by the durable Solana
+        // claim above. Only create a row when no claim or sponsorship row did.
+        if (!solanaExecutionToken && !sponsoredTransferStaged)
           await db.insert(transactions).values({
             id: actionId,
             agentId,
@@ -4341,6 +4364,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
             consumeExecutionClaim: consumeParsedSolanaExecutionClaim,
           },
         );
+        solanaSigningResult = { ...signed, caip2: toCaip2(transfer.chainId) };
         result = signed.signature;
         if (signed.artifactSignature && signed.recentBlockhash && signed.blockhashKind) {
           solanaArtifactEvidence = {
@@ -4374,12 +4398,13 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
       if (
         isSolanaTokenTransfer &&
         solanaExecutionToken &&
-        !(await finalizeSolanaRecoveryAnchor(actionId, agentId, solanaExecutionToken, {
-          signature: result,
-          broadcast: transfer.broadcast,
-          chainId: transfer.chainId,
-          caip2: toCaip2(transfer.chainId),
-        }))
+        (!solanaSigningResult ||
+          !(await finalizeSolanaRecoveryAnchor(
+            actionId,
+            agentId,
+            solanaExecutionToken,
+            solanaSigningResult,
+          )))
       ) {
         return solanaLostOwnershipResponse(c, actionId, agentId, "transfer");
       }
@@ -4414,7 +4439,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
                   eq(transactions.status, txStatus),
                   transfer.broadcast
                     ? eq(transactions.txHash, result)
-                    : sql`${transactions.txHash} is null`,
+                    : eq(transactions.txHash, solanaSigningResult?.artifactSignature ?? ""),
                   sql`${transactions.actionPayload}->>'executionToken' = ${solanaExecutionToken}`,
                 )
               : undefined,

--- a/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
+++ b/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
@@ -88,6 +88,34 @@ describe("SUBMIT_TRADE action", () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe(`${nearMiss}/v1/trade/sessions/ses_test`);
   });
 
+  it("strips terminal slash runs while preserving redirect refusal", async () => {
+    process.env.STEWARD_API_URL = `https://steward.example${"/".repeat(200_000)}`;
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, data: { status: "active" } }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      submitTradeAction.validate({} as any, mockMemory("buy 0.01 BTC") as any),
+    ).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://steward.example/v1/trade/sessions/ses_test",
+      expect.objectContaining({ redirect: "error" }),
+    );
+  });
+
+  it("rejects credential-bearing URLs after terminal slash normalization", async () => {
+    process.env.STEWARD_API_URL = "https://user:secret@steward.example////";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      submitTradeAction.validate({} as any, mockMemory("buy 0.01 BTC") as any),
+    ).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("posts parsed order with Bearer JWT and returns confirmation", async () => {
     const fetchMock = vi.fn(
       async () =>

--- a/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
+++ b/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
@@ -73,6 +73,21 @@ describe("SUBMIT_TRADE action", () => {
     );
   });
 
+  it("normalizes adversarial API URL slash runs without regex backtracking", async () => {
+    const nearMiss = `https://steward.example/${"/".repeat(200_000)}x`;
+    process.env.STEWARD_API_URL = nearMiss;
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, data: { status: "active" } }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      submitTradeAction.validate({} as any, mockMemory("buy 0.01 BTC") as any),
+    ).resolves.toBe(true);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(`${nearMiss}/v1/trade/sessions/ses_test`);
+  });
+
   it("posts parsed order with Bearer JWT and returns confirmation", async () => {
     const fetchMock = vi.fn(
       async () =>

--- a/packages/eliza-plugin/src/actions/submit-trade.ts
+++ b/packages/eliza-plugin/src/actions/submit-trade.ts
@@ -77,8 +77,15 @@ function stewardJwt(runtime: IAgentRuntime): string | undefined {
   return envValue(runtime, "STEWARD_JWT");
 }
 
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 0x2f) end -= 1;
+  return end === value.length ? value : value.slice(0, end);
+}
+
 function stewardApiUrl(runtime: IAgentRuntime): string | undefined {
-  const apiUrl = envValue(runtime, "STEWARD_API_URL")?.replace(/\/+$/, "");
+  const configuredUrl = envValue(runtime, "STEWARD_API_URL");
+  const apiUrl = configuredUrl ? stripTrailingSlashes(configuredUrl) : undefined;
   // Reject plaintext non-localhost URLs here too: this action reads the env URL
   // directly and would otherwise send the agent JWT in cleartext.
   if (apiUrl) assertSecureApiUrl(apiUrl);

--- a/packages/solana-signer/src/__tests__/bridge.test.ts
+++ b/packages/solana-signer/src/__tests__/bridge.test.ts
@@ -1,7 +1,9 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { connect } from "node:net";
 import { Keypair, Transaction } from "@solana/web3.js";
 import {
   BRIDGE_MAX_BODY_BYTES,
+  BRIDGE_MAX_TOKEN_BYTES,
   BRIDGE_MIN_TOKEN_BYTES,
   BRIDGE_TOKEN_ENV,
   BRIDGE_TOKEN_HEADER,
@@ -52,6 +54,37 @@ function authed(path: string, init: RequestInit = {}): Promise<Response> {
   return fetch(`${bridgeUrl}${path}`, {
     ...init,
     headers: { ...(init.headers ?? {}), [BRIDGE_TOKEN_HEADER]: bridgeToken },
+  });
+}
+
+/** Send exact duplicate fields without Fetch/Headers combining them. */
+async function rawBridgeStatus(headerLines: string[]): Promise<number> {
+  const url = new URL(bridgeUrl);
+  return new Promise<number>((resolve, reject) => {
+    const socket = connect(Number(url.port), url.hostname);
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.on("connect", () => {
+      socket.write(
+        [
+          `GET /pubkey HTTP/1.1`,
+          `Host: ${url.host}`,
+          ...headerLines,
+          "Connection: close",
+          "",
+          "",
+        ].join("\r\n"),
+      );
+    });
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
+    socket.on("end", () => {
+      const match = /^HTTP\/1\.1 (\d{3}) /.exec(response);
+      if (!match) return reject(new Error("bridge returned no HTTP status"));
+      resolve(Number(match[1]));
+    });
+    socket.on("error", reject);
   });
 }
 
@@ -177,11 +210,55 @@ describe("bridge shared-secret auth", () => {
     expect(body.address.length).toBeGreaterThan(30);
   });
 
+  it("treats the bearer scheme case-insensitively", async () => {
+    const res = await fetch(`${bridgeUrl}/pubkey`, {
+      headers: { authorization: `bearer ${bridgeToken}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
   it("refuses a wrong bearer token with 401", async () => {
     const res = await fetch(`${bridgeUrl}/pubkey`, {
       headers: { authorization: `Bearer ${bridgeToken}x` },
     });
     expect(res.status).toBe(401);
+  });
+
+  it("rejects ambiguous bearer whitespace, folded values, and duplicate fields", async () => {
+    for (const authorization of [
+      `Bearer  ${bridgeToken}`,
+      `Bearer\t${bridgeToken}`,
+      `Bearer ${bridgeToken}, Bearer ${bridgeToken}`,
+    ]) {
+      const res = await fetch(`${bridgeUrl}/pubkey`, { headers: { authorization } });
+      expect(res.status).toBe(401);
+    }
+    expect(
+      await rawBridgeStatus([
+        `Authorization: Bearer ${bridgeToken}`,
+        `Authorization: Bearer ${bridgeToken}`,
+      ]),
+    ).toBe(401);
+    expect(
+      await rawBridgeStatus([
+        `${BRIDGE_TOKEN_HEADER}: ${bridgeToken}`,
+        `${BRIDGE_TOKEN_HEADER}: ${bridgeToken}`,
+        `Authorization: Bearer ${bridgeToken}`,
+      ]),
+    ).toBe(401);
+  });
+
+  it("bounds bearer and configured tokens without reflecting them", async () => {
+    const canary = "TOKEN_SECRET_CANARY";
+    const oversized = `${canary}${"a".repeat(BRIDGE_MAX_TOKEN_BYTES)}`;
+    const res = await fetch(`${bridgeUrl}/pubkey`, {
+      headers: { authorization: `Bearer ${oversized}` },
+    });
+    expect(res.status).toBe(401);
+    expect(await res.text()).not.toContain(canary);
+    await expect(startSignerBridge(signer, { token: oversized })).rejects.toThrow(
+      new RegExp(`at most ${BRIDGE_MAX_TOKEN_BYTES} bytes`),
+    );
   });
 
   it("the custom header wins over a bearer header when both are present", async () => {

--- a/packages/solana-signer/src/__tests__/bridge.test.ts
+++ b/packages/solana-signer/src/__tests__/bridge.test.ts
@@ -261,11 +261,34 @@ describe("bridge shared-secret auth", () => {
     );
   });
 
-  it("the custom header wins over a bearer header when both are present", async () => {
-    const res = await fetch(`${bridgeUrl}/pubkey`, {
+  it("accepts the exact maximum token68 boundary on both transports", async () => {
+    const suffix = "-._~+/==";
+    const maxToken = `${"a".repeat(BRIDGE_MAX_TOKEN_BYTES - suffix.length)}${suffix}`;
+    expect(Buffer.byteLength(maxToken, "utf8")).toBe(BRIDGE_MAX_TOKEN_BYTES);
+    const boundaryBridge = await startSignerBridge(signer, { token: maxToken });
+    try {
+      const bearer = await fetch(`${boundaryBridge.url}/pubkey`, {
+        headers: { authorization: `bEaReR ${maxToken}` },
+      });
+      expect(bearer.status).toBe(200);
+      const custom = await fetch(`${boundaryBridge.url}/pubkey`, {
+        headers: { [BRIDGE_TOKEN_HEADER]: maxToken },
+      });
+      expect(custom.status).toBe(200);
+    } finally {
+      await boundaryBridge.close();
+    }
+  });
+
+  it("the custom header wins fail-closed over a bearer header when both are present", async () => {
+    const rejected = await fetch(`${bridgeUrl}/pubkey`, {
       headers: { [BRIDGE_TOKEN_HEADER]: `${bridgeToken}x`, authorization: `Bearer ${bridgeToken}` },
     });
-    expect(res.status).toBe(401);
+    expect(rejected.status).toBe(401);
+    const accepted = await fetch(`${bridgeUrl}/pubkey`, {
+      headers: { [BRIDGE_TOKEN_HEADER]: bridgeToken, authorization: "Basic ignored" },
+    });
+    expect(accepted.status).toBe(200);
   });
 
   it(`honors ${BRIDGE_TOKEN_ENV} from the env, the var both sides read`, async () => {

--- a/packages/solana-signer/src/bridge.ts
+++ b/packages/solana-signer/src/bridge.ts
@@ -38,6 +38,8 @@ export const BRIDGE_TOKEN_ENV = "STEWARD_SIGNER_BRIDGE_TOKEN";
 /** Enough for Solana's transaction limit plus JSON/hints, while bounding RAM. */
 export const BRIDGE_MAX_BODY_BYTES = 16 * 1024;
 export const BRIDGE_MIN_TOKEN_BYTES = 32;
+/** Bounds configured and presented secrets before hashing or comparison. */
+export const BRIDGE_MAX_TOKEN_BYTES = 1024;
 
 export interface SignerBridgeOptions {
   /** Bind host. Loopback by default; never expose this beyond the machine. */
@@ -49,7 +51,8 @@ export interface SignerBridgeOptions {
    *  (for callers that only speak standard bearer auth, e.g. AgentNet's
    *  remote-wallet client). Omitted: STEWARD_SIGNER_BRIDGE_TOKEN from the
    *  env when set, else a fresh random token per session (read it from the
-   *  returned bridge's `token`). Must contain at least 32 UTF-8 bytes. */
+   *  returned bridge's `token`). Must contain 32-1024 UTF-8 bytes. Bearer
+   *  transport additionally requires the standard token68 character set. */
   token?: string;
 }
 
@@ -61,24 +64,46 @@ export interface SignerBridge {
   close(): Promise<void>;
 }
 
-/** Constant-time header check; hashing first keeps lengths equal. */
-function tokenMatches(presented: string | string[] | undefined, expected: string): boolean {
-  if (typeof presented !== "string") return false;
+/** Constant-time check after a fixed public bound; hashing keeps lengths equal. */
+function tokenMatches(presented: string | undefined, expected: string): boolean {
+  if (presented === undefined || Buffer.byteLength(presented, "utf8") > BRIDGE_MAX_TOKEN_BYTES) {
+    return false;
+  }
   return timingSafeEqual(
     createHash("sha256").update(presented).digest(),
     createHash("sha256").update(expected).digest(),
   );
 }
 
-/** The request's presented secret: the bridge header verbatim, else the token
- *  of a standard `Authorization: Bearer <token>` header. Callers that cannot
- *  set custom headers (AgentNet's remote-wallet client sends only bearer
- *  auth) still authenticate; everyone else keeps the existing header. */
-function presentedToken(req: IncomingMessage): string | string[] | undefined {
-  const custom = req.headers[BRIDGE_TOKEN_HEADER];
-  if (custom !== undefined) return custom;
-  const auth = req.headers.authorization;
-  if (typeof auth === "string" && auth.startsWith("Bearer ")) return auth.slice("Bearer ".length);
+const BEARER_AUTHORIZATION = /^Bearer ([A-Za-z0-9\-._~+/]+={0,})$/i;
+
+function rawHeaderValues(req: IncomingMessage, name: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < req.rawHeaders.length; index += 2) {
+    if (req.rawHeaders[index]?.toLowerCase() === name) {
+      values.push(req.rawHeaders[index + 1] ?? "");
+    }
+  }
+  return values;
+}
+
+/** Return one unambiguous secret. `rawHeaders` is intentional: runtimes may
+ *  discard or join duplicate Authorization fields in `headers`, while peers
+ *  and proxies can choose a different occurrence. The custom header retains
+ *  precedence, including when malformed, so it cannot fall through to a
+ *  second credential. */
+function presentedToken(req: IncomingMessage): string | undefined {
+  const custom = rawHeaderValues(req, BRIDGE_TOKEN_HEADER);
+  if (custom.length > 0) return custom.length === 1 ? custom[0] : undefined;
+
+  const authorization = rawHeaderValues(req, "authorization");
+  if (authorization.length !== 1) return undefined;
+  const value = authorization[0];
+  if (Buffer.byteLength(value, "utf8") > BRIDGE_MAX_TOKEN_BYTES + "Bearer ".length) {
+    return undefined;
+  }
+  const match = BEARER_AUTHORIZATION.exec(value);
+  if (match) return match[1];
   return undefined;
 }
 
@@ -156,6 +181,12 @@ export async function startSignerBridge(
     throw new StewardSignerError(
       "api",
       `signer bridge token must contain at least ${BRIDGE_MIN_TOKEN_BYTES} bytes`,
+    );
+  }
+  if (Buffer.byteLength(token, "utf8") > BRIDGE_MAX_TOKEN_BYTES) {
+    throw new StewardSignerError(
+      "api",
+      `signer bridge token must contain at most ${BRIDGE_MAX_TOKEN_BYTES} bytes`,
     );
   }
 

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -5,11 +5,11 @@ export type {
 } from "./persistent-queue";
 export { PersistentQueue } from "./persistent-queue";
 export { RetryQueue } from "./queue";
-export type { WebhookSecretAuthority } from "./secret-codec";
 export {
   currentWebhookRuntimeAuthority,
   type WebhookRuntimeAuthority,
 } from "./runtime-authority";
+export type { WebhookSecretAuthority } from "./secret-codec";
 export {
   decryptWebhookSecret,
   encryptWebhookSecret,


### PR DESCRIPTION
## Summary
- recover the unique security fixes from closed PRs #566 and #570
- recover only the valid Docker required-check hunk from closed PR #784
- restore transfer idempotency metadata and lookup
- fix SPL parsed-signing recovery so its staged anchor is not inserted twice and complete signed-artifact evidence reaches the durable finalizer/CAS
- preserve complete digest-bound Solana evidence in durable replay responses
- clean current API lint failures without reviving superseded carriers

## Closed-PR audit
All 119 closed-but-unmerged PRs were classified by immutable ref, ancestry/patch equivalence, current-tree behavior, and closure history. The rest are already integrated/superseded or have documented correctness/security defects. Closed #862 was not cherry-picked; its corrected successor is now on develop.

## Exact-head verification
- base: `3519acdbb1faffe566542ec30e595c2f4e8478c8`
- head: `11d9207b166df7570c1a2970fd1e45bd2e956d68`
- API wallet-actions + Solana recovery: 22/22 tests, 292 assertions
- signer bridge: 22/22 tests, 49 assertions
- Eliza submit-trade Vitest: 17/17
- API TypeScript build, signer build, Eliza package build
- Biome on all 15 changed TS/JSON files
- `git diff --check origin/develop...HEAD`

Refs #653. Refs #657.

Do not merge without exact-head checks and independent review.