### PR TITLE
fix(vault): fence Hyperliquid transaction wallet

### DIFF
--- a/packages/plugin-trading/src/__tests__/operator-recovery.test.ts
+++ b/packages/plugin-trading/src/__tests__/operator-recovery.test.ts
@@ -56,6 +56,17 @@ const adapterVaultClients: Array<{
 }> = [];
 
 mock.module("@stwd/policy-engine", () => ({
+  PolicyEngine: class {
+    async evaluate() {
+      return { approved: true, results: [] };
+    }
+  },
+  policyRuleRegistry: {
+    register: () => undefined,
+    unregister: () => undefined,
+    get: () => undefined,
+    list: () => [],
+  },
   aggregationLookupFromMap: () => undefined,
   aggregationQueriesForPolicies: () => [],
   aggregationQueryKey: () => "unused",
@@ -1010,6 +1021,46 @@ describe("operator recovery add-margin", () => {
     expect(body.data.amountUsdc).toBe("25.5");
     expect(body.data.amountBaseUnits).toBe("25500000");
     expect(addIsolatedMarginCalls).toEqual([{ coin: "xyz:SPCX", amountUsdc: "25.5" }]);
+  });
+});
+
+describe("operator recovery deposit wallet binding", () => {
+  it("passes the resolved venue wallet assertion into transaction signing", async () => {
+    const tenantId = `tenant-deposit-wallet-${Date.now()}`;
+    const agentId = `agent-deposit-wallet-${Date.now()}`;
+    const walletAddress = "0x00000000000000000000000000000000000000bb";
+    await seedAgent({ tenantId, agentId });
+    const signedInputs: Array<Record<string, unknown>> = [];
+    const app = await buildApp({
+      vault: {
+        getWallet: async () => ({ address: walletAddress }),
+        signTransaction: async (input: Record<string, unknown>) => {
+          signedInputs.push(input);
+          return `0x${"1".repeat(64)}`;
+        },
+      } as unknown as StewardAppContext["vault"],
+    });
+
+    const res = await app.request("/v1/trade/hyperliquid/deposit", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Steward-Platform-Key": PLATFORM_KEY,
+        "X-Steward-Tenant": tenantId,
+        "Idempotency-Key": crypto.randomUUID(),
+      },
+      body: JSON.stringify({ agentId, amount: "5" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(signedInputs).toHaveLength(1);
+    expect(signedInputs[0]).toMatchObject({
+      tenantId,
+      agentId,
+      venue: "hyperliquid",
+      walletAddress,
+      broadcast: true,
+    });
   });
 });
 

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -995,6 +995,10 @@ export function createOperatorRecoveryRoutes(
         data,
         chainId: ARBITRUM_CHAIN_ID,
         venue: "hyperliquid",
+        // Bind the vault operation to the venue wallet that was authorized
+        // above. A concurrent venue-wallet rotation must fail closed instead
+        // of signing the deposit with the replacement key.
+        walletAddress,
         broadcast: true,
       });
     } catch (err) {

--- a/packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts
+++ b/packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts
@@ -37,6 +37,7 @@ const restoreFirstAgentId = `custody-race-restore-first-${suffix}`;
 const externalBeforeImportAgentId = `race-external-first-${suffix}`;
 const importBeforeExternalAgentId = `race-local-first-${suffix}`;
 const typedDataRotationAgentId = `typed-data-rotation-${suffix}`;
+const transactionRotationAgentId = `transaction-rotation-${suffix}`;
 const blocker = databaseUrl ? createPostgresClient(databaseUrl) : null;
 const inspector = databaseUrl ? createPostgresClient(databaseUrl) : null;
 
@@ -503,6 +504,84 @@ suite("custody transitions across real PostgreSQL connections", () => {
     if (result.status === "rejected") {
       expect(String(result.reason)).toContain(
         "Typed-data signer no longer matches the authorized wallet",
+      );
+    }
+  });
+
+  test("a queued transaction signature cannot use a concurrently rotated venue key", async () => {
+    if (!blocker || !inspector) throw new Error("real PostgreSQL clients are unavailable");
+    const venue = "hyperliquid";
+    const vault = new Vault({ masterPassword: MASTER_PASSWORD });
+    await vault.createAgent(tenantId, transactionRotationAgentId, "Transaction Rotation Agent");
+    const original = await vault.provisionVenueWallet({
+      tenantId,
+      agentId: transactionRotationAgentId,
+      venue,
+      chainFamily: "evm",
+      approvedAddresses: [],
+    });
+
+    const replacementPrivateKey = generatePrivateKey();
+    const replacementAddress = privateKeyToAccount(replacementPrivateKey).address;
+    const replacement = new KeyStore(MASTER_PASSWORD).encrypt(replacementPrivateKey, {
+      tenantId,
+      agentId: transactionRotationAgentId,
+      chainFamily: "evm",
+      venue,
+    });
+    const lockKey = JSON.stringify([
+      "vault-custody-v1",
+      tenantId,
+      transactionRotationAgentId,
+      "evm",
+      venue,
+    ]);
+    let signingResult!: Promise<
+      { status: "fulfilled"; value: string } | { status: "rejected"; reason: unknown }
+    >;
+
+    await blocker.begin(async (tx) => {
+      await tx`select pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`;
+      signingResult = vault
+        .signTransaction({
+          tenantId,
+          agentId: transactionRotationAgentId,
+          venue,
+          walletAddress: original.address,
+          to: "0x1111111111111111111111111111111111111111",
+          value: "1",
+          chainId: 8453,
+          nonce: 0,
+          gasLimit: "21000",
+          broadcast: false,
+        })
+        .then(
+          (value) => ({ status: "fulfilled" as const, value }),
+          (reason: unknown) => ({ status: "rejected" as const, reason }),
+        );
+      await waitForBlockedAdvisoryConnections(lockKey, 1);
+      await tx`
+        update encrypted_chain_keys
+        set ciphertext = ${replacement.ciphertext}, iv = ${replacement.iv},
+            tag = ${replacement.tag}, salt = ${replacement.salt}
+        where agent_id = ${transactionRotationAgentId}
+          and chain_family = 'evm'
+          and venue = ${venue}
+      `;
+      await tx`
+        update agent_wallets
+        set address = ${replacementAddress}
+        where agent_id = ${transactionRotationAgentId}
+          and chain_family = 'evm'
+          and venue = ${venue}
+      `;
+    });
+
+    const result = await signingResult;
+    expect(result.status).toBe("rejected");
+    if (result.status === "rejected") {
+      expect(String(result.reason)).toContain(
+        "Transaction signer no longer matches the authorized wallet",
       );
     }
   });

--- a/packages/vault/src/__tests__/venue-wallet-key-roundtrip.test.ts
+++ b/packages/vault/src/__tests__/venue-wallet-key-roundtrip.test.ts
@@ -114,6 +114,48 @@ describe("provisionVenueWallet key round-trip (AAD context regression)", () => {
         });
         expect(signature).toMatch(/^0x[0-9a-f]{130}$/i);
 
+        const transaction = {
+          agentId: "agent1",
+          tenantId: TENANT_ID,
+          to: "0x1111111111111111111111111111111111111111",
+          value: "1",
+          chainId: 8453,
+          nonce: 0,
+          gasLimit: "21000",
+          venue,
+          broadcast: false,
+        };
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+          const body = JSON.parse(String(init?.body)) as { id: number; method: string };
+          if (body.method === "eth_chainId") {
+            return Response.json({ jsonrpc: "2.0", id: body.id, result: "0x2105" });
+          }
+          if (body.method === "eth_gasPrice") {
+            return Response.json({ jsonrpc: "2.0", id: body.id, result: "0x3b9aca00" });
+          }
+          throw new Error(`Unexpected JSON-RPC method: ${body.method}`);
+        }) as typeof fetch;
+        try {
+          const signedTransaction = await vault.signTransaction({
+            ...transaction,
+            walletAddress: walletRow!.address,
+          });
+          expect(signedTransaction).toMatch(/^0x[0-9a-f]+$/i);
+
+          await expect(vault.signTransaction(transaction)).rejects.toThrow(
+            "Hyperliquid transaction signing requires an authorized wallet assertion",
+          );
+          await expect(
+            vault.signTransaction({
+              ...transaction,
+              walletAddress: "0x2222222222222222222222222222222222222222",
+            }),
+          ).rejects.toThrow("Transaction signer no longer matches the authorized wallet");
+        } finally {
+          globalThis.fetch = originalFetch;
+        }
+
         await expect(vault.signTypedData(typedData)).rejects.toThrow(
           "Hyperliquid typed-data signing requires an authorized wallet assertion",
         );

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -1690,6 +1690,9 @@ export class Vault {
     const chainFamilyToUse = isSolana ? "solana" : "evm";
     const shouldBroadcast = request.broadcast !== false;
     const venue = resolveSignVenueSelector(request);
+    if (venue === "hyperliquid" && !request.walletAddress) {
+      throw new Error("Hyperliquid transaction signing requires an authorized wallet assertion");
+    }
     await assertVaultSigningActive({
       tenantId: request.tenantId,
       agentId: request.agentId,
@@ -1701,19 +1704,91 @@ export class Vault {
     // ── Resolve the correct signing key ─────────────────────────────────
     // 1. Try the multi-chain key table (new agents)
     // 2. Fall back to legacy single-key table (old EVM-only agents)
-    let secretKey: string;
-    const [chainKey] = await db
-      .select()
-      .from(encryptedChainKeys)
-      .where(
-        and(
-          eq(encryptedChainKeys.agentId, request.agentId),
-          eq(encryptedChainKeys.chainFamily, chainFamilyToUse),
-          venue ? eq(encryptedChainKeys.venue, venue) : isNull(encryptedChainKeys.venue),
-        ),
-      );
+    let lockedVenueSecretKey: string | undefined;
+    if (venue === "hyperliquid") {
+      const resolveLockedVenueKey = async (queryDb: Pick<typeof db, "select">) => {
+        const [walletRow] = await queryDb
+          .select({ address: agentWallets.address })
+          .from(agentWallets)
+          .where(
+            and(
+              eq(agentWallets.agentId, request.agentId),
+              eq(agentWallets.chainFamily, chainFamilyToUse),
+              eq(agentWallets.venue, venue),
+            ),
+          );
+        const [keyRow] = await queryDb
+          .select()
+          .from(encryptedChainKeys)
+          .where(
+            and(
+              eq(encryptedChainKeys.agentId, request.agentId),
+              eq(encryptedChainKeys.chainFamily, chainFamilyToUse),
+              eq(encryptedChainKeys.venue, venue),
+            ),
+          );
 
-    if (chainKey) {
+        // External-custody wallets intentionally have no local encrypted key;
+        // their fresh provider identity/address check remains below.
+        if (!keyRow) return undefined;
+
+        const resolvedSecretKey = await this.keyStore.decrypt(
+          {
+            ciphertext: keyRow.ciphertext,
+            iv: keyRow.iv,
+            tag: keyRow.tag,
+            salt: keyRow.salt,
+          },
+          {
+            tenantId: request.tenantId,
+            agentId: request.agentId,
+            chainFamily: chainFamilyToUse,
+            venue,
+          },
+        );
+        if (
+          walletRow?.address.toLowerCase() !== request.walletAddress?.toLowerCase() ||
+          (chainFamilyToUse === "evm" &&
+            privateKeyToAccount(resolvedSecretKey as `0x${string}`).address.toLowerCase() !==
+              request.walletAddress?.toLowerCase())
+        ) {
+          throw new Error("Transaction signer no longer matches the authorized wallet");
+        }
+        return resolvedSecretKey;
+      };
+
+      if (usesCustodyAdvisoryLock()) {
+        lockedVenueSecretKey = await db.transaction(async (tx) => {
+          await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtextextended(${custodyTransitionLockKey(request.tenantId, request.agentId, chainFamilyToUse, venue)}, 0))`,
+          );
+          return resolveLockedVenueKey(tx);
+        });
+      } else {
+        lockedVenueSecretKey = await resolveLockedVenueKey(db);
+      }
+    }
+
+    let secretKey: string;
+    const [chainKey] = lockedVenueSecretKey
+      ? []
+      : await db
+          .select()
+          .from(encryptedChainKeys)
+          .where(
+            and(
+              eq(encryptedChainKeys.agentId, request.agentId),
+              eq(encryptedChainKeys.chainFamily, chainFamilyToUse),
+              venue ? eq(encryptedChainKeys.venue, venue) : isNull(encryptedChainKeys.venue),
+            ),
+          );
+
+    if (lockedVenueSecretKey) {
+      if (options.expectedBackend === "external-custody") {
+        throw new BackendBindingMismatchError("external-custody", "local-vault");
+      }
+      secretKey = lockedVenueSecretKey;
+    } else if (chainKey) {
       if (options.expectedBackend === "external-custody") {
         throw new BackendBindingMismatchError("external-custody", "local-vault");
       }


### PR DESCRIPTION
## Summary
- require every Hyperliquid transaction signer call to carry the already-authorized venue wallet address
- resolve the venue wallet row and encrypted key under the custody advisory lock, then fail closed if either no longer matches
- bind the mounted operator-recovery deposit route to that wallet assertion
- cover PGLite round-trip/mismatch, mounted route argument binding, and the real two-connection PostgreSQL rotation race

## Exact-head verification
- `bun run typecheck` (36 package tasks plus web TypeScript)
- `bun run lint` (1,490 files)
- vault and plugin dependency/package builds
- `venue-wallet-key-roundtrip.test.ts`: 2/2
- mounted operator deposit wallet assertion: 1/1
- `custody-transition-race.real-pg.test.ts`: 6/6 against a freshly migrated PostgreSQL database
- Biome and diff checks clean

Refs #870. The issue should close only after terminal hosted checks and independent exact-head review.