### PR TITLE
ci: gate production promotion on main image provenance

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -10,6 +10,9 @@
 # should also require reviewer approval.
 name: Deploy Railway (Production)
 
+# Deliberately dispatch-only. A reusable workflow executes in the caller's
+# repository context, so actions/checkout and github.repository would verify
+# the caller's main branch rather than this image-producing repository.
 on:
   workflow_dispatch:
     inputs:
@@ -22,21 +25,6 @@ on:
         required: false
         type: boolean
         default: false
-
-  workflow_call:
-    inputs:
-      main_sha:
-        description: "Full 40-character commit SHA on the caller repository's main branch"
-        required: true
-        type: string
-      dry_run:
-        description: "Dry run (resolve and verify the digest; skip Railway mutation)"
-        required: false
-        type: boolean
-        default: false
-    secrets:
-      RAILWAY_TOKEN:
-        required: true
 
 permissions:
   actions: read

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -4,42 +4,33 @@
 #   develop ──(deploy-staging.yml, auto)──▶ STAGING
 #   main    ──(THIS workflow, manual/gated)──▶ PRODUCTION
 #
-# Production is promoted DELIBERATELY, never auto-deployed. Promotion = merge
-# develop -> main (reviewed), then a maintainer dispatches this workflow with
-# the image tag to ship (`main` or a `v*` release tag). The `production` GitHub
-# environment can carry required-reviewer protection for a second gate. Prod
-# should rarely change.
-#
-# Triggers:
-#   1. Manual dispatch (workflow_dispatch) with image tag input
-#   2. Reusable workflow (workflow_call) for downstream consumers that embed
-#      Steward as a dependency (Steward is a standalone, self-hostable OSS
-#      product; consumers integrate via its API, they do not own it).
+# Production accepts only an immutable digest whose exact source commit is on
+# main and has a successful Docker push run for main. A branch/tag string is
+# never an admissible production selector. The production GitHub environment
+# should also require reviewer approval.
 name: Deploy Railway (Production)
 
 on:
-  # Manual trigger from Actions tab
   workflow_dispatch:
     inputs:
-      image_tag:
-        description: "Docker image tag to deploy (e.g. v0.5.0, develop)"
+      main_sha:
+        description: "Full 40-character commit SHA already merged to main"
         required: true
         type: string
       dry_run:
-        description: "Dry run (skip actual deploy)"
+        description: "Dry run (resolve and verify the digest; skip Railway mutation)"
         required: false
         type: boolean
         default: false
 
-  # Reusable workflow (callable by downstream consumers embedding Steward)
   workflow_call:
     inputs:
-      image_tag:
-        description: "Docker image tag to deploy"
+      main_sha:
+        description: "Full 40-character commit SHA on the caller repository's main branch"
         required: true
         type: string
       dry_run:
-        description: "Dry run (skip actual deploy)"
+        description: "Dry run (resolve and verify the digest; skip Railway mutation)"
         required: false
         type: boolean
         default: false
@@ -48,76 +39,136 @@ on:
         required: true
 
 permissions:
+  actions: read
   contents: read
+  packages: read
   deployments: write
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # Bind to the `production` GitHub environment so required-reviewer / wait
-    # timer protection rules (configured in repo Settings → Environments) gate
-    # the prod deploy. This is the second gate on top of "only from main".
+    timeout-minutes: 15
     environment:
       name: Production
       url: ${{ vars.PRODUCTION_RAILWAY_HEALTH_URL }}
 
     steps:
-      - name: Checkout
+      # Always inspect the authoritative main ref. Selecting another branch in
+      # the workflow-dispatch UI must not change the source of a prod deploy.
+      - name: Checkout main history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          fetch-depth: 0
 
-      # Resolve the image tag based on trigger type
-      - name: Resolve image tag
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Verify main provenance and resolve immutable digest
         id: resolve
-        # image_tag is a caller-supplied input; pass it via env (never inline
-        # into the script) to avoid shell expression-injection.
         env:
-          IMAGE_TAG: ${{ inputs.image_tag }}
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ inputs.main_sha }}
+          TARGET_REPOSITORY: ${{ github.repository }}
+          CONFIGURED_IMAGE_REPO: ${{ vars.PRODUCTION_RAILWAY_IMAGE_REPO }}
         run: |
-          TAG="$IMAGE_TAG"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Image tag resolved: ${TAG}"
+          set -euo pipefail
 
-      - name: Resolve dry-run flag
-        id: flags
-        env:
-          DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          echo "dry_run=${DRY_RUN}" >> "$GITHUB_OUTPUT"
+          if [[ ! "$MAIN_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "main_sha must be a full lowercase 40-character commit SHA" >&2
+            exit 1
+          fi
 
-      # Create GitHub deployment (shows in repo's Deployments tab)
+          git cat-file -e "${MAIN_SHA}^{commit}"
+          if ! git merge-base --is-ancestor "$MAIN_SHA" refs/remotes/origin/main; then
+            echo "Refusing production deploy: commit is not on origin/main" >&2
+            exit 1
+          fi
+
+          # Being reachable from main is not enough: require the exact main
+          # push to have completed the image-producing Docker workflow.
+          SUCCESSFUL_MAIN_BUILDS=$(gh api --method GET \
+            "repos/${TARGET_REPOSITORY}/actions/workflows/docker.yml/runs" \
+            -f branch=main \
+            -f head_sha="$MAIN_SHA" \
+            -f event=push \
+            -f status=success \
+            -f per_page=1 \
+            --jq '.total_count')
+          if [[ ! "$SUCCESSFUL_MAIN_BUILDS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Refusing production deploy: no successful exact-SHA main Docker build" >&2
+            exit 1
+          fi
+
+          IMAGE_REPO="${CONFIGURED_IMAGE_REPO:-ghcr.io/steward-fi/steward}"
+          if [[ ! "$IMAGE_REPO" =~ ^ghcr\.io/[a-z0-9._-]+(/[a-z0-9._-]+)+$ ]]; then
+            echo "PRODUCTION_RAILWAY_IMAGE_REPO must be a lowercase ghcr.io repository" >&2
+            exit 1
+          fi
+
+          MANIFEST=$(docker buildx imagetools inspect \
+            "${IMAGE_REPO}:sha-${MAIN_SHA}" --format '{{json .Manifest}}')
+          DIGEST=$(jq -er \
+            '.digest | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$MANIFEST")
+
+          # Verify the bytes currently behind the lookup tag still carry the
+          # exact main-build provenance. This catches a later tag overwrite
+          # even when the historic Actions run itself was green.
+          PROVENANCE=$(docker buildx imagetools inspect \
+            "${IMAGE_REPO}:sha-${MAIN_SHA}" \
+            --format '{{json .Provenance.SLSA.buildDefinition.externalParameters.request.args}}')
+          REVISION=$(jq -er '."label:org.opencontainers.image.revision"' <<<"$PROVENANCE")
+          VERSION=$(jq -er '."label:org.opencontainers.image.version"' <<<"$PROVENANCE")
+          SOURCE=$(jq -er '."label:org.opencontainers.image.source"' <<<"$PROVENANCE")
+          if [[ "$REVISION" != "$MAIN_SHA" || "$VERSION" != "main" || \
+            "$SOURCE" != "https://github.com/${TARGET_REPOSITORY}" ]]; then
+            echo "Refusing production deploy: image provenance is not the exact main build" >&2
+            exit 1
+          fi
+
+          echo "sha=${MAIN_SHA}" >> "$GITHUB_OUTPUT"
+          echo "image_repo=${IMAGE_REPO}" >> "$GITHUB_OUTPUT"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "image_ref=${IMAGE_REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Production candidate resolved to an immutable main-built digest."
+
       - name: Create GitHub deployment
         id: deployment
         uses: chrnorm/deployment-action@500aa6a23c81ffa1acf71072aee3cfa2cc2e556a # v2
         with:
           token: ${{ github.token }}
           environment: production
-          ref: ${{ github.sha }}
-          description: "Deploy ghcr.io/steward-fi/steward:${{ steps.resolve.outputs.tag }} to Railway"
+          ref: ${{ steps.resolve.outputs.sha }}
+          description: "Deploy ${{ steps.resolve.outputs.image_ref }} to Railway"
 
-      # Run the deploy script
-      - name: Deploy to Railway
-        id: deploy
+      - name: Deploy immutable digest to Railway
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          # Instance-specific deploy target comes from the DEPLOYER's own repo
-          # config (a self-hoster sets PRODUCTION_RAILWAY_* vars for their own
-          # Railway). Nothing about any specific instance is baked into source.
           RAILWAY_SERVICE_ID: ${{ vars.PRODUCTION_RAILWAY_SERVICE_ID }}
           RAILWAY_ENV_ID: ${{ vars.PRODUCTION_RAILWAY_ENV_ID }}
           RAILWAY_HEALTH_URL: ${{ vars.PRODUCTION_RAILWAY_HEALTH_URL }}
-          # Step outputs derive from the caller-supplied image_tag input, so they
-          # are still tainted — pass via env instead of inlining into the script.
-          RESOLVED_TAG: ${{ steps.resolve.outputs.tag }}
-          DRY_RUN: ${{ steps.flags.outputs.dry_run }}
+          RAILWAY_IMAGE_REPO: ${{ steps.resolve.outputs.image_repo }}
+          RAILWAY_IMAGE_DIGEST: ${{ steps.resolve.outputs.digest }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          ARGS=("$RESOLVED_TAG")
+          ARGS=()
           if [[ "$DRY_RUN" == "true" ]]; then
             ARGS+=(--dry-run)
           fi
           chmod +x scripts/railway-deploy.sh
           ./scripts/railway-deploy.sh "${ARGS[@]}"
 
-      # Update deployment status on success
       - name: Update deployment status (success)
         if: success()
         uses: chrnorm/deployment-status@6df8d036fd2fee9eb82936733953da1f8382b41e # v2
@@ -127,9 +178,8 @@ jobs:
           state: success
           environment-url: ${{ vars.PRODUCTION_RAILWAY_HEALTH_URL }}
 
-      # Update deployment status on failure
       - name: Update deployment status (failure)
-        if: failure()
+        if: failure() && steps.deployment.outputs.deployment_id != ''
         uses: chrnorm/deployment-status@6df8d036fd2fee9eb82936733953da1f8382b41e # v2
         with:
           token: ${{ github.token }}

--- a/docs/RAILWAY-DEPLOY.md
+++ b/docs/RAILWAY-DEPLOY.md
@@ -37,7 +37,9 @@ railway link
 
 Or do it in the Railway dashboard: **Project → Settings → Connect Repo → select steward-fi**.
 
-Set the deploy branch (e.g. `develop` or `main`) under **Settings → Deploy → Branch**.
+For a development or staging service, set its deploy branch under **Settings →
+Deploy → Branch**. Production should use the gated immutable-digest workflow,
+not Railway branch auto-deploy.
 
 ---
 
@@ -185,6 +187,10 @@ Under **Service → Settings → Deploy → Health Check**:
 - **Port:** `3200`
 - **Timeout:** `45s` (Steward runs migrations on first boot, may take a moment)
 
+The repository's `railway.json` also declares `/health` with a 120-second
+timeout. Verify the effective service setting explicitly for image-only
+services, which may not consume repository config as code.
+
 ### Start Command
 
 Leave blank — the Dockerfile's `CMD` handles it:
@@ -196,7 +202,7 @@ CMD ["bun", "packages/api/src/index.ts"]
 
 ## 5. Deploy
 
-### Via GitHub (auto-deploy)
+### Via GitHub (staging auto-deploy)
 
 Push to your configured branch:
 
@@ -204,13 +210,18 @@ Push to your configured branch:
 git push origin develop
 ```
 
-Railway picks it up automatically. Watch the build in the dashboard.
+Railway picks it up automatically. Watch the build in the dashboard. Do not
+configure production to follow this mutable branch.
 
 ### Via CLI (manual)
 
 ```bash
 railway up
 ```
+
+Use direct CLI deploys for development or initial self-hosting only. Established
+production instances should follow the immutable, main-built digest flow in the
+[production promotion and rollback runbook](runbooks/production-promotion.md).
 
 ### Database release gate
 
@@ -378,7 +389,7 @@ Redeploy the Vercel app after setting these.
 
 ## 9. CI/CD
 
-### Auto-deploy on push (recommended)
+### Staging auto-deploy on push
 
 Railway auto-deploys when you push to the connected branch:
 
@@ -388,20 +399,29 @@ git push origin develop
 ```
 
 Configure the branch in **Service → Settings → Source → Deploy Branch**.
+Production must not auto-deploy a mutable branch or tag.
 
-### Manual deploy via CLI
+### Manual development deploy via CLI
 
 ```bash
 # Deploy current directory
 railway up
 
-# Deploy with a specific environment
-railway up --environment production
+# Deploy with a specific non-production environment
+railway up --environment staging
 ```
+
+For production, dispatch **Deploy Railway (Production)** with a full commit SHA
+already on `main`. The workflow requires an exact successful main Docker build,
+resolves its manifest digest, and passes only that digest to Railway. See the
+[production promotion and rollback runbook](runbooks/production-promotion.md).
 
 ### Rollback
 
-In the Railway dashboard: **Deployments → click a previous successful deploy → Rollback**.
+Redeploy the last known-good main commit through the same production workflow;
+the provenance, immutable-digest, `/health`, and `/ready` gates still apply.
+Do not roll production back to a mutable branch/tag selector. See the
+[production promotion and rollback runbook](runbooks/production-promotion.md).
 
 ---
 

--- a/docs/runbooks/production-promotion.md
+++ b/docs/runbooks/production-promotion.md
@@ -1,0 +1,81 @@
+# Production promotion and rollback
+
+This runbook is the release boundary between the continuously validated
+`develop` branch and production. Production must run an immutable image digest
+built by the Docker workflow for an exact commit already on `main`. Mutable
+tags such as `develop`, `main`, `latest`, and version tags are not production
+deployment inputs.
+
+The workflow and scripts are instance-neutral. Each operator supplies its own
+Railway service, environment, health origin, token, and optional image
+repository through GitHub environment secrets and variables.
+
+## Required controls
+
+- Protect `main`; changes arrive through reviewed pull requests with required
+  CI and Docker checks.
+- Protect the GitHub `Production` environment with required reviewers.
+- Configure Railway's platform health check to use `/health`. The repository's
+  `railway.json` declares that path for repository-backed services; verify the
+  effective service setting when an image-only service does not consume config
+  as code.
+- Set `PRODUCTION_RAILWAY_HEALTH_URL` to a credential-free public HTTPS root.
+  The deploy script accepts a release only after both `/health` and `/ready`
+  succeed.
+- Keep production pinned to `repository@sha256:<digest>`. Never repoint it to a
+  branch or release tag.
+
+## Promote
+
+1. Deploy the exact `develop` candidate to staging and record its commit and
+   image digest. Wait for Railway's `/health` gate and the deploy script's
+   `/ready` probe.
+2. Run the release-specific staging checks, including authentication and any
+   migration or provider flows changed by the candidate. Save the receipts.
+3. Open a `develop` to `main` promotion pull request. Reconcile `main` back into
+   the candidate through a reviewed branch when branch protection reports the
+   promotion behind. Do not bypass protection or substitute earlier evidence
+   after the head changes.
+4. Merge only after all required checks and review are green on the exact
+   promotion head.
+5. Wait for the `Docker` workflow triggered by the resulting `main` push to
+   succeed. Record the full 40-character `main` commit SHA.
+6. Dispatch **Deploy Railway (Production)** with that full `main_sha`. Start
+   with `dry_run=true` when changing deployment configuration or credentials.
+   The workflow fails closed unless the SHA is reachable from `origin/main`,
+   an exact-SHA successful `main` Docker run exists, the current manifest's
+   provenance names that exact revision and `main`, and the image resolves to a
+   valid `sha256` digest.
+7. Approve the protected `Production` environment. Record the commit, resolved
+   digest, Railway deployment ID, `/health`, and `/ready` receipts.
+
+The `sha-<commit>` tag is used only to find the manifest produced by the exact
+main build. Railway receives the resolved digest, not the tag.
+
+## Roll back
+
+1. Select the last known-good full commit SHA that is already on `main` and
+   whose exact `main` Docker run succeeded. Confirm that its schema is backward
+   compatible with the currently applied migrations. Database rollback is a
+   separate, explicitly reviewed operation; never infer it from an image
+   rollback.
+2. Dispatch **Deploy Railway (Production)** with that SHA. The same provenance,
+   digest, Railway status, `/health`, and `/ready` gates apply to rollback.
+3. If the previous release cannot pass current readiness, stop. Preserve the
+   live healthy deployment, diagnose the incompatibility, and ship a forward
+   fix through `develop` and `main`.
+4. Record the reason, old and restored digests, deployment IDs, health receipts,
+   and follow-up issue. Do not use Railway's branch/tag source selector as a
+   shortcut.
+
+## Failure behavior
+
+- A Railway build/deploy failure fails the workflow; an empty-log control-plane
+  rejection is also fatal by default.
+- A container that never passes `/health` is not eligible for Railway cutover
+  when the platform health check is configured.
+- A deployment that Railway marks successful still fails acceptance unless the
+  public `/health` and durable `/ready` probes pass within their timeouts.
+- Failed promotion does not authorize a production configuration mutation or a
+  database downgrade. Escalate with the captured diagnostics and keep the last
+  known-good digest live.

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "deploy": {
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 120
+  }
+}

--- a/scripts/__tests__/production-deploy-policy.test.ts
+++ b/scripts/__tests__/production-deploy-policy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../..");
+const workflow = readFileSync(resolve(repoRoot, ".github/workflows/deploy-railway.yml"), "utf8");
+const railwayConfig = JSON.parse(readFileSync(resolve(repoRoot, "railway.json"), "utf8"));
+
+describe("production deploy policy", () => {
+  test("accepts only a full main commit and verifies its exact main Docker build", () => {
+    expect(workflow).toContain("main_sha:");
+    expect(workflow).not.toContain("image_tag:");
+    expect(workflow).toContain("^[0-9a-f]{40}$");
+    expect(workflow).toContain('git merge-base --is-ancestor "$MAIN_SHA" refs/remotes/origin/main');
+    expect(workflow).toContain("actions/workflows/docker.yml/runs");
+    expect(workflow).toContain("-f branch=main");
+    expect(workflow).toContain('-f head_sha="$MAIN_SHA"');
+    expect(workflow).toContain("-f event=push");
+    expect(workflow).toContain("-f status=success");
+    expect(workflow).toContain("label:org.opencontainers.image.revision");
+    expect(workflow).toContain('"$VERSION" != "main"');
+    expect(workflow).toContain('"$SOURCE" != "https://github.com/${TARGET_REPOSITORY}"');
+  });
+
+  test("resolves and passes an immutable digest to Railway", () => {
+    expect(workflow).toContain('"${IMAGE_REPO}:sha-${MAIN_SHA}"');
+    expect(workflow).toContain('test("^sha256:[0-9a-f]{64}$")');
+    expect(workflow).toContain("RAILWAY_IMAGE_DIGEST: ${{ steps.resolve.outputs.digest }}");
+    expect(workflow).not.toContain("RESOLVED_TAG");
+  });
+
+  test("ships a Railway platform health gate", () => {
+    expect(railwayConfig.deploy.healthcheckPath).toBe("/health");
+    expect(railwayConfig.deploy.healthcheckTimeout).toBeGreaterThanOrEqual(45);
+  });
+});

--- a/scripts/__tests__/production-deploy-policy.test.ts
+++ b/scripts/__tests__/production-deploy-policy.test.ts
@@ -10,6 +10,7 @@ describe("production deploy policy", () => {
   test("accepts only a full main commit and verifies its exact main Docker build", () => {
     expect(workflow).toContain("main_sha:");
     expect(workflow).not.toContain("image_tag:");
+    expect(workflow).not.toContain("workflow_call:");
     expect(workflow).toContain("^[0-9a-f]{40}$");
     expect(workflow).toContain('git merge-base --is-ancestor "$MAIN_SHA" refs/remotes/origin/main');
     expect(workflow).toContain("actions/workflows/docker.yml/runs");

--- a/scripts/__tests__/railway-deploy.test.ts
+++ b/scripts/__tests__/railway-deploy.test.ts
@@ -35,6 +35,7 @@ async function fakeRailwayRun(
   healthUrl: string | null = "https://example.test",
   remoteIp = "1.1.1.1",
   dnsAnswers = "1.1.1.1",
+  imageDigest: string | null = null,
 ) {
   const dir = await mkdtemp(join(tmpdir(), "steward-railway-deploy-"));
   temporaryDirectories.push(dir);
@@ -95,7 +96,9 @@ exec "$REAL_NODE" "$@"
   await writeFile(fakeSleep, '#!/bin/sh\n[ "$1" = "10" ] && exit 0\nexec /bin/sleep "$@"\n');
   await Promise.all([chmod(fakeCurl, 0o755), chmod(fakeNode, 0o755), chmod(fakeSleep, 0o755)]);
 
-  const child = Bun.spawn(["bash", SCRIPT, "sha-test"], {
+  const command = ["bash", SCRIPT];
+  if (imageDigest === null) command.push("sha-test");
+  const child = Bun.spawn(command, {
     cwd: repoRoot,
     env: {
       ...Bun.env,
@@ -114,6 +117,7 @@ exec "$REAL_NODE" "$@"
       RAILWAY_HEALTH_URL: healthUrl ?? "",
       RAILWAY_HEALTH_TIMEOUT: String(healthTimeout),
       RAILWAY_HEALTH_INTERVAL: "1",
+      RAILWAY_IMAGE_DIGEST: imageDigest ?? "",
     },
     stdout: "pipe",
     stderr: "pipe",
@@ -201,6 +205,37 @@ describe("SEC-129 redact_secrets filter", () => {
 });
 
 describe("Railway staging deployment", () => {
+  test("deploys an immutable digest without converting it back to a tag", async () => {
+    const digest = `sha256:${"a".repeat(64)}`;
+    const result = await fakeRailwayRun(
+      1,
+      2,
+      1,
+      "https://example.test",
+      "1.1.1.1",
+      "1.1.1.1",
+      digest,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.curlArguments).toContain(`ghcr.io/steward-fi/steward@${digest}`);
+    expect(result.curlArguments).not.toContain(`ghcr.io/steward-fi/steward:${digest}`);
+  });
+
+  test("rejects malformed image digests before the first mutation", async () => {
+    const result = await fakeRailwayRun(
+      1,
+      2,
+      1,
+      "https://example.test",
+      "1.1.1.1",
+      "1.1.1.1",
+      "sha256:not-a-digest",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("Invalid image digest");
+    expect(result.curlArguments).not.toContain("serviceInstanceUpdate");
+  });
+
   test("rejects deployment acceptance when no public probe authority is configured", async () => {
     const result = await fakeRailwayRun(1, 2, 1, null);
     expect(result.exitCode).toBe(1);

--- a/scripts/railway-deploy.sh
+++ b/scripts/railway-deploy.sh
@@ -7,8 +7,10 @@ set -euo pipefail
 # polls for deployment success, and verifies the /health endpoint.
 #
 # Usage: ./scripts/railway-deploy.sh <image-tag> [--dry-run]
+#        RAILWAY_IMAGE_DIGEST=sha256:<64-hex> ./scripts/railway-deploy.sh [--dry-run]
 #   e.g. ./scripts/railway-deploy.sh v0.5.0
 #        ./scripts/railway-deploy.sh develop --dry-run
+#        RAILWAY_IMAGE_DIGEST=sha256:<64-hex> ./scripts/railway-deploy.sh
 #
 # Environment variables:
 #   RAILWAY_TOKEN       (required) Railway API bearer token
@@ -16,6 +18,9 @@ set -euo pipefail
 #   RAILWAY_ENV_ID      (REQUIRED) the deployer's own Railway environment id
 #   RAILWAY_IMAGE_REPO  (optional) default: ghcr.io/steward-fi/steward (the
 #                                  canonical published OSS image)
+#   RAILWAY_IMAGE_DIGEST (optional) immutable sha256 digest. Mutually exclusive
+#                                  with the positional image tag. Production
+#                                  deploys should always use this mode.
 #   RAILWAY_HEALTH_URL  (required) the deployer's public HTTPS root origin
 #   DEPLOY_TIMEOUT      (optional) max seconds to wait for deploy, default: 300
 #   RAILWAY_HEALTH_TIMEOUT  (optional) max seconds to wait for health, default: 120
@@ -52,6 +57,7 @@ fail() { echo -e "${RED}[railway]${RESET} $*" >&2; }
 SERVICE_ID="${RAILWAY_SERVICE_ID:-}"
 ENV_ID="${RAILWAY_ENV_ID:-}"
 IMAGE_REPO="${RAILWAY_IMAGE_REPO:-ghcr.io/steward-fi/steward}"
+IMAGE_DIGEST="${RAILWAY_IMAGE_DIGEST:-}"
 HEALTH_URL="${RAILWAY_HEALTH_URL:-}"
 TIMEOUT="${DEPLOY_TIMEOUT:-300}"
 HEALTH_TIMEOUT="${RAILWAY_HEALTH_TIMEOUT:-120}"
@@ -79,6 +85,7 @@ for arg in "$@"; do
     --dry-run) DRY_RUN=true ;;
     -h|--help)
       echo "Usage: $0 <image-tag> [--dry-run]"
+      echo "       RAILWAY_IMAGE_DIGEST=sha256:<64-hex> $0 [--dry-run]"
       echo "  e.g. $0 v0.5.0"
       exit 0
       ;;
@@ -94,8 +101,13 @@ for arg in "$@"; do
   esac
 done
 
-if [[ -z "$IMAGE_TAG" ]]; then
-  fail "Image tag required. Usage: $0 <image-tag>"
+if [[ -n "$IMAGE_TAG" && -n "$IMAGE_DIGEST" ]]; then
+  fail "Choose exactly one image selector: a positional tag or RAILWAY_IMAGE_DIGEST"
+  exit 1
+fi
+
+if [[ -z "$IMAGE_TAG" && -z "$IMAGE_DIGEST" ]]; then
+  fail "Image selector required: pass an image tag or set RAILWAY_IMAGE_DIGEST"
   exit 1
 fi
 
@@ -111,8 +123,13 @@ fi
 # OCI/Docker tags are at most 128 characters and contain only this conservative
 # subset. Reject whitespace, shell-like syntax, slashes, and control characters
 # before the value reaches logs or a deployment API.
-if [[ ! "$IMAGE_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+if [[ -n "$IMAGE_TAG" && ! "$IMAGE_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
   fail "Invalid image tag: expected an OCI tag (letters, digits, _, ., -; max 128 chars)"
+  exit 1
+fi
+
+if [[ -n "$IMAGE_DIGEST" && ! "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  fail "Invalid image digest: expected sha256 followed by exactly 64 lowercase hex characters"
   exit 1
 fi
 
@@ -121,7 +138,11 @@ if [[ -z "${RAILWAY_TOKEN:-}" ]]; then
   exit 1
 fi
 
-FULL_IMAGE="${IMAGE_REPO}:${IMAGE_TAG}"
+if [[ -n "$IMAGE_DIGEST" ]]; then
+  FULL_IMAGE="${IMAGE_REPO}@${IMAGE_DIGEST}"
+else
+  FULL_IMAGE="${IMAGE_REPO}:${IMAGE_TAG}"
+fi
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
 # Validate the probe authority before the first control-plane request. Never


### PR DESCRIPTION
## Summary

- require production dispatches to name a full commit already reachable from `main`
- require an exact successful main Docker build and verify OCI revision/version/source provenance
- resolve the immutable manifest digest and pass only `repository@sha256:...` to Railway
- add a repository `/health` gate plus vendor-neutral promotion and rollback documentation
- retain tag-based deploy support for staging/self-hosters while adding strict digest mode

## Safety boundary

This PR changes repository policy, workflow, documentation, and tests only. It does not deploy or modify any Railway environment. The production job remains behind the protected GitHub `Production` environment.

## Validation

- `bun test scripts/__tests__/railway-deploy.test.ts scripts/__tests__/production-deploy-policy.test.ts` — 30 pass, 0 fail
- `bunx biome check scripts/__tests__/railway-deploy.test.ts scripts/__tests__/production-deploy-policy.test.ts railway.json` — clean
- workflow YAML parse — clean
- `bash -n scripts/railway-deploy.sh` — clean
- `git diff --check origin/develop...HEAD` — clean

Repository-wide lint was previously sampled before rebase and remains blocked by unrelated existing `develop` findings outside this diff; targeted changed-file validation is green.
