### PR TITLE
fix(trading): complete durable post-submit recovery

### DIFF
--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -882,19 +882,24 @@ async function findActionByReferenceId(
   return existing ?? null;
 }
 
-async function findActionByIdempotency(agentId: string, actionType: string, keyDigest: string) {
-  const [existing] = await db
+async function findActionByIdempotency(
+  agentId: string,
+  actionType: string,
+  idempotencyKeyDigest: string,
+) {
+  const rows = await db
     .select()
     .from(transactions)
     .where(
       and(
         eq(transactions.agentId, agentId),
         eq(transactions.actionType, actionType),
-        sql`${transactions.actionPayload}->>'idempotencyKeyDigest' = ${keyDigest}`,
+        sql`${transactions.actionPayload}->>'idempotencyKeyDigest' = ${idempotencyKeyDigest}`,
       ),
     )
-    .limit(1);
-  return existing ?? null;
+    .limit(2);
+  if (rows.length > 1) throw new Error("Duplicate action idempotency anchors");
+  return rows[0] ?? null;
 }
 
 function requireBroadcastActionIdempotency(

--- a/packages/db/drizzle/0121_trade_order_recovery.sql
+++ b/packages/db/drizzle/0121_trade_order_recovery.sql
@@ -8,6 +8,7 @@ CREATE TABLE "trade_order_recoveries" (
   "body_hash" varchar(64) NOT NULL,
   "state" varchar(32) DEFAULT 'prepared' NOT NULL,
   "venue_identity" varchar(255),
+  "effect_metadata" jsonb NOT NULL,
   "venue_result" jsonb,
   "response_envelope" jsonb,
   "occurrence_at" timestamp with time zone DEFAULT now() NOT NULL,

--- a/packages/db/drizzle/0121_trade_order_recovery.sql
+++ b/packages/db/drizzle/0121_trade_order_recovery.sql
@@ -8,7 +8,6 @@ CREATE TABLE "trade_order_recoveries" (
   "body_hash" varchar(64) NOT NULL,
   "state" varchar(32) DEFAULT 'prepared' NOT NULL,
   "venue_identity" varchar(255),
-  "effect_metadata" jsonb NOT NULL,
   "venue_result" jsonb,
   "response_envelope" jsonb,
   "occurrence_at" timestamp with time zone DEFAULT now() NOT NULL,

--- a/packages/db/drizzle/0124_trade_recovery_effect_metadata.sql
+++ b/packages/db/drizzle/0124_trade_recovery_effect_metadata.sql
@@ -1,0 +1,25 @@
+ALTER TABLE "trade_order_recoveries"
+  ADD COLUMN "effect_metadata" jsonb;
+--> statement-breakpoint
+UPDATE "trade_order_recoveries" AS recovery
+SET "effect_metadata" = jsonb_build_object(
+  'sessionId', recovery."session_id",
+  'venue', recovery."venue",
+  'walletAddress', session."wallet_id",
+  'orderId', recovery."venue_identity"
+)
+FROM "trade_sessions" AS session
+WHERE session."id" = recovery."session_id"
+  AND session."tenant_id" = recovery."tenant_id"
+  AND recovery."effect_metadata" IS NULL;
+--> statement-breakpoint
+UPDATE "trade_order_recoveries"
+SET "effect_metadata" = jsonb_build_object(
+  'sessionId', "session_id",
+  'venue', "venue",
+  'orderId', "venue_identity"
+)
+WHERE "effect_metadata" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "trade_order_recoveries"
+  ALTER COLUMN "effect_metadata" SET NOT NULL;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -708,6 +708,13 @@
       "when": 1787306405000,
       "tag": "0123_personal_lifecycle_invariants",
       "breakpoints": true
+    },
+    {
+      "idx": 124,
+      "version": "7",
+      "when": 1787390400000,
+      "tag": "0124_trade_recovery_effect_metadata",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -3079,6 +3079,7 @@ export const tradeOrderRecoveries = pgTable(
     bodyHash: varchar("body_hash", { length: 64 }).notNull(),
     state: varchar("state", { length: 32 }).notNull().default("prepared"),
     venueIdentity: varchar("venue_identity", { length: 255 }),
+    effectMetadata: jsonb("effect_metadata").$type<Record<string, unknown>>().notNull(),
     venueResult: jsonb("venue_result").$type<Record<string, unknown>>(),
     responseEnvelope: jsonb("response_envelope").$type<Record<string, unknown>>(),
     occurrenceAt: timestamp("occurrence_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/plugin-trading/src/__tests__/fixtures/trade-order-recovery-worker.ts
+++ b/packages/plugin-trading/src/__tests__/fixtures/trade-order-recovery-worker.ts
@@ -1,7 +1,6 @@
-import { closeDb, getDb, tradeOrderRecoveries, writeAuditEvent } from "@stwd/db";
+import { closeDb, createDb, getDb, tradeOrderRecoveries, writeAuditEvent } from "@stwd/db";
 import { eq } from "drizzle-orm";
 import Redis from "ioredis";
-import postgres from "postgres";
 import { DurableIdempotencyStore } from "../../routes/idempotency";
 import { drainTradeRecoveryAudit } from "../../routes/trade-recovery";
 
@@ -17,7 +16,7 @@ if (!databaseUrl || !redisUrl || !recoveryId || !scope || !key || !bodyHash) {
 }
 if (!Number.isSafeInteger(gateKey)) throw new Error("invalid recovery worker gate key");
 
-const gate = postgres(databaseUrl, { max: 1 });
+const gate = createDb(databaseUrl).client;
 const redis = new Redis(redisUrl, { maxRetriesPerRequest: 1 });
 try {
   // The parent owns the exclusive form until both processes are observably

--- a/packages/plugin-trading/src/__tests__/fixtures/trade-order-recovery-worker.ts
+++ b/packages/plugin-trading/src/__tests__/fixtures/trade-order-recovery-worker.ts
@@ -1,0 +1,51 @@
+import { closeDb, getDb, tradeOrderRecoveries, writeAuditEvent } from "@stwd/db";
+import { eq } from "drizzle-orm";
+import Redis from "ioredis";
+import postgres from "postgres";
+import { DurableIdempotencyStore } from "../../routes/idempotency";
+import { drainTradeRecoveryAudit } from "../../routes/trade-recovery";
+
+const databaseUrl = process.env.DATABASE_URL;
+const redisUrl = process.env.REDIS_URL;
+const recoveryId = process.env.TEST_RECOVERY_ID;
+const gateKey = Number(process.env.TEST_GATE_KEY);
+const scope = process.env.TEST_IDEMPOTENCY_SCOPE;
+const key = process.env.TEST_IDEMPOTENCY_KEY;
+const bodyHash = process.env.TEST_BODY_HASH;
+if (!databaseUrl || !redisUrl || !recoveryId || !scope || !key || !bodyHash) {
+  throw new Error("trade recovery worker fixture is missing required environment");
+}
+if (!Number.isSafeInteger(gateKey)) throw new Error("invalid recovery worker gate key");
+
+const gate = postgres(databaseUrl, { max: 1 });
+const redis = new Redis(redisUrl, { maxRetriesPerRequest: 1 });
+try {
+  // The parent owns the exclusive form until both processes are observably
+  // waiting. Releasing it starts both cold replicas at the same durable row.
+  await gate`select pg_advisory_lock_shared(${gateKey})`;
+  await gate`select pg_advisory_unlock_shared(${gateKey})`;
+
+  const replayStore = new DurableIdempotencyStore<{ status: number; body: unknown }>({
+    namespace: "trade-order-recovery-real-services",
+    getRedisClient: () => redis,
+  });
+  const replay = await replayStore.check(scope, key, bodyHash);
+  if (!replay.record || replay.record.status !== 200) {
+    throw new Error("real Redis durable response was not replayable in cold worker");
+  }
+
+  const db = getDb();
+  const [row] = await db
+    .select()
+    .from(tradeOrderRecoveries)
+    .where(eq(tradeOrderRecoveries.id, recoveryId));
+  if (!row) throw new Error("durable recovery row was not found");
+  const delivered = await drainTradeRecoveryAudit(db, {
+    row,
+    writeAuditEvent,
+    details: row.effectMetadata,
+  });
+  process.stdout.write(`${JSON.stringify({ delivered, replay: replay.record })}\n`);
+} finally {
+  await Promise.allSettled([redis.quit(), gate.end(), closeDb()]);
+}

--- a/packages/plugin-trading/src/__tests__/trade-order-recovery-postgres.integration.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-order-recovery-postgres.integration.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  auditChainHeads,
+  auditEvents,
+  createDb,
+  tradeOrderRecoveries,
+} from "@stwd/db";
+import { and, eq, sql } from "drizzle-orm";
+import Redis from "ioredis";
+import { DurableIdempotencyStore } from "../routes/idempotency";
+
+const databaseUrl = process.env.DATABASE_URL;
+const redisUrl = process.env.REDIS_URL;
+const enabled = Boolean(databaseUrl && redisUrl && process.env.STEWARD_PGLITE_MEMORY !== "true");
+const realServices = enabled ? describe : describe.skip;
+const suffix = crypto.randomUUID().replaceAll("-", "");
+const tenantId = `trade-recovery-${suffix}`;
+const agentId = `trade-recovery-agent-${suffix}`;
+const sessionId = `trade-recovery-session-${suffix}`;
+const idempotencyScope = `${tenantId}:${agentId}`;
+const idempotencyKey = `trade-recovery-key-${suffix}`;
+const bodyHash = suffix.padEnd(64, "a").slice(0, 64);
+const auditKey = `trade-recovery-audit-${suffix}`;
+const fixturePath = new URL("./fixtures/trade-order-recovery-worker.ts", import.meta.url).pathname;
+const repositoryRoot = new URL("../../../..", import.meta.url).pathname;
+
+realServices("trade recovery across real PostgreSQL and Redis processes", () => {
+  const offline = "postgresql://unused:unused@127.0.0.1:1/unused";
+  const admin = createDb(enabled ? databaseUrl! : offline);
+  const redis = new Redis(enabled ? redisUrl! : "redis://127.0.0.1:1", {
+    lazyConnect: !enabled,
+    maxRetriesPerRequest: 1,
+  });
+  let recoveryId: string;
+  let previousAuditKey: string | undefined;
+
+  beforeAll(async () => {
+    previousAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+    process.env.STEWARD_AUDIT_HMAC_KEY = auditKey;
+    __resetAuditHmacKeyCacheForTests();
+    expect(await redis.ping()).toBe("PONG");
+    const replayStore = new DurableIdempotencyStore<{ status: number; body: unknown }>({
+      namespace: "trade-order-recovery-real-services",
+      getRedisClient: () => redis,
+    });
+    const pending = await replayStore.check(idempotencyScope, idempotencyKey, bodyHash);
+    const owner = pending.claim ? await pending.claim() : pending;
+    if (!owner.store) throw new Error("failed to establish real Redis recovery response owner");
+    await owner.store({ status: 200, body: { ok: true, orderId: `venue-${suffix}` } });
+
+    const [row] = await admin.db
+      .insert(tradeOrderRecoveries)
+      .values({
+        tenantId,
+        agentId,
+        sessionId,
+        venue: "hyperliquid",
+        idempotencyKeyHash: suffix.padEnd(64, "b").slice(0, 64),
+        bodyHash,
+        state: "submitted",
+        venueIdentity: `venue-${suffix}`,
+        effectMetadata: { venue: "hyperliquid", orderId: `venue-${suffix}` },
+        venueResult: { status: "filled", orderId: `venue-${suffix}` },
+        responseEnvelope: { status: 200, body: { ok: true, orderId: `venue-${suffix}` } },
+        claimToken: crypto.randomUUID(),
+        claimedAt: new Date(0),
+      })
+      .returning({ id: tradeOrderRecoveries.id });
+    recoveryId = row!.id;
+  });
+
+  afterAll(async () => {
+    await admin.db.delete(auditEvents).where(eq(auditEvents.tenantId, tenantId));
+    await admin.db.delete(auditChainHeads).where(eq(auditChainHeads.tenantId, tenantId));
+    await admin.db.delete(tradeOrderRecoveries).where(eq(tradeOrderRecoveries.id, recoveryId));
+    const storageKey = createHash("sha256")
+      .update(
+        `${idempotencyScope.length}:${idempotencyScope}${idempotencyKey.length}:${idempotencyKey}`,
+        "utf8",
+      )
+      .digest("hex");
+    await redis.del(`idempotency:trade-order-recovery-real-services:${storageKey}`);
+    await Promise.all([admin.client.end(), redis.quit()]);
+    if (previousAuditKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditKey;
+    __resetAuditHmacKeyCacheForTests();
+  });
+
+  test("two cold replicas replay one Redis result and deliver one signed effect", async () => {
+    const gateKey = Number.parseInt(suffix.slice(0, 12), 16);
+    const locker = await admin.client.reserve();
+    await locker`select pg_advisory_lock(${gateKey})`;
+    let gateLocked = true;
+    const env = {
+      ...process.env,
+      DATABASE_URL: databaseUrl!,
+      REDIS_URL: redisUrl!,
+      STEWARD_AUDIT_HMAC_KEY: auditKey,
+      STEWARD_DB_MODE: "postgres",
+      STEWARD_PGLITE_MEMORY: "",
+      TEST_RECOVERY_ID: recoveryId,
+      TEST_GATE_KEY: String(gateKey),
+      TEST_IDEMPOTENCY_SCOPE: idempotencyScope,
+      TEST_IDEMPOTENCY_KEY: idempotencyKey,
+      TEST_BODY_HASH: bodyHash,
+    };
+    const workers = [
+      Bun.spawn([process.execPath, fixturePath], {
+        cwd: repositoryRoot,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      }),
+      Bun.spawn([process.execPath, fixturePath], {
+        cwd: repositoryRoot,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      }),
+    ];
+    try {
+      for (let attempt = 0; attempt < 2_000; attempt++) {
+        const [waiting] = await admin.client<{ count: string }[]>`
+          select count(*)::text as count
+          from pg_stat_activity
+          where wait_event = 'advisory'
+            and query ilike '%pg_advisory_lock_shared%'
+        `;
+        if (Number(waiting?.count ?? "0") >= 2) break;
+        if (attempt === 1_999) throw new Error("trade recovery workers missed the start gate");
+        await Bun.sleep(10);
+      }
+      await locker`select pg_advisory_unlock(${gateKey})`;
+      gateLocked = false;
+      const outputs = await Promise.all(
+        workers.map(async (worker) => {
+          const [exit, stdout, stderr] = await Promise.all([
+            worker.exited,
+            new Response(worker.stdout).text(),
+            new Response(worker.stderr).text(),
+          ]);
+          if (exit !== 0) throw new Error(`trade recovery worker failed (${exit}): ${stderr}`);
+          const lastLine = stdout.trim().split("\n").at(-1);
+          if (!lastLine) throw new Error("trade recovery worker returned no result");
+          return JSON.parse(lastLine) as { delivered: boolean; replay: { status: number } };
+        }),
+      );
+      expect(outputs.every((output) => output.replay.status === 200)).toBe(true);
+      expect(outputs.filter((output) => output.delivered)).toHaveLength(1);
+    } finally {
+      if (gateLocked) await locker`select pg_advisory_unlock(${gateKey})`;
+      locker.release();
+    }
+
+    const evidence = await admin.db
+      .select({ id: auditEvents.id })
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.tenantId, tenantId),
+          sql`${auditEvents.metadata}->>'tradeRecoveryId' = ${recoveryId}`,
+        ),
+      );
+    expect(evidence).toHaveLength(1);
+    const [completed] = await admin.db
+      .select()
+      .from(tradeOrderRecoveries)
+      .where(eq(tradeOrderRecoveries.id, recoveryId));
+    expect(completed!.state).toBe("completed");
+    expect(completed!.auditDeliveredAt).not.toBeNull();
+  }, 120_000);
+});

--- a/packages/plugin-trading/src/__tests__/trade-order-recovery-postgres.integration.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-order-recovery-postgres.integration.test.ts
@@ -119,8 +119,18 @@ realServices("trade recovery across real PostgreSQL and Redis processes", () => 
         stderr: "pipe",
       });
     });
+    const workerResults = workers.map(async (worker) => {
+      const [exit, stdout, stderr] = await Promise.all([
+        worker.exited,
+        new Response(worker.stdout).text(),
+        new Response(worker.stderr).text(),
+      ]);
+      return { exit, stdout, stderr };
+    });
     try {
-      for (let attempt = 0; attempt < 2_000; attempt++) {
+      const gateDeadline = Date.now() + 90_000;
+      let gateReady = false;
+      while (Date.now() < gateDeadline) {
         const [waiting] = await admin.client<{ count: string }[]>`
           select count(*)::text as count
           from pg_stat_activity
@@ -128,30 +138,47 @@ realServices("trade recovery across real PostgreSQL and Redis processes", () => 
             and query ilike '%pg_advisory_lock_shared%'
             and application_name in (${applicationNames[0]}, ${applicationNames[1]})
         `;
-        if (Number(waiting?.count ?? "0") >= 2) break;
-        if (attempt === 1_999) throw new Error("trade recovery workers missed the start gate");
-        await Bun.sleep(10);
+        if (Number(waiting?.count ?? "0") >= 2) {
+          gateReady = true;
+          break;
+        }
+        const failedIndex = workers.findIndex((worker) => worker.exitCode !== null);
+        if (failedIndex >= 0) {
+          const failed = await workerResults[failedIndex]!;
+          throw new Error(
+            `trade recovery worker exited before start gate (${failed.exit}): ${failed.stderr || failed.stdout}`,
+          );
+        }
+        await Bun.sleep(25);
+      }
+      if (!gateReady) {
+        for (const worker of workers) {
+          if (worker.exitCode === null) worker.kill("SIGTERM");
+        }
+        const diagnostics = await Promise.all(workerResults);
+        throw new Error(
+          `trade recovery workers missed the start gate: ${diagnostics
+            .map((result) => result.stderr || result.stdout || `exit ${result.exit}`)
+            .join(" | ")}`,
+        );
       }
       await locker`select pg_advisory_unlock(${gateKey})`;
       gateLocked = false;
-      const outputs = await Promise.all(
-        workers.map(async (worker) => {
-          const [exit, stdout, stderr] = await Promise.all([
-            worker.exited,
-            new Response(worker.stdout).text(),
-            new Response(worker.stderr).text(),
-          ]);
-          if (exit !== 0) throw new Error(`trade recovery worker failed (${exit}): ${stderr}`);
-          const lastLine = stdout.trim().split("\n").at(-1);
-          if (!lastLine) throw new Error("trade recovery worker returned no result");
-          return JSON.parse(lastLine) as { delivered: boolean; replay: { status: number } };
-        }),
-      );
+      const completedWorkers = await Promise.all(workerResults);
+      const outputs = completedWorkers.map((result) => {
+        if (result.exit !== 0) {
+          throw new Error(`trade recovery worker failed (${result.exit}): ${result.stderr}`);
+        }
+        const lastLine = result.stdout.trim().split("\n").at(-1);
+        if (!lastLine) throw new Error("trade recovery worker returned no result");
+        return JSON.parse(lastLine) as { delivered: boolean; replay: { status: number } };
+      });
       expect(outputs.every((output) => output.replay.status === 200)).toBe(true);
       expect(outputs.filter((output) => output.delivered)).toHaveLength(1);
     } finally {
       if (gateLocked) await locker`select pg_advisory_unlock(${gateKey})`;
       locker.release();
+      await Promise.allSettled(workerResults);
     }
 
     const evidence = await admin.db
@@ -170,5 +197,5 @@ realServices("trade recovery across real PostgreSQL and Redis processes", () => 
       .where(eq(tradeOrderRecoveries.id, recoveryId));
     expect(completed!.state).toBe("completed");
     expect(completed!.auditDeliveredAt).not.toBeNull();
-  }, 120_000);
+  }, 180_000);
 });

--- a/packages/plugin-trading/src/__tests__/trade-order-recovery-postgres.integration.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-order-recovery-postgres.integration.test.ts
@@ -90,12 +90,15 @@ realServices("trade recovery across real PostgreSQL and Redis processes", () => 
 
   test("two cold replicas replay one Redis result and deliver one signed effect", async () => {
     const gateKey = Number.parseInt(suffix.slice(0, 12), 16);
+    const applicationNames = [
+      `trade-recovery-${suffix}-worker-0`,
+      `trade-recovery-${suffix}-worker-1`,
+    ];
     const locker = await admin.client.reserve();
     await locker`select pg_advisory_lock(${gateKey})`;
     let gateLocked = true;
-    const env = {
+    const sharedEnv = {
       ...process.env,
-      DATABASE_URL: databaseUrl!,
       REDIS_URL: redisUrl!,
       STEWARD_AUDIT_HMAC_KEY: auditKey,
       STEWARD_DB_MODE: "postgres",
@@ -106,20 +109,16 @@ realServices("trade recovery across real PostgreSQL and Redis processes", () => 
       TEST_IDEMPOTENCY_KEY: idempotencyKey,
       TEST_BODY_HASH: bodyHash,
     };
-    const workers = [
-      Bun.spawn([process.execPath, fixturePath], {
+    const workers = applicationNames.map((applicationName) => {
+      const workerDatabaseUrl = new URL(databaseUrl!);
+      workerDatabaseUrl.searchParams.set("application_name", applicationName);
+      return Bun.spawn([process.execPath, fixturePath], {
         cwd: repositoryRoot,
-        env,
+        env: { ...sharedEnv, DATABASE_URL: workerDatabaseUrl.toString() },
         stdout: "pipe",
         stderr: "pipe",
-      }),
-      Bun.spawn([process.execPath, fixturePath], {
-        cwd: repositoryRoot,
-        env,
-        stdout: "pipe",
-        stderr: "pipe",
-      }),
-    ];
+      });
+    });
     try {
       for (let attempt = 0; attempt < 2_000; attempt++) {
         const [waiting] = await admin.client<{ count: string }[]>`
@@ -127,6 +126,7 @@ realServices("trade recovery across real PostgreSQL and Redis processes", () => 
           from pg_stat_activity
           where wait_event = 'advisory'
             and query ilike '%pg_advisory_lock_shared%'
+            and application_name in (${applicationNames[0]}, ${applicationNames[1]})
         `;
         if (Number(waiting?.count ?? "0") >= 2) break;
         if (attempt === 1_999) throw new Error("trade recovery workers missed the start gate");

--- a/packages/plugin-trading/src/__tests__/trade-order-recovery.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-order-recovery.test.ts
@@ -183,6 +183,11 @@ describe("durable trade order recovery", () => {
       venue: "hyperliquid" as const,
       idempotencyKey: "durable-key-prepared",
       bodyHash: "c".repeat(64),
+      effectMetadata: {
+        sessionId: "recovery-session-prepared",
+        venue: "hyperliquid",
+        walletAddress: "0x0000000000000000000000000000000000000001",
+      },
     };
     const original = await beginTradeRecovery(db, input);
     if (original.kind !== "new") throw new Error("expected new recovery");

--- a/packages/plugin-trading/src/__tests__/trade-order-recovery.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-order-recovery.test.ts
@@ -161,4 +161,46 @@ describe("durable trade order recovery", () => {
     expect(reconciled.row.venueIdentity).toBe(identity);
     expect(reconciled.row.state).toBe("submitted");
   });
+
+  test("one retry takes over a stale prepared claim before any venue submission", async () => {
+    const db = getDb();
+    const input = {
+      tenantId: "recovery-tenant-prepared",
+      agentId: "recovery-agent-prepared",
+      sessionId: "recovery-session-prepared",
+      venue: "hyperliquid" as const,
+      idempotencyKey: "durable-key-prepared",
+      bodyHash: "c".repeat(64),
+    };
+    const original = await beginTradeRecovery(db, input);
+    if (original.kind !== "new") throw new Error("expected new recovery");
+    await db
+      .update(tradeOrderRecoveries)
+      .set({ claimedAt: new Date(Date.now() - 60_000) })
+      .where(eq(tradeOrderRecoveries.id, original.row.id));
+
+    const contenders = await Promise.all([
+      beginTradeRecovery(db, input),
+      beginTradeRecovery(db, input),
+    ]);
+    const winners = contenders.filter((result) => result.kind === "new");
+    expect(winners).toHaveLength(1);
+    const winner = winners[0];
+    if (!winner || winner.kind !== "new") throw new Error("expected one takeover winner");
+    expect(winner.claimToken).not.toBe(original.claimToken);
+    expect(
+      await checkpointTradeSubmissionStart(db, {
+        id: original.row.id,
+        claimToken: original.claimToken,
+        venueIdentity: "old-owner-must-lose",
+      }),
+    ).toBe(false);
+    expect(
+      await checkpointTradeSubmissionStart(db, {
+        id: winner.row.id,
+        claimToken: winner.claimToken,
+        venueIdentity: "takeover-winner",
+      }),
+    ).toBe(true);
+  });
 });

--- a/packages/plugin-trading/src/__tests__/trade-order-recovery.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-order-recovery.test.ts
@@ -44,6 +44,7 @@ describe("durable trade order recovery", () => {
       venue: "hyperliquid",
       idempotencyKey: "durable-key-a",
       bodyHash: "a".repeat(64),
+      effectMetadata: { venue: "hyperliquid", orderId: "venue-1" },
     });
     expect(begun.kind).toBe("new");
     if (begun.kind !== "new") throw new Error("expected new recovery");
@@ -119,6 +120,7 @@ describe("durable trade order recovery", () => {
       venue: "polymarket",
       idempotencyKey: "durable-key-b",
       bodyHash: "b".repeat(64),
+      effectMetadata: { venue: "polymarket", orderId: `0x${"2".repeat(64)}` },
     });
     if (begun.kind !== "new") throw new Error("expected new recovery");
     const identity = `0x${"2".repeat(64)}`;
@@ -147,11 +149,21 @@ describe("durable trade order recovery", () => {
     const [winner, loser] = await Promise.all([
       checkpointReconciledTradeResult(db, {
         id: begun.row.id,
+        tenantId: begun.row.tenantId,
+        agentId: begun.row.agentId,
+        venue: "polymarket",
+        bodyHash: begun.row.bodyHash,
+        venueIdentity: identity,
         venueResult: { orderId: identity, status: "matched" },
         envelope: { status: 200, body: { ok: true, orderId: identity } },
       }),
       checkpointReconciledTradeResult(db, {
         id: begun.row.id,
+        tenantId: begun.row.tenantId,
+        agentId: begun.row.agentId,
+        venue: "polymarket",
+        bodyHash: begun.row.bodyHash,
+        venueIdentity: identity,
         venueResult: { orderId: identity, status: "matched" },
         envelope: { status: 200, body: { ok: true, orderId: identity } },
       }),
@@ -202,5 +214,77 @@ describe("durable trade order recovery", () => {
         venueIdentity: "takeover-winner",
       }),
     ).toBe(true);
+  });
+
+  test("recovers after audit append but before completion without moving occurrence time", async () => {
+    const db = getDb();
+    const begun = await beginTradeRecovery(db, {
+      tenantId: "recovery-tenant-crash",
+      agentId: "recovery-agent-crash",
+      sessionId: "recovery-session-crash",
+      venue: "polymarket",
+      idempotencyKey: "durable-key-crash",
+      bodyHash: "c".repeat(64),
+      effectMetadata: { venue: "polymarket", orderId: "venue-crash" },
+    });
+    if (begun.kind !== "new") throw new Error("expected new recovery");
+    expect(
+      await checkpointTradeSubmissionStart(db, {
+        id: begun.row.id,
+        claimToken: begun.claimToken,
+        venueIdentity: "venue-crash",
+      }),
+    ).toBe(true);
+    expect(
+      await checkpointTradeResult(db, {
+        id: begun.row.id,
+        claimToken: begun.claimToken,
+        venueResult: { orderId: "venue-crash", status: "matched" },
+        envelope: { status: 200, body: { ok: true, orderId: "venue-crash" } },
+      }),
+    ).toBe(true);
+    const checkpointed = await refreshTradeRecovery(db, begun.row.id);
+    await writeAuditEvent({
+      tenantId: checkpointed.tenantId,
+      actorType: "agent",
+      actorId: checkpointed.agentId,
+      action: "trade.order.submitted",
+      resourceType: "trade",
+      resourceId: checkpointed.sessionId,
+      requestId: checkpointed.sessionId,
+      metadata: {
+        ...checkpointed.effectMetadata,
+        correlationId: checkpointed.sessionId,
+        tradeRecoveryId: checkpointed.id,
+        occurrenceAt: checkpointed.occurrenceAt.toISOString(),
+        venueIdentity: checkpointed.venueIdentity,
+      },
+    });
+
+    // This is the process-death boundary: immutable audit committed, row still
+    // says submitted. A stale retry must only finish the marker.
+    await db
+      .update(tradeOrderRecoveries)
+      .set({ claimedAt: new Date(0) })
+      .where(eq(tradeOrderRecoveries.id, checkpointed.id));
+    const retry = await refreshTradeRecovery(db, checkpointed.id);
+    expect(
+      await drainTradeRecoveryAudit(db, {
+        row: retry,
+        writeAuditEvent,
+        details: retry.effectMetadata,
+      }),
+    ).toBe(true);
+    const evidence = await db
+      .select({ metadata: auditEvents.metadata })
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.tenantId, checkpointed.tenantId),
+          sql`${auditEvents.metadata}->>'tradeRecoveryId' = ${checkpointed.id}`,
+        ),
+      );
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0]?.metadata.occurrenceAt).toBe(checkpointed.occurrenceAt.toISOString());
   });
 });

--- a/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
@@ -49,6 +49,7 @@ let getWalletSpy: ReturnType<typeof spyOn> | undefined;
 let buildSpy: ReturnType<typeof spyOn> | undefined;
 let fenceSpy: ReturnType<typeof spyOn> | undefined;
 let orderIdentitySpy: ReturnType<typeof spyOn> | undefined;
+let getOrderSpy: ReturnType<typeof spyOn> | undefined;
 let createTradeRoutesForTest: typeof import("../routes/trade").createTradeRoutes;
 
 // Inject a polymarket venue wallet WITH funder metadata so the creds resolver
@@ -223,9 +224,11 @@ describe("POST /v1/trade/polymarket/order", () => {
     submitSpy?.mockRestore();
     getWalletSpy?.mockRestore();
     buildSpy?.mockRestore();
+    getOrderSpy?.mockRestore();
     submitSpy = undefined;
     getWalletSpy = undefined;
     buildSpy = undefined;
+    getOrderSpy = undefined;
   });
 
   it("rejects an order whose market is not allowlisted (400 policy-violation, no spend)", async () => {
@@ -842,6 +845,51 @@ describe("POST /v1/trade/polymarket/order", () => {
     }
   });
 
+  it("repairs a Polymarket post-submit audit outage on replay without another POST", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({});
+    let failSubmittedAudit = true;
+    const recoveryRoutes = createTradeRoutesForTest({
+      ...sharedTestContext,
+      writeAuditEvent: async (event) => {
+        if (failSubmittedAudit && event.action === "trade.order.submitted") {
+          throw new Error("injected Polymarket post-submit audit outage");
+        }
+        return sharedTestContext.writeAuditEvent(event);
+      },
+    });
+    const app = makeApp(tenantId, agentId, recoveryRoutes);
+    process.env.STEWARD_PM_TEST_CREDS = "1";
+    stubWallet(true);
+    buildSpy = spyOn(PolymarketExecutionAdapter.prototype, "buildSignedOrder").mockResolvedValue(
+      {} as never,
+    );
+    submitSpy = spyOn(PolymarketExecutionAdapter.prototype, "submitSignedOrder").mockResolvedValue({
+      venue: "polymarket" as const,
+      orderId: "pm-recovered-audit-1",
+      status: "matched",
+      success: true,
+      actualAmount: 20,
+      actualPrice: 0.5,
+    } as Awaited<ReturnType<PolymarketExecutionAdapter["submitSignedOrder"]>>);
+
+    try {
+      const key = crypto.randomUUID();
+      const first = await postOrder(app, sessionId, key);
+      expect(first.status).toBe(200);
+      expect(submitSpy).toHaveBeenCalledTimes(1);
+      expect(await auditCount(tenantId, "trade.order.submitted")).toBe(0);
+
+      failSubmittedAudit = false;
+      const replay = await postOrder(app, sessionId, key);
+      expect(replay.status).toBe(200);
+      expect(replay.headers.get("Idempotency-Replayed")).toBe("true");
+      expect(submitSpy).toHaveBeenCalledTimes(1);
+      expect(await auditCount(tenantId, "trade.order.submitted")).toBe(1);
+    } finally {
+      delete process.env.STEWARD_PM_TEST_CREDS;
+    }
+  });
+
   it("deterministic E2E: real vault wallet -> L2 derive -> policy/session -> SDK sign/post -> audit/idempotency", async () => {
     const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const tenantId = `pm-e2e-tenant-${suffix}`;
@@ -1171,6 +1219,46 @@ describe("POST /v1/trade/polymarket/order", () => {
       // The order may have landed -> spend is NOT released.
       expect(await dailySpendOf(sessionId)).toBe(10);
       expect(await auditCount(tenantId, "trade.order.submitted")).toBe(0);
+    } finally {
+      delete process.env.STEWARD_PM_TEST_CREDS;
+    }
+  });
+
+  it("reconciles ambiguous venue evidence before a revoked session can block recovery", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({});
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+    process.env.STEWARD_PM_TEST_CREDS = "1";
+    stubWallet(true);
+    buildSpy = spyOn(PolymarketExecutionAdapter.prototype, "buildSignedOrder").mockResolvedValue(
+      {} as never,
+    );
+    submitSpy = spyOn(PolymarketExecutionAdapter.prototype, "submitSignedOrder").mockRejectedValue(
+      new Error("lost response after POST"),
+    );
+
+    try {
+      const key = crypto.randomUUID();
+      const first = await postOrder(app, sessionId, key);
+      expect(first.status).toBe(502);
+      expect(submitSpy).toHaveBeenCalledTimes(1);
+
+      await getDb()
+        .update(tradeSessions)
+        .set({ status: "revoked", revokedAt: new Date() })
+        .where(eq(tradeSessions.id, sessionId));
+      getOrderSpy = spyOn(PolymarketExecutionAdapter.prototype, "getOrder").mockResolvedValue({
+        id: `0x${"7".repeat(64)}`,
+        status: "matched",
+        size_matched: 20,
+        price: 0.5,
+      });
+
+      const replay = await postOrder(app, sessionId, key);
+      expect(replay.status).toBe(200);
+      expect(replay.headers.get("Idempotency-Replayed")).toBe("true");
+      expect(getOrderSpy).toHaveBeenCalledTimes(1);
+      expect(submitSpy).toHaveBeenCalledTimes(1);
+      expect(await auditCount(tenantId, "trade.order.submitted")).toBe(1);
     } finally {
       delete process.env.STEWARD_PM_TEST_CREDS;
     }

--- a/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
@@ -686,8 +686,6 @@ describe("POST /v1/trade/polymarket/order", () => {
 
   it("SEC-111: STEWARD_PM_TEST_CREDS is hard-disabled in production", async () => {
     const { tenantId, agentId, sessionId } = await seedSession({});
-    stubWallet(true); // wallet + funder present, but no provisioned L2 creds
-    const app = makeApp(tenantId, agentId, tradeRoutes);
 
     const prevNodeEnv = process.env.NODE_ENV;
     const prevMemoryAck = process.env.STEWARD_ALLOW_MEMORY_TRADING_IDEMPOTENCY;
@@ -697,6 +695,20 @@ describe("POST /v1/trade/polymarket/order", () => {
     process.env.STEWARD_ALLOW_MEMORY_TRADING_RATE_LIMITS = "true";
     process.env.STEWARD_PM_TEST_CREDS = "1";
     try {
+      const routes = createTradeRoutesForTest({
+        ...sharedTestContext,
+        vault: {
+          getWallet: async () => ({
+            agentId,
+            chainFamily: "evm" as const,
+            venue: "polymarket",
+            purpose: null,
+            address: WALLET,
+            metadata: { funderAddress: FUNDER },
+          }),
+        } as StewardAppContext["vault"],
+      });
+      const app = makeApp(tenantId, agentId, routes);
       const res = await postOrder(app, sessionId, crypto.randomUUID());
       // The test-creds seam is ignored in production, so creds resolution falls
       // through to real L2 derivation, which fails closed in this harness.
@@ -721,7 +733,6 @@ describe("POST /v1/trade/polymarket/order", () => {
 
   it("SEC-111: a plain-http POLYMARKET_CLOB_API_URL is refused in production", async () => {
     const { tenantId, agentId, sessionId } = await seedSession({});
-    stubWallet(true);
     // Mock the adapter edge so the ONLY thing that can fail the order is creds
     // resolution: the HTTP override and test credentials must not bypass it.
     buildSpy = spyOn(PolymarketExecutionAdapter.prototype, "buildSignedOrder").mockResolvedValue(
@@ -737,8 +748,6 @@ describe("POST /v1/trade/polymarket/order", () => {
       actualAmount: 20,
       actualPrice: 0.5,
     } as Awaited<ReturnType<PolymarketExecutionAdapter["submitSignedOrder"]>>);
-    const app = makeApp(tenantId, agentId, tradeRoutes);
-
     const prevNodeEnv = process.env.NODE_ENV;
     const prevMemoryAck = process.env.STEWARD_ALLOW_MEMORY_TRADING_IDEMPOTENCY;
     const prevRateLimitMemoryAck = process.env.STEWARD_ALLOW_MEMORY_TRADING_RATE_LIMITS;
@@ -748,6 +757,20 @@ describe("POST /v1/trade/polymarket/order", () => {
     process.env.POLYMARKET_CLOB_API_URL = "http://clob.e2e.invalid";
     process.env.STEWARD_PM_TEST_CREDS = "1";
     try {
+      const routes = createTradeRoutesForTest({
+        ...sharedTestContext,
+        vault: {
+          getWallet: async () => ({
+            agentId,
+            chainFamily: "evm" as const,
+            venue: "polymarket",
+            purpose: null,
+            address: WALLET,
+            metadata: { funderAddress: FUNDER },
+          }),
+        } as StewardAppContext["vault"],
+      });
+      const app = makeApp(tenantId, agentId, routes);
       const res = await postOrder(app, sessionId, crypto.randomUUID());
       expect(res.status).toBe(409);
       expect(((await res.json()) as { error?: string }).error).toContain(
@@ -1326,6 +1349,12 @@ describe("POST /v1/trade/sessions (polymarket)", () => {
       tenantId,
       name: "PM Sess Agent",
       walletAddress: "0x0000000000000000000000000000000000000001",
+    });
+    await getDb().insert(agentWallets).values({
+      agentId,
+      chainFamily: "evm",
+      venue: "polymarket",
+      address: WALLET,
     });
     return { tenantId, agentId };
   }

--- a/packages/plugin-trading/src/__tests__/trade-venue-submit-fence.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-venue-submit-fence.test.ts
@@ -88,6 +88,7 @@ setDefaultTimeout(30000);
 let signSpy: ReturnType<typeof spyOn> | undefined;
 let submitSpy: ReturnType<typeof spyOn> | undefined;
 let updateLeverageSpy: ReturnType<typeof spyOn> | undefined;
+let orderStatusSpy: ReturnType<typeof spyOn> | undefined;
 let fenceSpy: ReturnType<typeof spyOn> | undefined;
 let checkpointSpy: ReturnType<typeof spyOn> | undefined;
 let createTradeRoutesForTest: typeof import("../routes/trade").createTradeRoutes;
@@ -213,11 +214,13 @@ describe("Hyperliquid venue-submit spend-fence (real /hyperliquid/order path)", 
     updateLeverageSpy?.mockRestore();
     vaultTypedSignSpy?.mockRestore();
     checkpointSpy?.mockRestore();
+    orderStatusSpy?.mockRestore();
     signSpy = undefined;
     submitSpy = undefined;
     updateLeverageSpy = undefined;
     vaultTypedSignSpy = undefined;
     checkpointSpy = undefined;
+    orderStatusSpy = undefined;
   });
 
   it("binds every Hyperliquid signature to the fenced session wallet", async () => {
@@ -319,6 +322,42 @@ describe("Hyperliquid venue-submit spend-fence (real /hyperliquid/order path)", 
       "Trade submission status unknown",
     );
     expect(submitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconciles exact Hyperliquid evidence after revocation without resubmitting", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession();
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+    signSpy = spyOn(HyperliquidAdapter.prototype, "signOrder").mockResolvedValue(
+      {} as Awaited<ReturnType<HyperliquidAdapter["signOrder"]>>,
+    );
+    submitSpy = spyOn(HyperliquidAdapter.prototype, "submitOrder").mockRejectedValue(
+      new Error("lost response after submit"),
+    );
+
+    const key = crypto.randomUUID();
+    const first = await postOrder(app, sessionId, key);
+    expect(first.status).toBe(502);
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+    await getDb()
+      .update(tradeSessions)
+      .set({ status: "revoked", revokedAt: new Date() })
+      .where(eq(tradeSessions.id, sessionId));
+    orderStatusSpy = spyOn(HyperliquidAdapter.prototype, "getOrderStatus").mockResolvedValue({
+      status: "order",
+      order: {
+        oid: `0x${"1".repeat(32)}`,
+        status: "filled",
+        filledSz: 1,
+        avgPx: 10,
+      },
+    });
+
+    const replay = await postOrder(app, sessionId, key);
+    expect(replay.status).toBe(200);
+    expect(replay.headers.get("Idempotency-Replayed")).toBe("true");
+    expect(orderStatusSpy).toHaveBeenCalledTimes(1);
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+    expect(await auditCount(tenantId, "trade.order.submitted")).toBe(1);
   });
 
   it("records submit-authorization before the submitted audit, with signOrder before submitOrder", async () => {

--- a/packages/plugin-trading/src/__tests__/trade-venue-submit-fence.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-venue-submit-fence.test.ts
@@ -54,7 +54,15 @@ import {
   setDefaultTimeout,
   spyOn,
 } from "bun:test";
-import { agents, auditEvents, closeDb, getDb, tenants, tradeSessions } from "@stwd/db";
+import {
+  agents,
+  auditEvents,
+  closeDb,
+  getDb,
+  tenants,
+  tradeOrderRecoveries,
+  tradeSessions,
+} from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { TradeSessionManager } from "@stwd/trade-sessions";
 import { Vault } from "@stwd/vault";
@@ -81,6 +89,7 @@ let signSpy: ReturnType<typeof spyOn> | undefined;
 let submitSpy: ReturnType<typeof spyOn> | undefined;
 let updateLeverageSpy: ReturnType<typeof spyOn> | undefined;
 let fenceSpy: ReturnType<typeof spyOn> | undefined;
+let checkpointSpy: ReturnType<typeof spyOn> | undefined;
 let createTradeRoutesForTest: typeof import("../routes/trade").createTradeRoutes;
 let sharedTestContext: StewardAppContext;
 let vaultTypedSignSpy: ReturnType<typeof spyOn> | undefined;
@@ -203,10 +212,12 @@ describe("Hyperliquid venue-submit spend-fence (real /hyperliquid/order path)", 
     submitSpy?.mockRestore();
     updateLeverageSpy?.mockRestore();
     vaultTypedSignSpy?.mockRestore();
+    checkpointSpy?.mockRestore();
     signSpy = undefined;
     submitSpy = undefined;
     updateLeverageSpy = undefined;
     vaultTypedSignSpy = undefined;
+    checkpointSpy = undefined;
   });
 
   it("binds every Hyperliquid signature to the fenced session wallet", async () => {
@@ -369,6 +380,46 @@ describe("Hyperliquid venue-submit spend-fence (real /hyperliquid/order path)", 
     expect(authorized[0].actorType).toBe("agent");
     expect(authorized[0].actorId).toBe(agentId);
     expect(authorized[0].seq).toBeLessThan(submitted[0].seq);
+  });
+
+  it("takes over a stale prepared journal through the mounted route without duplicate submit", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession();
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+    signSpy = spyOn(HyperliquidAdapter.prototype, "signOrder").mockResolvedValue(
+      {} as Awaited<ReturnType<HyperliquidAdapter["signOrder"]>>,
+    );
+    submitSpy = spyOn(HyperliquidAdapter.prototype, "submitOrder").mockResolvedValue({
+      orderId: "hl-takeover-1",
+      status: "filled",
+      filledQty: 1,
+      avgPrice: 10,
+    } as Awaited<ReturnType<HyperliquidAdapter["submitOrder"]>>);
+    const recoveryModule = await import("../routes/trade-recovery");
+    checkpointSpy = spyOn(recoveryModule, "checkpointTradeSubmissionStart").mockRejectedValueOnce(
+      new Error("injected crash after prepared journal"),
+    );
+
+    const key = crypto.randomUUID();
+    expect((await postOrder(app, sessionId, key)).status).toBe(500);
+    expect(submitSpy).not.toHaveBeenCalled();
+    const [prepared] = await getDb()
+      .select()
+      .from(tradeOrderRecoveries)
+      .where(
+        and(eq(tradeOrderRecoveries.tenantId, tenantId), eq(tradeOrderRecoveries.agentId, agentId)),
+      );
+    expect(prepared?.state).toBe("prepared");
+    await getDb()
+      .update(tradeOrderRecoveries)
+      .set({ claimedAt: new Date(Date.now() - 60_000) })
+      .where(eq(tradeOrderRecoveries.id, prepared!.id));
+    checkpointSpy.mockRestore();
+    checkpointSpy = undefined;
+
+    const retry = await postOrder(app, sessionId, key);
+    expect(retry.status).toBe(200);
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+    expect(signSpy).toHaveBeenCalledTimes(2);
   });
 
   it("repairs a post-submit audit outage on replay without a second venue submission", async () => {

--- a/packages/plugin-trading/src/routes/trade-recovery.ts
+++ b/packages/plugin-trading/src/routes/trade-recovery.ts
@@ -64,6 +64,7 @@ export async function beginTradeRecovery(
     venue: TradeRecoveryVenue;
     idempotencyKey: string;
     bodyHash: string;
+    effectMetadata: Record<string, unknown>;
   },
 ): Promise<BeginTradeRecoveryResult> {
   const claimToken = randomUUID();
@@ -77,6 +78,7 @@ export async function beginTradeRecovery(
       venue: input.venue,
       idempotencyKeyHash,
       bodyHash: input.bodyHash,
+      effectMetadata: input.effectMetadata,
       claimToken,
     })
     .onConflictDoNothing()
@@ -198,6 +200,11 @@ export async function checkpointReconciledTradeResult(
   db: DbHandle,
   input: {
     id: string;
+    tenantId: string;
+    agentId: string;
+    venue: TradeRecoveryVenue;
+    bodyHash: string;
+    venueIdentity: string;
     venueResult: Record<string, unknown>;
     envelope: TradeRecoveryEnvelope;
   },
@@ -210,6 +217,11 @@ export async function checkpointReconciledTradeResult(
     .where(
       and(
         eq(tradeOrderRecoveries.id, input.id),
+        eq(tradeOrderRecoveries.tenantId, input.tenantId),
+        eq(tradeOrderRecoveries.agentId, input.agentId),
+        eq(tradeOrderRecoveries.venue, input.venue),
+        eq(tradeOrderRecoveries.bodyHash, input.bodyHash),
+        eq(tradeOrderRecoveries.venueIdentity, input.venueIdentity),
         sql`${tradeOrderRecoveries.state} IN ('submitting','ambiguous')`,
         lt(tradeOrderRecoveries.claimedAt, staleBefore),
       ),

--- a/packages/plugin-trading/src/routes/trade-recovery.ts
+++ b/packages/plugin-trading/src/routes/trade-recovery.ts
@@ -22,6 +22,13 @@ export type BeginTradeRecoveryResult =
   | { kind: "existing"; row: TradeOrderRecoveryRow }
   | { kind: "conflict"; row: TradeOrderRecoveryRow };
 
+export function isPreparedTradeRecoveryStale(
+  row: TradeOrderRecoveryRow,
+  now = Date.now(),
+): boolean {
+  return row.state === "prepared" && row.claimedAt.getTime() < now - EFFECT_LEASE_MS;
+}
+
 export async function findTradeRecovery(
   db: DbHandle,
   input: {
@@ -89,9 +96,27 @@ export async function beginTradeRecovery(
     )
     .limit(1);
   if (!existing) throw new Error("TRADE_RECOVERY_INSERT_LOST");
-  return existing.bodyHash === input.bodyHash
-    ? { kind: "existing", row: existing }
-    : { kind: "conflict", row: existing };
+  if (existing.bodyHash !== input.bodyHash) return { kind: "conflict", row: existing };
+
+  // No venue I/O can occur before prepared -> submitting. If an owner crashes
+  // in that gap, a retry may safely take over the stale prepared claim. The
+  // token CAS ensures the old owner can no longer checkpoint submission.
+  const reclaimed = await db
+    .update(tradeOrderRecoveries)
+    .set({ claimToken, claimedAt: new Date(), updatedAt: new Date() })
+    .where(
+      and(
+        eq(tradeOrderRecoveries.id, existing.id),
+        eq(tradeOrderRecoveries.bodyHash, input.bodyHash),
+        eq(tradeOrderRecoveries.state, "prepared"),
+        lt(tradeOrderRecoveries.claimedAt, new Date(Date.now() - EFFECT_LEASE_MS)),
+      ),
+    )
+    .returning();
+  const reclaimedRow = reclaimed?.[0];
+  return reclaimedRow
+    ? { kind: "new", row: reclaimedRow, claimToken }
+    : { kind: "existing", row: existing };
 }
 
 export async function checkpointTradeSubmissionStart(

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -1110,15 +1110,6 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       return c.json<ApiResponse>({ ok: false, error: "Agent JWT required for trading" }, 403);
     }
 
-    const rate = await enforceOrderRateLimit(agentId);
-    if (rate.unavailable) {
-      return c.json<ApiResponse>({ ok: false, error: "Trade order rate limit unavailable" }, 503);
-    }
-    if (!rate.allowed) {
-      c.header("Retry-After", String(Math.ceil(rate.resetMs / 1000)));
-      return c.json<ApiResponse>({ ok: false, error: "Trade order rate limit exceeded" }, 429);
-    }
-
     const raw = await safeJsonParse(c);
     const parsed = submitOrderSchema.safeParse(raw);
     if (!parsed.success) {
@@ -1150,16 +1141,14 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       existingRecovery?.kind === "existing" && isPreparedTradeRecoveryStale(existingRecovery.row);
     if (existingRecovery?.kind === "existing" && !stalePreparedRecovery) {
       let recoveryRow = existingRecovery.row;
+      let recoveryClaimToken: string | undefined;
       let envelope = tradeRecoveryEnvelope(recoveryRow) as TradeIdempotencyResponse | null;
       if (
         (recoveryRow.state === "ambiguous" || recoveryRow.state === "submitting") &&
         recoveryRow.venueIdentity
       ) {
-        const storedSession = await getSessionManager().getSession({
-          tenantId,
-          id: recoveryRow.sessionId,
-        });
-        if (storedSession?.agentId === agentId && storedSession.venue === "hyperliquid") {
+        const durableWallet = recoveryRow.effectMetadata.walletAddress;
+        if (typeof durableWallet === "string" && durableWallet.length > 0) {
           const vaultClient = {
             signTypedData: (input: Omit<Parameters<typeof vault.signTypedData>[0], "tenantId">) =>
               vault.signTypedData({
@@ -1169,7 +1158,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
                 expectedWalletAddress: storedSession.walletId,
               }),
           };
-          const adapter = new HyperliquidAdapter(vaultClient, agentId, storedSession.walletId);
+          const adapter = new HyperliquidAdapter(vaultClient, agentId, durableWallet);
           try {
             const evidence = await adapter.getOrderStatus(recoveryRow.venueIdentity);
             const candidate =
@@ -1196,11 +1185,17 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
               };
               const reconciled = await checkpointReconciledTradeResult(db, {
                 id: recoveryRow.id,
+                tenantId: recoveryRow.tenantId,
+                agentId: recoveryRow.agentId,
+                venue: "hyperliquid",
+                bodyHash: recoveryRow.bodyHash,
+                venueIdentity: recoveryRow.venueIdentity,
                 venueResult: candidate ?? { order },
                 envelope: reconciledEnvelope,
               });
               if (reconciled) {
                 recoveryRow = reconciled.row;
+                recoveryClaimToken = reconciled.claimToken;
                 envelope = reconciledEnvelope;
               }
             }
@@ -1213,13 +1208,10 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       if (envelope && (recoveryRow.state === "submitted" || recoveryRow.state === "completed")) {
         await drainTradeRecoveryAudit(db, {
           row: recoveryRow,
+          currentClaimToken: recoveryClaimToken,
           writeAuditEvent,
           details: {
-            sessionId: recoveryRow.sessionId,
-            venue: "hyperliquid",
-            asset: body.coin ?? body.asset,
-            leverage: body.leverage,
-            size: body.size,
+            ...recoveryRow.effectMetadata,
             orderId: recoveryRow.venueIdentity,
           },
         });
@@ -1231,6 +1223,15 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         { ok: false, error: "Trade submission recovery is in progress" },
         409,
       );
+    }
+
+    const rate = await enforceOrderRateLimit(agentId);
+    if (rate.unavailable) {
+      return c.json<ApiResponse>({ ok: false, error: "Trade order rate limit unavailable" }, 503);
+    }
+    if (!rate.allowed) {
+      c.header("Retry-After", String(Math.ceil(rate.resetMs / 1000)));
+      return c.json<ApiResponse>({ ok: false, error: "Trade order rate limit exceeded" }, 429);
     }
 
     // A stale prepared journal proves the prior owner never crossed the
@@ -1569,6 +1570,16 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           venue: "hyperliquid",
           idempotencyKey: body.idempotencyKey!,
           bodyHash: durableBodyHash,
+          effectMetadata: {
+            sessionId: session.id,
+            venue: "hyperliquid",
+            walletAddress: session.walletId,
+            asset: parsedAsset.data,
+            leverage: effectiveLeverage,
+            size: body.size,
+            sizeUsd,
+            orderId: order.clientOrderId,
+          },
         });
         if (recovery.kind === "conflict") {
           await getSessionManager().releaseSpend({
@@ -2059,15 +2070,6 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       return c.json<ApiResponse>({ ok: false, error: "Agent JWT required for trading" }, 403);
     }
 
-    const rate = await enforcePolymarketOrderRateLimit(agentId);
-    if (rate.unavailable) {
-      return c.json<ApiResponse>({ ok: false, error: "Trade order rate limit unavailable" }, 503);
-    }
-    if (!rate.allowed) {
-      c.header("Retry-After", String(Math.ceil(rate.resetMs / 1000)));
-      return c.json<ApiResponse>({ ok: false, error: "Trade order rate limit exceeded" }, 429);
-    }
-
     const raw = await safeJsonParse(c);
     const parsed = pmSubmitOrderSchema.safeParse(raw);
     if (!parsed.success) {
@@ -2113,19 +2115,123 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             row: existingRecovery.row,
             writeAuditEvent,
             details: {
-              sessionId: existingRecovery.row.sessionId,
-              venue: "polymarket",
-              tokenId: body.tokenId,
-              conditionId: body.conditionId ?? null,
-              side: body.side,
-              amount: Number(body.amount),
-              price: Number(body.price),
+              ...existingRecovery.row.effectMetadata,
               orderId: existingRecovery.row.venueIdentity,
             },
           });
         }
         return tradeReplayResponse(c, envelope);
       }
+    }
+
+    // These are immutable request fields covered by durableBodyHash. Recovery
+    // below does not consult mutable session, policy, rate-limit, or market-book
+    // state before attempting exact venue reconciliation.
+    const amount = Number(body.amount);
+    const price = Number(body.price);
+
+    // Recovery is authorized by the immutable durable tuple, not by mutable
+    // session/policy state. An order may have landed before its session was
+    // revoked or expired; requiring that session to remain active would make
+    // exact venue evidence and its required audit permanently unreachable.
+    if (pendingPolymarketRecovery) {
+      let envelope = tradeRecoveryEnvelope(
+        pendingPolymarketRecovery,
+      ) as TradeIdempotencyResponse | null;
+      const durableWallet = pendingPolymarketRecovery.effectMetadata.walletAddress;
+      if (
+        pendingPolymarketRecovery.venueIdentity &&
+        typeof durableWallet === "string" &&
+        durableWallet.length > 0
+      ) {
+        try {
+          const recoveryCreds = await resolvePolymarketCreds(tenantId, agentId);
+          if (
+            recoveryCreds.ok &&
+            recoveryCreds.walletAddress.toLowerCase() === durableWallet.toLowerCase()
+          ) {
+            const recoverySigner = buildPolymarketVaultSigner(
+              tenantId,
+              agentId,
+              recoveryCreds.walletAddress,
+            );
+            const recoveryAdapter = new PolymarketExecutionAdapter(
+              {
+                apiCredentials: recoveryCreds.apiCredentials,
+                funderAddress: recoveryCreds.funderAddress,
+                signer: recoverySigner,
+                signatureType: recoveryCreds.signatureType,
+              },
+              {
+                builder: resolveBuilderConfig(),
+                ...(recoveryCreds.clobUrl ? { clobUrl: recoveryCreds.clobUrl } : {}),
+              },
+            );
+            const evidence = await recoveryAdapter.getOrder(
+              pendingPolymarketRecovery.venueIdentity,
+            );
+            if (evidence && typeof evidence === "object") {
+              const order = evidence as Record<string, unknown>;
+              const durableNotional = Number(pendingPolymarketRecovery.effectMetadata.notionalUsd);
+              const durablePrice = Number(pendingPolymarketRecovery.effectMetadata.price);
+              if (!Number.isFinite(durableNotional) || !Number.isFinite(durablePrice)) {
+                throw new Error("invalid durable Polymarket effect metadata");
+              }
+              const reconciledEnvelope: TradeIdempotencyResponse = {
+                status: 200,
+                body: responseData({
+                  orderId: pendingPolymarketRecovery.venueIdentity,
+                  status: String(order.status ?? "submitted"),
+                  filledQty: Number(order.size_matched ?? order.matched_size ?? 0),
+                  avgPrice: Number(order.price ?? durablePrice),
+                  notionalUsd: durableNotional,
+                }),
+              };
+              const reconciled = await checkpointReconciledTradeResult(db, {
+                id: pendingPolymarketRecovery.id,
+                tenantId: pendingPolymarketRecovery.tenantId,
+                agentId: pendingPolymarketRecovery.agentId,
+                venue: "polymarket",
+                bodyHash: pendingPolymarketRecovery.bodyHash,
+                venueIdentity: pendingPolymarketRecovery.venueIdentity,
+                venueResult: order,
+                envelope: reconciledEnvelope,
+              });
+              if (reconciled) {
+                await drainTradeRecoveryAudit(db, {
+                  row: reconciled.row,
+                  currentClaimToken: reconciled.claimToken,
+                  writeAuditEvent,
+                  details: {
+                    ...reconciled.row.effectMetadata,
+                    orderId: pendingPolymarketRecovery.venueIdentity,
+                  },
+                });
+                envelope = reconciledEnvelope;
+              }
+            }
+          }
+        } catch {
+          // Absence, credential rotation, timeout, or malformed evidence never
+          // authorizes a second POST. Preserve the durable ambiguous envelope
+          // for a later exact-evidence retry.
+        }
+      }
+      if (envelope) return tradeReplayResponse(c, envelope);
+      c.header("Retry-After", "1");
+      return c.json<ApiResponse>(
+        { ok: false, error: "Trade submission recovery is in progress" },
+        409,
+      );
+    }
+
+    const rate = await enforcePolymarketOrderRateLimit(agentId);
+    if (rate.unavailable) {
+      return c.json<ApiResponse>({ ok: false, error: "Trade order rate limit unavailable" }, 503);
+    }
+    if (!rate.allowed) {
+      c.header("Retry-After", String(Math.ceil(rate.resetMs / 1000)));
+      return c.json<ApiResponse>({ ok: false, error: "Trade order rate limit exceeded" }, 429);
     }
 
     let idempotency = await getPmIdempotency(tenantId, agentId, body.idempotencyKey, body);
@@ -2135,26 +2241,15 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         409,
       );
     }
-    if (idempotency.response && !pendingPolymarketRecovery) {
-      return tradeReplayResponse(c, idempotency.response);
-    }
-    if (idempotency.inProgress && !pendingPolymarketRecovery) {
+    if (idempotency.response) return tradeReplayResponse(c, idempotency.response);
+    if (idempotency.inProgress) {
       c.header("Retry-After", "1");
       return c.json<ApiResponse>(
         { ok: false, error: "Request with this idempotency key is in progress" },
         409,
       );
     }
-
-    // Validate price + amount as positive finite numbers up front (the policy gate
-    // needs the notional; the adapter re-validates the (0,1) price range).
-    const amount = Number(body.amount);
-    const price = Number(body.price);
-    idempotency = pendingPolymarketRecovery
-      ? {}
-      : idempotency.claim
-        ? await idempotency.claim()
-        : idempotency;
+    idempotency = idempotency.claim ? await idempotency.claim() : idempotency;
     if (idempotency.conflict) {
       return c.json<ApiResponse>(
         { ok: false, error: "Idempotency key reused with a different body" },
@@ -2185,6 +2280,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       await idempotency.store?.(envelope);
       return c.json(envelope.body, envelope.status);
     }
+
     // SEC-041: a SELL's notional must be floored at the live best bid — a FOK
     // sell at an arbitrarily low limit fills at the bid, so sizing on the
     // caller's price would understate notional and bypass the session caps.
@@ -2412,63 +2508,6 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       ...(creds.clobUrl ? { clobUrl: creds.clobUrl } : {}),
     });
 
-    if (pendingPolymarketRecovery) {
-      let envelope = tradeRecoveryEnvelope(
-        pendingPolymarketRecovery,
-      ) as TradeIdempotencyResponse | null;
-      if (pendingPolymarketRecovery.venueIdentity) {
-        try {
-          const evidence = await adapter.getOrder(pendingPolymarketRecovery.venueIdentity);
-          if (evidence && typeof evidence === "object") {
-            const order = evidence as Record<string, unknown>;
-            const reconciledEnvelope: TradeIdempotencyResponse = {
-              status: 200,
-              body: responseData({
-                orderId: pendingPolymarketRecovery.venueIdentity,
-                status: String(order.status ?? "submitted"),
-                filledQty: Number(order.size_matched ?? order.matched_size ?? 0),
-                avgPrice: Number(order.price ?? price),
-                notionalUsd,
-              }),
-            };
-            const reconciled = await checkpointReconciledTradeResult(db, {
-              id: pendingPolymarketRecovery.id,
-              venueResult: order,
-              envelope: reconciledEnvelope,
-            });
-            if (reconciled) {
-              await drainTradeRecoveryAudit(db, {
-                row: reconciled.row,
-                currentClaimToken: reconciled.claimToken,
-                writeAuditEvent,
-                details: {
-                  sessionId: reconciled.row.sessionId,
-                  venue: "polymarket",
-                  tokenId: body.tokenId,
-                  conditionId: verifiedConditionId ?? null,
-                  side: body.side,
-                  amount,
-                  price,
-                  notionalUsd,
-                  orderId: pendingPolymarketRecovery.venueIdentity,
-                },
-              });
-              envelope = reconciledEnvelope;
-            }
-          }
-        } catch {
-          // Absence, timeout, or malformed evidence never authorizes a second
-          // POST. Preserve the explicit ambiguous checkpoint for another poll.
-        }
-      }
-      if (envelope) return tradeReplayResponse(c, envelope);
-      c.header("Retry-After", "1");
-      return c.json<ApiResponse>(
-        { ok: false, error: "Trade submission recovery is in progress" },
-        409,
-      );
-    }
-
     const orderRequest: PolymarketOrderRequest = {
       tokenId: body.tokenId,
       side: body.side,
@@ -2599,6 +2638,18 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           venue: "polymarket",
           idempotencyKey: body.idempotencyKey!,
           bodyHash: durableBodyHash,
+          effectMetadata: {
+            sessionId: session.id,
+            venue: "polymarket",
+            walletAddress: creds.walletAddress,
+            tokenId: body.tokenId,
+            conditionId: verifiedConditionId ?? null,
+            side: body.side,
+            amount,
+            price,
+            notionalUsd,
+            orderId: venueIdentity,
+          },
         });
         if (recovery.kind === "conflict") {
           await getSessionManager().releaseSpend({
@@ -2821,14 +2872,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           currentClaimToken: recovery.claimToken,
           writeAuditEvent,
           details: {
-            sessionId: session.id,
-            venue: "polymarket",
-            tokenId: body.tokenId,
-            conditionId: verifiedConditionId ?? null,
-            side: body.side,
-            amount,
-            price,
-            notionalUsd,
+            ...checkpointed.effectMetadata,
             orderId: response.orderId,
           },
         });

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -1155,7 +1155,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
                 ...input,
                 tenantId,
                 venue: "hyperliquid",
-                expectedWalletAddress: storedSession.walletId,
+                expectedWalletAddress: durableWallet,
               }),
           };
           const adapter = new HyperliquidAdapter(vaultClient, agentId, durableWallet);

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -68,6 +68,7 @@ import {
   checkpointTradeSubmissionStart,
   drainTradeRecoveryAudit,
   findTradeRecovery,
+  isPreparedTradeRecoveryStale,
   refreshTradeRecovery,
   tradeRecoveryEnvelope,
   tradeRecoveryHash,
@@ -1145,7 +1146,9 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         409,
       );
     }
-    if (existingRecovery?.kind === "existing") {
+    const stalePreparedRecovery =
+      existingRecovery?.kind === "existing" && isPreparedTradeRecoveryStale(existingRecovery.row);
+    if (existingRecovery?.kind === "existing" && !stalePreparedRecovery) {
       let recoveryRow = existingRecovery.row;
       let envelope = tradeRecoveryEnvelope(recoveryRow) as TradeIdempotencyResponse | null;
       if (
@@ -1230,7 +1233,14 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       );
     }
 
-    let idempotency = await getIdempotency(tenantId, agentId, body.idempotencyKey, body);
+    // A stale prepared journal proves the prior owner never crossed the
+    // prepared -> submitting venue-I/O boundary. Let beginTradeRecovery perform
+    // the authoritative DB claim-token CAS below; the old idempotency marker is
+    // deliberately bypassed because it belongs to the crashed owner and the DB
+    // journal now supplies replay/conflict authority for this key.
+    let idempotency = stalePreparedRecovery
+      ? ({} satisfies RouteIdempotency)
+      : await getIdempotency(tenantId, agentId, body.idempotencyKey, body);
     if (idempotency.conflict) {
       return c.json<ApiResponse>(
         { ok: false, error: "Idempotency key reused with a different body" },

--- a/packages/vault/src/__tests__/signed-artifact-inspection.test.ts
+++ b/packages/vault/src/__tests__/signed-artifact-inspection.test.ts
@@ -143,6 +143,36 @@ describe("strict signed-artifact chain inspection", () => {
     status.mockRestore();
   });
 
+  it("rejects blockhash-validity responses without a canonical context slot", async () => {
+    const status = spyOn(Connection.prototype, "getSignatureStatuses").mockResolvedValue({
+      context: { slot: 1 },
+      value: [null],
+    });
+    spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const request = JSON.parse(String(init?.body)) as { method: string };
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: request.method === "getBlockHeight" ? 101 : { context: {}, value: false },
+        }),
+      );
+    });
+    try {
+      const vault = new Vault({ masterPassword: MASTER_PASSWORD, rpcUrl: "https://rpc.invalid" });
+      await expect(
+        vault.inspectSolanaSignedArtifact({
+          signature: SIGNATURE,
+          recentBlockhash: "11111111111111111111111111111111",
+          blockhashKind: "recent",
+          lastValidBlockHeight: 100,
+        }),
+      ).rejects.toThrow("Malformed Solana blockhash-validity response");
+    } finally {
+      status.mockRestore();
+    }
+  });
+
   it("retires durable-nonce evidence only after the exact authorized account advances", async () => {
     const status = spyOn(Connection.prototype, "getSignatureStatuses").mockResolvedValue({
       context: { slot: 1 },

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -3666,9 +3666,13 @@ export class Vault {
         throw new Error("Malformed Solana blockhash-validity response");
       }
       const validityRecord = validity as Record<string, unknown>;
+      const validityContext = validityRecord.context;
       if (
-        !validityRecord.context ||
-        typeof validityRecord.context !== "object" ||
+        !validityContext ||
+        typeof validityContext !== "object" ||
+        Array.isArray(validityContext) ||
+        !Number.isSafeInteger((validityContext as Record<string, unknown>).slot) ||
+        ((validityContext as Record<string, unknown>).slot as number) < 0 ||
         typeof validityRecord.value !== "boolean"
       ) {
         throw new Error("Malformed Solana blockhash-validity response");
@@ -3683,9 +3687,13 @@ export class Vault {
       throw new Error("Malformed Solana blockhash-validity response");
     }
     const validityRecord = validity as Record<string, unknown>;
+    const validityContext = validityRecord.context;
     if (
-      !validityRecord.context ||
-      typeof validityRecord.context !== "object" ||
+      !validityContext ||
+      typeof validityContext !== "object" ||
+      Array.isArray(validityContext) ||
+      !Number.isSafeInteger((validityContext as Record<string, unknown>).slot) ||
+      ((validityContext as Record<string, unknown>).slot as number) < 0 ||
       typeof validityRecord.value !== "boolean"
     ) {
       throw new Error("Malformed Solana blockhash-validity response");


### PR DESCRIPTION
## Summary
- recover and finish the post-merge durable trade journal corrective on current `develop`
- persist immutable effect metadata in appended migration 0124 so cold replicas can finish required audits without request-local authority
- process durable submitted/ambiguous recovery before mutable rate-limit, session, and Redis idempotency gates
- safely reclaim only stale `prepared` claims before any venue I/O; old claim tokens cannot checkpoint submission
- preserve the fenced Hyperliquid wallet in the recovery row and require exact venue evidence before ambiguous reconciliation
- retain one stable occurrence time and idempotently finish a committed audit after process death
- harden Solana signed-artifact response inspection and duplicate vault action anchors recovered with the same post-merge corrective

## Exact-head evidence (`92dad9317a5517ab1ea446c34d9d833e2834307d`)
- API dependency graph build: 24/24 packages
- durable recovery unit matrix: 4/4, 26 assertions
- mounted Hyperliquid fence/replay: 8/8, 64 assertions
- mounted Polymarket order/recovery: 37/37, 186 assertions
- vault signed-artifact inspection: 7/7, 13 assertions
- fresh migrated PostgreSQL + disposable real Redis, two cold worker processes: 1/1, 5 assertions
- changed-file Biome and `git diff --check`: green

## Acceptance boundary
No external venue was contacted. Merge and issue closure remain gated on independent review and the terminal protected hosted matrix. The current base also has a known lifecycle fixture regression tracked by PR #899; this branch must be restacked if #899 lands first.

Refs #765
Refs #883
Refs #657