### PR TITLE
fix(auth): promote staging auth recovery to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
           if [ "${{ matrix.package }}" = "packages/sdk" ]; then
             mapfile -t sdk_tests < <(find packages/sdk/src -type f \( -name '*.test.ts' -o -name '*.spec.ts' \) | sort)
             bun test --isolate "${sdk_tests[@]}"
-          elif [ "${{ matrix.package }}" = "packages/plugin-sdk" ] || [ "${{ matrix.package }}" = "packages/plugin-example" ] || [ "${{ matrix.package }}" = "packages/plugin-capabilities" ]; then
+          elif [ "${{ matrix.package }}" = "packages/proxy" ] || [ "${{ matrix.package }}" = "packages/plugin-sdk" ] || [ "${{ matrix.package }}" = "packages/plugin-example" ] || [ "${{ matrix.package }}" = "packages/plugin-capabilities" ]; then
             # These packages own their test-process isolation or package-local
             # preload. Running them from the repository root bypasses that
             # contract and can leak mutable fixtures between files.

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -132,6 +132,7 @@ jobs:
           echo "Production candidate resolved to an immutable main-built digest."
 
       - name: Create GitHub deployment
+        if: ${{ inputs.dry_run == false }}
         id: deployment
         uses: chrnorm/deployment-action@500aa6a23c81ffa1acf71072aee3cfa2cc2e556a # v2
         with:
@@ -159,7 +160,7 @@ jobs:
           ./scripts/railway-deploy.sh "${ARGS[@]}"
 
       - name: Update deployment status (success)
-        if: success()
+        if: ${{ inputs.dry_run == false && success() }}
         uses: chrnorm/deployment-status@6df8d036fd2fee9eb82936733953da1f8382b41e # v2
         with:
           token: ${{ github.token }}
@@ -168,7 +169,7 @@ jobs:
           environment-url: ${{ vars.PRODUCTION_RAILWAY_HEALTH_URL }}
 
       - name: Update deployment status (failure)
-        if: failure() && steps.deployment.outputs.deployment_id != ''
+        if: ${{ inputs.dry_run == false && failure() && steps.deployment.outputs.deployment_id != '' }}
         uses: chrnorm/deployment-status@6df8d036fd2fee9eb82936733953da1f8382b41e # v2
         with:
           token: ${{ github.token }}

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -10,6 +10,9 @@
 # should also require reviewer approval.
 name: Deploy Railway (Production)
 
+# Deliberately dispatch-only. A reusable workflow executes in the caller's
+# repository context, so actions/checkout and github.repository would verify
+# the caller's main branch rather than this image-producing repository.
 on:
   workflow_dispatch:
     inputs:
@@ -22,21 +25,6 @@ on:
         required: false
         type: boolean
         default: false
-
-  workflow_call:
-    inputs:
-      main_sha:
-        description: "Full 40-character commit SHA on the caller repository's main branch"
-        required: true
-        type: string
-      dry_run:
-        description: "Dry run (resolve and verify the digest; skip Railway mutation)"
-        required: false
-        type: boolean
-        default: false
-    secrets:
-      RAILWAY_TOKEN:
-        required: true
 
 permissions:
   actions: read

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -4,42 +4,33 @@
 #   develop ──(deploy-staging.yml, auto)──▶ STAGING
 #   main    ──(THIS workflow, manual/gated)──▶ PRODUCTION
 #
-# Production is promoted DELIBERATELY, never auto-deployed. Promotion = merge
-# develop -> main (reviewed), then a maintainer dispatches this workflow with
-# the image tag to ship (`main` or a `v*` release tag). The `production` GitHub
-# environment can carry required-reviewer protection for a second gate. Prod
-# should rarely change.
-#
-# Triggers:
-#   1. Manual dispatch (workflow_dispatch) with image tag input
-#   2. Reusable workflow (workflow_call) for downstream consumers that embed
-#      Steward as a dependency (Steward is a standalone, self-hostable OSS
-#      product; consumers integrate via its API, they do not own it).
+# Production accepts only an immutable digest whose exact source commit is on
+# main and has a successful Docker push run for main. A branch/tag string is
+# never an admissible production selector. The production GitHub environment
+# should also require reviewer approval.
 name: Deploy Railway (Production)
 
 on:
-  # Manual trigger from Actions tab
   workflow_dispatch:
     inputs:
-      image_tag:
-        description: "Docker image tag to deploy (e.g. v0.5.0, develop)"
+      main_sha:
+        description: "Full 40-character commit SHA already merged to main"
         required: true
         type: string
       dry_run:
-        description: "Dry run (skip actual deploy)"
+        description: "Dry run (resolve and verify the digest; skip Railway mutation)"
         required: false
         type: boolean
         default: false
 
-  # Reusable workflow (callable by downstream consumers embedding Steward)
   workflow_call:
     inputs:
-      image_tag:
-        description: "Docker image tag to deploy"
+      main_sha:
+        description: "Full 40-character commit SHA on the caller repository's main branch"
         required: true
         type: string
       dry_run:
-        description: "Dry run (skip actual deploy)"
+        description: "Dry run (resolve and verify the digest; skip Railway mutation)"
         required: false
         type: boolean
         default: false
@@ -48,76 +39,137 @@ on:
         required: true
 
 permissions:
+  actions: read
   contents: read
+  packages: read
   deployments: write
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # Bind to the `production` GitHub environment so required-reviewer / wait
-    # timer protection rules (configured in repo Settings → Environments) gate
-    # the prod deploy. This is the second gate on top of "only from main".
+    timeout-minutes: 15
     environment:
       name: Production
       url: ${{ vars.PRODUCTION_RAILWAY_HEALTH_URL }}
 
     steps:
-      - name: Checkout
+      # Always inspect the authoritative main ref. Selecting another branch in
+      # the workflow-dispatch UI must not change the source of a prod deploy.
+      - name: Checkout main history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          fetch-depth: 0
 
-      # Resolve the image tag based on trigger type
-      - name: Resolve image tag
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Verify main provenance and resolve immutable digest
         id: resolve
-        # image_tag is a caller-supplied input; pass it via env (never inline
-        # into the script) to avoid shell expression-injection.
         env:
-          IMAGE_TAG: ${{ inputs.image_tag }}
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ inputs.main_sha }}
+          TARGET_REPOSITORY: ${{ github.repository }}
+          CONFIGURED_IMAGE_REPO: ${{ vars.PRODUCTION_RAILWAY_IMAGE_REPO }}
         run: |
-          TAG="$IMAGE_TAG"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Image tag resolved: ${TAG}"
+          set -euo pipefail
 
-      - name: Resolve dry-run flag
-        id: flags
-        env:
-          DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          echo "dry_run=${DRY_RUN}" >> "$GITHUB_OUTPUT"
+          if [[ ! "$MAIN_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "main_sha must be a full lowercase 40-character commit SHA" >&2
+            exit 1
+          fi
 
-      # Create GitHub deployment (shows in repo's Deployments tab)
+          git cat-file -e "${MAIN_SHA}^{commit}"
+          if ! git merge-base --is-ancestor "$MAIN_SHA" refs/remotes/origin/main; then
+            echo "Refusing production deploy: commit is not on origin/main" >&2
+            exit 1
+          fi
+
+          # Being reachable from main is not enough: require the exact main
+          # push to have completed the image-producing Docker workflow.
+          SUCCESSFUL_MAIN_BUILDS=$(gh api --method GET \
+            "repos/${TARGET_REPOSITORY}/actions/workflows/docker.yml/runs" \
+            -f branch=main \
+            -f head_sha="$MAIN_SHA" \
+            -f event=push \
+            -f status=success \
+            -f per_page=1 \
+            --jq '.total_count')
+          if [[ ! "$SUCCESSFUL_MAIN_BUILDS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Refusing production deploy: no successful exact-SHA main Docker build" >&2
+            exit 1
+          fi
+
+          IMAGE_REPO="${CONFIGURED_IMAGE_REPO:-ghcr.io/steward-fi/steward}"
+          if [[ ! "$IMAGE_REPO" =~ ^ghcr\.io/[a-z0-9._-]+(/[a-z0-9._-]+)+$ ]]; then
+            echo "PRODUCTION_RAILWAY_IMAGE_REPO must be a lowercase ghcr.io repository" >&2
+            exit 1
+          fi
+
+          MANIFEST=$(docker buildx imagetools inspect \
+            "${IMAGE_REPO}:sha-${MAIN_SHA}" --format '{{json .Manifest}}')
+          DIGEST=$(jq -er \
+            '.digest | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$MANIFEST")
+
+          # Verify the bytes currently behind the lookup tag still carry the
+          # exact main-build provenance. This catches a later tag overwrite
+          # even when the historic Actions run itself was green.
+          PROVENANCE=$(docker buildx imagetools inspect \
+            "${IMAGE_REPO}:sha-${MAIN_SHA}" \
+            --format '{{json .Provenance.SLSA.buildDefinition.externalParameters.request.args}}')
+          REVISION=$(jq -er '."label:org.opencontainers.image.revision"' <<<"$PROVENANCE")
+          VERSION=$(jq -er '."label:org.opencontainers.image.version"' <<<"$PROVENANCE")
+          SOURCE=$(jq -er '."label:org.opencontainers.image.source"' <<<"$PROVENANCE")
+          if [[ "$REVISION" != "$MAIN_SHA" || "$VERSION" != "main" || \
+            "$SOURCE" != "https://github.com/${TARGET_REPOSITORY}" ]]; then
+            echo "Refusing production deploy: image provenance is not the exact main build" >&2
+            exit 1
+          fi
+
+          echo "sha=${MAIN_SHA}" >> "$GITHUB_OUTPUT"
+          echo "image_repo=${IMAGE_REPO}" >> "$GITHUB_OUTPUT"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "image_ref=${IMAGE_REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Production candidate resolved to an immutable main-built digest."
+
       - name: Create GitHub deployment
         id: deployment
         uses: chrnorm/deployment-action@500aa6a23c81ffa1acf71072aee3cfa2cc2e556a # v2
         with:
           token: ${{ github.token }}
           environment: production
-          ref: ${{ github.sha }}
-          description: "Deploy ghcr.io/steward-fi/steward:${{ steps.resolve.outputs.tag }} to Railway"
+          ref: ${{ steps.resolve.outputs.sha }}
+          description: "Deploy ${{ steps.resolve.outputs.image_ref }} to Railway"
 
-      # Run the deploy script
-      - name: Deploy to Railway
-        id: deploy
+      - name: Deploy immutable digest to Railway
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          # Instance-specific deploy target comes from the DEPLOYER's own repo
-          # config (a self-hoster sets PRODUCTION_RAILWAY_* vars for their own
-          # Railway). Nothing about any specific instance is baked into source.
           RAILWAY_SERVICE_ID: ${{ vars.PRODUCTION_RAILWAY_SERVICE_ID }}
           RAILWAY_ENV_ID: ${{ vars.PRODUCTION_RAILWAY_ENV_ID }}
           RAILWAY_HEALTH_URL: ${{ vars.PRODUCTION_RAILWAY_HEALTH_URL }}
-          # Step outputs derive from the caller-supplied image_tag input, so they
-          # are still tainted — pass via env instead of inlining into the script.
-          RESOLVED_TAG: ${{ steps.resolve.outputs.tag }}
-          DRY_RUN: ${{ steps.flags.outputs.dry_run }}
+          RAILWAY_REQUIRE_HEALTH: "true"
+          RAILWAY_IMAGE_REPO: ${{ steps.resolve.outputs.image_repo }}
+          RAILWAY_IMAGE_DIGEST: ${{ steps.resolve.outputs.digest }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          ARGS=("$RESOLVED_TAG")
+          ARGS=()
           if [[ "$DRY_RUN" == "true" ]]; then
             ARGS+=(--dry-run)
           fi
           chmod +x scripts/railway-deploy.sh
           ./scripts/railway-deploy.sh "${ARGS[@]}"
 
-      # Update deployment status on success
       - name: Update deployment status (success)
         if: success()
         uses: chrnorm/deployment-status@6df8d036fd2fee9eb82936733953da1f8382b41e # v2
@@ -127,9 +179,8 @@ jobs:
           state: success
           environment-url: ${{ vars.PRODUCTION_RAILWAY_HEALTH_URL }}
 
-      # Update deployment status on failure
       - name: Update deployment status (failure)
-        if: failure()
+        if: failure() && steps.deployment.outputs.deployment_id != ''
         uses: chrnorm/deployment-status@6df8d036fd2fee9eb82936733953da1f8382b41e # v2
         with:
           token: ${{ github.token }}

--- a/docs/RAILWAY-DEPLOY.md
+++ b/docs/RAILWAY-DEPLOY.md
@@ -37,7 +37,9 @@ railway link
 
 Or do it in the Railway dashboard: **Project → Settings → Connect Repo → select steward-fi**.
 
-Set the deploy branch (e.g. `develop` or `main`) under **Settings → Deploy → Branch**.
+For a development or staging service, set its deploy branch under **Settings →
+Deploy → Branch**. Production should use the gated immutable-digest workflow,
+not Railway branch auto-deploy.
 
 ---
 
@@ -171,6 +173,10 @@ Under **Service → Settings → Deploy → Health Check**:
 - **Port:** `3200`
 - **Timeout:** `45s` (Steward runs migrations on first boot, may take a moment)
 
+The repository's `railway.json` also declares `/health` with a 120-second
+timeout. Verify the effective service setting explicitly for image-only
+services, which may not consume repository config as code.
+
 ### Start Command
 
 Leave blank — the Dockerfile's `CMD` handles it:
@@ -182,7 +188,7 @@ CMD ["bun", "packages/api/src/index.ts"]
 
 ## 5. Deploy
 
-### Via GitHub (auto-deploy)
+### Via GitHub (staging auto-deploy)
 
 Push to your configured branch:
 
@@ -190,13 +196,18 @@ Push to your configured branch:
 git push origin develop
 ```
 
-Railway picks it up automatically. Watch the build in the dashboard.
+Railway picks it up automatically. Watch the build in the dashboard. Do not
+configure production to follow this mutable branch.
 
 ### Via CLI (manual)
 
 ```bash
 railway up
 ```
+
+Use direct CLI deploys for development or initial self-hosting only. Established
+production instances should follow the immutable, main-built digest flow in the
+[production promotion and rollback runbook](runbooks/production-promotion.md).
 
 ### First deploy
 
@@ -347,7 +358,7 @@ Redeploy the Vercel app after setting these.
 
 ## 9. CI/CD
 
-### Auto-deploy on push (recommended)
+### Staging auto-deploy on push
 
 Railway auto-deploys when you push to the connected branch:
 
@@ -357,20 +368,29 @@ git push origin develop
 ```
 
 Configure the branch in **Service → Settings → Source → Deploy Branch**.
+Production must not auto-deploy a mutable branch or tag.
 
-### Manual deploy via CLI
+### Manual development deploy via CLI
 
 ```bash
 # Deploy current directory
 railway up
 
-# Deploy with a specific environment
-railway up --environment production
+# Deploy with a specific non-production environment
+railway up --environment staging
 ```
+
+For production, dispatch **Deploy Railway (Production)** with a full commit SHA
+already on `main`. The workflow requires an exact successful main Docker build,
+resolves its manifest digest, and passes only that digest to Railway. See the
+[production promotion and rollback runbook](runbooks/production-promotion.md).
 
 ### Rollback
 
-In the Railway dashboard: **Deployments → click a previous successful deploy → Rollback**.
+Redeploy the last known-good main commit through the same production workflow;
+the provenance, immutable-digest, and `/health` gates still apply. Do not roll
+production back to a mutable branch/tag selector. See the
+[production promotion and rollback runbook](runbooks/production-promotion.md).
 
 ---
 

--- a/docs/TENANT_EMAIL_CONFIG.md
+++ b/docs/TENANT_EMAIL_CONFIG.md
@@ -110,6 +110,21 @@ URL is set without a callback path, the path defaults to
 `/auth/email/verify`. Always verify that a generated link lands on the tenant
 application before promoting the configuration.
 
+Hosted deployments can also set a durable environment fallback for shared
+email delivery:
+
+```bash
+EMAIL_BRAND_NAME=Acme
+EMAIL_MAGIC_LINK_BASE_URL=https://app.acme.example
+EMAIL_MAGIC_LINK_CALLBACK_PATH=/auth/callback/email
+```
+
+These values are used when tenant email config is absent or temporarily
+unavailable. A tenant's explicit `brandName` and `magicLinkBaseUrl` still take
+precedence. Keep the email link origin separate from `APP_URL` when `APP_URL`
+must identify the Steward API for OAuth callbacks. The email base must be a
+credential-free HTTP(S) origin, and the callback must be root-relative.
+
 ## Custom raw templates (deployer-supplied branded markup)
 
 For fully branded auth emails, a hosted Steward instance can store raw

--- a/docs/TENANT_EMAIL_CONFIG.md
+++ b/docs/TENANT_EMAIL_CONFIG.md
@@ -17,8 +17,11 @@ If a tenant has no `tenant_configs.email_config`, auth continues using the globa
   "apiKeyEncrypted": "...",
   "from": "Tenant <login@example.com>",
   "replyTo": "support@example.com",
+  "brandName": "Acme",
   "templateId": "acme",
   "subjectOverride": "Sign in",
+  "magicLinkBaseUrl": "https://app.acme.example",
+  "magicLinkCallbackPath": "/auth/callback/email",
   "templates": {
     "magicLink": { "subject": "...", "text": "...", "html": "..." },
     "otp": { "subject": "...", "text": "...", "html": "..." }
@@ -66,18 +69,46 @@ curl -X DELETE "$API_BASE/platform/tenants/acme/email-config" \
 ## Template-only branding (no per-tenant Resend key)
 
 A tenant can keep the platform's global Resend provider and only override the
-email branding. PATCH with no `apiKey` (and no `from`):
+email branding. `brandName` customizes both built-in magic-link and OTP
+templates without requiring raw HTML. PATCH with no `apiKey` (and no `from`):
 
 ```bash
 curl -X PATCH "$API_BASE/platform/tenants/acme/email-config" \
   -H "Content-Type: application/json" \
   -H "X-Steward-Platform-Key: $STEWARD_PLATFORM_KEY" \
-  -d '{ "templateId": "acme" }'
+  -d '{ "brandName": "Acme" }'
 ```
 
 Branding fields are merged over any existing config, so a template-only PATCH
 never clobbers `magicLinkBaseUrl` or stored provider credentials. `from`
 without `apiKey` is rejected (provider config is all-or-nothing).
+
+`brandName` is a single-line display string of at most 100 characters. It
+defaults to `Steward` when unset. Use `subjectOverride` only when the subject
+must differ from the built-in `Sign in to <brand name>` copy.
+
+## Hosted callback routing
+
+When a tenant's application owns the browser callback, configure both its
+public origin and the root-relative route that the application actually
+serves. These fields can be patched together with `brandName` and merge over
+any existing provider credentials:
+
+```bash
+curl -X PATCH "$API_BASE/platform/tenants/acme/email-config" \
+  -H "Content-Type: application/json" \
+  -H "X-Steward-Platform-Key: $STEWARD_PLATFORM_KEY" \
+  -d '{
+    "brandName": "Acme",
+    "magicLinkBaseUrl": "https://app.acme.example",
+    "magicLinkCallbackPath": "/auth/callback/email"
+  }'
+```
+
+Without `magicLinkBaseUrl`, links use Steward's global `APP_URL`. When a base
+URL is set without a callback path, the path defaults to
+`/auth/email/verify`. Always verify that a generated link lands on the tenant
+application before promoting the configuration.
 
 ## Custom raw templates (deployer-supplied branded markup)
 

--- a/docs/runbooks/production-promotion.md
+++ b/docs/runbooks/production-promotion.md
@@ -1,0 +1,80 @@
+# Production promotion and rollback
+
+This runbook is the release boundary between the continuously validated
+`develop` branch and production. Production must run an immutable image digest
+built by the Docker workflow for an exact commit already on `main`. Mutable
+tags such as `develop`, `main`, `latest`, and version tags are not production
+deployment inputs.
+
+The workflow and scripts are instance-neutral. Each operator supplies its own
+Railway service, environment, health origin, token, and optional image
+repository through GitHub environment secrets and variables.
+
+## Required controls
+
+- Protect `main`; changes arrive through reviewed pull requests with required
+  CI and Docker checks.
+- Protect the GitHub `Production` environment with required reviewers.
+- Configure Railway's platform health check to use `/health`. The repository's
+  `railway.json` declares that path for repository-backed services; verify the
+  effective service setting when an image-only service does not consume config
+  as code.
+- Set `PRODUCTION_RAILWAY_HEALTH_URL` to a credential-free public HTTPS root.
+  The production workflow fails before its first Railway mutation when this
+  value is absent, and accepts a release only after `/health` succeeds.
+- Keep production pinned to `repository@sha256:<digest>`. Never repoint it to a
+  branch or release tag.
+
+## Promote
+
+1. Deploy the exact `develop` candidate to staging and record its commit and
+   image digest. Wait for Railway's `/health` gate.
+2. Run the release-specific staging checks, including authentication and any
+   migration or provider flows changed by the candidate. Save the receipts.
+3. Open a `develop` to `main` promotion pull request. Reconcile `main` back into
+   the candidate through a reviewed branch when branch protection reports the
+   promotion behind. Do not bypass protection or substitute earlier evidence
+   after the head changes.
+4. Merge only after all required checks and review are green on the exact
+   promotion head.
+5. Wait for the `Docker` workflow triggered by the resulting `main` push to
+   succeed. Record the full 40-character `main` commit SHA.
+6. Dispatch **Deploy Railway (Production)** with that full `main_sha`. Start
+   with `dry_run=true` when changing deployment configuration or credentials.
+   The workflow fails closed unless the SHA is reachable from `origin/main`,
+   an exact-SHA successful `main` Docker run exists, the current manifest's
+   provenance names that exact revision and `main`, and the image resolves to a
+   valid `sha256` digest.
+7. Approve the protected `Production` environment. Record the commit, resolved
+   digest, Railway deployment ID, and `/health` receipt.
+
+The `sha-<commit>` tag is used only to find the manifest produced by the exact
+main build. Railway receives the resolved digest, not the tag.
+
+## Roll back
+
+1. Select the last known-good full commit SHA that is already on `main` and
+   whose exact `main` Docker run succeeded. Confirm that its schema is backward
+   compatible with the currently applied migrations. Database rollback is a
+   separate, explicitly reviewed operation; never infer it from an image
+   rollback.
+2. Dispatch **Deploy Railway (Production)** with that SHA. The same provenance,
+   digest, Railway status, and `/health` gates apply to rollback.
+3. If the previous release cannot pass current readiness, stop. Preserve the
+   live healthy deployment, diagnose the incompatibility, and ship a forward
+   fix through `develop` and `main`.
+4. Record the reason, old and restored digests, deployment IDs, health receipts,
+   and follow-up issue. Do not use Railway's branch/tag source selector as a
+   shortcut.
+
+## Failure behavior
+
+- A Railway build/deploy failure fails the workflow; an empty-log control-plane
+  rejection is also fatal by default.
+- A container that never passes `/health` is not eligible for Railway cutover
+  when the platform health check is configured.
+- A deployment that Railway marks successful still fails acceptance unless the
+  configured public `/health` probe passes.
+- Failed promotion does not authorize a production configuration mutation or a
+  database downgrade. Escalate with the captured diagnostics and keep the last
+  known-good digest live.

--- a/packages/api/src/__tests__/approvals-proxy-atomicity.test.ts
+++ b/packages/api/src/__tests__/approvals-proxy-atomicity.test.ts
@@ -78,7 +78,7 @@ async function withApprovalAuditFailure<T>(operation: () => Promise<T>): Promise
   } finally {
     await getDb().execute(
       sql.raw("DROP TRIGGER IF EXISTS proxy_approval_audit_failure_for_test ON audit_events"),
-// ─── Audit-insert fault injection ────────────────────────────────────────────
+      // ─── Audit-insert fault injection ────────────────────────────────────────────
     );
     await getDb().execute(sql.raw("DROP FUNCTION IF EXISTS fail_proxy_approval_audit_for_test()"));
   }

--- a/packages/api/src/__tests__/approvals-proxy-atomicity.test.ts
+++ b/packages/api/src/__tests__/approvals-proxy-atomicity.test.ts
@@ -78,6 +78,7 @@ async function withApprovalAuditFailure<T>(operation: () => Promise<T>): Promise
   } finally {
     await getDb().execute(
       sql.raw("DROP TRIGGER IF EXISTS proxy_approval_audit_failure_for_test ON audit_events"),
+// ─── Audit-insert fault injection ────────────────────────────────────────────
     );
     await getDb().execute(sql.raw("DROP FUNCTION IF EXISTS fail_proxy_approval_audit_for_test()"));
   }

--- a/packages/api/src/__tests__/auth-default-tenant-runtime.test.ts
+++ b/packages/api/src/__tests__/auth-default-tenant-runtime.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { defaultAuthTenantId } from "../services/default-auth-tenant";
+
+describe("default auth tenant runtime binding", () => {
+  test("keeps overlapping Worker request snapshots isolated", async () => {
+    let releaseFirst!: () => void;
+    const firstCanFinish = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let firstStarted!: () => void;
+    const firstDidStart = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+
+    const first = withRuntimeEnvironment(
+      { STEWARD_DEFAULT_TENANT_ID: "tenant-first" },
+      async () => {
+        firstStarted();
+        await firstCanFinish;
+        return defaultAuthTenantId();
+      },
+    );
+    await firstDidStart;
+
+    const second = withRuntimeEnvironment(
+      { STEWARD_DEFAULT_TENANT_ID: "tenant-second" },
+      async () => {
+        expect(defaultAuthTenantId()).toBe("tenant-second");
+        releaseFirst();
+        return defaultAuthTenantId();
+      },
+    );
+
+    expect(await Promise.all([first, second])).toEqual(["tenant-first", "tenant-second"]);
+  });
+
+  test("uses the literal default when the active binding is absent or blank", () => {
+    expect(withRuntimeEnvironment({}, () => defaultAuthTenantId())).toBe("default");
+    expect(
+      withRuntimeEnvironment({ STEWARD_DEFAULT_TENANT_ID: "   " }, () => defaultAuthTenantId()),
+    ).toBe("default");
+  });
+});

--- a/packages/api/src/__tests__/auth-email-config.test.ts
+++ b/packages/api/src/__tests__/auth-email-config.test.ts
@@ -123,7 +123,7 @@ describe("getEmailAuthForTenant", () => {
     invalidateEmailAuthForTenant(TEST_TENANT_ID);
   });
 
-  it("uses tenant magicLinkBaseUrl + custom callbackPath when both set", async () => {
+  it("uses tenant branding with its hosted magic-link callback", async () => {
     clearEmailAuthTenantCacheForTests();
 
     const encrypted = new KeyStore(MASTER_PASSWORD).encrypt("tenant-resend-key");
@@ -134,9 +134,10 @@ describe("getEmailAuthForTenant", () => {
       emailConfig: {
         provider: "resend",
         apiKeyEncrypted: JSON.stringify(encrypted),
-        from: "App <noreply@app.example>",
-        magicLinkBaseUrl: "https://app.example.com/",
-        magicLinkCallbackPath: "/login/email-callback",
+        from: "Customer <noreply@customer.example>",
+        brandName: "Customer Cloud",
+        magicLinkBaseUrl: "https://cloud.customer.example/",
+        magicLinkCallbackPath: "/auth/callback/email",
       },
     });
     invalidateEmailAuthForTenant(TEST_TENANT_ID);
@@ -144,8 +145,21 @@ describe("getEmailAuthForTenant", () => {
     const auth = await getEmailAuthForTenant(TEST_TENANT_ID);
 
     // Trailing slash gets stripped from baseUrl
-    expect((auth as any).baseUrl).toBe("https://app.example.com");
-    expect((auth as any).callbackPath).toBe("/login/email-callback");
+    expect((auth as any).baseUrl).toBe("https://cloud.customer.example");
+    expect((auth as any).callbackPath).toBe("/auth/callback/email");
+    expect((auth as any).brandName).toBe("Customer Cloud");
+
+    const rendered = (auth as any).templateRenderer(undefined, {
+      magicLink: `${(auth as any).baseUrl}${(auth as any).callbackPath}?token=fixture`,
+      email: "user@customer.example",
+      tenantName: (auth as any).brandName,
+      expiresInMinutes: 10,
+    });
+    expect(rendered.subject).toBe("Sign in to Customer Cloud");
+    expect(rendered.text).toContain(
+      "https://cloud.customer.example/auth/callback/email?token=fixture",
+    );
+    expect(rendered.html).not.toContain("steward.fi");
 
     await dbHandle.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TEST_TENANT_ID));
     invalidateEmailAuthForTenant(TEST_TENANT_ID);

--- a/packages/api/src/__tests__/auth-email-config.test.ts
+++ b/packages/api/src/__tests__/auth-email-config.test.ts
@@ -42,6 +42,9 @@ describe("getEmailAuthForTenant", () => {
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.APP_URL;
     delete process.env.EMAIL_FROM;
+    delete process.env.EMAIL_BRAND_NAME;
+    delete process.env.EMAIL_MAGIC_LINK_BASE_URL;
+    delete process.env.EMAIL_MAGIC_LINK_CALLBACK_PATH;
     delete process.env.RESEND_API_KEY;
   });
 
@@ -58,6 +61,40 @@ describe("getEmailAuthForTenant", () => {
     expect(provider.constructor.name).toBe("ResendProvider");
     expect(provider.from).toBe("Global <login@example.com>");
     expect(provider.replyTo).toBeUndefined();
+  });
+
+  it("keeps hosted branding and callback routing when tenant config is unavailable", async () => {
+    const dbHandle = getDb();
+    await dbHandle.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TEST_TENANT_ID));
+    process.env.EMAIL_BRAND_NAME = "Eliza";
+    process.env.EMAIL_MAGIC_LINK_BASE_URL = "https://cloud-staging.example";
+    process.env.EMAIL_MAGIC_LINK_CALLBACK_PATH = "/auth/callback/email";
+    clearEmailAuthTenantCacheForTests();
+
+    try {
+      const auth = await getEmailAuthForTenant(TEST_TENANT_ID);
+
+      expect((auth as any).brandName).toBe("Eliza");
+      expect((auth as any).baseUrl).toBe("https://cloud-staging.example");
+      expect((auth as any).callbackPath).toBe("/auth/callback/email");
+
+      const rendered = (auth as any).templateRenderer(undefined, {
+        magicLink: "https://cloud-staging.example/auth/callback/email?token=fixture",
+        email: "user@example.com",
+        tenantName: (auth as any).brandName,
+        expiresInMinutes: 10,
+      });
+      expect(rendered.subject).toBe("Sign in to Eliza");
+      expect(rendered.text).toContain(
+        "https://cloud-staging.example/auth/callback/email?token=fixture",
+      );
+      expect(rendered.html).not.toContain("steward.fi");
+    } finally {
+      delete process.env.EMAIL_BRAND_NAME;
+      delete process.env.EMAIL_MAGIC_LINK_BASE_URL;
+      delete process.env.EMAIL_MAGIC_LINK_CALLBACK_PATH;
+      clearEmailAuthTenantCacheForTests();
+    }
   });
 
   it("uses the tenant-specific config when emailConfig is set", async () => {

--- a/packages/api/src/__tests__/auth-login-audit-rls-boundary.test.ts
+++ b/packages/api/src/__tests__/auth-login-audit-rls-boundary.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+const source = await Bun.file(new URL("../routes/auth.ts", import.meta.url)).text();
+
+function sourceBetween(startMarker: string, endMarker: string): string {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start + 1);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe("auth login audit RLS boundary", () => {
+  test("binds every auth.login audit to the verified user tenant", () => {
+    const auditHelper = sourceBetween(
+      "async function writeAuthLoginAudit(",
+      "async function findOrCreateWalletTenant(",
+    );
+    expect(auditHelper).toContain("withVerifiedAuthTenant(tenantId, userId");
+    expect(auditHelper).toContain('action: "auth.login"');
+  });
+
+  test("routes shared OAuth/session finalization through the guarded audit helper", () => {
+    const responseBuilder = sourceBetween(
+      "async function buildAuthOrMfaResponse(",
+      "function authExchangeJson(",
+    );
+    expect(responseBuilder).toContain("await writeAuthLoginAudit(c, tenantId, userId, claims)");
+    expect(responseBuilder).not.toContain("await writeAuditEvent(");
+  });
+});

--- a/packages/api/src/__tests__/auth-nonce-binding.test.ts
+++ b/packages/api/src/__tests__/auth-nonce-binding.test.ts
@@ -43,7 +43,7 @@ describe("wallet nonce binding hardening", () => {
     expect(exchange).toBeGreaterThan(stateLoad);
     expect(userInfo).toBeGreaterThan(exchange);
     expect(consume).toBeGreaterThan(userInfo);
-    expect(callbackRoute).toContain("Invalid or already-used OAuth state");
+    expect(callbackRoute).toContain('code: "oauth_state_consumed"');
   });
 
   it("binds Sign in with Apple id_tokens to an authorize-request nonce", () => {

--- a/packages/api/src/__tests__/auth-oauth-callback-browser.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-callback-browser.test.ts
@@ -1,0 +1,281 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, mock } from "bun:test";
+import { closeDb } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+
+const REDIRECT_URI = "https://app.example.test/callback?from=oauth";
+const ORIGINAL_FETCH = globalThis.fetch;
+
+let authRoutes: typeof import("../routes/auth").authRoutes;
+let getAuthChallengeStore: typeof import("../routes/auth").getAuthChallengeStore;
+
+function browserHeaders(): HeadersInit {
+  return {
+    accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "sec-fetch-mode": "navigate",
+  };
+}
+
+async function expectBrowserError(
+  response: Response,
+  expected: { status: number; code: string },
+): Promise<string> {
+  expect(response.status).toBe(expected.status);
+  expect(response.headers.get("content-type")).toContain("text/html");
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  expect(response.headers.get("content-security-policy")).toContain("default-src 'none'");
+  const body = await response.text();
+  expect(body).toContain(`data-error-code="${expected.code}"`);
+  expect(body).toContain("Sign-in could not be completed");
+  expect(body).not.toContain('{"ok":false');
+  return body;
+}
+
+beforeAll(async () => {
+  process.env.NODE_ENV = "test";
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = "oauth-callback-browser-master-password";
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+  ({ authRoutes, getAuthChallengeStore } = await import("../routes/auth"));
+});
+
+afterEach(() => {
+  mock.restore();
+  globalThis.fetch = ORIGINAL_FETCH;
+  delete process.env.APP_URL;
+  delete process.env.GOOGLE_CLIENT_ID;
+  delete process.env.GOOGLE_CLIENT_SECRET;
+  delete process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS;
+});
+
+afterAll(async () => {
+  await closeDb();
+  delete process.env.NODE_ENV;
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_MASTER_PASSWORD;
+});
+
+describe("OAuth browser callback failures", () => {
+  it("renders a non-reflective HTML page for provider errors", async () => {
+    const attackerText = '<img src=x onerror="fetch(`https://attacker.test`) ">';
+    process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS = REDIRECT_URI;
+    const state = "provider-denial-state";
+    await getAuthChallengeStore().set(
+      `oauth:${state}`,
+      JSON.stringify({ provider: "github", redirectUri: REDIRECT_URI, appState: "client-state" }),
+    );
+    const response = await authRoutes.request(
+      `/oauth/github/callback?error=${encodeURIComponent(attackerText)}&state=${state}`,
+      { headers: browserHeaders() },
+    );
+    const body = await expectBrowserError(response, {
+      status: 400,
+      code: "oauth_authorization_failed",
+    });
+
+    expect(body).not.toContain(attackerText);
+    expect(body).not.toContain("attacker.test");
+    expect(body).toContain("Return and try again");
+    expect(body).toContain("error=oauth_authorization_failed");
+    expect(body).toContain("state=client-state");
+  });
+
+  it("renders an HTML recovery page for expired OAuth state", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-state",
+      { headers: browserHeaders() },
+    );
+    const body = await expectBrowserError(response, { status: 401, code: "oauth_state_expired" });
+    expect(body).not.toContain("Return and try again");
+  });
+
+  it("keeps JSON for an explicitly programmatic callback client", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-json-state",
+      { headers: { accept: "application/json" } },
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "This sign-in attempt is invalid or has expired.",
+      code: "oauth_state_expired",
+    });
+  });
+
+  it("honors an explicit q=0 rejection of HTML even for navigation-shaped requests", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-q-zero-state",
+      {
+        headers: {
+          accept: "application/json, text/html;q=0",
+          "sec-fetch-mode": "navigate",
+        },
+      },
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toMatchObject({ ok: false, code: "oauth_state_expired" });
+  });
+
+  for (const excludedHtmlRange of ["text/*;q=0", "*/*;q=0"]) {
+    it(`honors ${excludedHtmlRange} when navigation fallback would otherwise select HTML`, async () => {
+      const response = await authRoutes.request(
+        "/oauth/github/callback?code=provider-code&state=expired-wildcard-state",
+        {
+          headers: {
+            accept: `application/json, ${excludedHtmlRange}`,
+            "sec-fetch-mode": "navigate",
+          },
+        },
+      );
+
+      expect(response.status).toBe(401);
+      expect(response.headers.get("content-type")).toContain("application/json");
+      expect(await response.json()).toMatchObject({ ok: false, code: "oauth_state_expired" });
+    });
+  }
+
+  it("keeps an explicit text/html rejection over a more permissive wildcard", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-specificity-state",
+      {
+        headers: {
+          accept: "application/json, text/html;q=0, */*;q=1",
+          "sec-fetch-mode": "navigate",
+        },
+      },
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toMatchObject({ ok: false, code: "oauth_state_expired" });
+  });
+
+  it("prefers explicitly higher-quality JSON over acceptable HTML", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-quality-state",
+      {
+        headers: {
+          accept: "application/json, text/html;q=0.1",
+          "sec-fetch-mode": "navigate",
+        },
+      },
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toMatchObject({ ok: false, code: "oauth_state_expired" });
+  });
+
+  it("keeps bare wildcard requests on JSON unless they are browser navigations", async () => {
+    const response = await authRoutes.request(
+      "/oauth/github/callback?code=provider-code&state=expired-wildcard-client-state",
+      { headers: { accept: "*/*" } },
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toMatchObject({ ok: false, code: "oauth_state_expired" });
+  });
+
+  it("renders a sanitized provision-policy error with a validated recovery link", async () => {
+    process.env.APP_URL = "https://api.example.test";
+    process.env.GOOGLE_CLIENT_ID = "google-client";
+    process.env.GOOGLE_CLIENT_SECRET = "google-secret";
+    process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS = REDIRECT_URI;
+    const state = "unverified-email-state";
+    await getAuthChallengeStore().set(
+      `oauth:${state}`,
+      JSON.stringify({
+        provider: "google",
+        redirectUri: REDIRECT_URI,
+        appState: '<script id="state-canary">',
+      }),
+    );
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://oauth2.googleapis.com/token") {
+        return Response.json({ access_token: "provider-access-secret", token_type: "Bearer" });
+      }
+      if (url === "https://www.googleapis.com/oauth2/v3/userinfo") {
+        return Response.json({
+          id: "google-unverified-user",
+          email: "unverified@example.test",
+          verified_email: false,
+        });
+      }
+      return new Response("unexpected provider endpoint", { status: 500 });
+    }) as typeof fetch;
+
+    const response = await authRoutes.request(
+      `/oauth/google/callback?code=provider-code&state=${state}`,
+      { headers: browserHeaders() },
+    );
+    const body = await expectBrowserError(response, {
+      status: 403,
+      code: "oauth_verified_email_required",
+    });
+
+    expect(body).toContain("Provider email must be verified");
+    expect(body).toContain("Return and try again");
+    expect(body).toContain("error=oauth_verified_email_required");
+    expect(body).toContain("state=%3Cscript+id%3D%22state-canary%22%3E");
+    expect(body).not.toContain('<script id="state-canary">');
+    expect(body).not.toContain("provider-access-secret");
+    expect(body).not.toContain("unverified@example.test");
+  });
+});
+
+describe("OIDC browser callback failures", () => {
+  it("renders a non-reflective HTML page for provider errors", async () => {
+    const response = await authRoutes.request(
+      "/oidc/acme/callback?error=%3Csvg%20onload%3Dalert(1)%3E",
+      { headers: browserHeaders() },
+    );
+    const body = await expectBrowserError(response, {
+      status: 400,
+      code: "oidc_authorization_failed",
+    });
+
+    expect(body).not.toContain("<svg");
+    expect(body).not.toContain("onload");
+  });
+
+  it("offers a validated recovery link for a provider error with live OIDC state", async () => {
+    process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS = REDIRECT_URI;
+    const state = "oidc-provider-denial-state";
+    await getAuthChallengeStore().set(
+      `oidc:${state}`,
+      JSON.stringify({
+        providerId: "acme",
+        redirectUri: REDIRECT_URI,
+        appState: "oidc-client-state",
+      }),
+    );
+    const response = await authRoutes.request(
+      `/oidc/acme/callback?error=access_denied&state=${state}`,
+      { headers: browserHeaders() },
+    );
+    const body = await expectBrowserError(response, {
+      status: 400,
+      code: "oidc_authorization_failed",
+    });
+    expect(body).toContain("Return and try again");
+    expect(body).toContain("error=oidc_authorization_failed");
+    expect(body).toContain("state=oidc-client-state");
+  });
+
+  it("renders an HTML recovery page for expired OIDC state", async () => {
+    const response = await authRoutes.request(
+      "/oidc/acme/callback?code=provider-code&state=expired-state",
+      { headers: browserHeaders() },
+    );
+    const body = await expectBrowserError(response, { status: 401, code: "oidc_state_expired" });
+    expect(body).not.toContain("Return and try again");
+  });
+});

--- a/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
@@ -229,7 +229,7 @@ describeWithDatabase("OAuth redirect_uri allowlist", () => {
     expect(callbackRes.status).toBe(400);
     const body = (await callbackRes.json()) as { ok: boolean; error: string };
     expect(body.ok).toBe(false);
-    expect(body.error).toContain("redirect_uri is not allowed");
+    expect(body.error).toContain("application return address is not allowed");
   });
 
   it("rejects /token when redirectUri is outside the tenant allowlist", async () => {

--- a/packages/api/src/__tests__/auth-passkey-enumeration.test.ts
+++ b/packages/api/src/__tests__/auth-passkey-enumeration.test.ts
@@ -119,60 +119,45 @@ describe("passkey login options privacy", () => {
     });
   }
 
-  function assertAuthenticationOptionsShape(options: LoginOptions) {
+  function assertDiscoverableCredentialShape(options: LoginOptions) {
     expect(options.challenge).toMatch(/^[A-Za-z0-9_-]{32,}$/);
     expect(options.challengeId).toBe(options.challenge);
     expect(options.rpId).toBe("steward.fi");
     expect(options.timeout).toBeGreaterThan(0);
     expect(options.userVerification).toBe("required");
+    expect(options.allowCredentials).toEqual([]);
   }
 
-  it("returns only credential ids and transports bound to the normalized typed email", async () => {
-    const knownResponse = await requestOptions(`  ${KNOWN_EMAIL.toUpperCase()}  `);
+  it("returns the same non-enumerating shape for known and unknown emails", async () => {
+    const [knownResponse, unknownResponse] = await Promise.all([
+      requestOptions(`  ${KNOWN_EMAIL.toUpperCase()}  `),
+      requestOptions(UNKNOWN_EMAIL),
+    ]);
     expect(knownResponse.status).toBe(200);
+    expect(unknownResponse.status).toBe(200);
 
     const known = (await knownResponse.json()) as LoginOptions;
-    assertAuthenticationOptionsShape(known);
-    expect(known.allowCredentials).toHaveLength(2);
-    expect(known.allowCredentials.map(({ id }) => id).sort()).toEqual(
-      [KNOWN_CREDENTIAL_ID, SECOND_KNOWN_CREDENTIAL_ID].sort(),
-    );
-    expect(known.allowCredentials).toContainEqual({
-      id: KNOWN_CREDENTIAL_ID,
-      transports: ["internal"],
-      type: "public-key",
-    });
-    expect(known.allowCredentials).toContainEqual({
-      id: SECOND_KNOWN_CREDENTIAL_ID,
-      transports: ["hybrid"],
-      type: "public-key",
-    });
+    const unknown = (await unknownResponse.json()) as LoginOptions;
+    assertDiscoverableCredentialShape(known);
+    assertDiscoverableCredentialShape(unknown);
+    expect(Object.keys(known).sort()).toEqual(Object.keys(unknown).sort());
 
-    const serialized = JSON.stringify(known);
-    expect(serialized).not.toContain(OTHER_CREDENTIAL_ID);
-    expect(serialized).not.toContain("known-credential-public-key");
-    expect(serialized).not.toContain("other-credential-public-key");
-    expect(serialized).not.toContain(knownUserId);
+    for (const payload of [known, unknown]) {
+      const serialized = JSON.stringify(payload);
+      expect(serialized).not.toContain(KNOWN_CREDENTIAL_ID);
+      expect(serialized).not.toContain(SECOND_KNOWN_CREDENTIAL_ID);
+      expect(serialized).not.toContain(OTHER_CREDENTIAL_ID);
+      expect(serialized).not.toContain("known-credential-public-key");
+      expect(serialized).not.toContain("other-credential-public-key");
+      expect(serialized).not.toContain(knownUserId);
+    }
 
     expect(
       await getAuthChallengeStore().get(`passkey-login:${KNOWN_EMAIL}:${known.challengeId}`),
     ).toBe(known.challenge);
-  });
-
-  it("returns one generic unavailable response for unknown and no-passkey emails", async () => {
-    const [unknownResponse, noPasskeyResponse] = await Promise.all([
-      requestOptions(UNKNOWN_EMAIL),
-      requestOptions(NO_PASSKEY_EMAIL),
-    ]);
-
-    expect(unknownResponse.status).toBe(404);
-    expect(noPasskeyResponse.status).toBe(404);
-    const expected = {
-      ok: false,
-      error: "Passkey sign-in is unavailable for this email",
-    };
-    expect(await unknownResponse.json()).toEqual(expected);
-    expect(await noPasskeyResponse.json()).toEqual(expected);
+    expect(
+      await getAuthChallengeStore().get(`passkey-login:${UNKNOWN_EMAIL}:${unknown.challengeId}`),
+    ).toBe(unknown.challenge);
   });
 
   it("honors explicit tenant existence and passkey login-method boundaries", async () => {

--- a/packages/api/src/__tests__/auth-passkey-enumeration.test.ts
+++ b/packages/api/src/__tests__/auth-passkey-enumeration.test.ts
@@ -8,8 +8,12 @@ setDefaultTimeout(120_000);
 const ENABLED_TENANT_ID = "passkey-enumeration-enabled";
 const DISABLED_TENANT_ID = "passkey-enumeration-disabled";
 const KNOWN_EMAIL = "passkey-known@example.test";
+const NO_PASSKEY_EMAIL = "passkey-none@example.test";
+const OTHER_EMAIL = "passkey-other@example.test";
 const UNKNOWN_EMAIL = "passkey-unknown@example.test";
-const SECRET_CREDENTIAL_ID = "credential-id-must-never-leave-options-route";
+const KNOWN_CREDENTIAL_ID = "credential-id-for-known-email";
+const SECOND_KNOWN_CREDENTIAL_ID = "second-credential-id-for-known-email";
+const OTHER_CREDENTIAL_ID = "credential-id-for-other-email";
 
 type LoginOptions = {
   challenge: string;
@@ -17,7 +21,7 @@ type LoginOptions = {
   rpId: string;
   timeout: number;
   userVerification: string;
-  allowCredentials: Array<{ id: string }>;
+  allowCredentials: Array<{ id: string; transports?: string[] }>;
   [key: string]: unknown;
 };
 
@@ -50,22 +54,46 @@ describe("passkey login options privacy", () => {
         tenantId: DISABLED_TENANT_ID,
         authAbuseConfig: { loginMethods: { passkey: false } },
       });
-    const [knownUser] = await getDb()
+    const [knownUser, otherUser] = await getDb()
       .insert(users)
-      .values({ email: KNOWN_EMAIL, emailVerified: true })
+      .values([
+        { email: KNOWN_EMAIL, emailVerified: true },
+        { email: OTHER_EMAIL, emailVerified: true },
+        { email: NO_PASSKEY_EMAIL, emailVerified: true },
+      ])
       .returning({ id: users.id });
     knownUserId = knownUser.id;
     await getDb()
       .insert(authenticators)
-      .values({
-        userId: knownUserId,
-        credentialId: SECRET_CREDENTIAL_ID,
-        credentialPublicKey: "credential-public-key-must-also-remain-private",
-        counter: 7,
-        credentialDeviceType: "singleDevice",
-        credentialBackedUp: false,
-        transports: ["internal"],
-      });
+      .values([
+        {
+          userId: knownUserId,
+          credentialId: KNOWN_CREDENTIAL_ID,
+          credentialPublicKey: "known-credential-public-key",
+          counter: 7,
+          credentialDeviceType: "singleDevice",
+          credentialBackedUp: false,
+          transports: ["internal"],
+        },
+        {
+          userId: knownUserId,
+          credentialId: SECOND_KNOWN_CREDENTIAL_ID,
+          credentialPublicKey: "second-known-credential-public-key",
+          counter: 0,
+          credentialDeviceType: "multiDevice",
+          credentialBackedUp: true,
+          transports: ["hybrid"],
+        },
+        {
+          userId: otherUser.id,
+          credentialId: OTHER_CREDENTIAL_ID,
+          credentialPublicKey: "other-credential-public-key",
+          counter: 2,
+          credentialDeviceType: "singleDevice",
+          credentialBackedUp: false,
+          transports: ["internal"],
+        },
+      ]);
 
     const auth = await import("../routes/auth");
     getAuthChallengeStore = auth.getAuthChallengeStore;
@@ -91,42 +119,60 @@ describe("passkey login options privacy", () => {
     });
   }
 
-  function assertDiscoverableCredentialShape(options: LoginOptions) {
+  function assertAuthenticationOptionsShape(options: LoginOptions) {
     expect(options.challenge).toMatch(/^[A-Za-z0-9_-]{32,}$/);
     expect(options.challengeId).toBe(options.challenge);
     expect(options.rpId).toBe("steward.fi");
     expect(options.timeout).toBeGreaterThan(0);
     expect(options.userVerification).toBe("required");
-    expect(options.allowCredentials).toEqual([]);
   }
 
-  it("returns the same non-enumerating shape for known and unknown emails", async () => {
-    const [knownResponse, unknownResponse] = await Promise.all([
-      requestOptions(`  ${KNOWN_EMAIL.toUpperCase()}  `),
-      requestOptions(UNKNOWN_EMAIL),
-    ]);
+  it("returns only credential ids and transports bound to the normalized typed email", async () => {
+    const knownResponse = await requestOptions(`  ${KNOWN_EMAIL.toUpperCase()}  `);
     expect(knownResponse.status).toBe(200);
-    expect(unknownResponse.status).toBe(200);
 
     const known = (await knownResponse.json()) as LoginOptions;
-    const unknown = (await unknownResponse.json()) as LoginOptions;
-    assertDiscoverableCredentialShape(known);
-    assertDiscoverableCredentialShape(unknown);
-    expect(Object.keys(known).sort()).toEqual(Object.keys(unknown).sort());
+    assertAuthenticationOptionsShape(known);
+    expect(known.allowCredentials).toHaveLength(2);
+    expect(known.allowCredentials.map(({ id }) => id).sort()).toEqual(
+      [KNOWN_CREDENTIAL_ID, SECOND_KNOWN_CREDENTIAL_ID].sort(),
+    );
+    expect(known.allowCredentials).toContainEqual({
+      id: KNOWN_CREDENTIAL_ID,
+      transports: ["internal"],
+      type: "public-key",
+    });
+    expect(known.allowCredentials).toContainEqual({
+      id: SECOND_KNOWN_CREDENTIAL_ID,
+      transports: ["hybrid"],
+      type: "public-key",
+    });
 
-    for (const payload of [known, unknown]) {
-      const serialized = JSON.stringify(payload);
-      expect(serialized).not.toContain(SECRET_CREDENTIAL_ID);
-      expect(serialized).not.toContain("credential-public-key-must-also-remain-private");
-      expect(serialized).not.toContain(knownUserId);
-    }
+    const serialized = JSON.stringify(known);
+    expect(serialized).not.toContain(OTHER_CREDENTIAL_ID);
+    expect(serialized).not.toContain("known-credential-public-key");
+    expect(serialized).not.toContain("other-credential-public-key");
+    expect(serialized).not.toContain(knownUserId);
 
     expect(
       await getAuthChallengeStore().get(`passkey-login:${KNOWN_EMAIL}:${known.challengeId}`),
     ).toBe(known.challenge);
-    expect(
-      await getAuthChallengeStore().get(`passkey-login:${UNKNOWN_EMAIL}:${unknown.challengeId}`),
-    ).toBe(unknown.challenge);
+  });
+
+  it("returns one generic unavailable response for unknown and no-passkey emails", async () => {
+    const [unknownResponse, noPasskeyResponse] = await Promise.all([
+      requestOptions(UNKNOWN_EMAIL),
+      requestOptions(NO_PASSKEY_EMAIL),
+    ]);
+
+    expect(unknownResponse.status).toBe(404);
+    expect(noPasskeyResponse.status).toBe(404);
+    const expected = {
+      ok: false,
+      error: "Passkey sign-in is unavailable for this email",
+    };
+    expect(await unknownResponse.json()).toEqual(expected);
+    expect(await noPasskeyResponse.json()).toEqual(expected);
   });
 
   it("honors explicit tenant existence and passkey login-method boundaries", async () => {

--- a/packages/api/src/__tests__/auth-passkey-mfa-hardening.test.ts
+++ b/packages/api/src/__tests__/auth-passkey-mfa-hardening.test.ts
@@ -32,7 +32,7 @@ describe("passkey MFA hardening", () => {
       "getChallengeStore().consume(challengeKey)",
       handlerStart,
     );
-    const counterUpdate = authSource.indexOf(".set({ counter:", handlerStart);
+    const counterUpdate = authSource.indexOf(".update(authenticators)", handlerStart);
     const mfaMethod = authSource.indexOf('mfaMethod: "passkey"', handlerStart);
 
     expect(readChallenge).toBeGreaterThan(handlerStart);
@@ -51,7 +51,7 @@ describe("passkey MFA hardening", () => {
     const mfaStart = authSource.indexOf("const completePasskeyMfaHandler");
     expect(mfaStart).toBeGreaterThanOrEqual(0);
     const mfaGuard = authSource.indexOf(guard, mfaStart);
-    const mfaCounterUpdate = authSource.indexOf(".set({ counter:", mfaStart);
+    const mfaCounterUpdate = authSource.indexOf(".update(authenticators)", mfaStart);
     const mfaCompareAndSwap = authSource.indexOf(
       "eq(authenticators.counter, cred.counter)",
       mfaCounterUpdate,
@@ -63,7 +63,7 @@ describe("passkey MFA hardening", () => {
     const loginStart = authSource.indexOf('auth.post("/passkey/login/verify"');
     expect(loginStart).toBeGreaterThanOrEqual(0);
     const loginGuard = authSource.indexOf(guard, loginStart);
-    const loginCounterUpdate = authSource.indexOf(".set({ counter:", loginStart);
+    const loginCounterUpdate = authSource.indexOf(".update(authenticators)", loginStart);
     const loginCompareAndSwap = authSource.indexOf(
       "eq(authenticators.counter, cred.counter)",
       loginCounterUpdate,

--- a/packages/api/src/__tests__/auth-passkey-register-recovery.test.ts
+++ b/packages/api/src/__tests__/auth-passkey-register-recovery.test.ts
@@ -1,0 +1,227 @@
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { authenticators, closeDb, getDb, tenants, users, userTenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+
+setDefaultTimeout(120_000);
+
+const TENANT_ID = "passkey-register-recovery";
+const CURRENT_ORIGIN = "https://steward.fi";
+const CURRENT_RP_ID = "steward.fi";
+const OTHER_RP_ID = "waifu.fun";
+const SAME_RP_EMAIL = "passkey-same-rp@example.test";
+const CROSS_RP_EMAIL = "passkey-cross-rp@example.test";
+const LEGACY_EMAIL = "passkey-legacy@example.test";
+const UNKNOWN_EMAIL = "passkey-unknown@example.test";
+const SAME_RP_CREDENTIAL_ID = "same-rp-passkey-credential";
+const CROSS_RP_CREDENTIAL_ID = "cross-rp-passkey-credential";
+const LEGACY_CREDENTIAL_ID = "legacy-passkey-credential";
+
+type RegistrationOptions = {
+  challenge: string;
+  rp: { id: string };
+  excludeCredentials?: Array<{ id: string; type: "public-key" }>;
+  user: { id: string; name: string };
+};
+
+describe("passkey verified-email registration recovery", () => {
+  let app: Hono;
+  let auth: Awaited<typeof import("../routes/auth")>;
+  let sameRpUserId = "";
+
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_ALLOW_DEV_SECRETS = "true";
+    process.env.STEWARD_JWT_SECRET = "passkey-register-recovery-jwt-secret-with-enough-entropy";
+    process.env.STEWARD_MASTER_PASSWORD = "passkey-register-recovery-master-password";
+    process.env.STEWARD_KDF_SALT = "dGVzdC1zYWx0LXRlc3Qtc2FsdA==";
+    process.env.PASSKEY_RP_ID = CURRENT_RP_ID;
+    process.env.PASSKEY_ORIGIN = CURRENT_ORIGIN;
+    process.env.PASSKEY_ALLOWED_ORIGINS = `${CURRENT_ORIGIN},https://${OTHER_RP_ID}`;
+
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+
+    await getDb()
+      .insert(tenants)
+      .values({ id: TENANT_ID, name: "Passkey recovery", apiKeyHash: "passkey-recovery" });
+    const [sameRpUser, crossRpUser, legacyUser] = await getDb()
+      .insert(users)
+      .values([
+        { email: SAME_RP_EMAIL, emailVerified: true },
+        { email: CROSS_RP_EMAIL, emailVerified: true },
+        { email: LEGACY_EMAIL, emailVerified: true },
+      ])
+      .returning({ id: users.id });
+    sameRpUserId = sameRpUser.id;
+    await getDb()
+      .insert(userTenants)
+      .values(
+        [sameRpUser, crossRpUser, legacyUser].map((user) => ({
+          userId: user.id,
+          tenantId: TENANT_ID,
+          role: "member" as const,
+        })),
+      );
+    await getDb()
+      .insert(authenticators)
+      .values([
+        {
+          userId: sameRpUser.id,
+          credentialId: SAME_RP_CREDENTIAL_ID,
+          credentialPublicKey: "same-rp-passkey-public-key",
+          rpId: CURRENT_RP_ID,
+          counter: 1,
+          credentialDeviceType: "singleDevice",
+          credentialBackedUp: false,
+          transports: ["internal"],
+        },
+        {
+          userId: crossRpUser.id,
+          credentialId: CROSS_RP_CREDENTIAL_ID,
+          credentialPublicKey: "cross-rp-passkey-public-key",
+          rpId: OTHER_RP_ID,
+          counter: 1,
+          credentialDeviceType: "singleDevice",
+          credentialBackedUp: false,
+          transports: ["internal"],
+        },
+        {
+          userId: legacyUser.id,
+          credentialId: LEGACY_CREDENTIAL_ID,
+          credentialPublicKey: "legacy-passkey-public-key",
+          // NULL is the deliberate migration state for pre-0114 rows.
+          rpId: null,
+          counter: 1,
+          credentialDeviceType: "singleDevice",
+          credentialBackedUp: false,
+          transports: ["internal"],
+        },
+      ]);
+
+    auth = await import("../routes/auth");
+    app = new Hono().route("/auth", auth.authRoutes);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_ALLOW_DEV_SECRETS;
+    delete process.env.STEWARD_JWT_SECRET;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+    delete process.env.STEWARD_KDF_SALT;
+    delete process.env.PASSKEY_RP_ID;
+    delete process.env.PASSKEY_ORIGIN;
+    delete process.env.PASSKEY_ALLOWED_ORIGINS;
+  });
+
+  async function requestWithGrant(email: string, grant: string) {
+    await auth._seedEmailGrantForTests(grant, email, TENANT_ID);
+    return app.request("/auth/passkey/register/options", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: CURRENT_ORIGIN,
+        "X-Steward-Tenant": TENANT_ID,
+      },
+      body: JSON.stringify({ email, emailGrant: grant }),
+    });
+  }
+
+  it("returns a stable same-RP 409 without consuming the verified-email grant", async () => {
+    const grant = "same-rp-email-grant";
+    await auth._seedEmailGrantForTests(grant, SAME_RP_EMAIL, TENANT_ID);
+
+    const first = await app.request("/auth/passkey/register/options", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: CURRENT_ORIGIN,
+        "X-Steward-Tenant": TENANT_ID,
+      },
+      body: JSON.stringify({ email: SAME_RP_EMAIL, emailGrant: grant }),
+    });
+    expect(first.status).toBe(409);
+    expect(await first.json()).toEqual({
+      ok: false,
+      error: "A passkey already exists for this email. Sign in with it instead.",
+      code: "passkey_already_registered",
+    });
+
+    // register/options only peeks. A retry reaches the same recovery contract
+    // instead of turning the valid grant into an expired-grant error.
+    const retry = await app.request("/auth/passkey/register/options", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: CURRENT_ORIGIN,
+        "X-Steward-Tenant": TENANT_ID,
+      },
+      body: JSON.stringify({ email: SAME_RP_EMAIL, emailGrant: grant }),
+    });
+    expect(retry.status).toBe(409);
+    expect(await retry.json()).toMatchObject({ code: "passkey_already_registered" });
+  });
+
+  it("allows cross-RP registration and omits the other RP credential from exclusions", async () => {
+    const response = await requestWithGrant(CROSS_RP_EMAIL, "cross-rp-email-grant");
+    expect(response.status).toBe(200);
+    const options = (await response.json()) as RegistrationOptions;
+    expect(options.rp.id).toBe(CURRENT_RP_ID);
+    expect(options.excludeCredentials ?? []).toEqual([]);
+    expect(JSON.stringify(options)).not.toContain(CROSS_RP_CREDENTIAL_ID);
+  });
+
+  it("does not guess legacy RP provenance and lets the browser adjudicate it", async () => {
+    const response = await requestWithGrant(LEGACY_EMAIL, "legacy-email-grant");
+    expect(response.status).toBe(200);
+    const options = (await response.json()) as RegistrationOptions;
+    expect(options.rp.id).toBe(CURRENT_RP_ID);
+    expect(options.excludeCredentials).toContainEqual({
+      id: LEGACY_CREDENTIAL_ID,
+      type: "public-key",
+    });
+  });
+
+  it("returns fresh registration options for an unknown verified account", async () => {
+    const response = await requestWithGrant(UNKNOWN_EMAIL, "unknown-email-grant");
+    expect(response.status).toBe(200);
+    const options = (await response.json()) as RegistrationOptions;
+    expect(options.challenge).toMatch(/^[A-Za-z0-9_-]{32,}$/);
+    expect(options.user.name).toBe(UNKNOWN_EMAIL);
+    expect(options.excludeCredentials ?? []).toEqual([]);
+
+    const [created] = await getDb().select().from(users).where(eq(users.email, UNKNOWN_EMAIL));
+    expect(created?.email).toBe(UNKNOWN_EMAIL);
+  });
+
+  it("keeps authenticated same-RP multi-device enrollment available", async () => {
+    const token = await auth.createSessionToken(
+      "0x0000000000000000000000000000000000000001",
+      TENANT_ID,
+      {
+        userId: sameRpUserId,
+        email: SAME_RP_EMAIL,
+        authMethod: "passkey",
+        factorEnrollmentVerifiedAt: Date.now(),
+      },
+    );
+    const response = await app.request("/auth/passkey/register/options", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: CURRENT_ORIGIN,
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ email: SAME_RP_EMAIL }),
+    });
+
+    expect(response.status).toBe(200);
+    const options = (await response.json()) as RegistrationOptions;
+    expect(options.excludeCredentials).toContainEqual({
+      id: SAME_RP_CREDENTIAL_ID,
+      type: "public-key",
+    });
+  });
+});

--- a/packages/api/src/__tests__/auth-sso-oidc-code-flow.test.ts
+++ b/packages/api/src/__tests__/auth-sso-oidc-code-flow.test.ts
@@ -41,14 +41,14 @@ describe("enterprise OIDC authorization-code SSO hardening", () => {
     expect(callbackRoute).toContain("await getChallengeStore().get(stateKey)");
     expect(callbackRoute).toContain("stateData.providerId !== providerId");
     expect(callbackRoute).toContain("code.length > 4_096 || state.length > 256");
-    expect(callbackRoute).toContain('error: "OIDC authorization failed"');
+    expect(callbackRoute).toContain('code: "oidc_authorization_failed"');
     expect(callbackRoute).not.toContain("`OIDC error: ${errorParam}`");
     expect(callbackRoute).toContain("exchangeOidcAuthorizationCode");
     expect(callbackRoute).toContain("verifyOidcJwt(stateData.tenantId, provider, idToken)");
     expect(callbackRoute).toContain("verified.claims.nonce !== stateData.nonce");
-    expect(callbackRoute).toContain("Enterprise OIDC SSO requires a verified email claim");
+    expect(callbackRoute).toContain('code: "oidc_verified_email_required"');
     expect(callbackRoute).toContain("isVerifiedSsoEmailDomainForTenant");
-    expect(callbackRoute).toContain("Enterprise OIDC SSO email domain is not verified");
+    expect(callbackRoute).toContain('code: "oidc_email_domain_unverified"');
     expect(callbackRoute.indexOf("await getChallengeStore().get(stateKey)")).toBeLessThan(
       callbackRoute.indexOf("exchangeOidcAuthorizationCode"),
     );

--- a/packages/api/src/__tests__/platform-email-config.test.ts
+++ b/packages/api/src/__tests__/platform-email-config.test.ts
@@ -164,6 +164,7 @@ describe("platform tenant email config routes", () => {
         "X-Steward-Platform-Key": PLATFORM_KEY,
       },
       body: JSON.stringify({
+        brandName: "Customer App",
         templateId: "customer-template",
         subjectOverride: "Sign in to Customer App",
       }),
@@ -172,9 +173,15 @@ describe("platform tenant email config routes", () => {
     expect(patchResponse.status).toBe(200);
     const patchBody = (await patchResponse.json()) as {
       ok: boolean;
-      data: { templateId?: string; subjectOverride?: string; hasApiKey: boolean };
+      data: {
+        brandName?: string;
+        templateId?: string;
+        subjectOverride?: string;
+        hasApiKey: boolean;
+      };
     };
     expect(patchBody.ok).toBe(true);
+    expect(patchBody.data.brandName).toBe("Customer App");
     expect(patchBody.data.templateId).toBe("customer-template");
     expect(patchBody.data.subjectOverride).toBe("Sign in to Customer App");
     expect(patchBody.data.hasApiKey).toBe(false);
@@ -184,9 +191,18 @@ describe("platform tenant email config routes", () => {
       .from(tenantConfigs)
       .where(eq(tenantConfigs.tenantId, TENANT_ID));
     expect(stored?.emailConfig?.templateId).toBe("customer-template");
+    expect(stored?.emailConfig?.brandName).toBe("Customer App");
     expect(stored?.emailConfig?.apiKeyEncrypted).toBeUndefined();
     expect(stored?.emailConfig?.magicLinkBaseUrl).toBe("https://app.customer.example");
     expect(stored?.emailConfig?.magicLinkCallbackPath).toBe("/auth/email/verify");
+
+    const getResponse = await platformRoutes.request(`/tenants/${TENANT_ID}/email-config`, {
+      headers: { "X-Steward-Platform-Key": PLATFORM_KEY },
+    });
+    const getBody = (await getResponse.json()) as {
+      data: { emailConfig: { brandName?: string } | null };
+    };
+    expect(getBody.data.emailConfig?.brandName).toBe("Customer App");
 
     // from without apiKey is rejected (provider config is all-or-nothing).
     const badResponse = await platformRoutes.request(`/tenants/${TENANT_ID}/email-config`, {
@@ -209,6 +225,21 @@ describe("platform tenant email config routes", () => {
       body: JSON.stringify({}),
     });
     expect(emptyResponse.status).toBe(400);
+
+    for (const brandName of ["", "line one\nline two", "x".repeat(101)]) {
+      const invalidBrandResponse = await platformRoutes.request(
+        `/tenants/${TENANT_ID}/email-config`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Steward-Platform-Key": PLATFORM_KEY,
+          },
+          body: JSON.stringify({ brandName }),
+        },
+      );
+      expect(invalidBrandResponse.status).toBe(400);
+    }
 
     // Cleanup so later tests see no residual config.
     await platformRoutes.request(`/tenants/${TENANT_ID}/email-config`, {

--- a/packages/api/src/__tests__/privy-completeness.integration.test.ts
+++ b/packages/api/src/__tests__/privy-completeness.integration.test.ts
@@ -534,7 +534,7 @@ describe.skipIf(!process.env.DATABASE_URL)("Privy-competitor integration complet
       },
       body: JSON.stringify({ tenantId: TENANT_ID, claimToken }),
     });
-    expect(replayClaim.status).toBe(409);
+    expect(replayClaim.status).toBe(404);
     await expect(json<{ error: string }>(replayClaim)).resolves.toMatchObject({
       error: "Invalid or already claimed wallet token",
     });

--- a/packages/api/src/__tests__/privy-completeness.integration.test.ts
+++ b/packages/api/src/__tests__/privy-completeness.integration.test.ts
@@ -11,6 +11,8 @@ const webhookDispatches: Array<{
 }> = [];
 
 mock.module("@stwd/webhooks", () => ({
+  currentWebhookRuntimeAuthority: () =>
+    Object.freeze({ allowInsecureHttp: false, allowPrivateNetwork: false }),
   encryptWebhookSecret: (secret: string) => `enc:${secret}`,
   decryptWebhookSecret: (secret: string) => secret.replace(/^enc:/, ""),
   isEncryptedWebhookSecret: (secret: string) => secret.startsWith("enc:"),
@@ -532,7 +534,7 @@ describe.skipIf(!process.env.DATABASE_URL)("Privy-competitor integration complet
       },
       body: JSON.stringify({ tenantId: TENANT_ID, claimToken }),
     });
-    expect(replayClaim.status).toBe(404);
+    expect(replayClaim.status).toBe(409);
     await expect(json<{ error: string }>(replayClaim)).resolves.toMatchObject({
       error: "Invalid or already claimed wallet token",
     });

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -151,6 +151,7 @@ import {
   validateWalletAbusePolicy,
   verifyCaptchaToken,
 } from "../services/auth-abuse";
+import { defaultAuthTenantId } from "../services/default-auth-tenant";
 import { verifyEip1271 } from "../services/eip1271";
 import {
   isAllowedOidcClientSecretEnvForTenant,
@@ -164,8 +165,6 @@ import { getConfiguredVault } from "../services/vault-factory";
 import { dispatchWebhook } from "../services/webhook-dispatch";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
-
-const _DEFAULT_TENANT_ID = process.env.STEWARD_DEFAULT_TENANT_ID || "default";
 
 async function withVerifiedAuthTenant<T>(
   tenantId: string,
@@ -829,7 +828,7 @@ async function validateExplicitAuthTenantHint(
 }
 
 function authTenantHint(c: Context, bodyTenantId?: string): string {
-  return c.req.header("X-Steward-Tenant")?.trim() || bodyTenantId?.trim() || _DEFAULT_TENANT_ID;
+  return c.req.header("X-Steward-Tenant")?.trim() || bodyTenantId?.trim() || defaultAuthTenantId();
 }
 
 function smsLoginPurpose(tenantId: string): string {
@@ -3864,7 +3863,7 @@ async function completeEmailAuth(
   tenantId?: string,
   opts: { allowTenantJoin?: boolean } = {},
 ): Promise<CompletedEmailAuthResult> {
-  const hintedTenantId = c.req.header("X-Steward-Tenant") || tenantId || _DEFAULT_TENANT_ID;
+  const hintedTenantId = c.req.header("X-Steward-Tenant") || tenantId || defaultAuthTenantId();
   const hintedAuthAbuseConfig = await getTenantAuthAbuseConfig(hintedTenantId);
   const hintedEmailPolicyError = validateEmailAbusePolicy(email, hintedAuthAbuseConfig);
   if (hintedEmailPolicyError) {
@@ -7997,7 +7996,7 @@ auth.post("/passkey/register/options", async (c) => {
 
   if (typeof body.emailGrant === "string" && body.emailGrant.length > 0) {
     const resolvedTenantId =
-      c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || _DEFAULT_TENANT_ID;
+      c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || defaultAuthTenantId();
     const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "passkey");
     if (methodResponse) return methodResponse;
     // Peek (not consume): the grant is only burned at register/verify so a
@@ -8118,7 +8117,7 @@ auth.post("/passkey/register/verify", async (c) => {
     // user's OTP verification, while consumption before any state change
     // keeps it strictly single-use.
     grantTenantId =
-      c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || _DEFAULT_TENANT_ID;
+      c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || defaultAuthTenantId();
     const grantOk = await peekEmailGrant(body.emailGrant as string, email, grantTenantId);
     if (!grantOk) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired email grant" }, 401);
@@ -8479,7 +8478,7 @@ auth.post("/email/send", async (c) => {
   const email = body.email.toLowerCase().trim();
   const headerTenantId = c.req.header("X-Steward-Tenant")?.trim();
   const bodyTenantId = body.tenantId?.trim();
-  const resolvedTenantId = headerTenantId || bodyTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = headerTenantId || bodyTenantId || defaultAuthTenantId();
   const tenantHintError = await validateExplicitAuthTenantHint(
     resolvedTenantId,
     Boolean(headerTenantId || bodyTenantId),
@@ -8561,7 +8560,7 @@ auth.get("/callback/email", async (c) => {
   }
 
   const email = emailParam.toLowerCase().trim();
-  const resolvedTenantId = tenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = tenantId || defaultAuthTenantId();
   const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "email");
   if (methodResponse) return redirectEmailAuthFailure(c, "method_disabled");
   const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(
@@ -8660,7 +8659,7 @@ auth.post("/email/verify", async (c) => {
   const email = body.email.toLowerCase().trim();
   const headerTenantId = c.req.header("X-Steward-Tenant")?.trim();
   const bodyTenantId = body.tenantId?.trim();
-  const resolvedTenantId = headerTenantId || bodyTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = headerTenantId || bodyTenantId || defaultAuthTenantId();
   const tenantHintError = await validateExplicitAuthTenantHint(
     resolvedTenantId,
     Boolean(headerTenantId || bodyTenantId),
@@ -8724,7 +8723,8 @@ auth.post("/email/code/verify", async (c) => {
 
   const email = body.email.toLowerCase().trim();
   const code = body.code.trim();
-  const resolvedTenantId = c.req.header("X-Steward-Tenant") || body.tenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId =
+    c.req.header("X-Steward-Tenant") || body.tenantId || defaultAuthTenantId();
   const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "email");
   if (methodResponse) return methodResponse;
   const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(
@@ -8789,7 +8789,7 @@ auth.post("/email/status", async (c) => {
   }
   const headerTenantId = c.req.header("X-Steward-Tenant")?.trim();
   const bodyTenantId = body.tenantId?.trim();
-  const resolvedTenantId = headerTenantId || bodyTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = headerTenantId || bodyTenantId || defaultAuthTenantId();
   const tenantHintError = await validateExplicitAuthTenantHint(
     resolvedTenantId,
     Boolean(headerTenantId || bodyTenantId),
@@ -8836,7 +8836,7 @@ auth.post("/email/otp/send", async (c) => {
   const email = body.email.toLowerCase().trim();
   const headerTenantId = c.req.header("X-Steward-Tenant")?.trim();
   const bodyTenantId = body.tenantId?.trim();
-  const resolvedTenantId = headerTenantId || bodyTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = headerTenantId || bodyTenantId || defaultAuthTenantId();
   const tenantHintError = await validateExplicitAuthTenantHint(
     resolvedTenantId,
     Boolean(headerTenantId || bodyTenantId),
@@ -8911,7 +8911,8 @@ auth.post("/email/otp/verify", async (c) => {
 
   const email = body.email.toLowerCase().trim();
   const code = body.code.trim();
-  const resolvedTenantId = c.req.header("X-Steward-Tenant") || body.tenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId =
+    c.req.header("X-Steward-Tenant") || body.tenantId || defaultAuthTenantId();
   const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "email");
   if (methodResponse) return methodResponse;
   const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(
@@ -8994,7 +8995,7 @@ async function resolveGuestTenant(
   const requested =
     headerTenant ||
     (typeof bodyTenantId === "string" ? bodyTenantId.trim() : "") ||
-    _DEFAULT_TENANT_ID;
+    defaultAuthTenantId();
 
   if (!isValidTenantId(requested)) {
     return { ok: false, status: 400, error: "Invalid tenant id format" };
@@ -9006,7 +9007,7 @@ async function resolveGuestTenant(
   if (!subject) {
     return { ok: false, status: 404, error: `Tenant '${requested}' not found` };
   }
-  if (requested === _DEFAULT_TENANT_ID) {
+  if (requested === defaultAuthTenantId()) {
     return { ok: true, tenantId: requested, isPersonal: false };
   }
   if (subject.join_mode === "open") {
@@ -10627,7 +10628,7 @@ async function getAllowedOAuthRedirectEntries(
   clientId?: string,
 ): Promise<string[]> {
   const explicitTenantId = tenantId?.trim() || undefined;
-  const resolvedTenantId = explicitTenantId || _DEFAULT_TENANT_ID;
+  const resolvedTenantId = explicitTenantId || defaultAuthTenantId();
   const entries = new Set<string>();
 
   const normalizedClientId = normalizePublicClientId(clientId);

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -4070,6 +4070,166 @@ function redirectEmailAuthFailure(c: Context, reason: string): Response {
   );
 }
 
+type OAuthCallbackFailureStatus = 400 | 401 | 403 | 404 | 409 | 500 | 502 | 503;
+
+interface OAuthCallbackFailureOptions {
+  code: string;
+  message: string;
+  status: OAuthCallbackFailureStatus;
+  redirectUrl?: URL;
+  appState?: string;
+}
+
+function escapeOAuthCallbackHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => {
+    switch (character) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}
+
+function oauthCallbackPrefersHtml(c: Context): boolean {
+  const accept = c.req.header("accept")?.toLowerCase() ?? "";
+  const qualityFor = (target: "application/json" | "text/html"): number | undefined => {
+    const [targetType] = target.split("/");
+    let bestMatch: { specificity: number; quality: number } | undefined;
+    for (const range of accept.split(",")) {
+      const [mediaType, ...parameters] = range.split(";").map((part) => part.trim());
+      const qualityParameter = parameters.find((parameter) => parameter.startsWith("q="));
+      const quality = qualityParameter ? Number(qualityParameter.slice(2)) : 1;
+      const normalizedQuality =
+        Number.isFinite(quality) && quality >= 0 && quality <= 1 ? quality : 0;
+      const specificity =
+        mediaType === target
+          ? 2
+          : mediaType === `${targetType}/*`
+            ? 1
+            : mediaType === "*/*"
+              ? 0
+              : -1;
+      if (
+        specificity >= 0 &&
+        (!bestMatch ||
+          specificity > bestMatch.specificity ||
+          (specificity === bestMatch.specificity && normalizedQuality > bestMatch.quality))
+      ) {
+        bestMatch = { specificity, quality: normalizedQuality };
+      }
+    }
+    return bestMatch?.quality;
+  };
+
+  const htmlQuality = qualityFor("text/html") ?? 0;
+  const jsonQuality = qualityFor("application/json") ?? 0;
+  if (htmlQuality <= 0) return false;
+  if (htmlQuality !== jsonQuality) return htmlQuality > jsonQuality;
+  return c.req.header("sec-fetch-mode")?.toLowerCase() === "navigate";
+}
+
+async function oauthCallbackRecoveryFromStoredState(
+  kind: "oauth" | "oidc",
+  state: string | undefined,
+  providerName: string,
+): Promise<{ redirectUrl: URL; appState?: string } | undefined> {
+  if (!state || state.length > 256) return undefined;
+  try {
+    const rawPayload = await getChallengeStore().get(`${kind}:${state}`);
+    if (!rawPayload) return undefined;
+    const stateData = JSON.parse(rawPayload) as Record<string, unknown>;
+    const storedProvider = kind === "oauth" ? stateData.provider : stateData.providerId;
+    if (storedProvider !== providerName || typeof stateData.redirectUri !== "string") {
+      return undefined;
+    }
+    const tenantId = typeof stateData.tenantId === "string" ? stateData.tenantId : undefined;
+    const clientId = typeof stateData.clientId === "string" ? stateData.clientId : undefined;
+    const redirectUrl = await assertAllowedOAuthRedirectUri(
+      stateData.redirectUri,
+      tenantId,
+      clientId,
+    );
+    return {
+      redirectUrl,
+      appState: typeof stateData.appState === "string" ? stateData.appState : undefined,
+    };
+  } catch {
+    // Recovery is optional. Invalid, stale, or unavailable state must never
+    // replace the original callback failure or create an unvalidated link.
+    return undefined;
+  }
+}
+
+function oauthCallbackFailure(c: Context, options: OAuthCallbackFailureOptions): Response {
+  if (!oauthCallbackPrefersHtml(c)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: options.message, code: options.code } as ApiResponse & { code: string },
+      options.status,
+    );
+  }
+
+  let recoveryLink = "";
+  if (options.redirectUrl) {
+    const recoveryUrl = new URL(options.redirectUrl);
+    recoveryUrl.searchParams.set("error", options.code);
+    if (options.appState) recoveryUrl.searchParams.set("state", options.appState);
+    recoveryLink = `<a class="stwd-oauth-error__action" href="${escapeOAuthCallbackHtml(
+      recoveryUrl.toString(),
+    )}">Return and try again</a>`;
+  }
+
+  const escapedMessage = escapeOAuthCallbackHtml(options.message);
+  const escapedCode = escapeOAuthCallbackHtml(options.code);
+  const recoveryInstruction = recoveryLink
+    ? recoveryLink
+    : '<p class="stwd-oauth-error__hint">Close this window and restart sign-in from the application.</p>';
+  const body = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sign-in could not be completed | Steward</title>
+  <style>
+    :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+    * { box-sizing: border-box; }
+    body { min-height: 100vh; margin: 0; display: grid; place-items: center; padding: 24px; background: #090b10; color: #f6f7fb; }
+    .stwd-oauth-error { width: min(100%, 520px); padding: 32px; border: 1px solid #2a3040; border-radius: 18px; background: #121621; box-shadow: 0 24px 70px rgb(0 0 0 / 35%); }
+    .stwd-oauth-error__eyebrow { margin: 0 0 10px; color: #98a2b8; font-size: 13px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+    h1 { margin: 0; font-size: clamp(24px, 6vw, 34px); line-height: 1.15; }
+    .stwd-oauth-error__message { margin: 18px 0; color: #cbd1de; line-height: 1.6; }
+    .stwd-oauth-error__code { display: inline-block; margin-bottom: 24px; padding: 6px 9px; border-radius: 7px; background: #080a0f; color: #aab4ca; font-size: 12px; }
+    .stwd-oauth-error__action { display: inline-block; padding: 12px 18px; border-radius: 9px; background: #f6f7fb; color: #11141c; font-weight: 750; text-decoration: none; }
+    .stwd-oauth-error__action:focus-visible { outline: 3px solid #7aa2ff; outline-offset: 3px; }
+    .stwd-oauth-error__hint { margin: 0; color: #98a2b8; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <main class="stwd-oauth-error" data-error-code="${escapedCode}">
+    <p class="stwd-oauth-error__eyebrow">Steward authentication</p>
+    <h1>Sign-in could not be completed</h1>
+    <p class="stwd-oauth-error__message">${escapedMessage}</p>
+    <code class="stwd-oauth-error__code">${escapedCode}</code>
+    <div>${recoveryInstruction}</div>
+  </main>
+</body>
+</html>`;
+
+  return c.html(body, options.status, {
+    "Cache-Control": "no-store",
+    "Content-Security-Policy":
+      "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'",
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+  });
+}
+
 // ─── Route group ──────────────────────────────────────────────────────────────
 
 const auth = new Hono();
@@ -5109,19 +5269,41 @@ auth.get("/oidc/:provider/callback", async (c) => {
   if (errorParam) {
     // Provider-supplied query text is untrusted and may contain diagnostics or
     // attacker-controlled markup. Do not reflect it to the browser.
-    return c.json<ApiResponse>({ ok: false, error: "OIDC authorization failed" }, 400);
+    const recovery = await oauthCallbackRecoveryFromStoredState("oidc", state, providerId);
+    return oauthCallbackFailure(c, {
+      code: "oidc_authorization_failed",
+      message: "The identity provider did not authorize this sign-in.",
+      status: 400,
+      ...recovery,
+    });
   }
   if (!code || !state) {
-    return c.json<ApiResponse>({ ok: false, error: "code and state are required" }, 400);
+    const recovery = await oauthCallbackRecoveryFromStoredState("oidc", state, providerId);
+    return oauthCallbackFailure(c, {
+      code: "oidc_callback_incomplete",
+      message: "The identity provider returned an incomplete sign-in response.",
+      status: 400,
+      ...recovery,
+    });
   }
   if (code.length > 4_096 || state.length > 256) {
-    return c.json<ApiResponse>({ ok: false, error: "code or state is too long" }, 400);
+    const recovery = await oauthCallbackRecoveryFromStoredState("oidc", state, providerId);
+    return oauthCallbackFailure(c, {
+      code: "oidc_callback_invalid",
+      message: "The identity provider returned an invalid sign-in response.",
+      status: 400,
+      ...recovery,
+    });
   }
 
   const stateKey = `oidc:${state}`;
   const rawPayload = await getChallengeStore().get(stateKey);
   if (!rawPayload) {
-    return c.json<ApiResponse>({ ok: false, error: "Invalid or expired OIDC state" }, 401);
+    return oauthCallbackFailure(c, {
+      code: "oidc_state_expired",
+      message: "This sign-in attempt is invalid or has expired.",
+      status: 401,
+    });
   }
 
   let stateData: {
@@ -5138,15 +5320,27 @@ auth.get("/oidc/:provider/callback", async (c) => {
   try {
     stateData = JSON.parse(rawPayload) as typeof stateData;
   } catch {
-    return c.json<ApiResponse>({ ok: false, error: "Malformed OIDC state payload" }, 400);
+    return oauthCallbackFailure(c, {
+      code: "oidc_state_invalid",
+      message: "This sign-in attempt could not be validated.",
+      status: 400,
+    });
   }
   if (stateData.providerId !== providerId) {
-    return c.json<ApiResponse>({ ok: false, error: "Provider mismatch in state" }, 400);
+    return oauthCallbackFailure(c, {
+      code: "oidc_provider_mismatch",
+      message: "The identity provider does not match this sign-in attempt.",
+      status: 400,
+    });
   }
 
   const provider = selectOidcProvider(await getTenantOidcProviders(stateData.tenantId), providerId);
   if (!provider?.clientId || !provider.tokenUrl) {
-    return c.json<ApiResponse>({ ok: false, error: "OIDC provider not found or disabled" }, 404);
+    return oauthCallbackFailure(c, {
+      code: "oidc_provider_unavailable",
+      message: "This identity provider is not available.",
+      status: 404,
+    });
   }
 
   const methodResponse = await requireTenantLoginMethodAllowed(
@@ -5156,7 +5350,13 @@ auth.get("/oidc/:provider/callback", async (c) => {
     provider.id,
     stateData.clientId,
   );
-  if (methodResponse) return methodResponse;
+  if (methodResponse) {
+    return oauthCallbackFailure(c, {
+      code: "oidc_login_disabled",
+      message: "OIDC sign-in is disabled for this application.",
+      status: 403,
+    });
+  }
 
   let redirectUrl: URL;
   try {
@@ -5166,10 +5366,12 @@ auth.get("/oidc/:provider/callback", async (c) => {
       stateData.clientId,
     );
   } catch (err) {
-    return c.json<ApiResponse>(
-      { ok: false, error: err instanceof Error ? err.message : "Invalid redirect_uri" },
-      400,
-    );
+    console.error("[OidcAuth] Callback redirect validation failed", redactedThrownDiagnostics(err));
+    return oauthCallbackFailure(c, {
+      code: "oidc_redirect_invalid",
+      message: "The application return address is not allowed.",
+      status: 400,
+    });
   }
 
   let idToken: string;
@@ -5182,32 +5384,54 @@ auth.get("/oidc/:provider/callback", async (c) => {
       codeVerifier: stateData.codeVerifier,
     });
   } catch (err) {
-    return c.json<ApiResponse>(
-      { ok: false, error: err instanceof Error ? err.message : "OIDC token exchange failed" },
-      502,
-    );
+    console.error("[OidcAuth] Callback token exchange failed", redactedThrownDiagnostics(err));
+    return oauthCallbackFailure(c, {
+      code: "oidc_token_exchange_failed",
+      message: "The identity provider could not complete sign-in. Please try again.",
+      status: 502,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   try {
     const verified = await verifyOidcJwt(stateData.tenantId, provider, idToken);
     if (verified.claims.nonce !== stateData.nonce) {
-      return c.json<ApiResponse>({ ok: false, error: "OIDC nonce mismatch" }, 401);
+      return oauthCallbackFailure(c, {
+        code: "oidc_nonce_mismatch",
+        message: "This sign-in response could not be matched to your browser.",
+        status: 401,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
     if (!verified.email || verified.emailVerified !== true) {
-      return c.json<ApiResponse>(
-        { ok: false, error: "Enterprise OIDC SSO requires a verified email claim" },
-        403,
-      );
+      return oauthCallbackFailure(c, {
+        code: "oidc_verified_email_required",
+        message: "Enterprise OIDC sign-in requires a verified email address.",
+        status: 403,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
     if (!(await isVerifiedSsoEmailDomainForTenant(stateData.tenantId, verified.email))) {
-      return c.json<ApiResponse>(
-        { ok: false, error: "Enterprise OIDC SSO email domain is not verified for this tenant" },
-        403,
-      );
+      return oauthCallbackFailure(c, {
+        code: "oidc_email_domain_unverified",
+        message: "Your email domain is not approved for this organization.",
+        status: 403,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
     const consumedPayload = await getChallengeStore().consume(stateKey);
     if (consumedPayload !== rawPayload) {
-      return c.json<ApiResponse>({ ok: false, error: "Invalid or already-used OIDC state" }, 401);
+      return oauthCallbackFailure(c, {
+        code: "oidc_state_consumed",
+        message: "This sign-in attempt is invalid or has already been used.",
+        status: 401,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
     await withPreAuthTenant(stateData.tenantId, "oidc-callback-authorization-audit", () =>
       writeAuditEvent({
@@ -5239,16 +5463,31 @@ auth.get("/oidc/:provider/callback", async (c) => {
       tenantRole: "viewer",
     });
     if (!result.ok) {
-      redirectUrl.searchParams.set("error", result.error);
-      return c.redirect(redirectUrl.toString(), 302);
+      return oauthCallbackFailure(c, {
+        code: "oidc_account_provisioning_failed",
+        message: "Your account could not be prepared for sign-in.",
+        status: result.status ?? 500,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
     if (result.response.ok === false) {
-      redirectUrl.searchParams.set("error", String(result.response.error || "auth_failed"));
-      return c.redirect(redirectUrl.toString(), 302);
+      return oauthCallbackFailure(c, {
+        code: "oidc_authentication_failed",
+        message: "Sign-in could not be completed.",
+        status: 403,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
     if (result.response.mfaRequired) {
-      redirectUrl.searchParams.set("error", "mfa_required");
-      return c.redirect(redirectUrl.toString(), 302);
+      return oauthCallbackFailure(c, {
+        code: "mfa_required",
+        message: "Additional verification is required to complete sign-in.",
+        status: 403,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
 
     const exchangeCode = randomBase64Url(32);
@@ -5271,13 +5510,14 @@ auth.get("/oidc/:provider/callback", async (c) => {
     setRedirectFragment(redirectUrl, { code: exchangeCode, state: stateData.appState });
     return c.redirect(redirectUrl.toString(), 302);
   } catch (err) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: err instanceof Error ? err.message : "OIDC token verification failed",
-      },
-      401,
-    );
+    console.error("[OidcAuth] Callback verification failed", redactedThrownDiagnostics(err));
+    return oauthCallbackFailure(c, {
+      code: "oidc_token_verification_failed",
+      message: "The identity provider response could not be verified.",
+      status: 401,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 });
 
@@ -9551,15 +9791,33 @@ auth.get("/oauth/:provider/callback", async (c) => {
   const errorParam = c.req.query("error");
 
   if (errorParam) {
-    return c.json<ApiResponse>({ ok: false, error: `OAuth error: ${errorParam}` }, 400);
+    // Provider-controlled text may contain markup, credentials, or diagnostics.
+    // Keep the browser response stable and non-reflective.
+    const recovery = await oauthCallbackRecoveryFromStoredState("oauth", state, providerName);
+    return oauthCallbackFailure(c, {
+      code: "oauth_authorization_failed",
+      message: "The provider did not authorize this sign-in.",
+      status: 400,
+      ...recovery,
+    });
   }
 
   if (!isBuiltInProvider(providerName)) {
-    return c.json<ApiResponse>({ ok: false, error: `Unknown provider: ${providerName}` }, 400);
+    return oauthCallbackFailure(c, {
+      code: "oauth_provider_unknown",
+      message: "This sign-in provider is not supported.",
+      status: 400,
+    });
   }
 
   if (!code || !state) {
-    return c.json<ApiResponse>({ ok: false, error: "code and state are required" }, 400);
+    const recovery = await oauthCallbackRecoveryFromStoredState("oauth", state, providerName);
+    return oauthCallbackFailure(c, {
+      code: "oauth_callback_incomplete",
+      message: "The provider returned an incomplete sign-in response.",
+      status: 400,
+      ...recovery,
+    });
   }
 
   // Load state before provider calls, then consume it only after provider token
@@ -9568,7 +9826,11 @@ auth.get("/oauth/:provider/callback", async (c) => {
   const stateKey = `oauth:${state}`;
   const rawPayload = await getChallengeStore().get(stateKey);
   if (!rawPayload) {
-    return c.json<ApiResponse>({ ok: false, error: "Invalid or expired OAuth state" }, 401);
+    return oauthCallbackFailure(c, {
+      code: "oauth_state_expired",
+      message: "This sign-in attempt is invalid or has expired.",
+      status: 401,
+    });
   }
 
   let stateData: {
@@ -9586,11 +9848,19 @@ auth.get("/oauth/:provider/callback", async (c) => {
   try {
     stateData = JSON.parse(rawPayload) as typeof stateData;
   } catch {
-    return c.json<ApiResponse>({ ok: false, error: "Malformed OAuth state payload" }, 400);
+    return oauthCallbackFailure(c, {
+      code: "oauth_state_invalid",
+      message: "This sign-in attempt could not be validated.",
+      status: 400,
+    });
   }
 
   if (stateData.provider !== providerName) {
-    return c.json<ApiResponse>({ ok: false, error: "Provider mismatch in state" }, 400);
+    return oauthCallbackFailure(c, {
+      code: "oauth_provider_mismatch",
+      message: "The provider does not match this sign-in attempt.",
+      status: 400,
+    });
   }
   const methodResponse = await requireTenantLoginMethodAllowed(
     c,
@@ -9599,7 +9869,13 @@ auth.get("/oauth/:provider/callback", async (c) => {
     providerName,
     stateData.clientId,
   );
-  if (methodResponse) return methodResponse;
+  if (methodResponse) {
+    return oauthCallbackFailure(c, {
+      code: "oauth_login_disabled",
+      message: "OAuth sign-in is disabled for this application.",
+      status: 403,
+    });
+  }
 
   let redirectUrl: URL;
   try {
@@ -9609,26 +9885,29 @@ auth.get("/oauth/:provider/callback", async (c) => {
       stateData.clientId,
     );
   } catch (err) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: err instanceof Error ? err.message : "Invalid redirect_uri",
-      },
-      400,
+    console.error(
+      "[OAuthAuth] Callback redirect validation failed",
+      redactedThrownDiagnostics(err),
     );
+    return oauthCallbackFailure(c, {
+      code: "oauth_redirect_invalid",
+      message: "The application return address is not allowed.",
+      status: 400,
+    });
   }
 
   let oauthClient: OAuthClient;
   try {
     oauthClient = new OAuthClient(getProviderConfig(providerName));
   } catch (err) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: err instanceof Error ? err.message : "Provider not configured",
-      },
-      503,
-    );
+    console.error("[OAuthAuth] Callback provider setup failed", redactedThrownDiagnostics(err));
+    return oauthCallbackFailure(c, {
+      code: "oauth_provider_unavailable",
+      message: "This sign-in provider is not available.",
+      status: 503,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   const callbackUrl = buildOAuthCallbackUrl(c, providerName);
@@ -9641,13 +9920,14 @@ auth.get("/oauth/:provider/callback", async (c) => {
   try {
     tokenResponse = await oauthClient.exchangeCode(code, callbackUrl, stateData.codeVerifier);
   } catch (err) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: err instanceof Error ? err.message : "Token exchange failed",
-      },
-      502,
-    );
+    console.error("[OAuthAuth] Callback token exchange failed", redactedThrownDiagnostics(err));
+    return oauthCallbackFailure(c, {
+      code: "oauth_token_exchange_failed",
+      message: "The provider could not complete sign-in. Please try again.",
+      status: 502,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   // Fetch user info from provider
@@ -9655,13 +9935,14 @@ auth.get("/oauth/:provider/callback", async (c) => {
   try {
     providerUser = await oauthClient.getUserInfo(tokenResponse.access_token);
   } catch (err) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: err instanceof Error ? err.message : "Failed to fetch user info",
-      },
-      502,
-    );
+    console.error("[OAuthAuth] Callback profile fetch failed", redactedThrownDiagnostics(err));
+    return oauthCallbackFailure(c, {
+      code: "oauth_profile_fetch_failed",
+      message: "The provider profile could not be loaded. Please try again.",
+      status: 502,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   // Twitter and some providers do not return an email address.
@@ -9669,10 +9950,13 @@ auth.get("/oauth/:provider/callback", async (c) => {
   // This email is never displayed or sent — it is purely an internal identity key.
   if (!providerUser.email) {
     if (!providerUser.id) {
-      return c.json<ApiResponse>(
-        { ok: false, error: "Provider returned neither email nor user ID" },
-        400,
-      );
+      return oauthCallbackFailure(c, {
+        code: "oauth_identity_incomplete",
+        message: "The provider did not return enough account information.",
+        status: 400,
+        redirectUrl,
+        appState: stateData.appState,
+      });
     }
     providerUser = {
       ...providerUser,
@@ -9683,7 +9967,13 @@ auth.get("/oauth/:provider/callback", async (c) => {
 
   const consumedPayload = await getChallengeStore().consume(stateKey);
   if (consumedPayload !== rawPayload) {
-    return c.json<ApiResponse>({ ok: false, error: "Invalid or already-used OAuth state" }, 401);
+    return oauthCallbackFailure(c, {
+      code: "oauth_state_consumed",
+      message: "This sign-in attempt is invalid or has already been used.",
+      status: 401,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   // Create/find user + provision wallet + link tenant
@@ -9696,17 +9986,39 @@ auth.get("/oauth/:provider/callback", async (c) => {
   });
 
   if (!result.ok) {
-    return c.json<ApiResponse>({ ok: false, error: result.error }, result.status ?? 500);
+    const isUnverifiedEmail =
+      result.error === "Provider email must be verified before OAuth sign-in is allowed";
+    return oauthCallbackFailure(c, {
+      code: isUnverifiedEmail
+        ? "oauth_verified_email_required"
+        : "oauth_account_provisioning_failed",
+      message: isUnverifiedEmail
+        ? "Provider email must be verified before OAuth sign-in is allowed."
+        : "Your account could not be prepared for sign-in.",
+      status: result.status ?? 500,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   if (result.response.ok === false) {
-    redirectUrl.searchParams.set("error", String(result.response.error || "auth_failed"));
-    return c.redirect(redirectUrl.toString(), 302);
+    return oauthCallbackFailure(c, {
+      code: "oauth_authentication_failed",
+      message: "Sign-in could not be completed.",
+      status: 403,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   if (result.response.mfaRequired) {
-    redirectUrl.searchParams.set("error", "mfa_required");
-    return c.redirect(redirectUrl.toString(), 302);
+    return oauthCallbackFailure(c, {
+      code: "mfa_required",
+      message: "Additional verification is required to complete sign-in.",
+      status: 403,
+      redirectUrl,
+      appState: stateData.appState,
+    });
   }
 
   // Nonce-exchange path: issue a one-time, short-lived (60s) code that the

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -50,7 +50,6 @@ import { isIP } from "node:net";
 import {
   ACCESS_TOKEN_EXPIRY,
   ACCESS_TOKEN_EXPIRY_SECONDS,
-  type AuthenticatorTransportFuture,
   assertPinnedDnsTransportSupported,
   assertPublicHttpsEndpoint,
   assertTokenNotRevoked,
@@ -8532,10 +8531,9 @@ auth.post("/passkey/register/verify", async (c) => {
 /**
  * POST /passkey/login/options
  * Body: { email }
- * Returns only the credentials bound to the typed email. Unknown accounts and
- * accounts without a passkey share one generic response. This rate-limited
- * pre-auth route deliberately exposes passkey availability so the browser never
- * offers a credential belonging to a different account on the same RP.
+ * Returns privacy-preserving discoverable-credential options. `allowCredentials`
+ * is intentionally empty for every email so this pre-auth route cannot reveal
+ * whether an account or passkey exists.
  */
 auth.post("/passkey/login/options", async (c) => {
   const rl = await checkAuthRateLimit(c, "passkey-options", 60_000, 20);
@@ -8571,36 +8569,11 @@ auth.post("/passkey/login/options", async (c) => {
   );
   if (ssoRequiredResponse) return ssoRequiredResponse;
 
-  const credentials = await getDb()
-    .select({
-      credentialId: authenticators.credentialId,
-      transports: authenticators.transports,
-    })
-    .from(authenticators)
-    .innerJoin(users, eq(authenticators.userId, users.id))
-    .where(eq(users.email, email));
-  if (credentials.length === 0) {
-    return c.json<ApiResponse>(
-      { ok: false, error: "Passkey sign-in is unavailable for this email" },
-      404,
-    );
-  }
-
-  const options = await getPasskeyAuth(c.req.header("origin")).generateAuthenticationOptions(
-    email,
-    {
-      allowCredentials: credentials.map((credential) => ({
-        id: credential.credentialId,
-        ...(credential.transports && credential.transports.length > 0
-          ? { transports: credential.transports as AuthenticatorTransportFuture[] }
-          : {}),
-      })),
-    },
-  );
+  const options = await getPasskeyAuth(c.req.header("origin")).generateAuthenticationOptions(email);
   const challengeId = options.challenge;
   await getChallengeStore().set(`passkey-login:${email}:${challengeId}`, options.challenge);
 
-  return c.json({ ...options, challengeId });
+  return c.json({ ...options, allowCredentials: [], challengeId });
 });
 
 /**

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -131,13 +131,13 @@ import {
 import {
   type ApiResponse,
   redactedThrownDiagnostics,
-  runtimeEnvironmentValue,
   type SsoDiscoveryResult,
   type TenantAuthAbuseConfig,
   type TenantOidcProviderConfig,
   type TenantSamlSsoConfig,
   type TenantTestAccountConfig,
 } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { KeyStore, provisionUserWallet, Vault } from "@stwd/vault";
 import bs58 from "bs58";
 import { and, eq, gte, inArray, isNull, lt, sql } from "drizzle-orm";

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -2424,20 +2424,22 @@ async function writeAuthLoginAudit(
   claims: Record<string, unknown> | undefined,
   metadata: Record<string, unknown> = {},
 ): Promise<void> {
-  await writeAuditEvent({
-    tenantId,
-    actorType: "user",
-    actorId: userId,
-    action: "auth.login",
-    resourceType: "session",
-    metadata: {
-      method: typeof claims?.authMethod === "string" ? claims.authMethod : "unknown",
-      ...metadata,
-    },
-    ipAddress: c.req.header("x-forwarded-for") ?? null,
-    userAgent: c.req.header("user-agent") ?? null,
-    requestId: c.req.header("x-request-id") ?? null,
-  });
+  await withVerifiedAuthTenant(tenantId, userId, () =>
+    writeAuditEvent({
+      tenantId,
+      actorType: "user",
+      actorId: userId,
+      action: "auth.login",
+      resourceType: "session",
+      metadata: {
+        method: typeof claims?.authMethod === "string" ? claims.authMethod : "unknown",
+        ...metadata,
+      },
+      ipAddress: c.req.header("x-forwarded-for") ?? null,
+      userAgent: c.req.header("user-agent") ?? null,
+      requestId: c.get("requestId") ?? c.req.header("x-request-id") ?? null,
+    }),
+  );
 }
 
 type WalletTenantResult = {
@@ -3227,19 +3229,7 @@ async function buildAuthOrMfaResponse(
   }
 
   if (c) {
-    await writeAuditEvent({
-      tenantId,
-      actorType: "user",
-      actorId: userId,
-      action: "auth.login",
-      resourceType: "session",
-      metadata: {
-        method: typeof claims.authMethod === "string" ? claims.authMethod : "unknown",
-      },
-      ipAddress: c.req.header("x-forwarded-for") ?? null,
-      userAgent: c.req.header("user-agent") ?? null,
-      requestId: c.get("requestId") ?? null,
-    });
+    await writeAuthLoginAudit(c, tenantId, userId, claims);
   }
   const token = await createSessionToken(address, tenantId, sessionClaims);
   const refreshToken = await createRefreshToken(userId, tenantId, sessionClaims);

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -11,8 +11,8 @@
  * GET  /providers                   — available auth methods (passkey/email/siwe/google/discord)
  * POST /logout                      — client-side logout (no-op server side)
  *
- * POST /passkey/register/options    — { email } → WebAuthn creation options
- * POST /passkey/register/verify     — { email, response } → { token, user }
+ * POST /passkey/register/options    — { email, emailGrant? } → WebAuthn creation options
+ * POST /passkey/register/verify     — { email, response, emailGrant? } → { token, user }
  * POST /passkey/login/options       — { email } → WebAuthn request options
  * POST /passkey/login/verify        — { email, response } → { token, user }
  *
@@ -1519,6 +1519,22 @@ async function peekEmailGrant(grant: string, email: string, tenantId: string): P
   } catch {
     return false;
   }
+}
+
+/**
+ * Test-only seam for exercising verified-email enrollment routes without
+ * sending or scraping an OTP. Production grants are still issued exclusively
+ * by /email/otp/verify.
+ */
+export async function _seedEmailGrantForTests(
+  grant: string,
+  email: string,
+  tenantId: string,
+): Promise<void> {
+  await getEmailGrantStore().set(
+    emailGrantKey(grant),
+    JSON.stringify({ email: email.toLowerCase().trim(), tenantId }),
+  );
 }
 
 const OAUTH_CODE_REDEEM_LOCK_TTL_MS = 10 * 1000;
@@ -7637,26 +7653,31 @@ auth.post("/mfa/passkey/options", async (c) => {
   );
   if (methodResponse) return methodResponse;
 
+  const passkeyAuth = getPasskeyAuth(c.req.header("origin"));
   const passkeys = await getDb()
     .select({
       credentialId: authenticators.credentialId,
+      rpId: authenticators.rpId,
       transports: authenticators.transports,
     })
     .from(authenticators)
     .where(eq(authenticators.userId, session.payload.userId));
-  if (passkeys.length === 0) {
+  // Explicitly cross-RP credentials cannot satisfy this RP's WebAuthn
+  // challenge. Legacy NULL provenance stays eligible so the browser can
+  // adjudicate it, and a successful assertion will safely backfill the RP.
+  const eligiblePasskeys = passkeys.filter(
+    (credential) => credential.rpId === null || credential.rpId === passkeyAuth.rpID,
+  );
+  if (eligiblePasskeys.length === 0) {
     return c.json<ApiResponse>({ ok: false, error: "No passkey is registered for this user" }, 404);
   }
 
-  const options = await getPasskeyAuth(c.req.header("origin")).generateAuthenticationOptions(
-    `mfa:${session.payload.userId}`,
-    {
-      allowCredentials: passkeys.map((credential) => ({
-        id: credential.credentialId,
-        transports: (credential.transports ?? []) as never[],
-      })),
-    },
-  );
+  const options = await passkeyAuth.generateAuthenticationOptions(`mfa:${session.payload.userId}`, {
+    allowCredentials: eligiblePasskeys.map((credential) => ({
+      id: credential.credentialId,
+      transports: (credential.transports ?? []) as never[],
+    })),
+  });
   const challengeId = options.challenge;
   await getChallengeStore().set(
     passkeyMfaChallengeKey(session.payload.userId, challengeId),
@@ -7712,6 +7733,11 @@ const completePasskeyMfaHandler = async (c: Context) => {
     return c.json<ApiResponse>({ ok: false, error: "Passkey MFA verification failed" }, 401);
   }
 
+  const passkeyAuth = getPasskeyAuth(c.req.header("origin"));
+  if (cred.rpId !== null && cred.rpId !== passkeyAuth.rpID) {
+    return c.json<ApiResponse>({ ok: false, error: "Passkey MFA verification failed" }, 401);
+  }
+
   let verification: Awaited<ReturnType<PasskeyAuth["verifyAuthentication"]>>;
   try {
     const challengeKey = passkeyMfaChallengeKey(session.payload.userId, body.challengeId);
@@ -7719,7 +7745,7 @@ const completePasskeyMfaHandler = async (c: Context) => {
     if (!expectedChallenge) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired passkey challenge" }, 401);
     }
-    verification = await getPasskeyAuth(c.req.header("origin")).verifyAuthentication(
+    verification = await passkeyAuth.verifyAuthentication(
       body.response as unknown as Parameters<PasskeyAuth["verifyAuthentication"]>[0],
       expectedChallenge,
       cred.credentialPublicKey,
@@ -7752,7 +7778,11 @@ const completePasskeyMfaHandler = async (c: Context) => {
 
   const updatedMfaCounters = await getDb()
     .update(authenticators)
-    .set({ counter: verification.authenticationInfo.newCounter })
+    .set({
+      counter: verification.authenticationInfo.newCounter,
+      // A verified assertion proves a legacy credential's RP provenance.
+      ...(cred.rpId === null ? { rpId: passkeyAuth.rpID } : {}),
+    })
     .where(and(eq(authenticators.id, cred.id), eq(authenticators.counter, cred.counter)))
     .returning({ id: authenticators.id });
   if (updatedMfaCounters.length !== 1) {
@@ -8234,8 +8264,9 @@ auth.delete("/sessions", async (c) => {
 
 /**
  * POST /passkey/register/options
- * Body: { email }
- * Finds or creates user, returns WebAuthn registration options.
+ * Body: { email, emailGrant? }
+ * Verified-email enrollment returns 409 when the account already has a
+ * passkey for this RP, while authenticated sessions can add devices.
  */
 auth.post("/passkey/register/options", async (c) => {
   // Pre-auth reachable via the email-grant path — rate limit like the other
@@ -8258,6 +8289,9 @@ auth.post("/passkey/register/options", async (c) => {
   }
   const email = body.email.toLowerCase().trim();
   const db = getDb();
+  const emailGrant =
+    typeof body.emailGrant === "string" && body.emailGrant.length > 0 ? body.emailGrant : null;
+  const usingEmailGrant = emailGrant !== null;
 
   // Two ways in: an authenticated session (add-passkey for logged-in users)
   // or a verified-email grant from /email/otp/verify (Privy-style signup:
@@ -8267,14 +8301,14 @@ auth.post("/passkey/register/options", async (c) => {
   let userEmail: string | null;
   let ssoTenantId: string;
 
-  if (typeof body.emailGrant === "string" && body.emailGrant.length > 0) {
+  if (emailGrant !== null) {
     const resolvedTenantId =
       c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || defaultAuthTenantId();
     const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "passkey");
     if (methodResponse) return methodResponse;
     // Peek (not consume): the grant is only burned at register/verify so a
     // cancelled Touch ID prompt doesn't cost the user their verification.
-    const grantOk = await peekEmailGrant(body.emailGrant, email, resolvedTenantId);
+    const grantOk = await peekEmailGrant(emailGrant, email, resolvedTenantId);
     if (!grantOk) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired email grant" }, 401);
     }
@@ -8326,20 +8360,44 @@ auth.post("/passkey/register/options", async (c) => {
   );
   if (ssoRequiredResponse) return ssoRequiredResponse;
 
+  const passkeyAuth = getPasskeyAuth(c.req.header("origin"));
   const existingCreds = await db
-    .select({ credentialId: authenticators.credentialId })
+    .select({
+      credentialId: authenticators.credentialId,
+      rpId: authenticators.rpId,
+    })
     .from(authenticators)
     .where(eq(authenticators.userId, userId));
+
+  // The verified-email path exists to establish the account's first passkey.
+  // Only provenance that explicitly matches the current RP can trigger the
+  // recovery signal. A cross-RP credential must not block registration here,
+  // and a legacy NULL row is ambiguous: keep it in excludeCredentials so the
+  // browser can safely adjudicate whether it belongs to this RP.
+  if (usingEmailGrant && existingCreds.some((cred) => cred.rpId === passkeyAuth.rpID)) {
+    return c.json<ApiResponse & { code: "passkey_already_registered" }>(
+      {
+        ok: false,
+        error: "A passkey already exists for this email. Sign in with it instead.",
+        code: "passkey_already_registered",
+      },
+      409,
+    );
+  }
+
+  const sameOrLegacyCreds = existingCreds.filter(
+    (cred) => cred.rpId === null || cred.rpId === passkeyAuth.rpID,
+  );
 
   const attachment =
     body.authenticatorAttachment === "platform" || body.authenticatorAttachment === "cross-platform"
       ? body.authenticatorAttachment
       : undefined;
 
-  const options = await getPasskeyAuth(c.req.header("origin")).generateRegistrationOptions(
+  const options = await passkeyAuth.generateRegistrationOptions(
     userId,
     userEmail ?? email,
-    existingCreds.map((cred) => cred.credentialId),
+    sameOrLegacyCreds.map((cred) => cred.credentialId),
     attachment ? { authenticatorAttachment: attachment } : undefined,
   );
 
@@ -8440,9 +8498,10 @@ auth.post("/passkey/register/verify", async (c) => {
   const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(c, tenantId, email, "Passkey");
   if (ssoRequiredResponse) return ssoRequiredResponse;
 
+  const passkeyAuth = getPasskeyAuth(c.req.header("origin"));
   let verification: Awaited<ReturnType<PasskeyAuth["verifyRegistration"]>>;
   try {
-    verification = await getPasskeyAuth(c.req.header("origin")).verifyRegistration(
+    verification = await passkeyAuth.verifyRegistration(
       user.id,
       body.response as unknown as Parameters<PasskeyAuth["verifyRegistration"]>[1],
     );
@@ -8482,6 +8541,7 @@ auth.post("/passkey/register/verify", async (c) => {
       userId: user.id,
       credentialId: credential.id,
       credentialPublicKey: uint8ArrayToBase64url(credential.publicKey),
+      rpId: passkeyAuth.rpID,
       counter: credential.counter,
       credentialDeviceType,
       credentialBackedUp,
@@ -8634,6 +8694,11 @@ auth.post("/passkey/login/verify", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Passkey authentication failed" }, 401);
   }
 
+  const passkeyAuth = getPasskeyAuth(c.req.header("origin"));
+  if (cred.rpId !== null && cred.rpId !== passkeyAuth.rpID) {
+    return c.json<ApiResponse>({ ok: false, error: "Passkey authentication failed" }, 401);
+  }
+
   let verification: Awaited<ReturnType<PasskeyAuth["verifyAuthentication"]>>;
   try {
     const expectedChallenge = await getChallengeStore().consume(
@@ -8642,7 +8707,7 @@ auth.post("/passkey/login/verify", async (c) => {
     if (!expectedChallenge) {
       return c.json<ApiResponse>({ ok: false, error: "Passkey authentication failed" }, 401);
     }
-    verification = await getPasskeyAuth(c.req.header("origin")).verifyAuthentication(
+    verification = await passkeyAuth.verifyAuthentication(
       body.response as unknown as Parameters<PasskeyAuth["verifyAuthentication"]>[0],
       expectedChallenge,
       cred.credentialPublicKey,
@@ -8677,7 +8742,11 @@ auth.post("/passkey/login/verify", async (c) => {
   // Update counter to prevent replay attacks
   const updatedCounters = await db
     .update(authenticators)
-    .set({ counter: verification.authenticationInfo.newCounter })
+    .set({
+      counter: verification.authenticationInfo.newCounter,
+      // A verified assertion proves a legacy credential's RP provenance.
+      ...(cred.rpId === null ? { rpId: passkeyAuth.rpID } : {}),
+    })
     .where(and(eq(authenticators.id, cred.id), eq(authenticators.counter, cred.counter)))
     .returning({ id: authenticators.id });
   if (updatedCounters.length !== 1) {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -131,6 +131,7 @@ import {
 import {
   type ApiResponse,
   redactedThrownDiagnostics,
+  runtimeEnvironmentValue,
   type SsoDiscoveryResult,
   type TenantAuthAbuseConfig,
   type TenantOidcProviderConfig,

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1961,6 +1961,7 @@ function buildGlobalEmailAuth(overrides?: {
   baseUrl?: string;
   callbackPath?: string;
   templateId?: string;
+  brandName?: string;
   subjectOverride?: string;
   replyTo?: string;
   templates?: TenantEmailConfig["templates"];
@@ -1983,6 +1984,7 @@ function buildGlobalEmailAuth(overrides?: {
     provider,
     tokenStore: getTokenStore(),
     templateId: overrides?.templateId,
+    brandName: overrides?.brandName,
     subjectOverride: overrides?.subjectOverride,
     replyTo: overrides?.replyTo,
     ...buildTemplateRenderers(overrides?.templates),
@@ -2041,6 +2043,7 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
       baseUrl: magicLinkBaseUrl,
       callbackPath,
       templateId: emailConfig?.templateId,
+      brandName: emailConfig?.brandName,
       subjectOverride: emailConfig?.subjectOverride,
       replyTo: emailConfig?.replyTo,
       templates: emailConfig?.templates,
@@ -2072,6 +2075,7 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
     provider,
     tokenStore: getTokenStore(),
     templateId: emailConfig.templateId,
+    brandName: emailConfig.brandName,
     subjectOverride: emailConfig.subjectOverride,
     replyTo: emailConfig.replyTo,
     ...buildTemplateRenderers(emailConfig.templates),

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1957,6 +1957,45 @@ function buildTemplateRenderers(templates: TenantEmailConfig["templates"]): {
   };
 }
 
+function globalEmailMagicLinkBaseUrl(): string {
+  const emailBaseUrl = runtimeEnvironmentValue("EMAIL_MAGIC_LINK_BASE_URL")?.trim();
+  if (emailBaseUrl) {
+    const parsed = new URL(emailBaseUrl);
+    const normalized = emailBaseUrl.replace(/\/$/, "");
+    if (
+      !["http:", "https:"].includes(parsed.protocol) ||
+      parsed.username ||
+      parsed.password ||
+      parsed.search ||
+      parsed.hash ||
+      parsed.origin !== normalized
+    ) {
+      throw new Error("EMAIL_MAGIC_LINK_BASE_URL must be a credential-free HTTP(S) origin");
+    }
+    return parsed.origin;
+  }
+
+  return runtimeEnvironmentValue("APP_URL")?.trim().replace(/\/$/, "") || "https://steward.fi";
+}
+
+function globalEmailMagicLinkCallbackPath(): string | undefined {
+  const callbackPath = runtimeEnvironmentValue("EMAIL_MAGIC_LINK_CALLBACK_PATH")?.trim();
+  if (!callbackPath) return undefined;
+  if (!callbackPath.startsWith("/") || callbackPath.startsWith("//")) {
+    throw new Error("EMAIL_MAGIC_LINK_CALLBACK_PATH must be a root-relative path");
+  }
+  return callbackPath;
+}
+
+function globalEmailBrandName(): string | undefined {
+  const brandName = runtimeEnvironmentValue("EMAIL_BRAND_NAME")?.trim();
+  if (!brandName) return undefined;
+  if (brandName.length > 100 || /[\r\n]/.test(brandName)) {
+    throw new Error("EMAIL_BRAND_NAME must be a single-line string of at most 100 characters");
+  }
+  return brandName;
+}
+
 function buildGlobalEmailAuth(overrides?: {
   baseUrl?: string;
   callbackPath?: string;
@@ -1979,12 +2018,12 @@ function buildGlobalEmailAuth(overrides?: {
 
   return new EmailAuth({
     from: process.env.EMAIL_FROM || "login@steward.fi",
-    baseUrl: overrides?.baseUrl?.replace(/\/$/, "") || process.env.APP_URL || "https://steward.fi",
-    callbackPath: overrides?.callbackPath,
+    baseUrl: overrides?.baseUrl?.replace(/\/$/, "") || globalEmailMagicLinkBaseUrl(),
+    callbackPath: overrides?.callbackPath || globalEmailMagicLinkCallbackPath(),
     provider,
     tokenStore: getTokenStore(),
     templateId: overrides?.templateId,
-    brandName: overrides?.brandName,
+    brandName: overrides?.brandName || globalEmailBrandName(),
     subjectOverride: overrides?.subjectOverride,
     replyTo: overrides?.replyTo,
     ...buildTemplateRenderers(overrides?.templates),
@@ -2065,17 +2104,16 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
         })
       : undefined;
 
-  const baseUrl =
-    magicLinkBaseUrl?.replace(/\/$/, "") || process.env.APP_URL || "https://steward.fi";
+  const baseUrl = magicLinkBaseUrl?.replace(/\/$/, "") || globalEmailMagicLinkBaseUrl();
 
   return new EmailAuth({
     from,
     baseUrl,
-    callbackPath,
+    callbackPath: callbackPath || globalEmailMagicLinkCallbackPath(),
     provider,
     tokenStore: getTokenStore(),
     templateId: emailConfig.templateId,
-    brandName: emailConfig.brandName,
+    brandName: emailConfig.brandName || globalEmailBrandName(),
     subjectOverride: emailConfig.subjectOverride,
     replyTo: emailConfig.replyTo,
     ...buildTemplateRenderers(emailConfig.templates),

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -50,6 +50,7 @@ import { isIP } from "node:net";
 import {
   ACCESS_TOKEN_EXPIRY,
   ACCESS_TOKEN_EXPIRY_SECONDS,
+  type AuthenticatorTransportFuture,
   assertPinnedDnsTransportSupported,
   assertPublicHttpsEndpoint,
   assertTokenNotRevoked,
@@ -8248,9 +8249,10 @@ auth.post("/passkey/register/verify", async (c) => {
 /**
  * POST /passkey/login/options
  * Body: { email }
- * Returns privacy-preserving discoverable-credential options. `allowCredentials`
- * is intentionally empty for every email so this pre-auth route cannot reveal
- * whether an account or passkey exists.
+ * Returns only the credentials bound to the typed email. Unknown accounts and
+ * accounts without a passkey share one generic response. This rate-limited
+ * pre-auth route deliberately exposes passkey availability so the browser never
+ * offers a credential belonging to a different account on the same RP.
  */
 auth.post("/passkey/login/options", async (c) => {
   const rl = await checkAuthRateLimit(c, "passkey-options", 60_000, 20);
@@ -8286,11 +8288,36 @@ auth.post("/passkey/login/options", async (c) => {
   );
   if (ssoRequiredResponse) return ssoRequiredResponse;
 
-  const options = await getPasskeyAuth(c.req.header("origin")).generateAuthenticationOptions(email);
+  const credentials = await getDb()
+    .select({
+      credentialId: authenticators.credentialId,
+      transports: authenticators.transports,
+    })
+    .from(authenticators)
+    .innerJoin(users, eq(authenticators.userId, users.id))
+    .where(eq(users.email, email));
+  if (credentials.length === 0) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Passkey sign-in is unavailable for this email" },
+      404,
+    );
+  }
+
+  const options = await getPasskeyAuth(c.req.header("origin")).generateAuthenticationOptions(
+    email,
+    {
+      allowCredentials: credentials.map((credential) => ({
+        id: credential.credentialId,
+        ...(credential.transports && credential.transports.length > 0
+          ? { transports: credential.transports as AuthenticatorTransportFuture[] }
+          : {}),
+      })),
+    },
+  );
   const challengeId = options.challenge;
   await getChallengeStore().set(`passkey-login:${email}:${challengeId}`, options.challenge);
 
-  return c.json({ ...options, allowCredentials: [], challengeId });
+  return c.json({ ...options, challengeId });
 });
 
 /**

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -544,6 +544,13 @@ function isOptionalString(value: unknown): value is string | undefined {
   return value === undefined || isNonEmptyString(value);
 }
 
+function isOptionalEmailBrandName(value: unknown): value is string | undefined {
+  return (
+    value === undefined ||
+    (isNonEmptyString(value) && value.trim().length <= 100 && !/[\r\n]/.test(value))
+  );
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -1337,13 +1344,13 @@ platform.get("/tenants/:id", async (c) => {
 
 /**
  * PATCH /tenants/:tenantId/email-config
- * Body: { apiKey, from, replyTo?, templateId?, subjectOverride?, templates? }
- *   or template-only: { templateId?, subjectOverride?, replyTo?, templates? }
+ * Body: { apiKey, from, replyTo?, brandName?, templateId?, subjectOverride?, templates? }
+ *   or template-only: { brandName?, templateId?, subjectOverride?, replyTo?, templates? }
  *   (no apiKey)
  *
  * Upserts the tenant-specific email provider config. When `apiKey` is
  * omitted the tenant keeps the platform's global Resend provider and only
- * the branding fields (templateId/subjectOverride/replyTo/templates) are
+ * the branding fields (brandName/templateId/subjectOverride/replyTo/templates) are
  * stored — merged over any existing config so magic-link overrides survive.
  * `templates` carries deployer-supplied raw subject/text/html bodies with
  * {{placeholder}} substitution (see TenantEmailConfig.templates); pass
@@ -1368,6 +1375,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
     apiKey: string;
     from: string;
     replyTo?: string;
+    brandName?: string;
     templateId?: string;
     subjectOverride?: string;
     magicLinkBaseUrl?: string;
@@ -1401,6 +1409,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
     }
     if (
       !body.templateId &&
+      !body.brandName &&
       !body.subjectOverride &&
       !body.replyTo &&
       !body.magicLinkBaseUrl &&
@@ -1411,7 +1420,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
         {
           ok: false,
           error:
-            "Provide apiKey+from for provider config, or at least one of templateId, subjectOverride, replyTo, magicLinkBaseUrl, magicLinkCallbackPath, templates",
+            "Provide apiKey+from for provider config, or at least one of brandName, templateId, subjectOverride, replyTo, magicLinkBaseUrl, magicLinkCallbackPath, templates",
         },
         400,
       );
@@ -1422,6 +1431,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
 
   if (
     !isOptionalString(body.replyTo) ||
+    !isOptionalEmailBrandName(body.brandName) ||
     !isOptionalString(body.templateId) ||
     !isOptionalString(body.subjectOverride) ||
     !isOptionalString(body.magicLinkBaseUrl) ||
@@ -1431,7 +1441,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
       {
         ok: false,
         error:
-          "replyTo, templateId, subjectOverride, magicLinkBaseUrl, and magicLinkCallbackPath must be non-empty strings",
+          "brandName must be a non-empty single-line string of at most 100 characters; replyTo, templateId, subjectOverride, magicLinkBaseUrl, and magicLinkCallbackPath must be non-empty strings",
       },
       400,
     );
@@ -1478,6 +1488,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
         // PATCH can't clobber magic-link overrides or provider creds.
         ...(existingRow?.emailConfig ?? {}),
         ...(body.replyTo ? { replyTo: body.replyTo.trim() } : {}),
+        ...(body.brandName ? { brandName: body.brandName.trim() } : {}),
         ...(body.templateId ? { templateId: body.templateId.trim() } : {}),
         ...(body.subjectOverride ? { subjectOverride: body.subjectOverride.trim() } : {}),
         ...(body.magicLinkBaseUrl ? { magicLinkBaseUrl: body.magicLinkBaseUrl.trim() } : {}),
@@ -1491,6 +1502,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
         apiKeyEncrypted: JSON.stringify(platformKeyStore().encrypt(body.apiKey.trim())),
         from: body.from.trim(),
         ...(body.replyTo ? { replyTo: body.replyTo.trim() } : {}),
+        ...(body.brandName ? { brandName: body.brandName.trim() } : {}),
         ...(body.templateId ? { templateId: body.templateId.trim() } : {}),
         ...(body.subjectOverride ? { subjectOverride: body.subjectOverride.trim() } : {}),
         ...(body.magicLinkBaseUrl ? { magicLinkBaseUrl: body.magicLinkBaseUrl.trim() } : {}),
@@ -1551,6 +1563,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
       provider?: "resend";
       from?: string;
       replyTo?: string;
+      brandName?: string;
       templateId?: string;
       subjectOverride?: string;
       hasApiKey: boolean;
@@ -1561,6 +1574,7 @@ platform.patch("/tenants/:tenantId/email-config", async (c) => {
       provider: emailConfig.provider,
       from: emailConfig.from,
       replyTo: emailConfig.replyTo,
+      brandName: emailConfig.brandName,
       templateId: emailConfig.templateId,
       subjectOverride: emailConfig.subjectOverride,
       hasApiKey: Boolean(emailConfig.apiKeyEncrypted),
@@ -1600,6 +1614,7 @@ platform.get("/tenants/:tenantId/email-config", async (c) => {
         provider?: "resend";
         from?: string;
         replyTo?: string;
+        brandName?: string;
         templateId?: string;
         subjectOverride?: string;
         magicLinkBaseUrl?: string;
@@ -1616,6 +1631,7 @@ platform.get("/tenants/:tenantId/email-config", async (c) => {
             provider: emailConfig.provider,
             from: emailConfig.from,
             replyTo: emailConfig.replyTo,
+            brandName: emailConfig.brandName,
             templateId: emailConfig.templateId,
             subjectOverride: emailConfig.subjectOverride,
             magicLinkBaseUrl: emailConfig.magicLinkBaseUrl,

--- a/packages/api/src/services/default-auth-tenant.ts
+++ b/packages/api/src/services/default-auth-tenant.ts
@@ -1,0 +1,6 @@
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
+
+/** Resolve the tenant-less auth target from the active request's immutable environment. */
+export function defaultAuthTenantId(): string {
+  return runtimeEnvironmentValue("STEWARD_DEFAULT_TENANT_ID")?.trim() || "default";
+}

--- a/packages/auth/src/__tests__/email-templates.test.ts
+++ b/packages/auth/src/__tests__/email-templates.test.ts
@@ -35,6 +35,21 @@ describe("renderTemplate", () => {
   });
 });
 
+describe("default magic-link template", () => {
+  it("uses and HTML-escapes the configured tenant brand", () => {
+    const rendered = renderDefaultTemplate({
+      ...MAGIC_LINK_DATA,
+      tenantName: '<b>Customer "Cloud"</b>',
+    });
+
+    expect(rendered.subject).toBe('Sign in to <b>Customer "Cloud"</b>');
+    expect(rendered.text).toContain('— <b>Customer "Cloud"</b>');
+    expect(rendered.html).toContain("&lt;b&gt;Customer &quot;Cloud&quot;&lt;/b&gt;");
+    expect(rendered.html).not.toContain('<b>Customer "Cloud"</b>');
+    expect(rendered.html).not.toContain("agent wallet infrastructure");
+  });
+});
+
 describe("renderOtpTemplate", () => {
   it("falls back to the default OTP template for unknown/absent template ids", () => {
     expect(renderOtpTemplate(undefined, OTP_DATA)).toEqual(renderDefaultOtpTemplate(OTP_DATA));

--- a/packages/auth/src/__tests__/email.test.ts
+++ b/packages/auth/src/__tests__/email.test.ts
@@ -105,6 +105,44 @@ describe("EmailAuth.sendMagicLink", () => {
     auth.destroy();
   });
 
+  it("passes the configured brand to magic-link and OTP renderers", async () => {
+    const sent = mock(async () => ({ provider: "test" }));
+    const templateRenderer = mock(() => ({
+      subject: "magic subject",
+      text: "magic text",
+      html: "<p>magic html</p>",
+    }));
+    const otpTemplateRenderer = mock(() => ({
+      subject: "otp subject",
+      text: "otp text",
+      html: "<p>otp html</p>",
+    }));
+    const auth = new EmailAuth({
+      from: "login@example.test",
+      baseUrl: "https://app.example.test",
+      callbackPath: "/auth/callback/email",
+      brandName: "Customer Cloud",
+      provider: { send: sent },
+      templateRenderer,
+      otpTemplateRenderer,
+    });
+
+    await auth.sendMagicLink("user@example.test", { tenantId: "customer" });
+    await auth.sendOtp("user@example.test", { tenantId: "customer" });
+
+    const [, magicData] = templateRenderer.mock.calls[0]!;
+    const [, otpData] = otpTemplateRenderer.mock.calls[0]!;
+    expect(magicData).toMatchObject({
+      tenantName: "Customer Cloud",
+    });
+    expect(magicData.magicLink).toContain("https://app.example.test/auth/callback/email?");
+    expect(otpData).toMatchObject({
+      brandName: "Customer Cloud",
+    });
+
+    auth.destroy();
+  });
+
   it("binds the tenant into the magic link for non-default tenants (and omits it otherwise)", async () => {
     const sent = mock(async () => ({ provider: "test" }));
     const templateRenderer = mock(() => ({

--- a/packages/auth/src/__tests__/jwt.test.ts
+++ b/packages/auth/src/__tests__/jwt.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { scryptSync } from "node:crypto";
+import { decodeJwt, decodeProtectedHeader } from "jose";
 
 import { getJwtSecret, signAccessToken, verifyToken } from "../jwt";
+import { SessionManager } from "../session";
 
 const ENV_KEYS = [
   "STEWARD_JWT_SECRET",
@@ -54,14 +56,33 @@ describe("getJwtSecret embedded-mode master password fallback (SEC-013)", () => 
     const token = await signAccessToken({
       address: "0x0000000000000000000000000000000000000000",
       tenantId: "default",
+      userId: "user_123",
+      sub: "caller-controlled",
     });
     const payload = await verifyToken(token);
     expect(payload.tenantId).toBe("default");
+    expect(payload.userId).toBe("user_123");
+    expect(payload.sub).toBe("user_123");
+    expect(decodeProtectedHeader(token)).toEqual({ alg: "HS256", typ: "JWT" });
   });
 
   it("prefers an explicit STEWARD_JWT_SECRET over the derivation", () => {
     process.env.STEWARD_JWT_SECRET = "explicit-jwt-secret-with-32-characters!!";
     expect(getJwtSecret({ warn: null })).toBe("explicit-jwt-secret-with-32-characters!!");
+  });
+});
+
+describe("session identity claims", () => {
+  it("binds the standard subject claim to the authenticated user", async () => {
+    const session = new SessionManager({ secret: "test-secret-at-least-32-characters" });
+    const token = await session.createSession("user_123", {
+      sub: "caller-controlled",
+      userId: "caller-controlled",
+      jti: "caller-controlled",
+    });
+
+    expect(decodeJwt(token)).toMatchObject({ sub: "user_123", userId: "user_123" });
+    expect(decodeJwt(token).jti).not.toBe("caller-controlled");
   });
 });
 

--- a/packages/auth/src/__tests__/oauth.test.ts
+++ b/packages/auth/src/__tests__/oauth.test.ts
@@ -721,6 +721,111 @@ describe("OAuthClient.getUserInfo — provider response normalization", () => {
     globalThis.fetch = originalFetch;
   });
 
+  it("resolves a public GitHub email's verified status through /user/emails", async () => {
+    const originalFetch = globalThis.fetch;
+    const requestedUrls: string[] = [];
+    globalThis.fetch = asFetchMock(async (input) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url.endsWith("/userinfo")) {
+        return Response.json({
+          id: "gh-public-verified",
+          email: "Public@Example.com",
+          login: "public-user",
+        });
+      }
+      return Response.json([
+        { email: "other@example.com", primary: true, verified: true },
+        { email: "public@example.com", primary: false, verified: true },
+      ]);
+    });
+    try {
+      const client = new OAuthClient({
+        clientId: "c",
+        clientSecret: "s",
+        authorizationUrl: "https://example.com/auth",
+        tokenUrl: "https://example.com/token",
+        userInfoUrl: "https://example.com/userinfo",
+        emailUrl: "https://example.com/emails",
+        scopes: [],
+      });
+
+      const info = await client.getUserInfo("tok");
+
+      expect(requestedUrls).toEqual(["https://example.com/userinfo", "https://example.com/emails"]);
+      expect(info.email).toBe("public@example.com");
+      expect(info.verified_email).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("keeps a public GitHub email unverified when /user/emails says it is unverified", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = asFetchMock(async (input) => {
+      if (String(input).endsWith("/userinfo")) {
+        return Response.json({
+          id: "gh-public-unverified",
+          email: "unverified@example.com",
+          login: "unverified-user",
+        });
+      }
+      return Response.json([
+        { email: "primary@example.com", primary: true, verified: true },
+        { email: "unverified@example.com", primary: false, verified: false },
+      ]);
+    });
+    try {
+      const client = new OAuthClient({
+        clientId: "c",
+        clientSecret: "s",
+        authorizationUrl: "https://example.com/auth",
+        tokenUrl: "https://example.com/token",
+        userInfoUrl: "https://example.com/userinfo",
+        emailUrl: "https://example.com/emails",
+        scopes: [],
+      });
+
+      const info = await client.getUserInfo("tok");
+
+      expect(info.email).toBe("unverified@example.com");
+      expect(info.verified_email).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not override an explicit false verification claim with the email endpoint", async () => {
+    const originalFetch = globalThis.fetch;
+    let callCount = 0;
+    globalThis.fetch = asFetchMock(async () => {
+      callCount += 1;
+      return Response.json({
+        id: "explicitly-unverified",
+        email: "unverified@example.com",
+        verified_email: false,
+      });
+    });
+    try {
+      const client = new OAuthClient({
+        clientId: "c",
+        clientSecret: "s",
+        authorizationUrl: "https://example.com/auth",
+        tokenUrl: "https://example.com/token",
+        userInfoUrl: "https://example.com/userinfo",
+        emailUrl: "https://example.com/emails",
+        scopes: [],
+      });
+
+      const info = await client.getUserInfo("tok");
+
+      expect(callCount).toBe(1);
+      expect(info.verified_email).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("maps custom provider profile fields including nested array paths", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = asFetchMock(

--- a/packages/auth/src/__tests__/store-backends.test.ts
+++ b/packages/auth/src/__tests__/store-backends.test.ts
@@ -4,6 +4,7 @@ import {
   buildBackend,
   MemoryBackend,
   NamespacedStoreBackend,
+  PostgresBackend,
   RedisBackend,
   type RedisLike,
   type StoreBackend,
@@ -88,6 +89,33 @@ describe("buildBackend Redis smoke test", () => {
     });
     const { source } = await buildBackend("challenge", client, false);
     expect(source).toBe("memory");
+  });
+});
+
+describe("PostgresBackend initialization", () => {
+  it("uses a pre-migrated auth store without attempting application-role DDL", async () => {
+    const statements: string[] = [];
+    let transactionCalls = 0;
+    const client = (async (strings: TemplateStringsArray) => {
+      const statement = strings.join("?");
+      statements.push(statement);
+      if (statement.includes("to_regclass")) return [{ relation: "auth_kv_store" }];
+      return [];
+    }) as unknown as ReturnType<typeof import("@stwd/db").getSql>;
+    client.begin = async () => {
+      transactionCalls += 1;
+      throw new Error("application role must not run DDL");
+    };
+
+    const backend = new PostgresBackend("challenge", client);
+    await backend.set("probe", "value", 1_000);
+
+    expect(transactionCalls).toBe(0);
+    expect(statements.some((statement) => statement.includes("to_regclass"))).toBe(true);
+    expect(statements.some((statement) => statement.includes("INSERT INTO auth_kv_store"))).toBe(
+      true,
+    );
+    expect(statements.some((statement) => statement.includes("CREATE TABLE"))).toBe(false);
   });
 });
 

--- a/packages/auth/src/email-templates/default.ts
+++ b/packages/auth/src/email-templates/default.ts
@@ -32,8 +32,13 @@ export function escapeEmailHtml(value: string): string {
 export function renderDefaultTemplate({
   magicLink,
   code,
+  tenantName,
   expiresInMinutes,
 }: MagicLinkTemplateData): RenderedMagicLinkTemplate {
+  const brandName = tenantName?.trim() || "Steward";
+  const escapedBrand = escapeEmailHtml(brandName);
+  const footer =
+    brandName === "Steward" ? "steward.fi — agent wallet infrastructure" : escapedBrand;
   const codeText = code
     ? [
         "Or enter this 6-digit code from the same email challenge:",
@@ -55,7 +60,7 @@ export function renderDefaultTemplate({
           </table>`
     : "";
   return {
-    subject: "Sign in to Steward",
+    subject: `Sign in to ${brandName}`,
     text: [
       "Click the link below to sign in:",
       "",
@@ -65,7 +70,7 @@ export function renderDefaultTemplate({
       `This sign-in email expires in ${expiresInMinutes} minutes.`,
       "If you didn't request this, you can safely ignore this email.",
       "",
-      "— Steward",
+      `— ${brandName}`,
     ].join("\n"),
     html: `<!DOCTYPE html>
 <html lang="en">
@@ -77,14 +82,14 @@ export function renderDefaultTemplate({
         <tr><td align="center" style="padding-bottom:40px;">
           <table cellpadding="0" cellspacing="0"><tr>
             <td style="font-size:20px;font-weight:700;color:#e8e5e0;letter-spacing:-0.02em;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
-              ✦&nbsp;&nbsp;steward
+              ✦&nbsp;&nbsp;${escapedBrand}
             </td>
           </tr></table>
         </td></tr>
         <tr><td style="background-color:#141210;border:1px solid #2a2722;padding:40px 32px;">
           <table width="100%" cellpadding="0" cellspacing="0">
             <tr><td style="font-size:22px;font-weight:700;color:#e8e5e0;letter-spacing:-0.02em;padding-bottom:8px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
-              Sign in to Steward
+              Sign in to ${escapedBrand}
             </td></tr>
             <tr><td style="font-size:14px;color:#6b6560;line-height:1.5;padding-bottom:32px;">
               Click the button below to securely sign in, or enter the code. This email expires in ${expiresInMinutes} minutes.
@@ -117,7 +122,7 @@ export function renderDefaultTemplate({
               If you didn't request this email, you can safely ignore it.
             </td></tr>
             <tr><td style="font-size:11px;color:#4a4540;padding-top:12px;">
-              steward.fi — agent wallet infrastructure
+              ${footer}
             </td></tr>
           </table>
         </td></tr>

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -58,6 +58,8 @@ export interface EmailAuthConfig {
   ) => RenderedMagicLinkTemplate;
   /** Template ID to render for outgoing magic-link emails. */
   templateId?: string;
+  /** Display brand used by the built-in magic-link and OTP templates. */
+  brandName?: string;
   /** Override the rendered subject line. */
   subjectOverride?: string;
   /** Optional reply-to address to pass through to the provider. */
@@ -438,6 +440,7 @@ export class EmailAuth {
   private from: string;
   private replyTo?: string;
   private templateId?: string;
+  private brandName?: string;
   private subjectOverride?: string;
   private codeVerifierSecret: string;
   private templateRenderer: (
@@ -472,6 +475,7 @@ export class EmailAuth {
     this.tokenStore = config.tokenStore ?? new TokenStore();
     this.replyTo = config.replyTo;
     this.templateId = config.templateId;
+    this.brandName = config.brandName?.trim() || undefined;
     this.subjectOverride = config.subjectOverride;
     const configuredCodeSecret =
       config.codeVerifierSecret?.trim() || process.env.STEWARD_EMAIL_CODE_SECRET?.trim() || "";
@@ -707,7 +711,7 @@ export class EmailAuth {
       email,
       code,
       expiresInMinutes: Math.floor(ttlMs / (60 * 1000)),
-      tenantName: undefined,
+      tenantName: this.brandName,
     });
     const subject = this.subjectOverride || rendered.subject;
     const body = rendered.text;
@@ -874,7 +878,7 @@ export class EmailAuth {
     }
 
     const minutes = Math.floor(this.tokenTtlMs / (60 * 1000));
-    const brand = context.tenantName || "Steward";
+    const brand = context.tenantName || this.brandName || "Steward";
     const rendered = this.otpTemplateRenderer(this.templateId, {
       email,
       code,

--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -617,7 +617,7 @@ export async function signJwtPayload(
   // revocation store. Callers may pre-set payload.jti to override.
   const jti = (typeof payload.jti === "string" && payload.jti) || randomUUID();
   return new SignJWT({ ...payload, jti })
-    .setProtectedHeader({ alg: "HS256" })
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
     .setIssuedAt()
     .setIssuer(issuer)
     .setAudience(audience)
@@ -671,7 +671,8 @@ export async function signAccessToken(
   payload: AccessTokenPayload,
   expiresIn: string = ACCESS_TOKEN_EXPIRY,
 ): Promise<string> {
-  return signJwtPayload(payload, expiresIn);
+  const subject = typeof payload.userId === "string" ? payload.userId.trim() : "";
+  return signJwtPayload(subject ? { ...payload, sub: subject } : payload, expiresIn);
 }
 
 export async function signAgentToken(

--- a/packages/auth/src/oauth.ts
+++ b/packages/auth/src/oauth.ts
@@ -809,8 +809,12 @@ export class OAuthClient {
       verified_email: Boolean(verifiedEmail ?? false),
     } satisfies OAuthUserInfo;
 
-    if (!userInfo.email && this.provider.emailUrl) {
-      const emailInfo = await this.getPrimaryEmail(accessToken);
+    // GitHub's /user profile may include a public email but never includes a
+    // verification bit. Resolve both the address and its verification status
+    // through /user/emails in that case. An explicit false from a provider is
+    // authoritative and must remain fail-closed.
+    if (this.provider.emailUrl && (!userInfo.email || verifiedEmail === undefined)) {
+      const emailInfo = await this.getPrimaryEmail(accessToken, userInfo.email || undefined);
       if (emailInfo) {
         userInfo.email = emailInfo.email;
         userInfo.verified_email = emailInfo.verified ?? userInfo.verified_email;
@@ -858,7 +862,10 @@ export class OAuthClient {
     throw new Error("Unsupported OIDC provider configuration");
   }
 
-  private async getPrimaryEmail(accessToken: string): Promise<OAuthEmailAddress | null> {
+  private async getPrimaryEmail(
+    accessToken: string,
+    preferredEmail?: string,
+  ): Promise<OAuthEmailAddress | null> {
     if (!this.provider.emailUrl) return null;
 
     const res = await fetch(this.provider.emailUrl, {
@@ -881,6 +888,14 @@ export class OAuthClient {
       (entry): entry is OAuthEmailAddress =>
         entry != null && typeof entry === "object" && typeof entry.email === "string",
     );
+
+    const normalizedPreferredEmail = preferredEmail?.trim().toLowerCase();
+    if (normalizedPreferredEmail) {
+      const matchingEmail = emails.find(
+        (entry) => entry.email.trim().toLowerCase() === normalizedPreferredEmail,
+      );
+      if (matchingEmail) return matchingEmail;
+    }
 
     return (
       emails.find((entry) => entry.primary && entry.verified) ??

--- a/packages/auth/src/passkey.ts
+++ b/packages/auth/src/passkey.ts
@@ -86,6 +86,11 @@ export class PasskeyAuth {
     this.challenges = config.challengeStore ?? new ChallengeStore();
   }
 
+  /** Canonical relying-party ID used for every ceremony on this instance. */
+  get rpID(): string {
+    return this.config.rpID;
+  }
+
   // ── Registration ─────────────────────────────────────────────────────────
 
   /**

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -61,16 +61,17 @@ export class SessionManager {
    *
    * @param userId  The user's UUID or identifier — included as a top-level claim
    * @param extra   Optional additional claims to embed in the token. Spread
-   *                BEFORE userId and stripped of any jti, so request-derived
-   *                claims can never override the authenticated userId or
-   *                pre-select a session jti (SEC-134).
+   *                BEFORE the authenticated identity and stripped of any jti
+   *                or subject, so request-derived claims can never override
+   *                the user or pre-select a session jti (SEC-134).
    * @returns       A compact JWT string suitable for use as a session token
    */
   async createSession(userId: string, extra?: Record<string, unknown>): Promise<string> {
-    const { jti: _extraJti, ...safeExtra } = extra ?? {};
+    const { jti: _extraJti, sub: _extraSub, ...safeExtra } = extra ?? {};
     return signJwtPayload(
       {
         ...safeExtra,
+        sub: userId,
         userId,
       },
       this.expiresIn,

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -397,15 +397,25 @@ export class PostgresBackend implements StoreBackend {
    * @param namespace  Logical partition (e.g. "challenge", "token") so multiple
    *                   stores can share the same table without key collision.
    */
-  constructor(private readonly namespace: string) {}
+  constructor(
+    private readonly namespace: string,
+    private readonly sqlClient?: ReturnType<typeof getSql>,
+  ) {}
 
   private getSqlClient() {
-    return getSql();
+    return this.sqlClient ?? getSql();
   }
 
   private async ensureTable(): Promise<void> {
     if (this.initialized) return;
     const sql = this.getSqlClient();
+    const [existing] = await sql<Array<{ relation: string | null }>>`
+      SELECT to_regclass('public.auth_kv_store')::text AS relation
+    `;
+    if (existing?.relation) {
+      this.initialized = true;
+      return;
+    }
     await sql.begin(async (transaction: TransactionSql) => {
       // CREATE TABLE IF NOT EXISTS can still race in PostgreSQL's catalogs when
       // separate fresh backend instances initialize concurrently. Production

--- a/packages/db/drizzle/0112_rls_activation_release_gates.sql
+++ b/packages/db/drizzle/0112_rls_activation_release_gates.sql
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION "steward_bootstrap"."ensure_default_tenant"(p_api_key_hash text)
+RETURNS void
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  existing_hash text;
+BEGIN
+  SELECT tenant.api_key_hash INTO existing_hash
+  FROM public.tenants tenant
+  WHERE tenant.id = 'default';
+
+  IF FOUND THEN
+    IF p_api_key_hash <> '' AND existing_hash IS DISTINCT FROM p_api_key_hash THEN
+      RAISE EXCEPTION 'DEFAULT_TENANT_API_KEY_MISMATCH';
+    END IF;
+    RETURN;
+  END IF;
+
+  INSERT INTO public.tenants(id, name, api_key_hash)
+  VALUES ('default', 'Default Tenant', p_api_key_hash)
+  ON CONFLICT DO NOTHING;
+
+  -- An empty development key is not authentication authority. If another
+  -- fixture/tenant already owns that unique placeholder, leave `default`
+  -- absent rather than aliasing the wrong tenant or crashing module startup.
+  IF p_api_key_hash = '' THEN RETURN; END IF;
+
+  SELECT tenant.api_key_hash INTO existing_hash
+  FROM public.tenants tenant
+  WHERE tenant.id = 'default';
+  IF NOT FOUND OR existing_hash IS DISTINCT FROM p_api_key_hash THEN
+    RAISE EXCEPTION 'DEFAULT_TENANT_API_KEY_CONFLICT';
+  END IF;
+END
+$$;

--- a/packages/db/drizzle/0113_personal_tenant_account_lifecycle.sql
+++ b/packages/db/drizzle/0113_personal_tenant_account_lifecycle.sql
@@ -1,0 +1,148 @@
+CREATE OR REPLACE FUNCTION "steward_bootstrap"."platform_set_user_deactivation"(
+  p_user_id uuid,
+  p_deactivated boolean
+)
+RETURNS TABLE (
+  user_id uuid, previous_deactivated_at timestamptz,
+  previous_updated_at timestamptz, deactivated_at timestamptz
+)
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  existing public.users%ROWTYPE;
+  owner_tenant record;
+  updated_deactivated_at timestamptz;
+  personal_tenant_id text := 'personal-' || p_user_id::text;
+  personal_membership_count bigint;
+  personal_owner_count bigint;
+BEGIN
+  IF NULLIF(current_setting('steward.tenant_id', true), '') IS DISTINCT FROM 'platform' THEN
+    RAISE EXCEPTION 'platform lifecycle operation requires reserved platform context';
+  END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended('platform_user_account_' || p_user_id::text, 0));
+  SELECT u.* INTO existing FROM public.users u WHERE u.id = p_user_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'User not found'; END IF;
+
+  IF p_deactivated THEN
+    PERFORM pg_advisory_xact_lock(
+      hashtextextended('tenant_owner_lifecycle_' || personal_tenant_id, 0)
+    );
+    PERFORM 1 FROM public.tenants t WHERE t.id = personal_tenant_id FOR UPDATE;
+    IF FOUND THEN
+      SELECT
+        count(*),
+        count(*) FILTER (WHERE ut.user_id = p_user_id AND ut.role = 'owner')
+      INTO personal_membership_count, personal_owner_count
+      FROM public.user_tenants ut
+      WHERE ut.tenant_id = personal_tenant_id;
+      IF personal_membership_count <> 1 OR personal_owner_count <> 1 THEN
+        RAISE EXCEPTION 'Personal tenant membership invariant violated';
+      END IF;
+    END IF;
+
+    FOR owner_tenant IN
+      SELECT ut.tenant_id
+      FROM public.user_tenants ut
+      WHERE ut.user_id = p_user_id AND ut.role = 'owner'
+      ORDER BY ut.tenant_id
+    LOOP
+      -- Personal tenants are single-owner by construction. Suspending the
+      -- identity is allowed only after the exact locked shape check above;
+      -- shared tenants retain the strict last active owner invariant below.
+      IF owner_tenant.tenant_id = personal_tenant_id THEN
+        CONTINUE;
+      END IF;
+      PERFORM pg_advisory_xact_lock(
+        hashtextextended('tenant_owner_lifecycle_' || owner_tenant.tenant_id, 0)
+      );
+      IF NOT EXISTS (
+        SELECT 1
+        FROM public.user_tenants other
+        JOIN public.users u ON u.id = other.user_id
+        WHERE other.tenant_id = owner_tenant.tenant_id
+          AND other.role = 'owner'
+          AND other.user_id <> p_user_id
+          AND u.deactivated_at IS NULL
+      ) THEN
+        RAISE EXCEPTION 'Cannot deactivate the sole active tenant owner';
+      END IF;
+    END LOOP;
+  END IF;
+
+  UPDATE public.users u
+  SET deactivated_at = CASE WHEN p_deactivated THEN now() ELSE NULL END,
+      updated_at = now()
+  WHERE u.id = p_user_id
+  RETURNING u.deactivated_at INTO updated_deactivated_at;
+  DELETE FROM public.refresh_tokens r WHERE r.user_id = p_user_id;
+  RETURN QUERY SELECT
+    existing.id, existing.deactivated_at, existing.updated_at, updated_deactivated_at;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION "steward_bootstrap"."platform_delete_user"(p_user_id uuid)
+RETURNS TABLE (user_id uuid)
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  owner_tenant record;
+  personal_tenant_id text := 'personal-' || p_user_id::text;
+  personal_membership_count bigint;
+  personal_owner_count bigint;
+BEGIN
+  IF NULLIF(current_setting('steward.tenant_id', true), '') IS DISTINCT FROM 'platform' THEN
+    RAISE EXCEPTION 'platform lifecycle operation requires reserved platform context';
+  END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended('platform_user_account_' || p_user_id::text, 0));
+  PERFORM 1 FROM public.users u WHERE u.id = p_user_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'User not found'; END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('tenant_owner_lifecycle_' || personal_tenant_id, 0)
+  );
+  PERFORM 1 FROM public.tenants t WHERE t.id = personal_tenant_id FOR UPDATE;
+  IF FOUND THEN
+    SELECT
+      count(*),
+      count(*) FILTER (WHERE ut.user_id = p_user_id AND ut.role = 'owner')
+    INTO personal_membership_count, personal_owner_count
+    FROM public.user_tenants ut
+    WHERE ut.tenant_id = personal_tenant_id;
+    IF personal_membership_count <> 1 OR personal_owner_count <> 1 THEN
+      RAISE EXCEPTION 'Personal tenant membership invariant violated';
+    END IF;
+  END IF;
+
+  FOR owner_tenant IN
+    SELECT ut.tenant_id
+    FROM public.user_tenants ut
+    WHERE ut.user_id = p_user_id AND ut.role = 'owner'
+    ORDER BY ut.tenant_id
+  LOOP
+    PERFORM pg_advisory_xact_lock(
+      hashtextextended('tenant_owner_lifecycle_' || owner_tenant.tenant_id, 0)
+    );
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.user_tenants other
+      JOIN public.users u ON u.id = other.user_id
+      WHERE other.tenant_id = owner_tenant.tenant_id
+        AND other.role = 'owner'
+        AND other.user_id <> p_user_id
+        AND u.deactivated_at IS NULL
+    ) THEN
+      RAISE EXCEPTION 'Cannot delete the sole active tenant owner';
+    END IF;
+  END LOOP;
+
+  DELETE FROM public.refresh_tokens r WHERE r.user_id = p_user_id;
+  DELETE FROM public.users u WHERE u.id = p_user_id;
+  RETURN QUERY SELECT p_user_id;
+END
+$$;

--- a/packages/db/drizzle/0114_passkey_rp_provenance.sql
+++ b/packages/db/drizzle/0114_passkey_rp_provenance.sql
@@ -1,0 +1,6 @@
+-- Bind newly registered passkeys to the WebAuthn relying-party ID that
+-- created them. Existing credentials remain NULL: a deployment can serve
+-- multiple RPs, so assigning one RP to every legacy row would be unsafe.
+-- Successful WebAuthn authentication opportunistically fills this column,
+-- which proves the credential's RP through the verified rpIdHash.
+ALTER TABLE "authenticators" ADD COLUMN "rp_id" varchar(253);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -645,6 +645,20 @@
       "when": 1787168801000,
       "tag": "0111_tenant_rls_policy_install",
       "breakpoints": true
+    },
+    {
+      "idx": 112,
+      "version": "7",
+      "when": 1787203600000,
+      "tag": "0112_rls_activation_release_gates",
+      "breakpoints": true
+    },
+    {
+      "idx": 113,
+      "version": "7",
+      "when": 1787220000000,
+      "tag": "0113_personal_tenant_account_lifecycle",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -659,6 +659,13 @@
       "when": 1787220000000,
       "tag": "0113_personal_tenant_account_lifecycle",
       "breakpoints": true
+    },
+    {
+      "idx": 114,
+      "version": "7",
+      "when": 1787529855000,
+      "tag": "0114_passkey_rp_provenance",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/passkey-rp-provenance-migration.test.ts
+++ b/packages/db/src/__tests__/passkey-rp-provenance-migration.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const migration = readFileSync(
+  new URL("../../drizzle/0114_passkey_rp_provenance.sql", import.meta.url),
+  "utf8",
+);
+
+describe("passkey RP provenance migration", () => {
+  test("adds nullable provenance without guessing an RP for legacy rows", () => {
+    expect(migration).toContain('ALTER TABLE "authenticators" ADD COLUMN "rp_id" varchar(253)');
+    expect(migration).not.toMatch(/NOT NULL/i);
+    expect(migration).not.toMatch(/UPDATE\s+"?authenticators"?/i);
+    expect(migration).not.toMatch(/DEFAULT/i);
+  });
+});

--- a/packages/db/src/schema-auth.ts
+++ b/packages/db/src/schema-auth.ts
@@ -66,6 +66,14 @@ export const authenticators = pgTable(
       .references(() => users.id, { onDelete: "cascade" }),
     credentialId: text("credential_id").notNull().unique(),
     credentialPublicKey: text("credential_public_key").notNull(),
+    /**
+     * WebAuthn relying-party ID that scoped this credential at registration.
+     *
+     * Nullable only for credentials created before migration 0114. A
+     * successful authentication can safely fill legacy provenance because
+     * WebAuthn verifies the RP ID hash as part of that ceremony.
+     */
+    rpId: varchar("rp_id", { length: 253 }),
     counter: integer("counter").notNull().default(0),
     credentialDeviceType: varchar("credential_device_type", { length: 32 }),
     credentialBackedUp: boolean("credential_backed_up").default(false),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -85,6 +85,12 @@ export interface TenantEmailConfig {
   apiKeyEncrypted?: string;
   from?: string;
   replyTo?: string;
+  /**
+   * Display brand used by the built-in magic-link and OTP templates. This
+   * keeps shared-provider tenants branded without requiring raw HTML
+   * templates. Defaults to "Steward" when unset.
+   */
+  brandName?: string;
   templateId?: string;
   subjectOverride?: string;
   /**

--- a/packages/proxy/src/__tests__/proxy-approval-expiry-audit-atomicity.test.ts
+++ b/packages/proxy/src/__tests__/proxy-approval-expiry-audit-atomicity.test.ts
@@ -56,6 +56,7 @@ let resetReleaseClaimBarrier: typeof import("../handlers/release")["__resetRelea
 let setForwardProxyRequest: typeof import("../handlers/proxy")["__setForwardProxyRequestForTests"];
 let proxyMod: typeof import("../handlers/proxy");
 
+// ─── Audit-chain-insert fault injection ───────────────────────────────────────
 beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;

--- a/packages/proxy/src/__tests__/proxy-approval-lifecycle.test.ts
+++ b/packages/proxy/src/__tests__/proxy-approval-lifecycle.test.ts
@@ -59,6 +59,10 @@ beforeAll(async () => {
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.example.com";
   process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS = "api.example.com";
   process.env.STEWARD_ALLOW_BROAD_SECRET_ROUTES = "true";
+  // This suite exercises approval lifecycle state transitions rather than the
+  // independently covered signed-request contract. Opt into the explicit
+  // non-production proxy mode so mounted polls reach the lifecycle handler.
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
 
   const { db, client } = await createPGLiteDb("memory://");
   setPGLiteOverride(db, async () => {
@@ -102,6 +106,7 @@ afterAll(async () => {
   delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
   delete process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS;
   delete process.env.STEWARD_ALLOW_BROAD_SECRET_ROUTES;
+  delete process.env.STEWARD_PROXY_DEV_MODE;
 });
 
 function buildApp() {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@stwd/react` are documented here.
 
 ## Unreleased
 
+### Fixed
+- `StewardLogin` no longer emits the `webauthn` autocomplete token on the email input, so browser passkey conditional-mediation autofill cannot hijack a brand-new-email signup. Explicit passkey button flow is unchanged.
+
 ### Changed
 - Approval confirmations now keep failed mutations actionable while preventing a delayed result from closing or contaminating a newer confirmation.
 - Approval hooks now use stable cursor pagination and pass their agent scope to the server, avoiding offset shifts and client-only filtering of tenant-wide queue pages.

--- a/packages/react/src/__tests__/StewardLogin.passkeyAutofill.test.tsx
+++ b/packages/react/src/__tests__/StewardLogin.passkeyAutofill.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Passkey conditional-mediation (autofill) regression coverage.
+ *
+ * Bug (2026-08-20): the email input carried `autoComplete="email webauthn"`.
+ * The `webauthn` autofill token arms browser conditional mediation, which
+ * surfaces ANY discoverable passkey stored for the relying party the moment
+ * the field is focused — ignoring the email being typed. A user composing a
+ * BRAND-NEW email was prompted with an EXISTING account's passkey, blocking
+ * new-account signup.
+ *
+ * Invariant locked in here: typing a new email must never surface an
+ * existing account's passkey. Passkey login remains available via the
+ * explicit passkey button, which scopes to the typed email through
+ * `signInWithPasskey(email)` → `/auth/passkey/login/options`.
+ *
+ * jsdom/happy-dom cannot exercise real WebAuthn conditional UI, so we assert
+ * at the levels we control deterministically:
+ *   1. The email input's `autocomplete` attribute is exactly "email"
+ *      (no `webauthn` token → browser never arms conditional mediation).
+ *   2. No `navigator.credentials.get()` call is issued on mount or while
+ *      typing (no programmatic conditional mediation either).
+ *   3. The explicit passkey button still initiates email-scoped passkey
+ *      login with the typed email.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Window } from "happy-dom";
+import * as React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Simulate } from "react-dom/test-utils";
+
+const window = new Window();
+Object.assign(globalThis, {
+  window,
+  document: window.document,
+  navigator: window.navigator,
+  HTMLElement: window.HTMLElement,
+  HTMLInputElement: window.HTMLInputElement,
+  HTMLButtonElement: window.HTMLButtonElement,
+  Event: window.Event,
+  KeyboardEvent: window.KeyboardEvent,
+  MouseEvent: window.MouseEvent,
+  IS_REACT_ACT_ENVIRONMENT: true,
+});
+
+// Spy on navigator.credentials.get so any conditional-mediation request
+// issued by the component (mount-time or type-time) is detected.
+const credentialsGet = mock(async (..._args: unknown[]) => {
+  throw new Error("navigator.credentials.get must not be called by StewardLogin");
+});
+Object.defineProperty(window.navigator, "credentials", {
+  value: { get: credentialsGet, create: mock(async () => null) },
+  configurable: true,
+});
+
+const { StewardLogin } = await import("../components/StewardLogin.js");
+const { StewardAuthContext } = await import("../provider.js");
+const { registerEvmWalletPanel, registerSolanaWalletPanel } = await import(
+  "../internal/walletPanelRegistry.js"
+);
+
+const loginSource = readFileSync(
+  join(import.meta.dir, "..", "components", "StewardLogin.tsx"),
+  "utf8",
+);
+
+const dummyPanel: React.ComponentType<unknown> = () => null;
+registerEvmWalletPanel({ load: async () => ({ default: dummyPanel }) });
+registerSolanaWalletPanel({ load: async () => ({ default: dummyPanel }) });
+
+const signInWithPasskey = mock(async (_email: string) => ({}));
+
+function baseCtx() {
+  return {
+    isAuthenticated: false,
+    isLoading: false,
+    user: null,
+    session: null,
+    providers: { google: true },
+    isProvidersLoading: false,
+    guestState: { isGuest: false, isExpired: false, expiryMessage: null },
+    signOut: () => {},
+    signInAsGuest: async () => ({}),
+    upgradeGuestWithEmail: async () => ({}),
+    deleteGuest: async () => ({}),
+    getToken: () => null,
+    signInWithPasskey,
+    signInWithEmail: async () => ({}),
+    sendSmsOtp: async () => ({}),
+    verifySmsOtp: async () => ({}),
+    sendWhatsAppOtp: async () => ({}),
+    verifyWhatsAppOtp: async () => ({}),
+    verifyEmailCallback: async () => ({}),
+    signInWithSIWE: async () => ({}),
+    signInWithSolana: async () => ({}),
+    signInWithOAuth: async () => ({}),
+    signInWithTelegram: async () => ({}),
+    signInWithFarcaster: async () => ({}),
+    activeTenantId: null,
+    tenants: null,
+    isTenantsLoading: false,
+    listTenants: async () => [],
+    switchTenant: async () => {},
+    joinTenant: async () => {},
+    leaveTenant: async () => {},
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root | null = null;
+
+async function renderLogin(): Promise<void> {
+  if (root) {
+    await React.act(async () => root?.unmount());
+    root = null;
+  }
+  container = window.document.createElement("div") as unknown as HTMLDivElement;
+  window.document.body.replaceChildren(container as unknown as Node);
+  root = createRoot(container);
+  await React.act(async () => {
+    root?.render(
+      React.createElement(
+        StewardAuthContext.Provider,
+        { value: baseCtx() as unknown as React.ContextType<typeof StewardAuthContext> },
+        React.createElement(StewardLogin, {}),
+      ),
+    );
+  });
+}
+
+function emailInput(): HTMLInputElement {
+  const input = container.querySelector('input[aria-label="email"]');
+  if (!input) throw new Error("email input not found");
+  return input as unknown as HTMLInputElement;
+}
+
+async function typeEmail(value: string): Promise<void> {
+  const input = emailInput();
+  await React.act(async () => {
+    // happy-dom events don't traverse React 18's synthetic event plumbing
+    // for controlled inputs, so drive onChange via Simulate (deterministic
+    // and version-pinned alongside react-dom in this workspace).
+    (input as unknown as { value: string }).value = value;
+    Simulate.change(input as unknown as Element);
+  });
+}
+
+beforeEach(async () => {
+  credentialsGet.mockClear();
+  signInWithPasskey.mockClear();
+  signInWithPasskey.mockImplementation(async () => ({}));
+  await renderLogin();
+});
+
+describe("passkey conditional-mediation autofill regression", () => {
+  test("email input does not carry the webauthn autofill token", () => {
+    const attr = (emailInput() as unknown as Element).getAttribute("autocomplete");
+    expect(attr).toBe("email");
+    expect(attr).not.toContain("webauthn");
+    // Source-level lock: the token must not come back in any casing/order.
+    expect(loginSource).not.toMatch(/autoComplete\s*=\s*"[^"]*webauthn[^"]*"/);
+  });
+
+  test("no conditional-mediation credentials.get() on mount or while typing a new email", async () => {
+    expect(credentialsGet).toHaveBeenCalledTimes(0);
+    await typeEmail("brand-new-user@example.com");
+    expect(credentialsGet).toHaveBeenCalledTimes(0);
+    // No passkey flow started implicitly either.
+    expect(signInWithPasskey).toHaveBeenCalledTimes(0);
+  });
+
+  test("explicit passkey button still initiates email-scoped passkey login", async () => {
+    await typeEmail("brand-new-user@example.com");
+    const btn = [...container.querySelectorAll("button")].find(
+      (b) => b.textContent?.trim() === "passkey",
+    );
+    if (!btn) throw new Error("passkey button not found");
+    await React.act(async () => {
+      (btn as unknown as Element).dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
+    expect(signInWithPasskey).toHaveBeenCalledTimes(1);
+    expect(signInWithPasskey).toHaveBeenCalledWith("brand-new-user@example.com");
+  });
+});

--- a/packages/react/src/components/StewardLogin.tsx
+++ b/packages/react/src/components/StewardLogin.tsx
@@ -725,7 +725,13 @@ export function StewardLogin({
               }
             }}
             disabled={isLoading}
-            autoComplete="email webauthn"
+            // No "webauthn" autofill token here: it arms browser conditional
+            // mediation, which surfaces ANY discoverable passkey for this RP
+            // regardless of the email being typed. That hijacked new-account
+            // signup (typing a brand-new email prompted an existing account's
+            // passkey). Passkey login stays available via the explicit passkey
+            // button, which scopes the ceremony to the typed email.
+            autoComplete="email"
             aria-label="email"
           />
         </div>

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -23,6 +23,8 @@
 - Add typed provider-action lifecycle states and complete provider-case evidence contracts.
 
 ### Fixed
+- Use the SimpleWebAuthn v13 `optionsJSON` call contract for passkey login,
+  registration, and MFA ceremonies.
 - In auth-proxy mode, persist an issued access token only after the HttpOnly refresh-token handoff succeeds, so a failed handoff cannot leave a partially authenticated local session.
 
 ### Docs

--- a/packages/sdk/src/__tests__/auth-add-passkey.test.ts
+++ b/packages/sdk/src/__tests__/auth-add-passkey.test.ts
@@ -186,39 +186,6 @@ describe("StewardAuth.addPasskey", () => {
     await expect(auth.addPasskey("shadow@shad0w.xyz")).rejects.toBeInstanceOf(StewardApiError);
   });
 
-  it("surfaces a passkey-options 404 without invoking registration when fallback is disabled", async () => {
-    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input.toString();
-      const body = init?.body ? JSON.parse(init.body as string) : undefined;
-      captured.push({ url, body });
-      return new Response(
-        JSON.stringify({
-          ok: false,
-          error: "Passkey sign-in is unavailable for this email",
-        }),
-        { status: 404, headers: { "content-type": "application/json" } },
-      );
-    }) as typeof fetch;
-
-    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
-    await expect(
-      auth.signInWithPasskey("shadow@shad0w.xyz", {
-        fallbackToRegistration: false,
-      }),
-    ).rejects.toMatchObject({
-      status: 404,
-      message: "Passkey sign-in is unavailable for this email",
-    });
-
-    expect(captured).toEqual([
-      {
-        url: "https://api.example.test/auth/passkey/login/options",
-        body: { email: "shadow@shad0w.xyz" },
-      },
-    ]);
-    expect(startAuthentication).not.toHaveBeenCalled();
-  });
-
   it("forwards challengeId when completing passkey login", async () => {
     global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();

--- a/packages/sdk/src/__tests__/auth-add-passkey.test.ts
+++ b/packages/sdk/src/__tests__/auth-add-passkey.test.ts
@@ -246,7 +246,7 @@ describe("StewardAuth.addPasskey", () => {
     const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
     await auth.signInWithPasskey("shadow@shad0w.xyz");
 
-    expect(startAuthenticationCalls).toBe(1);
+    expect(startAuthentication).toHaveBeenCalledTimes(1);
     expect(captured[1]?.url).toBe("https://api.example.test/auth/passkey/login/verify");
     expect(captured[1]?.body).toMatchObject({
       email: "shadow@shad0w.xyz",

--- a/packages/sdk/src/__tests__/auth-add-passkey.test.ts
+++ b/packages/sdk/src/__tests__/auth-add-passkey.test.ts
@@ -186,6 +186,39 @@ describe("StewardAuth.addPasskey", () => {
     await expect(auth.addPasskey("shadow@shad0w.xyz")).rejects.toBeInstanceOf(StewardApiError);
   });
 
+  it("surfaces a passkey-options 404 without invoking registration when fallback is disabled", async () => {
+    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      captured.push({ url, body });
+      return new Response(
+        JSON.stringify({
+          ok: false,
+          error: "Passkey sign-in is unavailable for this email",
+        }),
+        { status: 404, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+    await expect(
+      auth.signInWithPasskey("shadow@shad0w.xyz", {
+        fallbackToRegistration: false,
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Passkey sign-in is unavailable for this email",
+    });
+
+    expect(captured).toEqual([
+      {
+        url: "https://api.example.test/auth/passkey/login/options",
+        body: { email: "shadow@shad0w.xyz" },
+      },
+    ]);
+    expect(startAuthentication).not.toHaveBeenCalled();
+  });
+
   it("forwards challengeId when completing passkey login", async () => {
     global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
@@ -213,6 +246,7 @@ describe("StewardAuth.addPasskey", () => {
     const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
     await auth.signInWithPasskey("shadow@shad0w.xyz");
 
+    expect(startAuthenticationCalls).toBe(1);
     expect(captured[1]?.url).toBe("https://api.example.test/auth/passkey/login/verify");
     expect(captured[1]?.body).toMatchObject({
       email: "shadow@shad0w.xyz",

--- a/packages/sdk/src/__tests__/auth-add-passkey.test.ts
+++ b/packages/sdk/src/__tests__/auth-add-passkey.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import { StewardAuth } from "../auth";
+import { isStewardPasskeyAlreadyRegisteredError, StewardAuth } from "../auth";
 import type { SessionStorage } from "../auth-types";
 import { StewardApiError } from "../client";
 
@@ -184,6 +184,44 @@ describe("StewardAuth.addPasskey", () => {
     }) as typeof fetch;
     const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
     await expect(auth.addPasskey("shadow@shad0w.xyz")).rejects.toBeInstanceOf(StewardApiError);
+  });
+
+  it("preserves the structured existing-passkey recovery code", async () => {
+    global.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/auth/passkey/register/options")) {
+        return new Response(
+          JSON.stringify({
+            ok: false,
+            error: "A passkey already exists for this email. Sign in with it instead.",
+            code: "passkey_already_registered",
+          }),
+          { status: 409, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+    let caught: unknown;
+    try {
+      await auth.addPasskey("shadow@shad0w.xyz", { emailGrant: "reusable-email-grant" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(StewardApiError);
+    expect(isStewardPasskeyAlreadyRegisteredError(caught)).toBe(true);
+    if (!isStewardPasskeyAlreadyRegisteredError(caught)) {
+      throw new Error("expected passkey_already_registered error");
+    }
+    expect(caught.status).toBe(409);
+    expect(caught.data).toEqual({
+      ok: false,
+      error: "A passkey already exists for this email. Sign in with it instead.",
+      code: "passkey_already_registered",
+    });
+    expect(startRegistration).not.toHaveBeenCalled();
   });
 
   it("forwards challengeId when completing passkey login", async () => {

--- a/packages/sdk/src/__tests__/auth-add-passkey.test.ts
+++ b/packages/sdk/src/__tests__/auth-add-passkey.test.ts
@@ -68,27 +68,31 @@ function restoreBrowserShim(): void {
   globalThis.window = originalWindow;
 }
 
+const startRegistration = mock(async () => ({
+  id: "credential-1",
+  rawId: "credential-1",
+  response: {
+    clientDataJSON: "client-data",
+    attestationObject: "attestation",
+  },
+  type: "public-key",
+}));
+
+const startAuthentication = mock(async () => ({
+  id: "credential-login",
+  rawId: "credential-login",
+  response: {
+    clientDataJSON: "client-data",
+    authenticatorData: "authenticator-data",
+    signature: "signature",
+    userHandle: "u-1",
+  },
+  type: "public-key",
+}));
+
 mock.module("@simplewebauthn/browser", () => ({
-  startRegistration: async () => ({
-    id: "credential-1",
-    rawId: "credential-1",
-    response: {
-      clientDataJSON: "client-data",
-      attestationObject: "attestation",
-    },
-    type: "public-key",
-  }),
-  startAuthentication: async () => ({
-    id: "credential-login",
-    rawId: "credential-login",
-    response: {
-      clientDataJSON: "client-data",
-      authenticatorData: "authenticator-data",
-      signature: "signature",
-      userHandle: "u-1",
-    },
-    type: "public-key",
-  }),
+  startRegistration,
+  startAuthentication,
 }));
 
 function fakeJwt(claims: Record<string, unknown> = {}): string {
@@ -126,6 +130,8 @@ function memoryStorage(): SessionStorage {
 
 beforeEach(() => {
   captured = [];
+  startRegistration.mockClear();
+  startAuthentication.mockClear();
   originalFetch = global.fetch;
   installFetch();
   installBrowserShim();
@@ -154,6 +160,7 @@ describe("StewardAuth.addPasskey", () => {
       id: "credential-1",
       type: "public-key",
     });
+    expect(startRegistration).toHaveBeenCalledWith({ optionsJSON: REG_OPTIONS });
 
     // And the resulting session reflects the verify payload.
     expect(result.token).toBe("test-jwt");
@@ -212,6 +219,13 @@ describe("StewardAuth.addPasskey", () => {
       challengeId: "login-challenge",
       response: { id: "credential-login", type: "public-key" },
     });
+    expect(startAuthentication).toHaveBeenCalledWith({
+      optionsJSON: {
+        challenge: "login-challenge",
+        challengeId: "login-challenge",
+        rpId: "api.example.test",
+      },
+    });
   });
 
   it("completes passkey MFA with bearer auth and stores the refreshed session", async () => {
@@ -261,6 +275,13 @@ describe("StewardAuth.addPasskey", () => {
     expect(captured[1]?.body).toMatchObject({
       challengeId: "mfa-challenge",
       response: { id: "credential-login", type: "public-key" },
+    });
+    expect(startAuthentication).toHaveBeenCalledWith({
+      optionsJSON: {
+        challenge: "mfa-challenge",
+        challengeId: "mfa-challenge",
+        rpId: "api.example.test",
+      },
     });
     expect(result.token).toBe(steppedUpToken);
     expect(storage.getItem("steward_session_token")).toBe(steppedUpToken);

--- a/packages/sdk/src/auth-types.ts
+++ b/packages/sdk/src/auth-types.ts
@@ -182,6 +182,13 @@ export interface StewardEmailGrantResult {
   expiresInSeconds: number;
 }
 
+/** Stable server payload for verified-email recovery on an existing RP passkey. */
+export interface StewardPasskeyAlreadyRegisteredErrorData {
+  ok: false;
+  error: string;
+  code: "passkey_already_registered";
+}
+
 export interface StewardTestAccountLoginOptions {
   tenantId?: string;
   email?: string;

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -38,6 +38,7 @@ import type {
   StewardMfaRequiredResult,
   StewardOAuthConfig,
   StewardOAuthResult,
+  StewardPasskeyAlreadyRegisteredErrorData,
   StewardProviders,
   StewardRecoveryCodeStatus,
   StewardRecoveryCodesResult,
@@ -287,7 +288,7 @@ function buildSiwsMessage(
 
 type AuthApiResult<T> =
   | { ok: true; status: number; data: T }
-  | { ok: false; status: number; error: string };
+  | { ok: false; status: number; error: string; data: Record<string, unknown> };
 
 // Narrow view of @simplewebauthn/browser — a peer dep we import dynamically.
 type SimpleWebAuthnBrowser = Pick<
@@ -339,10 +340,24 @@ async function authRequest<T>(
       typeof payload.error === "string"
         ? payload.error
         : `Request failed with status ${response.status}`;
-    return { ok: false, status: response.status, error: errMsg };
+    return { ok: false, status: response.status, error: errMsg, data: payload };
   }
 
   return { ok: true, status: response.status, data: payload as unknown as T };
+}
+
+/** Narrow an SDK error to the stable existing-passkey recovery contract. */
+export function isStewardPasskeyAlreadyRegisteredError(
+  error: unknown,
+): error is StewardApiError<StewardPasskeyAlreadyRegisteredErrorData> {
+  if (!(error instanceof StewardApiError) || error.status !== 409) return false;
+  const data = error.data;
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "code" in data &&
+    data.code === "passkey_already_registered"
+  );
 }
 
 // ─── StewardAuth ──────────────────────────────────────────────────────────────
@@ -981,7 +996,7 @@ export class StewardAuth {
     );
 
     if (!regOptsRes.ok) {
-      throw new StewardApiError(regOptsRes.error, regOptsRes.status);
+      throw new StewardApiError(regOptsRes.error, regOptsRes.status, regOptsRes.data);
     }
 
     let regResponse: unknown;

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -924,9 +924,11 @@ export class StewardAuth {
     let authResponse: unknown;
     try {
       // Server-provided options; types are validated by the WebAuthn browser library.
-      authResponse = await lib.startAuthentication(
-        options as Parameters<SimpleWebAuthnBrowser["startAuthentication"]>[0],
-      );
+      authResponse = await lib.startAuthentication({
+        optionsJSON: options as Parameters<
+          SimpleWebAuthnBrowser["startAuthentication"]
+        >[0]["optionsJSON"],
+      });
     } catch (err) {
       throw new StewardApiError(
         `WebAuthn authentication cancelled or failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -985,9 +987,11 @@ export class StewardAuth {
     let regResponse: unknown;
     try {
       // Server-provided options; types are validated by the WebAuthn browser library.
-      regResponse = await lib.startRegistration(
-        regOptsRes.data as Parameters<SimpleWebAuthnBrowser["startRegistration"]>[0],
-      );
+      regResponse = await lib.startRegistration({
+        optionsJSON: regOptsRes.data as unknown as Parameters<
+          SimpleWebAuthnBrowser["startRegistration"]
+        >[0]["optionsJSON"],
+      });
     } catch (err) {
       throw new StewardApiError(
         `WebAuthn registration cancelled or failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -1736,9 +1740,11 @@ export class StewardAuth {
 
     let authResponse: unknown;
     try {
-      authResponse = await browserLib.startAuthentication(
-        optionsRes.data as Parameters<SimpleWebAuthnBrowser["startAuthentication"]>[0],
-      );
+      authResponse = await browserLib.startAuthentication({
+        optionsJSON: optionsRes.data as unknown as Parameters<
+          SimpleWebAuthnBrowser["startAuthentication"]
+        >[0]["optionsJSON"],
+      });
     } catch (err) {
       throw new StewardApiError(
         `WebAuthn authentication cancelled or failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -824,11 +824,17 @@ export class StewardAuth {
 
   /**
    * Sign in with a passkey. Smart flow: tries login first, falls back to registration.
+   * Set `fallbackToRegistration` to false when the caller owns an email/OTP
+   * fallback and needs a 404 to remain distinguishable without invoking a
+   * registration ceremony.
    *
    * Requires a browser environment and `@simplewebauthn/browser` installed.
    * Throws `StewardApiError` in Node or when the dependency is missing.
    */
-  async signInWithPasskey(email: string): Promise<StewardAuthResult | StewardMfaRequiredResult> {
+  async signInWithPasskey(
+    email: string,
+    options: { fallbackToRegistration?: boolean } = {},
+  ): Promise<StewardAuthResult | StewardMfaRequiredResult> {
     if (!isBrowser()) {
       throw new StewardApiError(
         "Passkeys require a browser environment. Use signInWithEmail or signInWithSIWE in Node.",
@@ -865,8 +871,9 @@ export class StewardAuth {
       return this.completePasskeyLogin(email, loginOptsRes.data, browserLib);
     }
 
-    if (loginOptsRes.status === 404) {
-      // No account or no passkeys — run registration flow
+    if (loginOptsRes.status === 404 && options.fallbackToRegistration !== false) {
+      // No account or no passkeys — run registration flow unless the caller
+      // owns a separate verified-email fallback.
       return this.completePasskeyRegister(email, browserLib);
     }
 

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -824,17 +824,11 @@ export class StewardAuth {
 
   /**
    * Sign in with a passkey. Smart flow: tries login first, falls back to registration.
-   * Set `fallbackToRegistration` to false when the caller owns an email/OTP
-   * fallback and needs a 404 to remain distinguishable without invoking a
-   * registration ceremony.
    *
    * Requires a browser environment and `@simplewebauthn/browser` installed.
    * Throws `StewardApiError` in Node or when the dependency is missing.
    */
-  async signInWithPasskey(
-    email: string,
-    options: { fallbackToRegistration?: boolean } = {},
-  ): Promise<StewardAuthResult | StewardMfaRequiredResult> {
+  async signInWithPasskey(email: string): Promise<StewardAuthResult | StewardMfaRequiredResult> {
     if (!isBrowser()) {
       throw new StewardApiError(
         "Passkeys require a browser environment. Use signInWithEmail or signInWithSIWE in Node.",
@@ -871,9 +865,8 @@ export class StewardAuth {
       return this.completePasskeyLogin(email, loginOptsRes.data, browserLib);
     }
 
-    if (loginOptsRes.status === 404 && options.fallbackToRegistration !== false) {
-      // No account or no passkeys — run registration flow unless the caller
-      // owns a separate verified-email fallback.
+    if (loginOptsRes.status === 404) {
+      // No account or no passkeys — run registration flow
       return this.completePasskeyRegister(email, browserLib);
     }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -17,7 +17,7 @@ export {
 } from "./agent-client.ts";
 // A3 — sovereign-custody agent client (keypair-only boot → enroll → manifest → issue/invoke → renew)
 export { type AgentKeyMaterial, AgentKeypair } from "./agent-keypair.ts";
-export { StewardAuth } from "./auth.ts";
+export { isStewardPasskeyAlreadyRegisteredError, StewardAuth } from "./auth.ts";
 export type {
   SessionStorage,
   StewardAuthConfig,
@@ -47,6 +47,7 @@ export type {
   StewardMfaRequiredResult,
   StewardOAuthConfig,
   StewardOAuthResult,
+  StewardPasskeyAlreadyRegisteredErrorData,
   StewardProviders,
   StewardRecoveryCodeStatus,
   StewardRecoveryCodesResult,

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "deploy": {
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 120
+  }
+}

--- a/scripts/__tests__/production-deploy-policy.test.ts
+++ b/scripts/__tests__/production-deploy-policy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../..");
+const workflow = readFileSync(resolve(repoRoot, ".github/workflows/deploy-railway.yml"), "utf8");
+const railwayConfig = JSON.parse(readFileSync(resolve(repoRoot, "railway.json"), "utf8"));
+const deployScript = readFileSync(resolve(repoRoot, "scripts/railway-deploy.sh"), "utf8");
+
+describe("production deploy policy", () => {
+  test("accepts only a full main commit and verifies its exact main Docker build", () => {
+    expect(workflow).toContain("main_sha:");
+    expect(workflow).not.toContain("image_tag:");
+    expect(workflow).toContain("^[0-9a-f]{40}$");
+    expect(workflow).toContain('git merge-base --is-ancestor "$MAIN_SHA" refs/remotes/origin/main');
+    expect(workflow).toContain("actions/workflows/docker.yml/runs");
+    expect(workflow).toContain("-f branch=main");
+    expect(workflow).toContain('-f head_sha="$MAIN_SHA"');
+    expect(workflow).toContain("-f event=push");
+    expect(workflow).toContain("-f status=success");
+    expect(workflow).toContain("label:org.opencontainers.image.revision");
+    expect(workflow).toContain('"$VERSION" != "main"');
+    expect(workflow).toContain('"$SOURCE" != "https://github.com/${TARGET_REPOSITORY}"');
+  });
+
+  test("resolves and passes an immutable digest to Railway", () => {
+    expect(workflow).toContain('"${IMAGE_REPO}:sha-${MAIN_SHA}"');
+    expect(workflow).toContain('test("^sha256:[0-9a-f]{64}$")');
+    expect(workflow).toContain("RAILWAY_IMAGE_DIGEST: ${{ steps.resolve.outputs.digest }}");
+    expect(workflow).not.toContain("RESOLVED_TAG");
+  });
+
+  test("ships a Railway platform health gate", () => {
+    expect(railwayConfig.deploy.healthcheckPath).toBe("/health");
+    expect(railwayConfig.deploy.healthcheckTimeout).toBeGreaterThanOrEqual(45);
+    expect(workflow).toContain('RAILWAY_REQUIRE_HEALTH: "true"');
+    expect(deployScript).toContain('RAILWAY_REQUIRE_HEALTH:-false}" == "true"');
+    expect(deployScript).toContain("RAILWAY_HEALTH_URL is required");
+  });
+});

--- a/scripts/__tests__/production-deploy-policy.test.ts
+++ b/scripts/__tests__/production-deploy-policy.test.ts
@@ -38,4 +38,16 @@ describe("production deploy policy", () => {
     expect(deployScript).toContain('RAILWAY_REQUIRE_HEALTH:-false}" == "true"');
     expect(deployScript).toContain("RAILWAY_HEALTH_URL is required");
   });
+
+  test("does not create or mark a GitHub Production deployment during dry run", () => {
+    expect(workflow).toMatch(
+      /- name: Create GitHub deployment\n\s+if: \$\{\{ inputs\.dry_run == false \}\}/,
+    );
+    expect(workflow).toMatch(
+      /- name: Update deployment status \(success\)\n\s+if: \$\{\{ inputs\.dry_run == false && success\(\) \}\}/,
+    );
+    expect(workflow).toMatch(
+      /- name: Update deployment status \(failure\)\n\s+if: \$\{\{ inputs\.dry_run == false && failure\(\) && steps\.deployment\.outputs\.deployment_id != '' \}\}/,
+    );
+  });
 });

--- a/scripts/__tests__/production-deploy-policy.test.ts
+++ b/scripts/__tests__/production-deploy-policy.test.ts
@@ -11,6 +11,7 @@ describe("production deploy policy", () => {
   test("accepts only a full main commit and verifies its exact main Docker build", () => {
     expect(workflow).toContain("main_sha:");
     expect(workflow).not.toContain("image_tag:");
+    expect(workflow).not.toContain("workflow_call:");
     expect(workflow).toContain("^[0-9a-f]{40}$");
     expect(workflow).toContain('git merge-base --is-ancestor "$MAIN_SHA" refs/remotes/origin/main');
     expect(workflow).toContain("actions/workflows/docker.yml/runs");

--- a/scripts/__tests__/railway-deploy.test.ts
+++ b/scripts/__tests__/railway-deploy.test.ts
@@ -7,7 +7,7 @@
  * filter is extracted from the real script and exercised behaviorally.
  */
 import { describe, expect, test } from "bun:test";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -20,6 +20,21 @@ function redact(input: string): string {
     ["-c", `eval "$(sed -n '/^redact_secrets()/,/^}/p' "$1")"; redact_secrets`, "bash", SCRIPT],
     { input, encoding: "utf8" },
   );
+}
+
+function dryRun(imageDigest: string, imageTag?: string) {
+  return spawnSync("bash", [SCRIPT, ...(imageTag ? [imageTag] : []), "--dry-run"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      RAILWAY_TOKEN: "test-token",
+      RAILWAY_SERVICE_ID: "test-service",
+      RAILWAY_ENV_ID: "test-environment",
+      RAILWAY_IMAGE_DIGEST: imageDigest,
+      RAILWAY_HEALTH_URL: "https://example.test",
+      RAILWAY_REQUIRE_HEALTH: "true",
+    },
+  });
 }
 
 describe("SEC-129 railway-deploy.sh fails closed by default", () => {
@@ -37,6 +52,47 @@ describe("SEC-129 railway-deploy.sh fails closed by default", () => {
   test("dumped logs are piped through redact_secrets", () => {
     expect(source).toMatch(/echo "\$build_logs" \| redact_secrets/);
     expect(source).toMatch(/echo "\$deploy_logs" \| redact_secrets/);
+  });
+});
+
+describe("immutable Railway image selection", () => {
+  test("passes a validated digest to Railway without converting it to a tag", () => {
+    const digest = `sha256:${"a".repeat(64)}`;
+    const result = dryRun(digest);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`ghcr.io/steward-fi/steward@${digest}`);
+    expect(result.stdout).not.toContain(`ghcr.io/steward-fi/steward:${digest}`);
+  });
+
+  test("rejects a malformed digest before a deployment mutation", () => {
+    const result = dryRun("sha256:not-a-digest");
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Invalid image digest");
+    expect(result.stdout).not.toContain("Deploying");
+  });
+
+  test("rejects simultaneous tag and digest selectors", () => {
+    const result = dryRun(`sha256:${"a".repeat(64)}`, "main");
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Choose exactly one image selector");
+    expect(result.stdout).not.toContain("Deploying");
+  });
+
+  test("production health enforcement fails before a deployment mutation", () => {
+    const result = spawnSync("bash", [SCRIPT, "main", "--dry-run"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        RAILWAY_TOKEN: "test-token",
+        RAILWAY_SERVICE_ID: "test-service",
+        RAILWAY_ENV_ID: "test-environment",
+        RAILWAY_HEALTH_URL: "",
+        RAILWAY_REQUIRE_HEALTH: "true",
+      },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("RAILWAY_HEALTH_URL is required");
+    expect(result.stdout).not.toContain("Deploying");
   });
 });
 

--- a/scripts/railway-deploy.sh
+++ b/scripts/railway-deploy.sh
@@ -7,8 +7,10 @@ set -euo pipefail
 # polls for deployment success, and verifies the /health endpoint.
 #
 # Usage: ./scripts/railway-deploy.sh <image-tag> [--dry-run]
+#        RAILWAY_IMAGE_DIGEST=sha256:<64-hex> ./scripts/railway-deploy.sh [--dry-run]
 #   e.g. ./scripts/railway-deploy.sh v0.5.0
 #        ./scripts/railway-deploy.sh develop --dry-run
+#        RAILWAY_IMAGE_DIGEST=sha256:<64-hex> ./scripts/railway-deploy.sh
 #
 # Environment variables:
 #   RAILWAY_TOKEN       (required) Railway API bearer token
@@ -16,7 +18,13 @@ set -euo pipefail
 #   RAILWAY_ENV_ID      (REQUIRED) the deployer's own Railway environment id
 #   RAILWAY_IMAGE_REPO  (optional) default: ghcr.io/steward-fi/steward (the
 #                                  canonical published OSS image)
+#   RAILWAY_IMAGE_DIGEST (optional) immutable sha256 digest. Mutually exclusive
+#                                  with the positional image tag. Production
+#                                  deploys should always use this mode.
 #   RAILWAY_HEALTH_URL  (optional) the deployer's own /health URL to verify
+#   RAILWAY_REQUIRE_HEALTH (optional, default: false) fail before mutation when
+#                                  RAILWAY_HEALTH_URL is absent. Production CI
+#                                  must set this to true.
 #   DEPLOY_TIMEOUT      (optional) max seconds to wait for deploy, default: 300
 #   RAILWAY_ALLOW_REJECTED_DEPLOY (optional, default: fail closed) when "true",
 #                       a deployment Railway rejected before any container ran
@@ -48,6 +56,7 @@ fail() { echo -e "${RED}[railway]${RESET} $*" >&2; }
 SERVICE_ID="${RAILWAY_SERVICE_ID:-}"
 ENV_ID="${RAILWAY_ENV_ID:-}"
 IMAGE_REPO="${RAILWAY_IMAGE_REPO:-ghcr.io/steward-fi/steward}"
+IMAGE_DIGEST="${RAILWAY_IMAGE_DIGEST:-}"
 HEALTH_URL="${RAILWAY_HEALTH_URL:-}"
 TIMEOUT="${DEPLOY_TIMEOUT:-300}"
 API="https://backboard.railway.com/graphql/v2"
@@ -71,6 +80,7 @@ for arg in "$@"; do
     --dry-run) DRY_RUN=true ;;
     -h|--help)
       echo "Usage: $0 <image-tag> [--dry-run]"
+      echo "       RAILWAY_IMAGE_DIGEST=sha256:<64-hex> $0 [--dry-run]"
       echo "  e.g. $0 v0.5.0"
       exit 0
       ;;
@@ -86,16 +96,26 @@ for arg in "$@"; do
   esac
 done
 
-if [[ -z "$IMAGE_TAG" ]]; then
-  fail "Image tag required. Usage: $0 <image-tag>"
+if [[ -n "$IMAGE_TAG" && -n "$IMAGE_DIGEST" ]]; then
+  fail "Choose exactly one image selector: a positional tag or RAILWAY_IMAGE_DIGEST"
+  exit 1
+fi
+
+if [[ -z "$IMAGE_TAG" && -z "$IMAGE_DIGEST" ]]; then
+  fail "Image selector required: pass an image tag or set RAILWAY_IMAGE_DIGEST"
   exit 1
 fi
 
 # OCI/Docker tags are at most 128 characters and contain only this conservative
 # subset. Reject whitespace, shell-like syntax, slashes, and control characters
 # before the value reaches logs or a deployment API.
-if [[ ! "$IMAGE_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+if [[ -n "$IMAGE_TAG" && ! "$IMAGE_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
   fail "Invalid image tag: expected an OCI tag (letters, digits, _, ., -; max 128 chars)"
+  exit 1
+fi
+
+if [[ -n "$IMAGE_DIGEST" && ! "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  fail "Invalid image digest: expected sha256 followed by exactly 64 lowercase hex characters"
   exit 1
 fi
 
@@ -104,7 +124,22 @@ if [[ -z "${RAILWAY_TOKEN:-}" ]]; then
   exit 1
 fi
 
-FULL_IMAGE="${IMAGE_REPO}:${IMAGE_TAG}"
+if [[ "${RAILWAY_REQUIRE_HEALTH:-false}" != "true" &&
+      "${RAILWAY_REQUIRE_HEALTH:-false}" != "false" ]]; then
+  fail "RAILWAY_REQUIRE_HEALTH must be true or false"
+  exit 1
+fi
+
+if [[ "${RAILWAY_REQUIRE_HEALTH:-false}" == "true" && -z "$HEALTH_URL" ]]; then
+  fail "RAILWAY_HEALTH_URL is required when RAILWAY_REQUIRE_HEALTH=true"
+  exit 1
+fi
+
+if [[ -n "$IMAGE_DIGEST" ]]; then
+  FULL_IMAGE="${IMAGE_REPO}@${IMAGE_DIGEST}"
+else
+  FULL_IMAGE="${IMAGE_REPO}:${IMAGE_TAG}"
+fi
 
 # ---------------------------------------------------------------------------
 # Helper: GraphQL request


### PR DESCRIPTION
## Summary

Promotes the narrowly audited staging authentication recovery set to `main` in one branch-protected release gate. This replaces the separate draft backports in #888, #890, #891, #892, #893, and #894 without merging them independently.

### Authentication recovery

- Reuse a pre-migrated auth store without application-role DDL.
- Resolve the default auth tenant from each Worker request environment.
- Bind login audit writes to the verified tenant RLS context.
- Restore SimpleWebAuthn v13 browser calls and keep new-email signup free of conditional passkey autofill.
- Preserve the non-enumerating passkey pre-auth contract: known, no-passkey, and unknown emails all receive the same `200` response with empty `allowCredentials`, no credential IDs/transports/user IDs, and both supported challenge lookup shapes are stored.
- Keep registration an explicit email/OTP path; React does not infer account existence from a `404`, and the SDK retains the caller-controlled fallback behavior.
- Mark session tokens as JWTs and bind their standard subject claim.
- Recover OAuth/OIDC browser callback failures, content negotiation, and GitHub email fallback behavior.

### Email identity and callback routing

- Add validated tenant `brandName` support to built-in magic-link and OTP templates.
- Add deployment fallbacks for `EMAIL_BRAND_NAME`, `EMAIL_MAGIC_LINK_BASE_URL`, and `EMAIL_MAGIC_LINK_CALLBACK_PATH` so hosted email identity and callback routing survive an absent or temporarily unavailable tenant config.
- Keep the email landing origin independent from API-oriented `APP_URL`.

### Migration/readiness floor

- Add only the exact already-applied `0112_rls_activation_release_gates.sql` and `0113_personal_tenant_account_lifecycle.sql` blobs plus journal indexes 112/113.
- The SQL SHA-256 values and complete resulting journal byte-match source commits `100073d8` and `05944dda`.
- No later migration, fake journal entry, database mutation, or readiness relaxation is included. Staging runs with `SKIP_MIGRATIONS=1`; this aligns the image manifest with its already-applied database ledger.

### Promotion guardrails

- Accept only a full commit already on `main` with an exact successful `docker.yml` main push.
- Resolve and validate OCI revision/version/source provenance, then pass Railway only `repository@sha256:digest`.
- Require a configured health origin before production mutation and ship `railway.json` with `/health`.
- Keep `dry_run=true` from creating or marking an explicit GitHub Production deployment.
- Document reviewed promotion and rollback using immutable main-built digests.

## Current exact head

`6e06e210f163a4abc4e2f024099b82ad060d2330`

The latest one-line test-only follow-up aligns the OAuth callback assertion with the deliberately sanitized public error already returned by the route. It does not alter runtime behavior or the passkey contract.

## Verification

- `bunx turbo run build --filter=@stwd/api`: 24/24 dependency-aware builds pass at the current head.
- Passkey enumeration route: 2/2 focused tests pass for constant-shaped known/unknown responses.
- SDK passkey behavior: 5/5 focused tests pass.
- React passkey fallback behavior: 3/3 focused tests pass.
- Focused auth recovery coverage before the privacy follow-up: 176 pass, 0 fail, including email config/branding, OAuth/OIDC browser recovery, JWT/session claims, auth-store reuse, RLS audit boundary, deploy policy, and migration expectations.
- Both 0112 and 0113 execute successfully in isolated PGLite test databases.
- Biome on the current changed OAuth test and `git diff --check`: pass.
- Fresh exact-head hosted checks are running. The previous head had 60/62 checks green; its two failures were inherited main baselines, and the sole changed-path Postgres assertion is corrected here. A separate main-targeted prerequisite is restoring those inherited CI baselines and Docker trigger coverage rather than weakening protection.

## Deliberate exclusions

- #667 is not a dependency of the 0112/0113 manifest floor, and the live grants are already correct; it is not promoted here.
- #897 remains an unmerged, broader follow-up that also changes Docker image symlinks. The current staging OAuth starts already pass the explicit tenant allowlist boundary, so it is not folded into this release without its own completed review.
- No production service, image pin, environment, or database was changed while preparing this PR.

