### PR TITLE
fix(api): isolate remaining Worker security authority

### DIFF
--- a/packages/api/src/__tests__/worker-runtime-env-inventory.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-env-inventory.test.ts
@@ -47,21 +47,9 @@ const migratedRuntimeAuthorityKeys = [
   "STEWARD_OAUTH_REDIRECT_ALLOWLIST",
 ] as const;
 
-const pendingAuthRouteReaders = [
-  "EMAIL_AUTH_REDIRECT_BASE_URL",
-  "FARCASTER_LOGIN_ENABLED",
-  "NODE_ENV",
-  "SMS_PROVIDER",
-  "STEWARD_DB_MODE",
-  "STEWARD_ENABLE_PROD_TEST_ACCOUNT_TOKEN",
-  "STEWARD_PGLITE_MEMORY",
-  "TELEGRAM_BOT_TOKEN",
-  "TOTP_ISSUER",
-  "TWILIO_ACCOUNT_SID",
-  "TWILIO_AUTH_TOKEN",
-  "TWILIO_FROM",
-  "WHATSAPP_OTP_ENABLED",
-];
+// The auth route now resolves every request-sensitive switch and credential
+// through the immutable runtime binding.
+const pendingAuthRouteReaders: string[] = [];
 
 describe("Worker runtime environment static inventory", () => {
   it("rejects unclassified direct process.env readers in security middleware", () => {

--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -494,8 +494,8 @@ test("Worker cron gives every autonomous sweep its own request database", async 
     }
   }
 
-  expect(databaseCount).toBe(5);
-  expect(seen.sort()).toEqual(["cron-db-2", "cron-db-3", "cron-db-4", "cron-db-5"]);
+  expect(databaseCount).toBe(6);
+  expect(seen.sort()).toEqual(["cron-db-2", "cron-db-3", "cron-db-4", "cron-db-5", "cron-db-6"]);
 });
 
 test("configured webhook work retains its request database until Worker cleanup", async () => {
@@ -512,7 +512,14 @@ test("configured webhook work retains its request database until Worker cleanup"
     ({ dispatchWebhook } = await import("../services/webhook-dispatch"));
     const webhooks = await import("@stwd/webhooks");
     WebhookDispatcher = webhooks.WebhookDispatcher;
-    encryptedSecret = webhooks.encryptWebhookSecret("worker-webhook-signing-secret");
+    encryptedSecret = withRuntimeEnvironment(
+      {
+        NODE_ENV: "test",
+        STEWARD_MASTER_PASSWORD: "worker-webhook-test-master-password",
+        STEWARD_WEBHOOK_SECRET_KDF_SALT: "ab".repeat(32),
+      },
+      () => webhooks.encryptWebhookSecret("worker-webhook-signing-secret"),
+    );
   } catch (error) {
     await databaseModule.closeDb();
     if (previousMasterPassword === undefined) delete process.env.STEWARD_MASTER_PASSWORD;
@@ -563,28 +570,34 @@ test("configured webhook work retains its request database until Worker cleanup"
       return { success: true, attempts: 1, deliveredAt: new Date() };
     },
   );
-  const owner = withWorkerRequestDatabase(
-    {
-      DATABASE_URL: "postgresql://worker.invalid/steward",
-      DATABASE_DRIVER: "neon-websocket",
-    },
-    async () => {
-      dispatchWebhook("tenant-worker-webhook", "agent-worker-webhook", "tx_signed", {});
-      return new Response("accepted");
-    },
-    {
-      createHandle: () => ({
-        driver: "neon-websocket" as const,
-        db: requestDb as never,
-        async close() {
-          expect(deliveryFinished).toBe(true);
-          closes += 1;
-        },
-      }),
-      waitUntil(promise) {
-        deferredCleanup = promise;
+  const webhookEnv = {
+    DATABASE_URL: "postgresql://worker.invalid/steward",
+    DATABASE_DRIVER: "neon-websocket",
+    NODE_ENV: "test",
+    STEWARD_MASTER_PASSWORD: "worker-webhook-test-master-password",
+    STEWARD_WEBHOOK_SECRET_KDF_SALT: "ab".repeat(32),
+  };
+  const owner = withRuntimeEnvironment(webhookEnv, () =>
+    withWorkerRequestDatabase(
+      webhookEnv,
+      async () => {
+        dispatchWebhook("tenant-worker-webhook", "agent-worker-webhook", "tx_signed", {});
+        return new Response("accepted");
       },
-    },
+      {
+        createHandle: () => ({
+          driver: "neon-websocket" as const,
+          db: requestDb as never,
+          async close() {
+            expect(deliveryFinished).toBe(true);
+            closes += 1;
+          },
+        }),
+        waitUntil(promise) {
+          deferredCleanup = promise;
+        },
+      },
+    ),
   );
 
   try {

--- a/packages/api/src/__tests__/worker-security-authority.test.ts
+++ b/packages/api/src/__tests__/worker-security-authority.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { withRuntimeEnvironment } from "@stwd/shared/runtime-env";
+import { Hono } from "hono";
 import { resolveJwksUrl } from "../middleware/agent-jwt";
+import {
+  authorizationSignature,
+  createAuthorizationSignature,
+} from "../middleware/authorization-signature";
+import { requestExpiry } from "../middleware/request-expiry";
 import { isHstsEnabled } from "../middleware/security-headers";
+import { apiKeyAdminMutationsEnabled } from "../routes/agents";
+import { getPhoneAuth, isUnsafeUnboundOAuthProviderCodeExchangeAllowed } from "../routes/auth";
 
 const originalEnvironment = {
   ELIZA_CLOUD_JWKS_URL: process.env.ELIZA_CLOUD_JWKS_URL,
@@ -71,5 +79,185 @@ describe("Worker request-local security authority", () => {
     process.env.STEWARD_HSTS_DISABLED = "true";
     expect(withRuntimeEnvironment({ STEWARD_HSTS_DISABLED: "false" }, isHstsEnabled)).toBe(true);
     expect(withRuntimeEnvironment({ STEWARD_HSTS_DISABLED: "true" }, isHstsEnabled)).toBe(false);
+  });
+
+  it("does not let a weak invocation poison cached freshness middleware", async () => {
+    const app = new Hono();
+    const reachedWeakRoute = Promise.withResolvers<void>();
+    const releaseWeakRoute = Promise.withResolvers<void>();
+    app.use("*", requestExpiry());
+    app.post("/vault/sign", async (c) => {
+      reachedWeakRoute.resolve();
+      await releaseWeakRoute.promise;
+      return c.text("ok");
+    });
+
+    const weak = withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        NODE_ENV: "development",
+        STEWARD_REQUIRE_REQUEST_EXPIRY: "false",
+      },
+      () => app.request("/vault/sign", { method: "POST" }),
+    );
+    await reachedWeakRoute.promise;
+    const strong = await withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        NODE_ENV: "production",
+        STEWARD_REQUIRE_REQUEST_EXPIRY: "true",
+      },
+      () => app.request("/vault/sign", { method: "POST" }),
+    );
+    releaseWeakRoute.resolve();
+
+    expect(strong.status).toBe(400);
+    expect(await strong.json()).toEqual({ ok: false, error: "Request expiry header required" });
+    expect((await weak).status).toBe(200);
+  });
+
+  it("does not let a weak invocation poison cached signature middleware or signing roots", async () => {
+    const app = new Hono<{ Variables: { requestSignatureVerified?: boolean } }>();
+    const reachedWeakRoute = Promise.withResolvers<void>();
+    const releaseWeakRoute = Promise.withResolvers<void>();
+    app.use("*", authorizationSignature());
+    app.post("/vault/sign", async (c) => {
+      if (!c.get("requestSignatureVerified")) {
+        reachedWeakRoute.resolve();
+        await releaseWeakRoute.promise;
+      }
+      return c.json({ verified: Boolean(c.get("requestSignatureVerified")) });
+    });
+
+    const weak = withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        NODE_ENV: "development",
+        STEWARD_REQUIRE_AUTH_SIGNATURE: "false",
+        STEWARD_REQUEST_SIGNING_SECRET: "weak-generation-signing-root",
+      },
+      () => app.request("/vault/sign", { method: "POST" }),
+    );
+    await reachedWeakRoute.promise;
+
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const idempotencyKey = "worker-generation-idempotency";
+    const strongSecret = "strong-generation-signing-root";
+    const signature = await createAuthorizationSignature(
+      {
+        method: "POST",
+        url: "https://worker.test/vault/sign",
+        timestamp,
+        idempotencyKey,
+      },
+      strongSecret,
+    );
+    const strong = await withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        NODE_ENV: "production",
+        STEWARD_REQUIRE_AUTH_SIGNATURE: "true",
+        STEWARD_REQUEST_SIGNING_SECRET: strongSecret,
+      },
+      () =>
+        app.request("https://worker.test/vault/sign", {
+          method: "POST",
+          headers: {
+            "X-Steward-Request-Timestamp": timestamp,
+            "Idempotency-Key": idempotencyKey,
+            "X-Steward-Signature": signature,
+          },
+        }),
+    );
+    const unsignedStrong = await withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        NODE_ENV: "production",
+        STEWARD_REQUIRE_AUTH_SIGNATURE: "true",
+      },
+      () => app.request("/vault/sign", { method: "POST" }),
+    );
+    releaseWeakRoute.resolve();
+
+    expect(strong.status).toBe(200);
+    expect(await strong.json()).toEqual({ verified: true });
+    expect(unsignedStrong.status).toBe(401);
+    expect((await weak).status).toBe(200);
+  });
+
+  it("keeps root-equivalent route gates isolated across hostile overlap", async () => {
+    let releaseWeak!: () => void;
+    let weakReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      weakReady = resolve;
+    });
+    const barrier = new Promise<void>((resolve) => {
+      releaseWeak = resolve;
+    });
+    const weak = withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        STEWARD_ALLOW_UNBOUND_OAUTH_PROVIDER_CODE_EXCHANGE: "true",
+        STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS: "true",
+      },
+      async () => {
+        weakReady();
+        await barrier;
+        return {
+          oauth: isUnsafeUnboundOAuthProviderCodeExchangeAllowed(),
+          apiKeyAdmin: apiKeyAdminMutationsEnabled(),
+        };
+      },
+    );
+    await ready;
+    const strong = withRuntimeEnvironment(
+      {
+        STEWARD_RUNTIME: "workers",
+        STEWARD_ALLOW_UNBOUND_OAUTH_PROVIDER_CODE_EXCHANGE: "false",
+        STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS: "false",
+      },
+      () => ({
+        oauth: isUnsafeUnboundOAuthProviderCodeExchangeAllowed(),
+        apiKeyAdmin: apiKeyAdminMutationsEnabled(),
+      }),
+    );
+    releaseWeak();
+
+    expect(strong).toEqual({ oauth: false, apiKeyAdmin: false });
+    await expect(weak).resolves.toEqual({ oauth: true, apiKeyAdmin: true });
+  });
+
+  it("generation-scopes cached auth clients instead of retaining a weak first invocation", () => {
+    expect(
+      withRuntimeEnvironment(
+        { STEWARD_RUNTIME: "workers", NODE_ENV: "test", SMS_PROVIDER: "mock" },
+        getPhoneAuth,
+      ),
+    ).toBeDefined();
+    expect(() =>
+      withRuntimeEnvironment({ STEWARD_RUNTIME: "workers", NODE_ENV: "production" }, getPhoneAuth),
+    ).toThrow("SMS provider not configured");
+  });
+
+  it("keeps the exact Worker security inventory off the process environment mirror", async () => {
+    const files = [
+      "../app.ts",
+      "../middleware/authorization-signature.ts",
+      "../middleware/idempotency.ts",
+      "../middleware/redis-enforcement.ts",
+      "../middleware/request-expiry.ts",
+      "../middleware/tenant-cors.ts",
+      "../routes/agents.ts",
+      "../routes/audit.ts",
+      "../routes/auth.ts",
+      "../routes/platform.ts",
+      "../routes/tenant-config.ts",
+      "../routes/user.ts",
+      "../services/evm-simulator.ts",
+    ];
+    for (const file of files) {
+      const source = await Bun.file(new URL(file, import.meta.url)).text();
+      expect(source).not.toContain("process.env");
+    }
   });
 });

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -14,6 +14,7 @@ import { agentPolicies, toPersistedPolicyRule } from "@stwd/db";
 import { shouldUsePGLite } from "@stwd/db/pglite";
 import { getSpend, getSpendByHost, invalidateCache, type SpendPeriod } from "@stwd/redis";
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { and, eq, gte, inArray, isNull, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { isRedisAvailable } from "../middleware/redis";
@@ -305,10 +306,12 @@ function requireTenantAdminOrApiKey(c: Parameters<typeof requireTenantLevel>[0])
  * machine automation can explicitly restore the legacy api-key path via
  * STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS=true (documented as fully-root).
  */
+export function apiKeyAdminMutationsEnabled(): boolean {
+  return runtimeEnvironmentValue("STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS") === "true";
+}
+
 function allowApiKeyAdminMutations(c: Parameters<typeof requireTenantLevel>[0]): boolean {
-  return (
-    c.get("authType") === "api-key" && process.env.STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS === "true"
-  );
+  return c.get("authType") === "api-key" && apiKeyAdminMutationsEnabled();
 }
 
 function requireSensitiveMutationPrincipal(c: Parameters<typeof requireTenantLevel>[0]): boolean {

--- a/packages/api/src/routes/audit.ts
+++ b/packages/api/src/routes/audit.ts
@@ -8,6 +8,7 @@
 import { auditChainHeads, auditCheckpoints, proxyAuditLog } from "@stwd/db";
 import { shouldUsePGLite } from "@stwd/db/pglite";
 import { redactedThrownDiagnostics } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { and, count, desc, eq, gte, inArray, lte, type SQL, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { auditOwnerAdminMfaGate } from "../middleware/audit-gate";
@@ -455,7 +456,7 @@ auditRoutes.get("/summary", async (c) => {
       since = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
       break;
     case "all":
-      if (process.env.STEWARD_ALLOW_UNBOUNDED_AUDIT_SUMMARY !== "true") {
+      if (runtimeEnvironmentValue("STEWARD_ALLOW_UNBOUNDED_AUDIT_SUMMARY") !== "true") {
         return c.json<ApiResponse>(
           { ok: false, error: "range=all requires STEWARD_ALLOW_UNBOUNDED_AUDIT_SUMMARY=true" },
           400,
@@ -840,7 +841,9 @@ auditRoutes.post("/verify", async (c) => {
 // applies; no HMAC key or private signing material is returned.
 auditRoutes.get("/integrity", async (c) => {
   const tenantId = c.get("tenantId");
-  const configuredLimit = Number(process.env.STEWARD_DOCTOR_AUDIT_MAX_EVENTS ?? "100000");
+  const configuredLimit = Number(
+    runtimeEnvironmentValue("STEWARD_DOCTOR_AUDIT_MAX_EVENTS") ?? "100000",
+  );
   const maxEvents =
     Number.isSafeInteger(configuredLimit) && configuredLimit > 0 ? configuredLimit : 100_000;
   const data = await db.transaction(async (tx) => {
@@ -1196,7 +1199,7 @@ auditRoutes.get("/bundle", async (c) => {
   const tenantId = c.get("tenantId");
 
   if (!isCheckpointSigningConfigured()) {
-    if (process.env.NODE_ENV === "production") {
+    if (runtimeEnvironmentValue("NODE_ENV") === "production") {
       return c.json<ApiResponse>(
         {
           ok: false,

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -187,7 +187,8 @@ async function withVerifiedAuthTenant<T>(
     userId: subject,
   });
   const driver =
-    process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true"
+    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" ||
+    runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
       ? "pglite"
       : getDatabaseDriver();
   return withTenantRlsTransaction(getDb() as never, driver, context, async (tx) =>
@@ -207,7 +208,8 @@ async function withPreAuthTenant<T>(
     subject: "public-auth-flow",
   });
   const driver =
-    process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true"
+    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" ||
+    runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
       ? "pglite"
       : getDatabaseDriver();
   return withTenantRlsTransaction(getDb() as never, driver, context, async (tx) =>
@@ -1375,6 +1377,21 @@ let _authStoreSources: AuthStoreSources = {
   importSession: "memory",
 };
 let _phoneAuth: PhoneAuth | null = null;
+interface RuntimeAuthClientCache {
+  phoneAuth: PhoneAuth | null;
+}
+let _runtimeAuthClients = new WeakMap<object, RuntimeAuthClientCache>();
+
+function runtimeAuthClientCache(): RuntimeAuthClientCache | null {
+  const identity = runtimeEnvironmentIdentity();
+  if (!identity) return null;
+  let cache = _runtimeAuthClients.get(identity);
+  if (!cache) {
+    cache = { phoneAuth: null };
+    _runtimeAuthClients.set(identity, cache);
+  }
+  return cache;
+}
 
 export type AuthStoreSource = "redis" | "postgres" | "memory";
 export type AuthStoreSources = {
@@ -1457,6 +1474,7 @@ export async function initAuthStores(usePostgres = false): Promise<void> {
   _passkeyAuthByRequest = new WeakMap();
   _phoneAuth = null;
   _passkeyAuthWithoutRequest.clear();
+  _runtimeAuthClients = new WeakMap();
   _emailAuthByRequest = new WeakMap();
 }
 
@@ -1590,7 +1608,7 @@ async function markOidcIdTokenUsedOnce(
   return inserted ? { ok: true } : { ok: false, response: "replayed" };
 }
 
-function isUnsafeUnboundOAuthProviderCodeExchangeAllowed(): boolean {
+export function isUnsafeUnboundOAuthProviderCodeExchangeAllowed(): boolean {
   return runtimeEnvironmentValue("STEWARD_ALLOW_UNBOUND_OAUTH_PROVIDER_CODE_EXCHANGE") === "true";
 }
 
@@ -2921,38 +2939,45 @@ async function requireRecentFactorEnrollmentStepUp(
 }
 
 export function getPhoneAuth(): PhoneAuth {
-  if (_phoneAuth) return _phoneAuth;
+  const runtimeCache = runtimeAuthClientCache();
+  const cached = runtimeCache?.phoneAuth ?? _phoneAuth;
+  if (cached) return cached;
 
   let provider: SmsProvider | undefined;
-  if (process.env.SMS_PROVIDER === "mock" && process.env.NODE_ENV !== "production") {
+  if (
+    runtimeEnvironmentValue("SMS_PROVIDER") === "mock" &&
+    runtimeEnvironmentValue("NODE_ENV") !== "production"
+  ) {
     provider = new MockSmsProvider();
   } else if (
-    process.env.TWILIO_ACCOUNT_SID &&
-    process.env.TWILIO_AUTH_TOKEN &&
-    process.env.TWILIO_FROM
+    runtimeEnvironmentValue("TWILIO_ACCOUNT_SID") &&
+    runtimeEnvironmentValue("TWILIO_AUTH_TOKEN") &&
+    runtimeEnvironmentValue("TWILIO_FROM")
   ) {
     provider = new TwilioSmsProvider({
-      accountSid: process.env.TWILIO_ACCOUNT_SID,
-      authToken: process.env.TWILIO_AUTH_TOKEN,
-      from: process.env.TWILIO_FROM,
+      accountSid: runtimeEnvironmentValue("TWILIO_ACCOUNT_SID") as string,
+      authToken: runtimeEnvironmentValue("TWILIO_AUTH_TOKEN") as string,
+      from: runtimeEnvironmentValue("TWILIO_FROM") as string,
     });
-  } else if (process.env.NODE_ENV === "production") {
+  } else if (runtimeEnvironmentValue("NODE_ENV") === "production") {
     throw new Error("SMS provider not configured");
   }
 
-  _phoneAuth = new PhoneAuth({
+  const phoneAuth = new PhoneAuth({
     provider,
     tokenStore: new TokenStore({ backend: getMfaBackend() }),
   });
-  return _phoneAuth;
+  if (runtimeCache) runtimeCache.phoneAuth = phoneAuth;
+  else _phoneAuth = phoneAuth;
+  return phoneAuth;
 }
 
 function isWhatsAppOtpEnabled(): boolean {
-  return process.env.WHATSAPP_OTP_ENABLED === "true";
+  return runtimeEnvironmentValue("WHATSAPP_OTP_ENABLED") === "true";
 }
 
 function isFarcasterLoginEnabled(): boolean {
-  return process.env.FARCASTER_LOGIN_ENABLED === "true";
+  return runtimeEnvironmentValue("FARCASTER_LOGIN_ENABLED") === "true";
 }
 
 const TELEGRAM_LOGIN_MAX_AGE_SEC = 24 * 60 * 60;
@@ -3201,8 +3226,14 @@ class MfaRecoveryCodeStore implements RecoveryCodeStore {
   }
 }
 
-const recoveryCodeStore: RecoveryCodeStore =
-  process.env.NODE_ENV === "test" ? new InMemoryRecoveryCodeStore() : new MfaRecoveryCodeStore();
+const durableRecoveryCodeStore: RecoveryCodeStore = new MfaRecoveryCodeStore();
+const testRecoveryCodeStore: RecoveryCodeStore = new InMemoryRecoveryCodeStore();
+
+function getRecoveryCodeStore(): RecoveryCodeStore {
+  return runtimeEnvironmentValue("NODE_ENV") === "test"
+    ? testRecoveryCodeStore
+    : durableRecoveryCodeStore;
+}
 
 type PendingMfaAuth = {
   mfaType: "totp" | "sms";
@@ -4121,10 +4152,9 @@ function resolveSamlMappedRole(config: TenantSamlSsoConfig, groups: string[]): s
 }
 
 function getEmailAuthRedirectBaseUrl(): string {
-  return (process.env.EMAIL_AUTH_REDIRECT_BASE_URL || "https://www.elizacloud.ai").replace(
-    /\/$/,
-    "",
-  );
+  return (
+    runtimeEnvironmentValue("EMAIL_AUTH_REDIRECT_BASE_URL") || "https://www.elizacloud.ai"
+  ).replace(/\/$/, "");
 }
 
 function buildEmailAuthRedirectUrl(params?: Record<string, string | undefined>): string {
@@ -4775,7 +4805,8 @@ auth.get("/providers", async (c) => {
     discord: enabledOauth.includes("discord"),
     github: enabledOauth.includes("github"),
     twitter: enabledOauth.includes("twitter"),
-    telegram: methodEnabled("telegram") && Boolean(process.env.TELEGRAM_BOT_TOKEN?.trim()),
+    telegram:
+      methodEnabled("telegram") && Boolean(runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim()),
     farcaster: methodEnabled("farcaster") && isFarcasterLoginEnabled(),
     linkedin: enabledOauth.includes("linkedin"),
     spotify: enabledOauth.includes("spotify"),
@@ -4804,7 +4835,7 @@ auth.post("/telegram/challenge", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
   }
 
-  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -4847,7 +4878,7 @@ auth.post("/telegram/verify", async (c) => {
   >(c);
   if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
 
-  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -5675,8 +5706,8 @@ auth.get("/test/inbox/:email", (c) => {
 
 auth.get("/test/sms-inbox/:phone", (c) => {
   if (
-    process.env.SMS_PROVIDER !== "mock" ||
-    process.env.NODE_ENV === "production" ||
+    runtimeEnvironmentValue("SMS_PROVIDER") !== "mock" ||
+    runtimeEnvironmentValue("NODE_ENV") === "production" ||
     !authTestInboxEnabled()
   ) {
     return c.json<ApiResponse>({ ok: false, error: "Not found" }, 404);
@@ -5713,8 +5744,8 @@ auth.post("/test/token", async (c) => {
   // supervised app-review / automation windows and disable it immediately
   // afterward. Never leave it enabled on an internet-reachable prod deploy.
   if (
-    process.env.NODE_ENV === "production" &&
-    process.env.STEWARD_ENABLE_PROD_TEST_ACCOUNT_TOKEN !== "true"
+    runtimeEnvironmentValue("NODE_ENV") === "production" &&
+    runtimeEnvironmentValue("STEWARD_ENABLE_PROD_TEST_ACCOUNT_TOKEN") !== "true"
   ) {
     return c.json<ApiResponse>(
       { ok: false, error: "Test account token exchange is disabled" },
@@ -7039,7 +7070,7 @@ auth.post("/mfa/totp/enroll", async (c) => {
   const secret = generateTotpSecret();
   const accountName =
     session.payload.email || session.payload.address || `user:${session.payload.userId}`;
-  const issuer = process.env.TOTP_ISSUER || "Steward";
+  const issuer = runtimeEnvironmentValue("TOTP_ISSUER") || "Steward";
 
   await writeMfaJson(
     mfaKey("totp:pending", session.payload.userId),
@@ -7117,7 +7148,10 @@ auth.post("/mfa/totp/verify", async (c) => {
     });
     await writeMfaJson(mfaKey("totp:enabled", session.payload.userId), stored);
     await getMfaBackend().delete(mfaKey("totp:pending", session.payload.userId));
-    const recoveryCodes = await generateRecoveryCodes(recoveryCodeStore, session.payload.userId);
+    const recoveryCodes = await generateRecoveryCodes(
+      getRecoveryCodeStore(),
+      session.payload.userId,
+    );
     const { issuedBefore } = await revokeUserRefreshSessions(session.payload.userId);
     await writeAuditEvent({
       tenantId: session.payload.tenantId,
@@ -7216,7 +7250,7 @@ auth.post("/mfa/totp/complete", async (c) => {
     // the pending login retryable; a valid code is burned only after this
     // request atomically wins the challenge claim.
     const recoveryCode = await findUnusedRecoveryCode(
-      recoveryCodeStore,
+      getRecoveryCodeStore(),
       challenge.userId,
       body.recoveryCode ?? "",
     );
@@ -7227,7 +7261,7 @@ auth.post("/mfa/totp/complete", async (c) => {
     if ((await getMfaBackend().consume(challengeKey)) === null) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired MFA challenge" }, 401);
     }
-    if (!(await recoveryCodeStore.markUsed(recoveryCode.id, new Date()))) {
+    if (!(await getRecoveryCodeStore().markUsed(recoveryCode.id, new Date()))) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid code" }, 401);
     }
     method = "recovery_code";
@@ -7310,7 +7344,7 @@ auth.post("/mfa/totp/step-up", async (c) => {
   let method: "totp" | "recovery_code" = "totp";
   if (hasRecoveryCode) {
     const verified = await verifyRecoveryCode(
-      recoveryCodeStore,
+      getRecoveryCodeStore(),
       session.payload.userId,
       body?.recoveryCode ?? "",
     );
@@ -7341,7 +7375,7 @@ auth.get("/mfa/recovery-codes/status", async (c) => {
 
   const enabled = await hasTotpEnabled(session.payload.userId);
   const remaining = enabled
-    ? await unusedRecoveryCodeCount(recoveryCodeStore, session.payload.userId)
+    ? await unusedRecoveryCodeCount(getRecoveryCodeStore(), session.payload.userId)
     : 0;
   return c.json({ ok: true, enabled, remaining });
 });
@@ -7394,7 +7428,7 @@ auth.post("/mfa/recovery-codes/regenerate", async (c) => {
     ...verified.stored,
     lastAcceptedStep: verified.acceptedStep,
   });
-  const recoveryCodes = await generateRecoveryCodes(recoveryCodeStore, session.payload.userId);
+  const recoveryCodes = await generateRecoveryCodes(getRecoveryCodeStore(), session.payload.userId);
   await writeAuditEvent({
     tenantId: session.payload.tenantId,
     actorType: "user",

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -63,6 +63,7 @@ import {
   type TenantOidcProviderConfig,
   type TenantTestAccountConfig,
 } from "@stwd/shared";
+import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { type KeyStore, Vault } from "@stwd/vault";
 import {
   and,
@@ -458,7 +459,7 @@ async function lockLinkedAccountIdentity(
 }
 
 function platformIdentityMigrationAllowed(): boolean {
-  return process.env.STEWARD_ALLOW_PLATFORM_IDENTITY_MIGRATION === "true";
+  return runtimeEnvironmentValue("STEWARD_ALLOW_PLATFORM_IDENTITY_MIGRATION") === "true";
 }
 
 function platformIdentityMigrationDisabledResponse(c: Context) {

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -1000,7 +1000,7 @@ function slugifyTenantId(value: string): string {
 }
 
 function userTenantCreationAllowed(): boolean {
-  return process.env.ALLOW_USER_TENANT_CREATION === "true";
+  return runtimeEnvironmentValue("ALLOW_USER_TENANT_CREATION") === "true";
 }
 
 async function writeUserAudit(
@@ -1668,7 +1668,10 @@ function userWalletRowsToAccountWallets(
 }
 
 async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
-  if (process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true") {
+  if (
+    runtimeEnvironmentValue("STEWARD_DB_MODE") === "pglite" ||
+    runtimeEnvironmentValue("STEWARD_PGLITE_MEMORY") === "true"
+  ) {
     return fn();
   }
   const db = getDb();
@@ -3240,7 +3243,7 @@ for (const channel of ["sms", "whatsapp"] as const) {
   user.post(`/me/accounts/phone/${channel}/send`, async (c) => {
     const personalSessionResponse = requirePersonalUserSession(c);
     if (personalSessionResponse) return personalSessionResponse;
-    if (channel === "whatsapp" && process.env.WHATSAPP_OTP_ENABLED !== "true") {
+    if (channel === "whatsapp" && runtimeEnvironmentValue("WHATSAPP_OTP_ENABLED") !== "true") {
       return c.json<ApiResponse>({ ok: false, error: "WhatsApp OTP is not configured" }, 503);
     }
     const session = c.get("userSession");
@@ -3285,7 +3288,7 @@ for (const channel of ["sms", "whatsapp"] as const) {
   user.post(`/me/accounts/phone/${channel}/verify`, async (c) => {
     const personalSessionResponse = requirePersonalUserSession(c);
     if (personalSessionResponse) return personalSessionResponse;
-    if (channel === "whatsapp" && process.env.WHATSAPP_OTP_ENABLED !== "true") {
+    if (channel === "whatsapp" && runtimeEnvironmentValue("WHATSAPP_OTP_ENABLED") !== "true") {
       return c.json<ApiResponse>({ ok: false, error: "WhatsApp OTP is not configured" }, 503);
     }
     const session = c.get("userSession");
@@ -3411,7 +3414,7 @@ user.post("/me/accounts/telegram/challenge", async (c) => {
     );
   }
 
-  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -3438,7 +3441,7 @@ user.post("/me/accounts/telegram", async (c) => {
     );
   }
 
-  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  const botToken = runtimeEnvironmentValue("TELEGRAM_BOT_TOKEN")?.trim();
   if (!botToken) {
     return c.json<ApiResponse>({ ok: false, error: "Telegram login is not configured" }, 503);
   }
@@ -3536,7 +3539,7 @@ user.post("/me/accounts/farcaster/nonce", async (c) => {
       403,
     );
   }
-  if (process.env.FARCASTER_LOGIN_ENABLED !== "true") {
+  if (runtimeEnvironmentValue("FARCASTER_LOGIN_ENABLED") !== "true") {
     return c.json<ApiResponse>({ ok: false, error: "Farcaster login is not configured" }, 503);
   }
 
@@ -3565,7 +3568,7 @@ user.post("/me/accounts/farcaster", async (c) => {
     );
   }
 
-  if (process.env.FARCASTER_LOGIN_ENABLED !== "true") {
+  if (runtimeEnvironmentValue("FARCASTER_LOGIN_ENABLED") !== "true") {
     return c.json<ApiResponse>({ ok: false, error: "Farcaster login is not configured" }, 503);
   }
   const body = await safeJsonParse<Parameters<typeof verifyFarcasterLogin>[0]>(c);

--- a/packages/api/src/services/evm-simulator.ts
+++ b/packages/api/src/services/evm-simulator.ts
@@ -72,7 +72,7 @@ function hexWei(decimal: string): `0x${string}` {
 export class JsonRpcEvmSimulator implements EvmSimulator {
   private readonly env: Readonly<Record<string, string | undefined>>;
 
-  constructor(env: Record<string, string | undefined> = process.env) {
+  constructor(env: Record<string, string | undefined>) {
     this.env = Object.freeze({ ...env });
   }
 


### PR DESCRIPTION
## Summary
- resolve remaining request-sensitive auth/provider/root-route gates through the immutable Worker runtime binding instead of mutable `process.env`
- generation-scope PhoneAuth and other cached auth authority while preserving the newer request-scoped passkey implementation already on `develop`
- bind unsafe OAuth exchange, platform identity migration, fully-root API-key mutation, audit/user feature gates, provider secrets, and EVM simulator selection to the active request
- retain the merged #882 idempotency/Redis/CORS implementation rather than replacing it with the older local version
- update Worker lifecycle tests for the current six-database scheduled topology and prove deferred webhook work retains both database and runtime authority

## Exact local evidence on `fd22aec82`
- focused Worker/runtime/auth suite: 45/45, 205 assertions
- `bun run typecheck`: 36 package builds plus web TypeScript
- `bun run lint`: 1,490 files clean
- changed-file Biome and `git diff --check`: clean

This intentionally uses `Refs`: closure still requires the protected exact-head hosted matrix and an independent approving review.

Refs #786
Refs #770
Refs #657
