### PR TITLE
fix(auth): backport tenant-scoped login audits to main

### DIFF
--- a/packages/api/src/__tests__/auth-login-audit-rls-boundary.test.ts
+++ b/packages/api/src/__tests__/auth-login-audit-rls-boundary.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+const source = await Bun.file(new URL("../routes/auth.ts", import.meta.url)).text();
+
+function sourceBetween(startMarker: string, endMarker: string): string {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start + 1);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe("auth login audit RLS boundary", () => {
+  test("binds every auth.login audit to the verified user tenant", () => {
+    const auditHelper = sourceBetween(
+      "async function writeAuthLoginAudit(",
+      "async function findOrCreateWalletTenant(",
+    );
+    expect(auditHelper).toContain("withVerifiedAuthTenant(tenantId, userId");
+    expect(auditHelper).toContain('action: "auth.login"');
+  });
+
+  test("routes shared OAuth/session finalization through the guarded audit helper", () => {
+    const responseBuilder = sourceBetween(
+      "async function buildAuthOrMfaResponse(",
+      "function authExchangeJson(",
+    );
+    expect(responseBuilder).toContain("await writeAuthLoginAudit(c, tenantId, userId, claims)");
+    expect(responseBuilder).not.toContain("await writeAuditEvent(");
+  });
+});

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -2425,20 +2425,22 @@ async function writeAuthLoginAudit(
   claims: Record<string, unknown> | undefined,
   metadata: Record<string, unknown> = {},
 ): Promise<void> {
-  await writeAuditEvent({
-    tenantId,
-    actorType: "user",
-    actorId: userId,
-    action: "auth.login",
-    resourceType: "session",
-    metadata: {
-      method: typeof claims?.authMethod === "string" ? claims.authMethod : "unknown",
-      ...metadata,
-    },
-    ipAddress: c.req.header("x-forwarded-for") ?? null,
-    userAgent: c.req.header("user-agent") ?? null,
-    requestId: c.req.header("x-request-id") ?? null,
-  });
+  await withVerifiedAuthTenant(tenantId, userId, () =>
+    writeAuditEvent({
+      tenantId,
+      actorType: "user",
+      actorId: userId,
+      action: "auth.login",
+      resourceType: "session",
+      metadata: {
+        method: typeof claims?.authMethod === "string" ? claims.authMethod : "unknown",
+        ...metadata,
+      },
+      ipAddress: c.req.header("x-forwarded-for") ?? null,
+      userAgent: c.req.header("user-agent") ?? null,
+      requestId: c.get("requestId") ?? c.req.header("x-request-id") ?? null,
+    }),
+  );
 }
 
 type WalletTenantResult = {
@@ -3228,19 +3230,7 @@ async function buildAuthOrMfaResponse(
   }
 
   if (c) {
-    await writeAuditEvent({
-      tenantId,
-      actorType: "user",
-      actorId: userId,
-      action: "auth.login",
-      resourceType: "session",
-      metadata: {
-        method: typeof claims.authMethod === "string" ? claims.authMethod : "unknown",
-      },
-      ipAddress: c.req.header("x-forwarded-for") ?? null,
-      userAgent: c.req.header("user-agent") ?? null,
-      requestId: c.get("requestId") ?? null,
-    });
+    await writeAuthLoginAudit(c, tenantId, userId, claims);
   }
   const token = await createSessionToken(address, tenantId, sessionClaims);
   const refreshToken = await createRefreshToken(userId, tenantId, sessionClaims);


### PR DESCRIPTION
## Summary

Narrow main backport of develop commit 95909cfe1f456d7b74f5cc04598f73017b25b9c9 from PR #876. Shared OAuth/session completion now writes auth.login inside the verified user/tenant RLS transaction instead of using the unscoped duplicate path.

## Live staging evidence

On the current main-built staging image, a Discord callback at 2026-08-22T21:08:38Z completed provider exchange and wallet/default-policy provisioning, then logged OAuthAuth:discord provisionOAuthUser failed and returned HTTP 500 at 21:08:39Z. That post-provision failure boundary matches the RLS-denied login audit fixed here.

## Dependency assessment

Earlier develop commits 3b764500 (OAuth browser callback recovery) and 36e8a62d (IPv6 loopback redirects) are not on current main. They are not prerequisites for this fix: the cherry-pick applies without conflict, the existing main callback reached post-provision finalization live, and the exact main-based API graph builds. The IPv6 change is local-development-only; the browser recovery change should be reviewed as a separate backport because it is an 800-line callback/error-surface change.

This PR is a draft and must not bypass main branch protection.

## Validation on this exact main-based head

- API dependency build: 24/24 packages passed
- OAuth/login focused suites: 71 passed / 11 PostgreSQL-only skips / 0 failed
- Added login-audit RLS boundary: 2 passed / 0 failed
- git diff --check: passed

No database migration, deployment, or production mutation is included.
