### PR TITLE
fix(auth): scope passkey login to typed email

### DIFF
--- a/packages/api/src/__tests__/auth-passkey-enumeration.test.ts
+++ b/packages/api/src/__tests__/auth-passkey-enumeration.test.ts
@@ -8,8 +8,12 @@ setDefaultTimeout(120_000);
 const ENABLED_TENANT_ID = "passkey-enumeration-enabled";
 const DISABLED_TENANT_ID = "passkey-enumeration-disabled";
 const KNOWN_EMAIL = "passkey-known@example.test";
+const NO_PASSKEY_EMAIL = "passkey-none@example.test";
+const OTHER_EMAIL = "passkey-other@example.test";
 const UNKNOWN_EMAIL = "passkey-unknown@example.test";
-const SECRET_CREDENTIAL_ID = "credential-id-must-never-leave-options-route";
+const KNOWN_CREDENTIAL_ID = "credential-id-for-known-email";
+const SECOND_KNOWN_CREDENTIAL_ID = "second-credential-id-for-known-email";
+const OTHER_CREDENTIAL_ID = "credential-id-for-other-email";
 
 type LoginOptions = {
   challenge: string;
@@ -17,7 +21,7 @@ type LoginOptions = {
   rpId: string;
   timeout: number;
   userVerification: string;
-  allowCredentials: Array<{ id: string }>;
+  allowCredentials: Array<{ id: string; transports?: string[] }>;
   [key: string]: unknown;
 };
 
@@ -50,22 +54,46 @@ describe("passkey login options privacy", () => {
         tenantId: DISABLED_TENANT_ID,
         authAbuseConfig: { loginMethods: { passkey: false } },
       });
-    const [knownUser] = await getDb()
+    const [knownUser, otherUser] = await getDb()
       .insert(users)
-      .values({ email: KNOWN_EMAIL, emailVerified: true })
+      .values([
+        { email: KNOWN_EMAIL, emailVerified: true },
+        { email: OTHER_EMAIL, emailVerified: true },
+        { email: NO_PASSKEY_EMAIL, emailVerified: true },
+      ])
       .returning({ id: users.id });
     knownUserId = knownUser.id;
     await getDb()
       .insert(authenticators)
-      .values({
-        userId: knownUserId,
-        credentialId: SECRET_CREDENTIAL_ID,
-        credentialPublicKey: "credential-public-key-must-also-remain-private",
-        counter: 7,
-        credentialDeviceType: "singleDevice",
-        credentialBackedUp: false,
-        transports: ["internal"],
-      });
+      .values([
+        {
+          userId: knownUserId,
+          credentialId: KNOWN_CREDENTIAL_ID,
+          credentialPublicKey: "known-credential-public-key",
+          counter: 7,
+          credentialDeviceType: "singleDevice",
+          credentialBackedUp: false,
+          transports: ["internal"],
+        },
+        {
+          userId: knownUserId,
+          credentialId: SECOND_KNOWN_CREDENTIAL_ID,
+          credentialPublicKey: "second-known-credential-public-key",
+          counter: 0,
+          credentialDeviceType: "multiDevice",
+          credentialBackedUp: true,
+          transports: ["hybrid"],
+        },
+        {
+          userId: otherUser.id,
+          credentialId: OTHER_CREDENTIAL_ID,
+          credentialPublicKey: "other-credential-public-key",
+          counter: 2,
+          credentialDeviceType: "singleDevice",
+          credentialBackedUp: false,
+          transports: ["internal"],
+        },
+      ]);
 
     const auth = await import("../routes/auth");
     getAuthChallengeStore = auth.getAuthChallengeStore;
@@ -91,42 +119,60 @@ describe("passkey login options privacy", () => {
     });
   }
 
-  function assertDiscoverableCredentialShape(options: LoginOptions) {
+  function assertAuthenticationOptionsShape(options: LoginOptions) {
     expect(options.challenge).toMatch(/^[A-Za-z0-9_-]{32,}$/);
     expect(options.challengeId).toBe(options.challenge);
     expect(options.rpId).toBe("steward.fi");
     expect(options.timeout).toBeGreaterThan(0);
     expect(options.userVerification).toBe("required");
-    expect(options.allowCredentials).toEqual([]);
   }
 
-  it("returns the same non-enumerating shape for known and unknown emails", async () => {
-    const [knownResponse, unknownResponse] = await Promise.all([
-      requestOptions(`  ${KNOWN_EMAIL.toUpperCase()}  `),
-      requestOptions(UNKNOWN_EMAIL),
-    ]);
+  it("returns only credential ids and transports bound to the normalized typed email", async () => {
+    const knownResponse = await requestOptions(`  ${KNOWN_EMAIL.toUpperCase()}  `);
     expect(knownResponse.status).toBe(200);
-    expect(unknownResponse.status).toBe(200);
 
     const known = (await knownResponse.json()) as LoginOptions;
-    const unknown = (await unknownResponse.json()) as LoginOptions;
-    assertDiscoverableCredentialShape(known);
-    assertDiscoverableCredentialShape(unknown);
-    expect(Object.keys(known).sort()).toEqual(Object.keys(unknown).sort());
+    assertAuthenticationOptionsShape(known);
+    expect(known.allowCredentials).toHaveLength(2);
+    expect(known.allowCredentials.map(({ id }) => id).sort()).toEqual(
+      [KNOWN_CREDENTIAL_ID, SECOND_KNOWN_CREDENTIAL_ID].sort(),
+    );
+    expect(known.allowCredentials).toContainEqual({
+      id: KNOWN_CREDENTIAL_ID,
+      transports: ["internal"],
+      type: "public-key",
+    });
+    expect(known.allowCredentials).toContainEqual({
+      id: SECOND_KNOWN_CREDENTIAL_ID,
+      transports: ["hybrid"],
+      type: "public-key",
+    });
 
-    for (const payload of [known, unknown]) {
-      const serialized = JSON.stringify(payload);
-      expect(serialized).not.toContain(SECRET_CREDENTIAL_ID);
-      expect(serialized).not.toContain("credential-public-key-must-also-remain-private");
-      expect(serialized).not.toContain(knownUserId);
-    }
+    const serialized = JSON.stringify(known);
+    expect(serialized).not.toContain(OTHER_CREDENTIAL_ID);
+    expect(serialized).not.toContain("known-credential-public-key");
+    expect(serialized).not.toContain("other-credential-public-key");
+    expect(serialized).not.toContain(knownUserId);
 
     expect(
       await getAuthChallengeStore().get(`passkey-login:${KNOWN_EMAIL}:${known.challengeId}`),
     ).toBe(known.challenge);
-    expect(
-      await getAuthChallengeStore().get(`passkey-login:${UNKNOWN_EMAIL}:${unknown.challengeId}`),
-    ).toBe(unknown.challenge);
+  });
+
+  it("returns one generic unavailable response for unknown and no-passkey emails", async () => {
+    const [unknownResponse, noPasskeyResponse] = await Promise.all([
+      requestOptions(UNKNOWN_EMAIL),
+      requestOptions(NO_PASSKEY_EMAIL),
+    ]);
+
+    expect(unknownResponse.status).toBe(404);
+    expect(noPasskeyResponse.status).toBe(404);
+    const expected = {
+      ok: false,
+      error: "Passkey sign-in is unavailable for this email",
+    };
+    expect(await unknownResponse.json()).toEqual(expected);
+    expect(await noPasskeyResponse.json()).toEqual(expected);
   });
 
   it("honors explicit tenant existence and passkey login-method boundaries", async () => {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -50,6 +50,7 @@ import { isIP } from "node:net";
 import {
   ACCESS_TOKEN_EXPIRY,
   ACCESS_TOKEN_EXPIRY_SECONDS,
+  type AuthenticatorTransportFuture,
   assertPinnedDnsTransportSupported,
   assertPublicHttpsEndpoint,
   assertTokenNotRevoked,
@@ -8259,9 +8260,10 @@ auth.post("/passkey/register/verify", async (c) => {
 /**
  * POST /passkey/login/options
  * Body: { email }
- * Returns privacy-preserving discoverable-credential options. `allowCredentials`
- * is intentionally empty for every email so this pre-auth route cannot reveal
- * whether an account or passkey exists.
+ * Returns only the credentials bound to the typed email. Unknown accounts and
+ * accounts without a passkey share one generic response. This rate-limited
+ * pre-auth route deliberately exposes passkey availability so the browser never
+ * offers a credential belonging to a different account on the same RP.
  */
 auth.post("/passkey/login/options", async (c) => {
   const rl = await checkAuthRateLimit(c, "passkey-options", 60_000, 20);
@@ -8297,11 +8299,36 @@ auth.post("/passkey/login/options", async (c) => {
   );
   if (ssoRequiredResponse) return ssoRequiredResponse;
 
-  const options = await getPasskeyAuth(c.req.header("origin")).generateAuthenticationOptions(email);
+  const credentials = await getDb()
+    .select({
+      credentialId: authenticators.credentialId,
+      transports: authenticators.transports,
+    })
+    .from(authenticators)
+    .innerJoin(users, eq(authenticators.userId, users.id))
+    .where(eq(users.email, email));
+  if (credentials.length === 0) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Passkey sign-in is unavailable for this email" },
+      404,
+    );
+  }
+
+  const options = await getPasskeyAuth(c.req.header("origin")).generateAuthenticationOptions(
+    email,
+    {
+      allowCredentials: credentials.map((credential) => ({
+        id: credential.credentialId,
+        ...(credential.transports && credential.transports.length > 0
+          ? { transports: credential.transports as AuthenticatorTransportFuture[] }
+          : {}),
+      })),
+    },
+  );
   const challengeId = options.challenge;
   await getChallengeStore().set(`passkey-login:${email}:${challengeId}`, options.challenge);
 
-  return c.json({ ...options, allowCredentials: [], challengeId });
+  return c.json({ ...options, challengeId });
 });
 
 /**

--- a/packages/sdk/src/__tests__/auth-add-passkey.test.ts
+++ b/packages/sdk/src/__tests__/auth-add-passkey.test.ts
@@ -8,6 +8,7 @@ type Captured = { url: string; body?: Record<string, unknown> };
 let captured: Captured[];
 let originalFetch: typeof fetch;
 let originalWindow: unknown;
+let startAuthenticationCalls: number;
 
 const REG_OPTIONS = {
   challenge: "abc",
@@ -78,17 +79,20 @@ mock.module("@simplewebauthn/browser", () => ({
     },
     type: "public-key",
   }),
-  startAuthentication: async () => ({
-    id: "credential-login",
-    rawId: "credential-login",
-    response: {
-      clientDataJSON: "client-data",
-      authenticatorData: "authenticator-data",
-      signature: "signature",
-      userHandle: "u-1",
-    },
-    type: "public-key",
-  }),
+  startAuthentication: async () => {
+    startAuthenticationCalls += 1;
+    return {
+      id: "credential-login",
+      rawId: "credential-login",
+      response: {
+        clientDataJSON: "client-data",
+        authenticatorData: "authenticator-data",
+        signature: "signature",
+        userHandle: "u-1",
+      },
+      type: "public-key",
+    };
+  },
 }));
 
 function fakeJwt(claims: Record<string, unknown> = {}): string {
@@ -126,6 +130,7 @@ function memoryStorage(): SessionStorage {
 
 beforeEach(() => {
   captured = [];
+  startAuthenticationCalls = 0;
   originalFetch = global.fetch;
   installFetch();
   installBrowserShim();
@@ -179,6 +184,39 @@ describe("StewardAuth.addPasskey", () => {
     await expect(auth.addPasskey("shadow@shad0w.xyz")).rejects.toBeInstanceOf(StewardApiError);
   });
 
+  it("surfaces a passkey-options 404 without invoking registration when fallback is disabled", async () => {
+    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      captured.push({ url, body });
+      return new Response(
+        JSON.stringify({
+          ok: false,
+          error: "Passkey sign-in is unavailable for this email",
+        }),
+        { status: 404, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+    await expect(
+      auth.signInWithPasskey("shadow@shad0w.xyz", {
+        fallbackToRegistration: false,
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Passkey sign-in is unavailable for this email",
+    });
+
+    expect(captured).toEqual([
+      {
+        url: "https://api.example.test/auth/passkey/login/options",
+        body: { email: "shadow@shad0w.xyz" },
+      },
+    ]);
+    expect(startAuthenticationCalls).toBe(0);
+  });
+
   it("forwards challengeId when completing passkey login", async () => {
     global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
@@ -206,6 +244,7 @@ describe("StewardAuth.addPasskey", () => {
     const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
     await auth.signInWithPasskey("shadow@shad0w.xyz");
 
+    expect(startAuthenticationCalls).toBe(1);
     expect(captured[1]?.url).toBe("https://api.example.test/auth/passkey/login/verify");
     expect(captured[1]?.body).toMatchObject({
       email: "shadow@shad0w.xyz",

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -824,11 +824,17 @@ export class StewardAuth {
 
   /**
    * Sign in with a passkey. Smart flow: tries login first, falls back to registration.
+   * Set `fallbackToRegistration` to false when the caller owns an email/OTP
+   * fallback and needs a 404 to remain distinguishable without invoking a
+   * registration ceremony.
    *
    * Requires a browser environment and `@simplewebauthn/browser` installed.
    * Throws `StewardApiError` in Node or when the dependency is missing.
    */
-  async signInWithPasskey(email: string): Promise<StewardAuthResult | StewardMfaRequiredResult> {
+  async signInWithPasskey(
+    email: string,
+    options: { fallbackToRegistration?: boolean } = {},
+  ): Promise<StewardAuthResult | StewardMfaRequiredResult> {
     if (!isBrowser()) {
       throw new StewardApiError(
         "Passkeys require a browser environment. Use signInWithEmail or signInWithSIWE in Node.",
@@ -865,8 +871,9 @@ export class StewardAuth {
       return this.completePasskeyLogin(email, loginOptsRes.data, browserLib);
     }
 
-    if (loginOptsRes.status === 404) {
-      // No account or no passkeys — run registration flow
+    if (loginOptsRes.status === 404 && options.fallbackToRegistration !== false) {
+      // No account or no passkeys — run registration flow unless the caller
+      // owns a separate verified-email fallback.
       return this.completePasskeyRegister(email, browserLib);
     }
 


### PR DESCRIPTION
## Summary

- resolve passkey login options from the normalized typed email and return only that user's credential IDs and stored transports
- return the same generic 404 for unknown accounts and existing accounts without passkeys
- let SDK callers disable automatic registration so an owning UI can enter its email/OTP fallback before any WebAuthn ceremony

## Privacy / UX decision

This is the product-approved tradeoff: typed-email credential scoping intentionally supersedes the prior discoverable-login enumeration test. The rate-limited pre-auth route now reveals passkey availability through 200 versus 404 so the browser cannot offer an unrelated discoverable credential for the RP. Unknown and no-passkey emails still execute the same lookup and receive the identical generic 404 body. Public error copy does not distinguish account existence from passkey absence.

The companion Eliza UI change will call signInWithPasskey with fallbackToRegistration disabled, route this generic 404 directly to email-verified enrollment, and reserve cancellation recovery for a browser-owned WebAuthn cancellation. Merge/deploy order will be coordinated; this PR does not deploy anything.

## Verification

- bun test packages/api/src/__tests__/auth-passkey-enumeration.test.ts packages/sdk/src/__tests__/auth-add-passkey.test.ts (9 passed, 42 expectations)
- bunx turbo run build --filter=@stwd/api --filter=@stwd/sdk (24/24 tasks)
- bunx @biomejs/biome check on all four changed files