### PR TITLE
feat(auth): support tenant email brand names

### DIFF
--- a/docs/TENANT_EMAIL_CONFIG.md
+++ b/docs/TENANT_EMAIL_CONFIG.md
@@ -17,8 +17,11 @@ If a tenant has no `tenant_configs.email_config`, auth continues using the globa
   "apiKeyEncrypted": "...",
   "from": "Tenant <login@example.com>",
   "replyTo": "support@example.com",
+  "brandName": "Acme",
   "templateId": "acme",
   "subjectOverride": "Sign in",
+  "magicLinkBaseUrl": "https://app.acme.example",
+  "magicLinkCallbackPath": "/auth/callback/email",
   "templates": {
     "magicLink": { "subject": "...", "text": "...", "html": "..." },
     "otp": { "subject": "...", "text": "...", "html": "..." }
@@ -66,18 +69,46 @@ curl -X DELETE "$API_BASE/platform/tenants/acme/email-config" \
 ## Template-only branding (no per-tenant Resend key)
 
 A tenant can keep the platform's global Resend provider and only override the
-email branding. PATCH with no `apiKey` (and no `from`):
+email branding. `brandName` customizes both built-in magic-link and OTP
+templates without requiring raw HTML. PATCH with no `apiKey` (and no `from`):
 
 ```bash
 curl -X PATCH "$API_BASE/platform/tenants/acme/email-config" \
   -H "Content-Type: application/json" \
   -H "X-Steward-Platform-Key: $STEWARD_PLATFORM_KEY" \
-  -d '{ "templateId": "acme" }'
+  -d '{ "brandName": "Acme" }'
 ```
 
 Branding fields are merged over any existing config, so a template-only PATCH
 never clobbers `magicLinkBaseUrl` or stored provider credentials. `from`
 without `apiKey` is rejected (provider config is all-or-nothing).
+
+`brandName` is a single-line display string of at most 100 characters. It
+defaults to `Steward` when unset. Use `subjectOverride` only when the subject
+must differ from the built-in `Sign in to <brand name>` copy.
+
+## Hosted callback routing
+
+When a tenant's application owns the browser callback, configure both its
+public origin and the root-relative route that the application actually
+serves. These fields can be patched together with `brandName` and merge over
+any existing provider credentials:
+
+```bash
+curl -X PATCH "$API_BASE/platform/tenants/acme/email-config" \
+  -H "Content-Type: application/json" \
+  -H "X-Steward-Platform-Key: $STEWARD_PLATFORM_KEY" \
+  -d '{
+    "brandName": "Acme",
+    "magicLinkBaseUrl": "https://app.acme.example",
+    "magicLinkCallbackPath": "/auth/callback/email"
+  }'
+```
+
+Without `magicLinkBaseUrl`, links use Steward's global `APP_URL`. When a base
+URL is set without a callback path, the path defaults to
+`/auth/email/verify`. Always verify that a generated link lands on the tenant
+application before promoting the configuration.
 
 ## Custom raw templates (deployer-supplied branded markup)
 

--- a/packages/api/src/__tests__/auth-email-config.test.ts
+++ b/packages/api/src/__tests__/auth-email-config.test.ts
@@ -225,7 +225,7 @@ describe("getEmailAuthForTenant", () => {
     invalidateEmailAuthForTenant(TEST_TENANT_ID);
   });
 
-  it("uses tenant magicLinkBaseUrl + custom callbackPath when both set", async () => {
+  it("uses tenant branding with its hosted magic-link callback", async () => {
     clearEmailAuthTenantCacheForTests();
 
     const encrypted = new KeyStore(MASTER_PASSWORD).encrypt("tenant-resend-key");
@@ -236,9 +236,10 @@ describe("getEmailAuthForTenant", () => {
       emailConfig: {
         provider: "resend",
         apiKeyEncrypted: JSON.stringify(encrypted),
-        from: "App <noreply@app.example>",
-        magicLinkBaseUrl: "https://app.example.com/",
-        magicLinkCallbackPath: "/login/email-callback",
+        from: "Customer <noreply@customer.example>",
+        brandName: "Customer Cloud",
+        magicLinkBaseUrl: "https://cloud.customer.example/",
+        magicLinkCallbackPath: "/auth/callback/email",
       },
     });
     invalidateEmailAuthForTenant(TEST_TENANT_ID);
@@ -246,8 +247,21 @@ describe("getEmailAuthForTenant", () => {
     const auth = await getEmailAuthForTenant(TEST_TENANT_ID);
 
     // Trailing slash gets stripped from baseUrl
-    expect((auth as any).baseUrl).toBe("https://app.example.com");
-    expect((auth as any).callbackPath).toBe("/login/email-callback");
+    expect((auth as any).baseUrl).toBe("https://cloud.customer.example");
+    expect((auth as any).callbackPath).toBe("/auth/callback/email");
+    expect((auth as any).brandName).toBe("Customer Cloud");
+
+    const rendered = (auth as any).templateRenderer(undefined, {
+      magicLink: `${(auth as any).baseUrl}${(auth as any).callbackPath}?token=fixture`,
+      email: "user@customer.example",
+      tenantName: (auth as any).brandName,
+      expiresInMinutes: 10,
+    });
+    expect(rendered.subject).toBe("Sign in to Customer Cloud");
+    expect(rendered.text).toContain(
+      "https://cloud.customer.example/auth/callback/email?token=fixture",
+    );
+    expect(rendered.html).not.toContain("steward.fi");
 
     await dbHandle.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TEST_TENANT_ID));
     invalidateEmailAuthForTenant(TEST_TENANT_ID);

--- a/packages/api/src/__tests__/platform-email-config.test.ts
+++ b/packages/api/src/__tests__/platform-email-config.test.ts
@@ -253,6 +253,7 @@ describe("platform tenant email config routes", () => {
         "X-Steward-Platform-Key": PLATFORM_KEY,
       },
       body: JSON.stringify({
+        brandName: "Customer App",
         templateId: "customer-template",
         subjectOverride: "Sign in to Customer App",
       }),
@@ -261,9 +262,15 @@ describe("platform tenant email config routes", () => {
     expect(patchResponse.status).toBe(200);
     const patchBody = (await patchResponse.json()) as {
       ok: boolean;
-      data: { templateId?: string; subjectOverride?: string; hasApiKey: boolean };
+      data: {
+        brandName?: string;
+        templateId?: string;
+        subjectOverride?: string;
+        hasApiKey: boolean;
+      };
     };
     expect(patchBody.ok).toBe(true);
+    expect(patchBody.data.brandName).toBe("Customer App");
     expect(patchBody.data.templateId).toBe("customer-template");
     expect(patchBody.data.subjectOverride).toBe("Sign in to Customer App");
     expect(patchBody.data.hasApiKey).toBe(false);
@@ -273,9 +280,18 @@ describe("platform tenant email config routes", () => {
       .from(tenantConfigs)
       .where(eq(tenantConfigs.tenantId, TENANT_ID));
     expect(stored?.emailConfig?.templateId).toBe("customer-template");
+    expect(stored?.emailConfig?.brandName).toBe("Customer App");
     expect(stored?.emailConfig?.apiKeyEncrypted).toBeUndefined();
     expect(stored?.emailConfig?.magicLinkBaseUrl).toBe("https://app.customer.example");
     expect(stored?.emailConfig?.magicLinkCallbackPath).toBe("/auth/email/verify");
+
+    const getResponse = await platformRoutes.request(`/tenants/${TENANT_ID}/email-config`, {
+      headers: { "X-Steward-Platform-Key": PLATFORM_KEY },
+    });
+    const getBody = (await getResponse.json()) as {
+      data: { emailConfig: { brandName?: string } | null };
+    };
+    expect(getBody.data.emailConfig?.brandName).toBe("Customer App");
 
     // from without apiKey is rejected (provider config is all-or-nothing).
     const badResponse = await platformRoutes.request(`/tenants/${TENANT_ID}/email-config`, {
@@ -298,6 +314,21 @@ describe("platform tenant email config routes", () => {
       body: JSON.stringify({}),
     });
     expect(emptyResponse.status).toBe(400);
+
+    for (const brandName of ["", "line one\nline two", "x".repeat(101)]) {
+      const invalidBrandResponse = await platformRoutes.request(
+        `/tenants/${TENANT_ID}/email-config`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Steward-Platform-Key": PLATFORM_KEY,
+          },
+          body: JSON.stringify({ brandName }),
+        },
+      );
+      expect(invalidBrandResponse.status).toBe(400);
+    }
 
     // Cleanup so later tests see no residual config.
     await platformRoutes.request(`/tenants/${TENANT_ID}/email-config`, {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -2012,6 +2012,7 @@ function buildGlobalEmailAuth(overrides?: {
   baseUrl?: string;
   callbackPath?: string;
   templateId?: string;
+  brandName?: string;
   subjectOverride?: string;
   replyTo?: string;
   templates?: TenantEmailConfig["templates"];
@@ -2039,6 +2040,7 @@ function buildGlobalEmailAuth(overrides?: {
     tokenStore: getTokenStore(),
     codeVerifierSecret: runtimeEnvironmentValue("STEWARD_EMAIL_CODE_SECRET"),
     templateId: overrides?.templateId,
+    brandName: overrides?.brandName,
     subjectOverride: overrides?.subjectOverride,
     replyTo: overrides?.replyTo,
     ...buildTemplateRenderers(overrides?.templates),
@@ -2097,6 +2099,7 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
       baseUrl: magicLinkBaseUrl,
       callbackPath,
       templateId: emailConfig?.templateId,
+      brandName: emailConfig?.brandName,
       subjectOverride: emailConfig?.subjectOverride,
       replyTo: emailConfig?.replyTo,
       templates: emailConfig?.templates,
@@ -2131,6 +2134,7 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
     tokenStore: getTokenStore(),
     codeVerifierSecret: runtimeEnvironmentValue("STEWARD_EMAIL_CODE_SECRET"),
     templateId: emailConfig.templateId,
+    brandName: emailConfig.brandName,
     subjectOverride: emailConfig.subjectOverride,
     replyTo: emailConfig.replyTo,
     ...buildTemplateRenderers(emailConfig.templates),

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -616,6 +616,13 @@ function isOptionalString(value: unknown): value is string | undefined {
   return value === undefined || isNonEmptyString(value);
 }
 
+function isOptionalEmailBrandName(value: unknown): value is string | undefined {
+  return (
+    value === undefined ||
+    (isNonEmptyString(value) && value.trim().length <= 100 && !/[\r\n]/.test(value))
+  );
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -1424,13 +1431,13 @@ platform.get("/tenants/:id", async (c) => {
 
 /**
  * PATCH /tenants/:tenantId/email-config
- * Body: { apiKey, from, replyTo?, templateId?, subjectOverride?, templates? }
- *   or template-only: { templateId?, subjectOverride?, replyTo?, templates? }
+ * Body: { apiKey, from, replyTo?, brandName?, templateId?, subjectOverride?, templates? }
+ *   or template-only: { brandName?, templateId?, subjectOverride?, replyTo?, templates? }
  *   (no apiKey)
  *
  * Upserts the tenant-specific email provider config. When `apiKey` is
  * omitted the tenant keeps the platform's global Resend provider and only
- * the branding fields (templateId/subjectOverride/replyTo/templates) are
+ * the branding fields (brandName/templateId/subjectOverride/replyTo/templates) are
  * stored — merged over any existing config so magic-link overrides survive.
  * `templates` carries deployer-supplied raw subject/text/html bodies with
  * {{placeholder}} substitution (see TenantEmailConfig.templates); pass
@@ -1455,6 +1462,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
     apiKey: string;
     from: string;
     replyTo?: string;
+    brandName?: string;
     templateId?: string;
     subjectOverride?: string;
     magicLinkBaseUrl?: string;
@@ -1488,6 +1496,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
     }
     if (
       !body.templateId &&
+      !body.brandName &&
       !body.subjectOverride &&
       !body.replyTo &&
       !body.magicLinkBaseUrl &&
@@ -1498,7 +1507,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
         {
           ok: false,
           error:
-            "Provide apiKey+from for provider config, or at least one of templateId, subjectOverride, replyTo, magicLinkBaseUrl, magicLinkCallbackPath, templates",
+            "Provide apiKey+from for provider config, or at least one of brandName, templateId, subjectOverride, replyTo, magicLinkBaseUrl, magicLinkCallbackPath, templates",
         },
         400,
       );
@@ -1509,6 +1518,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
 
   if (
     !isOptionalString(body.replyTo) ||
+    !isOptionalEmailBrandName(body.brandName) ||
     !isOptionalString(body.templateId) ||
     !isOptionalString(body.subjectOverride) ||
     !isOptionalString(body.magicLinkBaseUrl) ||
@@ -1518,7 +1528,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
       {
         ok: false,
         error:
-          "replyTo, templateId, subjectOverride, magicLinkBaseUrl, and magicLinkCallbackPath must be non-empty strings",
+          "brandName must be a non-empty single-line string of at most 100 characters; replyTo, templateId, subjectOverride, magicLinkBaseUrl, and magicLinkCallbackPath must be non-empty strings",
       },
       400,
     );
@@ -1561,6 +1571,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
         apiKeyEncrypted: JSON.stringify(platformKeyStore().encrypt(body.apiKey.trim())),
         from: body.from.trim(),
         ...(body.replyTo ? { replyTo: body.replyTo.trim() } : {}),
+        ...(body.brandName ? { brandName: body.brandName.trim() } : {}),
         ...(body.templateId ? { templateId: body.templateId.trim() } : {}),
         ...(body.subjectOverride ? { subjectOverride: body.subjectOverride.trim() } : {}),
         ...(body.magicLinkBaseUrl ? { magicLinkBaseUrl: body.magicLinkBaseUrl.trim() } : {}),
@@ -1597,6 +1608,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
         // authoritative committed config without clobbering concurrent fields.
         ...(lockedConfig?.emailConfig ?? {}),
         ...(body.replyTo ? { replyTo: body.replyTo.trim() } : {}),
+        ...(body.brandName ? { brandName: body.brandName.trim() } : {}),
         ...(body.templateId ? { templateId: body.templateId.trim() } : {}),
         ...(body.subjectOverride ? { subjectOverride: body.subjectOverride.trim() } : {}),
         ...(body.magicLinkBaseUrl ? { magicLinkBaseUrl: body.magicLinkBaseUrl.trim() } : {}),
@@ -1638,6 +1650,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
       provider?: "resend";
       from?: string;
       replyTo?: string;
+      brandName?: string;
       templateId?: string;
       subjectOverride?: string;
       hasApiKey: boolean;
@@ -1648,6 +1661,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
       provider: emailConfig.provider,
       from: emailConfig.from,
       replyTo: emailConfig.replyTo,
+      brandName: emailConfig.brandName,
       templateId: emailConfig.templateId,
       subjectOverride: emailConfig.subjectOverride,
       hasApiKey: Boolean(emailConfig.apiKeyEncrypted),
@@ -1687,6 +1701,7 @@ platform.get("/tenants/:tenantId/email-config", async (c) => {
         provider?: "resend";
         from?: string;
         replyTo?: string;
+        brandName?: string;
         templateId?: string;
         subjectOverride?: string;
         magicLinkBaseUrl?: string;
@@ -1703,6 +1718,7 @@ platform.get("/tenants/:tenantId/email-config", async (c) => {
             provider: emailConfig.provider,
             from: emailConfig.from,
             replyTo: emailConfig.replyTo,
+            brandName: emailConfig.brandName,
             templateId: emailConfig.templateId,
             subjectOverride: emailConfig.subjectOverride,
             magicLinkBaseUrl: emailConfig.magicLinkBaseUrl,

--- a/packages/auth/src/__tests__/email-templates.test.ts
+++ b/packages/auth/src/__tests__/email-templates.test.ts
@@ -35,6 +35,21 @@ describe("renderTemplate", () => {
   });
 });
 
+describe("default magic-link template", () => {
+  it("uses and HTML-escapes the configured tenant brand", () => {
+    const rendered = renderDefaultTemplate({
+      ...MAGIC_LINK_DATA,
+      tenantName: '<b>Customer "Cloud"</b>',
+    });
+
+    expect(rendered.subject).toBe('Sign in to <b>Customer "Cloud"</b>');
+    expect(rendered.text).toContain('— <b>Customer "Cloud"</b>');
+    expect(rendered.html).toContain("&lt;b&gt;Customer &quot;Cloud&quot;&lt;/b&gt;");
+    expect(rendered.html).not.toContain('<b>Customer "Cloud"</b>');
+    expect(rendered.html).not.toContain("agent wallet infrastructure");
+  });
+});
+
 describe("renderOtpTemplate", () => {
   it("falls back to the default OTP template for unknown/absent template ids", () => {
     expect(renderOtpTemplate(undefined, OTP_DATA)).toEqual(renderDefaultOtpTemplate(OTP_DATA));

--- a/packages/auth/src/__tests__/email.test.ts
+++ b/packages/auth/src/__tests__/email.test.ts
@@ -108,6 +108,44 @@ describe("EmailAuth.sendMagicLink", () => {
     auth.destroy();
   });
 
+  it("passes the configured brand to magic-link and OTP renderers", async () => {
+    const sent = mock(async () => ({ provider: "test" }));
+    const templateRenderer = mock(() => ({
+      subject: "magic subject",
+      text: "magic text",
+      html: "<p>magic html</p>",
+    }));
+    const otpTemplateRenderer = mock(() => ({
+      subject: "otp subject",
+      text: "otp text",
+      html: "<p>otp html</p>",
+    }));
+    const auth = new EmailAuth({
+      from: "login@example.test",
+      baseUrl: "https://app.example.test",
+      callbackPath: "/auth/callback/email",
+      brandName: "Customer Cloud",
+      provider: { send: sent },
+      templateRenderer,
+      otpTemplateRenderer,
+    });
+
+    await auth.sendMagicLink("user@example.test", { tenantId: "customer" });
+    await auth.sendOtp("user@example.test", { tenantId: "customer" });
+
+    const [, magicData] = templateRenderer.mock.calls[0]!;
+    const [, otpData] = otpTemplateRenderer.mock.calls[0]!;
+    expect(magicData).toMatchObject({
+      tenantName: "Customer Cloud",
+    });
+    expect(magicData.magicLink).toContain("https://app.example.test/auth/callback/email?");
+    expect(otpData).toMatchObject({
+      brandName: "Customer Cloud",
+    });
+
+    auth.destroy();
+  });
+
   it("binds the tenant into the magic link for non-default tenants (and omits it otherwise)", async () => {
     const sent = mock(async () => ({ provider: "test" }));
     const templateRenderer = mock(() => ({

--- a/packages/auth/src/email-templates/default.ts
+++ b/packages/auth/src/email-templates/default.ts
@@ -32,8 +32,13 @@ export function escapeEmailHtml(value: string): string {
 export function renderDefaultTemplate({
   magicLink,
   code,
+  tenantName,
   expiresInMinutes,
 }: MagicLinkTemplateData): RenderedMagicLinkTemplate {
+  const brandName = tenantName?.trim() || "Steward";
+  const escapedBrand = escapeEmailHtml(brandName);
+  const footer =
+    brandName === "Steward" ? "steward.fi — agent wallet infrastructure" : escapedBrand;
   const codeText = code
     ? [
         "Or enter this 6-digit code from the same email challenge:",
@@ -55,7 +60,7 @@ export function renderDefaultTemplate({
           </table>`
     : "";
   return {
-    subject: "Sign in to Steward",
+    subject: `Sign in to ${brandName}`,
     text: [
       "Click the link below to sign in:",
       "",
@@ -65,7 +70,7 @@ export function renderDefaultTemplate({
       `This sign-in email expires in ${expiresInMinutes} minutes.`,
       "If you didn't request this, you can safely ignore this email.",
       "",
-      "— Steward",
+      `— ${brandName}`,
     ].join("\n"),
     html: `<!DOCTYPE html>
 <html lang="en">
@@ -77,14 +82,14 @@ export function renderDefaultTemplate({
         <tr><td align="center" style="padding-bottom:40px;">
           <table cellpadding="0" cellspacing="0"><tr>
             <td style="font-size:20px;font-weight:700;color:#e8e5e0;letter-spacing:-0.02em;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
-              ✦&nbsp;&nbsp;steward
+              ✦&nbsp;&nbsp;${escapedBrand}
             </td>
           </tr></table>
         </td></tr>
         <tr><td style="background-color:#141210;border:1px solid #2a2722;padding:40px 32px;">
           <table width="100%" cellpadding="0" cellspacing="0">
             <tr><td style="font-size:22px;font-weight:700;color:#e8e5e0;letter-spacing:-0.02em;padding-bottom:8px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
-              Sign in to Steward
+              Sign in to ${escapedBrand}
             </td></tr>
             <tr><td style="font-size:14px;color:#6b6560;line-height:1.5;padding-bottom:32px;">
               Click the button below to securely sign in, or enter the code. This email expires in ${expiresInMinutes} minutes.
@@ -117,7 +122,7 @@ export function renderDefaultTemplate({
               If you didn't request this email, you can safely ignore it.
             </td></tr>
             <tr><td style="font-size:11px;color:#4a4540;padding-top:12px;">
-              steward.fi — agent wallet infrastructure
+              ${footer}
             </td></tr>
           </table>
         </td></tr>

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -59,6 +59,8 @@ export interface EmailAuthConfig {
   ) => RenderedMagicLinkTemplate;
   /** Template ID to render for outgoing magic-link emails. */
   templateId?: string;
+  /** Display brand used by the built-in magic-link and OTP templates. */
+  brandName?: string;
   /** Override the rendered subject line. */
   subjectOverride?: string;
   /** Optional reply-to address to pass through to the provider. */
@@ -451,6 +453,7 @@ export class EmailAuth {
   private from: string;
   private replyTo?: string;
   private templateId?: string;
+  private brandName?: string;
   private subjectOverride?: string;
   private codeVerifierSecret: string;
   private templateRenderer: (
@@ -486,6 +489,7 @@ export class EmailAuth {
     this.tokenStore = config.tokenStore ?? new TokenStore();
     this.replyTo = config.replyTo;
     this.templateId = config.templateId;
+    this.brandName = config.brandName?.trim() || undefined;
     this.subjectOverride = config.subjectOverride;
     const configuredCodeSecret =
       config.codeVerifierSecret?.trim() ||
@@ -730,7 +734,7 @@ export class EmailAuth {
       email,
       code,
       expiresInMinutes: Math.floor(ttlMs / (60 * 1000)),
-      tenantName: undefined,
+      tenantName: this.brandName,
     });
     const subject = this.subjectOverride || rendered.subject;
     const body = rendered.text;
@@ -897,7 +901,7 @@ export class EmailAuth {
     }
 
     const minutes = Math.floor(this.tokenTtlMs / (60 * 1000));
-    const brand = context.tenantName || "Steward";
+    const brand = context.tenantName || this.brandName || "Steward";
     const rendered = this.otpTemplateRenderer(this.templateId, {
       email,
       code,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -86,6 +86,12 @@ export interface TenantEmailConfig {
   apiKeyEncrypted?: string;
   from?: string;
   replyTo?: string;
+  /**
+   * Display brand used by the built-in magic-link and OTP templates. This
+   * keeps shared-provider tenants branded without requiring raw HTML
+   * templates. Defaults to "Steward" when unset.
+   */
+  brandName?: string;
   templateId?: string;
   subjectOverride?: string;
   /**


### PR DESCRIPTION
## Summary

- add an optional, validated brandName to per-tenant email config
- apply the brand to built-in magic-link and OTP templates while preserving the Steward default
- expose brandName through platform PATCH/GET and preserve it in template-only merges
- document tenant-owned callback routing so generated links land on the application that serves them

## Safety

- no database migration: the field lives in the existing JSON email config
- tenant markup remains configuration; no downstream brand is hardcoded in Steward
- HTML output escapes the display brand; platform input is single-line and capped at 100 characters
- existing raw templates continue to take precedence

## Validation

- 46 focused auth/API tests passed (344 assertions)
- package typechecks passed for db, auth, and api
- Biome check passed for all changed TypeScript files
- git diff --check passed

Base: origin/develop at 297437b2. No dependency beyond current develop.