### PR TITLE
fix(web): normalize non-JSON provider errors

### DIFF
--- a/web/e2e/provider-trust-ux-a11y.spec.ts
+++ b/web/e2e/provider-trust-ux-a11y.spec.ts
@@ -794,7 +794,7 @@ test("terminal approvals disable both decisions and errors do not enumerate priv
           ? `/dashboard/approvals/${ACTION_ID}`
           : `/dashboard/actions/${ACTION_ID}`,
       );
-      const alert = errorPage.getByRole("alert");
+      const alert = errorPage.locator("main").getByRole("alert");
       await expect(alert.getByText("Not found or not authorized")).toBeVisible();
       await expect(alert).not.toContainText(`PRIVATE_${status}`);
       renderedErrors.push((await alert.innerText()).replaceAll(/\s+/g, " ").trim());
@@ -815,7 +815,7 @@ test("non-auth provider failures preserve reachable API diagnostics", async ({ b
     caseErrorBody: { ok: false, error: "CASE_EXPORT_UNAVAILABLE" },
   });
   await page.goto(`/dashboard/actions/${ACTION_ID}`);
-  await expect(page.getByRole("alert")).toContainText("CASE_EXPORT_UNAVAILABLE");
+  await expect(page.locator("main").getByRole("alert")).toContainText("CASE_EXPORT_UNAVAILABLE");
 
   const approvalContext = await browser.newContext();
   const approvalPage = await approvalContext.newPage();

--- a/web/src/lib/provider-actions.test.ts
+++ b/web/src/lib/provider-actions.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { decideApproval, getCase, ProviderActionError } from "./provider-actions";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function respond(body: string, status: number, contentType = "text/plain"): void {
+  const mockedFetch = async () =>
+    new Response(body, { status, headers: { "Content-Type": contentType } });
+  globalThis.fetch = Object.assign(mockedFetch, { preconnect: originalFetch.preconnect });
+}
+
+describe("provider action response normalization", () => {
+  for (const status of [403, 404]) {
+    test(`collapses non-JSON ${status} without exposing parser diagnostics`, async () => {
+      respond("<html>private upstream response</html>", status, "text/html");
+
+      await expect(getCase("action", "token", "tenant")).rejects.toEqual(
+        expect.objectContaining({
+          name: "ProviderActionError",
+          code: "not found / not authorized",
+          httpStatus: status,
+        }),
+      );
+    });
+  }
+
+  test("preserves HTTP status when a server error body is HTML", async () => {
+    respond("<html>gateway failure</html>", 502, "text/html");
+
+    await expect(getCase("action", "token", "tenant")).rejects.toEqual(
+      expect.objectContaining({ code: "HTTP 502", httpStatus: 502 }),
+    );
+  });
+
+  test("preserves a structured API error code", async () => {
+    respond(JSON.stringify({ ok: false, error: { code: "APPROVAL_FIELD_INVALID" } }), 400);
+
+    await expect(
+      decideApproval(
+        "action",
+        {
+          decision: "approve",
+          reason: "reviewed",
+          expectedVersion: 1,
+          expectedRequestHash: "sha256:request",
+          expectedActionDigest: "sha256:action",
+        },
+        "token",
+        "tenant",
+      ),
+    ).rejects.toEqual(expect.objectContaining({ code: "APPROVAL_FIELD_INVALID", httpStatus: 400 }));
+  });
+
+  test("normalizes malformed successful responses", async () => {
+    respond("not-json", 200);
+
+    await expect(getCase("action", "token", "tenant")).rejects.toEqual(
+      new ProviderActionError("invalid JSON response", 200),
+    );
+  });
+});

--- a/web/src/lib/provider-actions.ts
+++ b/web/src/lib/provider-actions.ts
@@ -64,25 +64,39 @@ function authHeaders(token: string | null, tenantId: string | null): HeadersInit
 
 async function readJsonOrThrow(res: Response): Promise<unknown> {
   const text = await res.text();
-  const parsed = text ? JSON.parse(text) : null;
   if (!res.ok) {
     // Non-enumerating 404/403 surfaces as a uniform "not found / not authorized"
     // (SCOPE_RESOURCE_NOT_FOUND and CASE_NOT_FOUND both collapse here, §7.3).
     let code = `HTTP ${res.status}`;
     if (res.status === 403 || res.status === 404) {
       code = "not found / not authorized";
-    } else if (parsed && typeof parsed === "object" && "error" in parsed) {
-      const error = (parsed as { error?: unknown }).error;
-      if (error && typeof error === "object" && "code" in error) {
-        const nestedCode = (error as { code?: unknown }).code;
-        if (typeof nestedCode === "string" && nestedCode.length > 0) code = nestedCode;
-      } else if (typeof error === "string" && error.length > 0) {
-        code = error;
+    } else {
+      let parsed: unknown = null;
+      try {
+        parsed = text ? JSON.parse(text) : null;
+      } catch {
+        // Proxies and upstreams commonly return HTML/text for failures. The
+        // HTTP status remains authoritative; malformed error bodies must not
+        // bypass normalization with a raw SyntaxError.
+      }
+      if (parsed && typeof parsed === "object" && "error" in parsed) {
+        const error = (parsed as { error?: unknown }).error;
+        if (error && typeof error === "object" && "code" in error) {
+          const nestedCode = (error as { code?: unknown }).code;
+          if (typeof nestedCode === "string" && nestedCode.length > 0) code = nestedCode;
+        } else if (typeof error === "string" && error.length > 0) {
+          code = error;
+        }
       }
     }
     throw new ProviderActionError(code, res.status);
   }
-  return parsed;
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new ProviderActionError("invalid JSON response", res.status);
+  }
 }
 
 export class ProviderActionError extends Error {


### PR DESCRIPTION
## Summary

- preserve uniform 403/404 provider error handling even when an upstream returns HTML or text
- preserve structured API diagnostics for other failures and convert malformed success bodies into typed provider errors
- keep the production browser assertions scoped to the page alert after the source-string suite was retired

## Exact-head verification

Head: 37bc3360477b337973b5f925568a3ae3df84e6d5

- bun test web/src/lib/provider-actions.test.ts: 5 passed
- bun run typecheck: 36 package builds plus web TypeScript passed
- bun run --cwd web e2e:trust-ux: production Next build plus 15 Chromium tests passed
- Biome on changed files: clean
- git diff --check: clean

Refs #757