### PR TITLE
test(api): prove provider outbox lease survives process death

### DIFF
--- a/packages/api/src/__tests__/fixtures/provider-audit-outbox-worker.ts
+++ b/packages/api/src/__tests__/fixtures/provider-audit-outbox-worker.ts
@@ -1,13 +1,32 @@
 import { closeDb, createDb } from "@stwd/db";
-import { providerActionService } from "../../services/provider-action-service";
+import {
+  __setProviderAuditOutboxAfterClaimForTests,
+  providerActionService,
+} from "../../services/provider-action-service";
 
 const databaseUrl = process.env.DATABASE_URL;
 const tenantId = process.env.TEST_TENANT_ID;
 const intentId = process.env.TEST_INTENT_ID;
-const gateKey = Number(process.env.TEST_GATE_KEY);
+const mode = process.env.TEST_WORKER_MODE ?? "race";
 
-if (!databaseUrl || !tenantId || !intentId || !Number.isSafeInteger(gateKey)) {
+if (!databaseUrl || !tenantId || !intentId) {
   throw new Error("missing provider audit-outbox worker configuration");
+}
+
+if (mode === "crash-after-claim") {
+  __setProviderAuditOutboxAfterClaimForTests(async (_claimToken, rowIds) => {
+    if (rowIds.length === 0) throw new Error("crash worker did not claim an outbox row");
+    // Deliberately bypass every finally/compensation path. The parent verifies
+    // that this committed lease survives process death and is safely reclaimed.
+    process.exit(86);
+  });
+  await providerActionService.recoverRequiredAuditOutbox(tenantId, intentId);
+  throw new Error("crash-after-claim worker unexpectedly survived");
+}
+
+const gateKey = Number(process.env.TEST_GATE_KEY);
+if (!Number.isSafeInteger(gateKey)) {
+  throw new Error("missing provider audit-outbox race gate configuration");
 }
 
 // A parent-held exclusive advisory lock keeps both child processes poised at

--- a/packages/api/src/__tests__/provider-audit-outbox-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/provider-audit-outbox-postgres.integration.test.ts
@@ -201,6 +201,55 @@ describe.skipIf(!databaseUrl)("provider required-audit outbox (real Postgres)", 
     expect(await evidenceRows()).toEqual([{ outbox_id: row.id }]);
   });
 
+  test("a process death after claim leaves a reclaimable lease and no audit", async () => {
+    const row = await resetEvidence();
+    const worker = Bun.spawn(
+      [
+        process.execPath,
+        new URL("./fixtures/provider-audit-outbox-worker.ts", import.meta.url).pathname,
+      ],
+      {
+        cwd: new URL("../../../..", import.meta.url).pathname,
+        env: {
+          ...process.env,
+          DATABASE_URL: databaseUrl!,
+          STEWARD_AUDIT_HMAC_KEY: auditKey,
+          STEWARD_DB_MODE: "postgres",
+          STEWARD_PGLITE_MEMORY: "",
+          TEST_TENANT_ID: tenantId,
+          TEST_INTENT_ID: intentId,
+          TEST_WORKER_MODE: "crash-after-claim",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const exit = await worker.exited;
+    if (exit !== 86) throw new Error(await new Response(worker.stderr).text());
+
+    const [abandoned] = await admin!.db
+      .select()
+      .from(providerActionAuditOutbox)
+      .where(eq(providerActionAuditOutbox.id, row.id));
+    expect(abandoned.deliveredAt).toBeNull();
+    expect(abandoned.claimToken).not.toBeNull();
+    expect(await evidenceRows()).toHaveLength(0);
+
+    await admin!.db.execute(sql`
+      UPDATE provider_action_audit_outbox
+      SET claimed_at = now() - interval '2 minutes'
+      WHERE id = ${row.id}::uuid
+    `);
+    expect(await providerActionService.recoverRequiredAuditOutbox(tenantId, intentId)).toBe(1);
+    expect(await evidenceRows()).toEqual([{ outbox_id: row.id }]);
+    const [completed] = await admin!.db
+      .select()
+      .from(providerActionAuditOutbox)
+      .where(eq(providerActionAuditOutbox.id, row.id));
+    expect(completed.deliveredAt).not.toBeNull();
+    expect(completed.claimToken).toBeNull();
+  }, 120_000);
+
   test("stale takeover fences the expired worker token", async () => {
     const row = await resetEvidence();
     let releaseExpired!: () => void;


### PR DESCRIPTION
## Summary
- extend the existing real-Postgres provider required-audit outbox worker with an actual crash-after-claim mode
- prove a child process can die after committing its lease without appending an audit
- age the abandoned lease, reclaim it, and prove exactly one signed event plus one completed outbox row

## Exact-head evidence (`2fcf8bbcfbb43c2896ae74ed9299ffe10abc6ad7`)
- real PostgreSQL provider outbox suite: 5/5, 21 assertions
- API dependency graph build: 24/24 packages
- changed-file Biome and `git diff --check`: green

## Acceptance boundary
This is the missing real process-death evidence for the durable outbox implementation already on `develop`. A broader legacy PGlite concurrency file currently reuses fixed retired user identities after migration 0123 and fails independently of this two-file diff; its lifecycle correction is tracked by pending PR #899. Merge and issue closure remain gated on independent review, terminal protected hosted checks, and correct ordering with #899.

Refs #766
Refs #883
Refs #657