### PR TITLE
fix(auth): recover explicit-tenant OAuth fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -164,29 +164,29 @@ COPY packages/webhooks    packages/webhooks
 
 # Create workspace symlinks (Bun 1.3 doesn't auto-link in Docker)
 RUN mkdir -p node_modules/@stwd && \
-    ln -sf ../../../packages/adapters      node_modules/@stwd/adapters && \
-    ln -sf ../../../packages/attestation   node_modules/@stwd/attestation && \
-    ln -sf ../../../packages/shared        node_modules/@stwd/shared && \
-    ln -sf ../../../packages/sdk           node_modules/@stwd/sdk && \
-    ln -sf ../../../packages/auth          node_modules/@stwd/auth && \
-    ln -sf ../../../packages/db            node_modules/@stwd/db && \
-    ln -sf ../../../packages/vault         node_modules/@stwd/vault && \
-    ln -sf ../../../packages/redis         node_modules/@stwd/redis && \
-    ln -sf ../../../packages/proxy         node_modules/@stwd/proxy && \
-    ln -sf ../../../packages/webhooks      node_modules/@stwd/webhooks && \
-    ln -sf ../../../packages/policy-engine     node_modules/@stwd/policy-engine && \
-    ln -sf ../../../packages/plugin-capabilities node_modules/@stwd/plugin-capabilities && \
-    ln -sf ../../../packages/plugin-trading    node_modules/@stwd/plugin-trading && \
-    ln -sf ../../../packages/plugin-wxmr       node_modules/@stwd/plugin-wxmr && \
-    ln -sf ../../../packages/provider-github   node_modules/@stwd/provider-github && \
-    ln -sf ../../../packages/provider-slack    node_modules/@stwd/provider-slack && \
-    ln -sf ../../../packages/provider-google   node_modules/@stwd/provider-google && \
-    ln -sf ../../../packages/provider-aws      node_modules/@stwd/provider-aws && \
-    ln -sf ../../../packages/provider-x         node_modules/@stwd/provider-x && \
-    ln -sf ../../../packages/proxy-client      node_modules/@stwd/proxy-client && \
-    ln -sf ../../../packages/trade-sessions    node_modules/@stwd/trade-sessions && \
-    ln -sf ../../../packages/venue-hyperliquid node_modules/@stwd/venue-hyperliquid && \
-    ln -sf ../../../packages/venue-polymarket  node_modules/@stwd/venue-polymarket
+    ln -sf ../../packages/adapters      node_modules/@stwd/adapters && \
+    ln -sf ../../packages/attestation   node_modules/@stwd/attestation && \
+    ln -sf ../../packages/shared        node_modules/@stwd/shared && \
+    ln -sf ../../packages/sdk           node_modules/@stwd/sdk && \
+    ln -sf ../../packages/auth          node_modules/@stwd/auth && \
+    ln -sf ../../packages/db            node_modules/@stwd/db && \
+    ln -sf ../../packages/vault         node_modules/@stwd/vault && \
+    ln -sf ../../packages/redis         node_modules/@stwd/redis && \
+    ln -sf ../../packages/proxy         node_modules/@stwd/proxy && \
+    ln -sf ../../packages/webhooks      node_modules/@stwd/webhooks && \
+    ln -sf ../../packages/policy-engine     node_modules/@stwd/policy-engine && \
+    ln -sf ../../packages/plugin-capabilities node_modules/@stwd/plugin-capabilities && \
+    ln -sf ../../packages/plugin-trading    node_modules/@stwd/plugin-trading && \
+    ln -sf ../../packages/plugin-wxmr       node_modules/@stwd/plugin-wxmr && \
+    ln -sf ../../packages/provider-github   node_modules/@stwd/provider-github && \
+    ln -sf ../../packages/provider-slack    node_modules/@stwd/provider-slack && \
+    ln -sf ../../packages/provider-google   node_modules/@stwd/provider-google && \
+    ln -sf ../../packages/provider-aws      node_modules/@stwd/provider-aws && \
+    ln -sf ../../packages/provider-x         node_modules/@stwd/provider-x && \
+    ln -sf ../../packages/proxy-client      node_modules/@stwd/proxy-client && \
+    ln -sf ../../packages/trade-sessions    node_modules/@stwd/trade-sessions && \
+    ln -sf ../../packages/venue-hyperliquid node_modules/@stwd/venue-hyperliquid && \
+    ln -sf ../../packages/venue-polymarket  node_modules/@stwd/venue-polymarket
 
 # Build api and proxy (and their deps) via turborepo
 RUN bunx turbo run build --filter=@stwd/api --filter=@stwd/proxy
@@ -280,31 +280,31 @@ COPY --from=build /app/packages/webhooks    packages/webhooks
 
 # Create workspace symlinks manually — bun 1.3 doesn't auto-link workspace packages
 RUN mkdir -p node_modules/@stwd && \
-    ln -sf ../../../packages/adapters      node_modules/@stwd/adapters && \
-    ln -sf ../../../packages/attestation   node_modules/@stwd/attestation && \
-    ln -sf ../../../packages/shared        node_modules/@stwd/shared && \
-    ln -sf ../../../packages/sdk           node_modules/@stwd/sdk && \
-    ln -sf ../../../packages/auth          node_modules/@stwd/auth && \
-    ln -sf ../../../packages/db            node_modules/@stwd/db && \
-    ln -sf ../../../packages/vault         node_modules/@stwd/vault && \
-    ln -sf ../../../packages/redis         node_modules/@stwd/redis && \
-    ln -sf ../../../packages/api           node_modules/@stwd/api && \
-    ln -sf ../../../packages/proxy         node_modules/@stwd/proxy && \
-    ln -sf ../../../packages/webhooks      node_modules/@stwd/webhooks && \
-    ln -sf ../../../packages/policy-engine node_modules/@stwd/policy-engine && \
-    ln -sf ../../../packages/plugin-capabilities node_modules/@stwd/plugin-capabilities && \
-    ln -sf ../../../packages/plugin-trading    node_modules/@stwd/plugin-trading && \
-    ln -sf ../../../packages/plugin-wxmr       node_modules/@stwd/plugin-wxmr && \
-    ln -sf ../../../packages/provider-github   node_modules/@stwd/provider-github && \
-    ln -sf ../../../packages/provider-slack    node_modules/@stwd/provider-slack && \
-    ln -sf ../../../packages/provider-google   node_modules/@stwd/provider-google && \
-    ln -sf ../../../packages/provider-aws      node_modules/@stwd/provider-aws && \
-    ln -sf ../../../packages/provider-x         node_modules/@stwd/provider-x && \
-    ln -sf ../../../packages/proxy-client      node_modules/@stwd/proxy-client && \
-    ln -sf ../../../packages/trade-sessions    node_modules/@stwd/trade-sessions && \
-    ln -sf ../../../packages/venue-hyperliquid node_modules/@stwd/venue-hyperliquid && \
-    ln -sf ../../../packages/venue-polymarket  node_modules/@stwd/venue-polymarket && \
-    ln -sf ../../../packages/eliza-plugin  node_modules/@stwd/eliza-plugin 2>/dev/null; true
+    ln -sf ../../packages/adapters      node_modules/@stwd/adapters && \
+    ln -sf ../../packages/attestation   node_modules/@stwd/attestation && \
+    ln -sf ../../packages/shared        node_modules/@stwd/shared && \
+    ln -sf ../../packages/sdk           node_modules/@stwd/sdk && \
+    ln -sf ../../packages/auth          node_modules/@stwd/auth && \
+    ln -sf ../../packages/db            node_modules/@stwd/db && \
+    ln -sf ../../packages/vault         node_modules/@stwd/vault && \
+    ln -sf ../../packages/redis         node_modules/@stwd/redis && \
+    ln -sf ../../packages/api           node_modules/@stwd/api && \
+    ln -sf ../../packages/proxy         node_modules/@stwd/proxy && \
+    ln -sf ../../packages/webhooks      node_modules/@stwd/webhooks && \
+    ln -sf ../../packages/policy-engine node_modules/@stwd/policy-engine && \
+    ln -sf ../../packages/plugin-capabilities node_modules/@stwd/plugin-capabilities && \
+    ln -sf ../../packages/plugin-trading    node_modules/@stwd/plugin-trading && \
+    ln -sf ../../packages/plugin-wxmr       node_modules/@stwd/plugin-wxmr && \
+    ln -sf ../../packages/provider-github   node_modules/@stwd/provider-github && \
+    ln -sf ../../packages/provider-slack    node_modules/@stwd/provider-slack && \
+    ln -sf ../../packages/provider-google   node_modules/@stwd/provider-google && \
+    ln -sf ../../packages/provider-aws      node_modules/@stwd/provider-aws && \
+    ln -sf ../../packages/provider-x         node_modules/@stwd/provider-x && \
+    ln -sf ../../packages/proxy-client      node_modules/@stwd/proxy-client && \
+    ln -sf ../../packages/trade-sessions    node_modules/@stwd/trade-sessions && \
+    ln -sf ../../packages/venue-hyperliquid node_modules/@stwd/venue-hyperliquid && \
+    ln -sf ../../packages/venue-polymarket  node_modules/@stwd/venue-polymarket && \
+    ln -sf ../../packages/eliza-plugin  node_modules/@stwd/eliza-plugin 2>/dev/null; true
 
 # Install the production dependency closure AFTER copying the built packages.
 # `COPY --from=build /app/packages/*` lines above overwrite each package dir

--- a/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
@@ -169,6 +169,22 @@ describeWithDatabase("OAuth redirect_uri allowlist", () => {
     expect(body.error).toContain("redirect_uri is not allowed");
   });
 
+  it("uses the deployment allowlist when an explicit tenant has no redirect configuration", async () => {
+    const db = getDb();
+    await db.delete(tenantAppClients).where(eq(tenantAppClients.tenantId, TENANT_ID));
+    await db.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TENANT_ID));
+    process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS = "https://global.example.test/callback";
+
+    const res = await authRoutes.request(
+      `/oauth/google/authorize?tenant_id=${TENANT_ID}&redirect_uri=${encodeURIComponent("https://global.example.test/callback")}${PKCE_QUERY}`,
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toStartWith(
+      "https://accounts.google.com/o/oauth2/v2/auth?",
+    );
+  });
+
   it("rejects tenant origin-only entries for non-root OAuth redirect_uri paths", async () => {
     const db = getDb();
     await db.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TENANT_ID));

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -11183,7 +11183,11 @@ async function getAllowedOAuthRedirectEntries(
     }
   }
 
-  if (!explicitTenantId) {
+  // A deployment-level allowlist is the compatibility fallback when an
+  // explicit tenant has not configured its own redirect URLs yet. Keep a
+  // populated tenant allowlist authoritative so the environment variable
+  // cannot silently broaden an existing tenant boundary.
+  if (!explicitTenantId || entries.size === 0) {
     for (const entry of parseOAuthRedirectAllowlistEnv()) {
       entries.add(entry);
     }

--- a/packages/proxy/src/__tests__/deploy-artifacts.test.ts
+++ b/packages/proxy/src/__tests__/deploy-artifacts.test.ts
@@ -26,7 +26,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, posix } from "node:path";
 
 const DEPLOY_DIR = join(import.meta.dir, "..", "..", "..", "..", "deploy");
 const ROOT_DIR = join(DEPLOY_DIR, "..");
@@ -42,6 +42,18 @@ describe("published Docker runtime network contract", () => {
 
     expect(runtime).toContain("ENV STEWARD_BIND_HOST=0.0.0.0");
     expect(runtime).toContain('CMD ["bun", "packages/api/src/index.ts"]');
+  });
+
+  test("workspace links resolve inside /app instead of escaping the image root", () => {
+    const dockerfile = readFileSync(join(ROOT_DIR, "Dockerfile"), "utf8");
+    const links = [
+      ...dockerfile.matchAll(/ln -sf (\.\.\/[^\s]+)\s+node_modules\/@stwd\/([^\s;&]+)/g),
+    ];
+
+    expect(links.length).toBeGreaterThan(0);
+    for (const [, target, packageName] of links) {
+      expect(posix.resolve("/app/node_modules/@stwd", target)).toBe(`/app/packages/${packageName}`);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- use the deployment OAuth allowlist only when an explicit tenant has no tenant-scoped redirect configuration
- keep populated tenant redirect lists authoritative so the global setting cannot broaden them
- add the explicit-tenant fallback regression case
- correct Docker workspace symlink targets so build and runtime images resolve packages under `/app/packages`
- add a deployment-artifact regression that resolves every workspace link from `/app/node_modules/@stwd`

## Exact-head validation (`d50a1da644a2b868fa367f97481197e327301995`)
- migrated fresh real Postgres: OAuth redirect allowlist 12/12, 38 assertions
- deployment artifact suite: 60/60, 484 assertions
- `bun run --cwd packages/api build`
- Biome check for all changed TypeScript
- `git diff --check`
- prior live staging deployment `247918ac-fb03-4a49-a009-d7e9073c7df2`: health 200; Google and Discord authorize endpoints returned 302 to the correct providers

## Acceptance boundary
Hosted Docker and required protected checks restarted after the exact-head force update. Merge remains gated on their terminal success and independent approval.