### PR TITLE
fix(auth): backport migrated auth-store reuse to main

### DIFF
--- a/packages/auth/src/__tests__/store-backends.test.ts
+++ b/packages/auth/src/__tests__/store-backends.test.ts
@@ -4,6 +4,7 @@ import {
   buildBackend,
   MemoryBackend,
   NamespacedStoreBackend,
+  PostgresBackend,
   RedisBackend,
   type RedisLike,
   type StoreBackend,
@@ -88,6 +89,33 @@ describe("buildBackend Redis smoke test", () => {
     });
     const { source } = await buildBackend("challenge", client, false);
     expect(source).toBe("memory");
+  });
+});
+
+describe("PostgresBackend initialization", () => {
+  it("uses a pre-migrated auth store without attempting application-role DDL", async () => {
+    const statements: string[] = [];
+    let transactionCalls = 0;
+    const client = (async (strings: TemplateStringsArray) => {
+      const statement = strings.join("?");
+      statements.push(statement);
+      if (statement.includes("to_regclass")) return [{ relation: "auth_kv_store" }];
+      return [];
+    }) as unknown as ReturnType<typeof import("@stwd/db").getSql>;
+    client.begin = async () => {
+      transactionCalls += 1;
+      throw new Error("application role must not run DDL");
+    };
+
+    const backend = new PostgresBackend("challenge", client);
+    await backend.set("probe", "value", 1_000);
+
+    expect(transactionCalls).toBe(0);
+    expect(statements.some((statement) => statement.includes("to_regclass"))).toBe(true);
+    expect(statements.some((statement) => statement.includes("INSERT INTO auth_kv_store"))).toBe(
+      true,
+    );
+    expect(statements.some((statement) => statement.includes("CREATE TABLE"))).toBe(false);
   });
 });
 

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -397,15 +397,25 @@ export class PostgresBackend implements StoreBackend {
    * @param namespace  Logical partition (e.g. "challenge", "token") so multiple
    *                   stores can share the same table without key collision.
    */
-  constructor(private readonly namespace: string) {}
+  constructor(
+    private readonly namespace: string,
+    private readonly sqlClient?: ReturnType<typeof getSql>,
+  ) {}
 
   private getSqlClient() {
-    return getSql();
+    return this.sqlClient ?? getSql();
   }
 
   private async ensureTable(): Promise<void> {
     if (this.initialized) return;
     const sql = this.getSqlClient();
+    const [existing] = await sql<Array<{ relation: string | null }>>`
+      SELECT to_regclass('public.auth_kv_store')::text AS relation
+    `;
+    if (existing?.relation) {
+      this.initialized = true;
+      return;
+    }
     await sql.begin(async (transaction: TransactionSql) => {
       // CREATE TABLE IF NOT EXISTS can still race in PostgreSQL's catalogs when
       // separate fresh backend instances initialize concurrently. Production


### PR DESCRIPTION
## Summary

Narrow main backport of e5f84b782972568027460bec042d1b25a1df3265 from develop PR #832. A PostgreSQL-backed auth store now checks for the already-migrated auth_kv_store relation before attempting DDL, so a restricted application role can serve email/passkey challenges against a provisioned database.

This intentionally excludes sibling commit 482242f1. That commit modifies the later RLS deployment-safety subsystem, whose source files do not exist on current main, and cannot be cherry-picked without importing its broader migration/release dependency chain. The runtime auth-store change is independently applicable and tested on main.

This PR is a draft and must not bypass main branch protection.

## Validation on this exact main-based head

- @stwd/auth dependency build: 7/7 packages passed
- store-backends suite: 19 passed / 0 failed
- git diff --check: passed

## Operational scope

No database migration or deployment is included. This avoids application-role DDL only when the canonical auth table is already present; absent/incomplete schema still fails closed through the existing path.
