### PR TITLE
fix(readiness): bound Redis probes atomically

### DIFF
--- a/packages/api/src/__tests__/capability-rate-limit-readiness.test.ts
+++ b/packages/api/src/__tests__/capability-rate-limit-readiness.test.ts
@@ -21,17 +21,15 @@ describe("capability rate-limit Redis readiness", () => {
       else process.env.NODE_ENV = priorNodeEnvironment;
     }
   });
-  it("executes a bounded physical-generation reservation and cleans it up", async () => {
+
+  it("executes and cleans an isolated physical-generation reservation atomically", async () => {
     const evaluatedKeys: string[] = [];
-    const deletedKeys: string[] = [];
+    const scripts: string[] = [];
     const client = {
-      async eval(_script: string, _keyCount: number, ...args: Array<string | number>) {
+      async eval(script: string, _keyCount: number, ...args: Array<string | number>) {
+        scripts.push(script);
         evaluatedKeys.push(String(args[0]));
         return [1, 1, "1000000", 1_000_000, 1_000];
-      },
-      async del(...keys: string[]) {
-        deletedKeys.push(...keys);
-        return keys.length;
       },
     } as unknown as IoredisLike;
 
@@ -44,18 +42,13 @@ describe("capability rate-limit Redis readiness", () => {
 
     expect(evaluatedKeys).toHaveLength(1);
     expect(evaluatedKeys[0]).toMatch(/^ratelimit:capability-readiness:[^:]+:policy:1000:1$/);
-    expect(deletedKeys).toEqual(evaluatedKeys);
+    expect(scripts[0]).toContain("redis.call('DEL', KEYS[1])");
   });
 
   it("reports not-ready when a stale cached client cannot execute the probe", async () => {
-    const deletedKeys: string[] = [];
     const staleClient = {
       async eval() {
         throw new Error("connection closed");
-      },
-      async del(...keys: string[]) {
-        deletedKeys.push(...keys);
-        return keys.length;
       },
     } as unknown as IoredisLike;
 
@@ -69,28 +62,27 @@ describe("capability rate-limit Redis readiness", () => {
       source: "redis",
       error: "Configured Redis capability rate-limit backend exercise failed",
     });
-    expect(deletedKeys).toHaveLength(1);
-    expect(deletedKeys[0]).toEndWith(":policy:1000:1");
   });
 
-  it("bounds a stalled cached client and still attempts isolated-key cleanup", async () => {
-    const deletedKeys: string[] = [];
+  it("bounds and single-flights a stalled cached client", async () => {
+    let evalCalls = 0;
     const stalledClient = {
       async eval() {
+        evalCalls += 1;
         return await new Promise<never>(() => undefined);
-      },
-      async del(...keys: string[]) {
-        deletedKeys.push(...keys);
-        return keys.length;
       },
     } as unknown as IoredisLike;
 
     const startedAt = performance.now();
-    const result = await checkCapabilityRateLimitReadiness({
+    const options = {
       getRedisClient: () => stalledClient,
       isRedisConfigured: () => true,
       redisProbeTimeoutMs: 10,
-    });
+    };
+    const [result, repeated] = await Promise.all([
+      checkCapabilityRateLimitReadiness(options),
+      checkCapabilityRateLimitReadiness(options),
+    ]);
 
     expect(performance.now() - startedAt).toBeLessThan(500);
     expect(result).toEqual({
@@ -98,7 +90,37 @@ describe("capability rate-limit Redis readiness", () => {
       source: "redis",
       error: "Configured Redis capability rate-limit backend exercise failed",
     });
-    expect(deletedKeys).toHaveLength(1);
-    expect(deletedKeys[0]).toEndWith(":policy:1000:1");
+    expect(repeated).toEqual(result);
+    expect(evalCalls).toBe(1);
+  });
+
+  it("cannot recreate a probe bucket after a caller deadline", async () => {
+    let release: ((value: unknown) => void) | undefined;
+    let script = "";
+    const keys = new Set<string>();
+    const client = {
+      async eval(source: string, _keyCount: number, key: string) {
+        script = source;
+        await new Promise<unknown>((resolve) => {
+          release = resolve;
+        });
+        // Model the atomic script's externally visible effect: its temporary
+        // write and delete commit together, so no bucket can survive late EVAL.
+        keys.add(key);
+        if (source.includes("redis.call('DEL', KEYS[1])")) keys.delete(key);
+        return [1, 1, "1000000", 1_000_000, 1_000];
+      },
+    } as unknown as IoredisLike;
+
+    const result = await checkCapabilityRateLimitReadiness({
+      getRedisClient: () => client,
+      isRedisConfigured: () => true,
+      redisProbeTimeoutMs: 10,
+    });
+    expect(result.ok).toBe(false);
+    expect(script).toContain("redis.call('DEL', KEYS[1])");
+    release?.(undefined);
+    await Bun.sleep(0);
+    expect(keys.size).toBe(0);
   });
 });

--- a/packages/api/src/__tests__/redis-connection-readiness.test.ts
+++ b/packages/api/src/__tests__/redis-connection-readiness.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import type { IoredisLike } from "@stwd/redis";
+import { checkRedisConnectionReadiness } from "../middleware/redis";
+
+describe("Redis connection readiness", () => {
+  it("bounds a stalled ping, discards the stale client, and single-flights the ping", async () => {
+    let pingCalls = 0;
+    let discardCalls = 0;
+    let refreshCalls = 0;
+    const client = {
+      async ping() {
+        pingCalls += 1;
+        return await new Promise<string>(() => undefined);
+      },
+    } as unknown as IoredisLike;
+    const options = {
+      timeoutMs: 10,
+      getClient: () => client,
+      discardClient: () => {
+        discardCalls += 1;
+      },
+      refreshClient: async () => {
+        refreshCalls += 1;
+        return false;
+      },
+    };
+
+    const startedAt = performance.now();
+    const results = await Promise.all([
+      checkRedisConnectionReadiness(options),
+      checkRedisConnectionReadiness(options),
+    ]);
+
+    expect(performance.now() - startedAt).toBeLessThan(500);
+    expect(results).toEqual([false, false]);
+    expect(pingCalls).toBe(1);
+    expect(discardCalls).toBe(2);
+    expect(refreshCalls).toBe(2);
+  });
+
+  it("bounds and shares a replacement initialization supplied by middleware", async () => {
+    let refreshCalls = 0;
+    const refresh = async () => {
+      refreshCalls += 1;
+      return await new Promise<boolean>(() => undefined);
+    };
+    const startedAt = performance.now();
+    const results = await Promise.all([
+      checkRedisConnectionReadiness({
+        timeoutMs: 10,
+        getClient: () => null,
+        refreshClient: refresh,
+      }),
+      checkRedisConnectionReadiness({
+        timeoutMs: 10,
+        getClient: () => null,
+        refreshClient: refresh,
+      }),
+    ]);
+
+    expect(performance.now() - startedAt).toBeLessThan(500);
+    expect(results).toEqual([false, false]);
+    // Production's initRedis owns the replacement single-flight. This injected
+    // seam intentionally does not invent sharing outside that authority.
+    expect(refreshCalls).toBe(2);
+  });
+
+  it("accepts a healthy client without replacement", async () => {
+    let refreshCalls = 0;
+    const client = { ping: async () => "PONG" } as unknown as IoredisLike;
+    await expect(
+      checkRedisConnectionReadiness({
+        getClient: () => client,
+        refreshClient: async () => {
+          refreshCalls += 1;
+          return false;
+        },
+      }),
+    ).resolves.toBe(true);
+    expect(refreshCalls).toBe(0);
+  });
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -19,6 +19,7 @@ import { redactedThrownDiagnostics } from "@stwd/shared";
 import { composeApp, getComposedPluginMigrationSources } from "./compose";
 import { globalRateLimitRequiresRedis } from "./middleware/global-rate-limit";
 import {
+  checkRedisConnectionReadiness,
   getRedisClient,
   initRedis,
   isRedisConfigured,
@@ -167,7 +168,7 @@ app.get(
       try {
         const redis = getRedisClient();
         return redis
-          ? { ok: (await redis.ping()).toUpperCase() === "PONG" }
+          ? { ok: await checkRedisConnectionReadiness() }
           : isRedisConfigured()
             ? redisRequired
               ? { ok: false, error: "Redis is configured but not connected" }

--- a/packages/api/src/middleware/redis.ts
+++ b/packages/api/src/middleware/redis.ts
@@ -37,7 +37,9 @@ type RedisBinding = Readonly<{
 
 const redisClients = new Map<string, IoredisLike>();
 const redisInitializations = new Map<string, Promise<boolean>>();
+const redisPingFlights = new WeakMap<IoredisLike, Promise<boolean>>();
 const MAX_REDIS_BINDING_GENERATIONS = 8;
+const REDIS_READINESS_TIMEOUT_MS = 1_000;
 const MAX_MEMORY_ADAPTER_BUCKETS = 1_000;
 const MAX_MEMORY_ADAPTER_RESERVATIONS_PER_BUCKET = 1_000;
 type MemoryAdapterBucket = { units: number; markers: Map<string, string> };
@@ -221,6 +223,87 @@ export function isRedisConfigured(): boolean {
 export function getRedisClient(): IoredisLike | null {
   const binding = redisBinding();
   return binding ? (redisClients.get(redisBindingKey(binding)) ?? null) : null;
+}
+
+interface RedisConnectionReadinessOptions {
+  timeoutMs?: number;
+  getClient?: () => IoredisLike | null;
+  discardClient?: (client: IoredisLike) => void;
+  refreshClient?: () => Promise<boolean>;
+}
+
+async function withinRedisReadinessDeadline<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error("Redis readiness timed out")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function pingRedisClient(client: IoredisLike): Promise<boolean> {
+  const pending = redisPingFlights.get(client);
+  if (pending) return pending;
+  const operation = client.ping().then((reply) => reply.toUpperCase() === "PONG");
+  redisPingFlights.set(client, operation);
+  const clearFlight = () => {
+    if (redisPingFlights.get(client) === operation) redisPingFlights.delete(client);
+  };
+  void operation.then(clearFlight, clearFlight);
+  return operation;
+}
+
+function discardCurrentRedisClient(client: IoredisLike): void {
+  const binding = redisBinding();
+  if (!binding) return;
+  const key = redisBindingKey(binding);
+  if (redisClients.get(key) !== client) return;
+  redisClients.delete(key);
+  if ("quit" in client && typeof client.quit === "function") {
+    void client.quit().catch(() => undefined);
+  }
+}
+
+/** Bound Redis health I/O and replace a stale cached client through the same
+ * single-flight initialization path used at startup. A timed-out PING remains
+ * in one WeakMap flight until it settles, and the replacement initialization
+ * is likewise shared, so repeated public readiness probes cannot accumulate
+ * unbounded socket work. */
+export async function checkRedisConnectionReadiness(
+  options: RedisConnectionReadinessOptions = {},
+): Promise<boolean> {
+  const timeoutMs = options.timeoutMs ?? REDIS_READINESS_TIMEOUT_MS;
+  const getClient = options.getClient ?? getRedisClient;
+  const refreshClient = options.refreshClient ?? (() => initRedis());
+  const client = getClient();
+  if (!client) {
+    try {
+      return await withinRedisReadinessDeadline(refreshClient(), timeoutMs);
+    } catch {
+      return false;
+    }
+  }
+
+  try {
+    if (await withinRedisReadinessDeadline(pingRedisClient(client), timeoutMs)) return true;
+  } catch {
+    // A configured but stalled client is not a usable readiness authority.
+  }
+
+  (options.discardClient ?? discardCurrentRedisClient)(client);
+  try {
+    return await withinRedisReadinessDeadline(refreshClient(), timeoutMs);
+  } catch {
+    return false;
+  }
 }
 
 // Package helpers that have not yet grown an explicit client parameter must

--- a/packages/api/src/services/capability-rate-limit-readiness.ts
+++ b/packages/api/src/services/capability-rate-limit-readiness.ts
@@ -1,5 +1,5 @@
 import { getDb } from "@stwd/db";
-import { checkRateLimit, type IoredisLike, rateLimitBucketKey } from "@stwd/redis";
+import { exerciseRateLimitReadiness, type IoredisLike } from "@stwd/redis";
 import { redactedThrownDiagnostics } from "@stwd/shared";
 import { runtimeEnvironmentValue } from "@stwd/shared/runtime-env";
 import { sql } from "drizzle-orm";
@@ -16,6 +16,8 @@ const READINESS_TENANT_ID = "steward-capability-rate-readiness";
 const REDIS_PROBE_WINDOW_MS = 1_000;
 const REDIS_PROBE_MAX_REQUESTS = 1;
 const REDIS_PROBE_TIMEOUT_MS = 1_000;
+
+const redisProbeFlights = new WeakMap<IoredisLike, Promise<void>>();
 
 interface CapabilityRateLimitReadinessOptions {
   getRedisClient?: () => IoredisLike | null;
@@ -40,6 +42,28 @@ async function withinRedisProbeDeadline<T>(operation: Promise<T>, timeoutMs: num
   }
 }
 
+function exerciseRedisCapabilityBackend(client: IoredisLike): Promise<void> {
+  const pending = redisProbeFlights.get(client);
+  if (pending) return pending;
+
+  const logicalKey = `ratelimit:capability-readiness:${crypto.randomUUID()}`;
+  const operation = (async () => {
+    const result = await exerciseRateLimitReadiness(
+      logicalKey,
+      REDIS_PROBE_WINDOW_MS,
+      REDIS_PROBE_MAX_REQUESTS,
+      client,
+    );
+    if (!result.allowed) throw new Error("capability Redis readiness reservation denied");
+  })();
+  redisProbeFlights.set(client, operation);
+  const clearFlight = () => {
+    if (redisProbeFlights.get(client) === operation) redisProbeFlights.delete(client);
+  };
+  void operation.then(clearFlight, clearFlight);
+  return operation;
+}
+
 function resultRows<T>(result: unknown): T[] {
   return (Array.isArray(result) ? result : ((result as { rows?: T[] } | null)?.rows ?? [])) as T[];
 }
@@ -55,38 +79,21 @@ export async function checkCapabilityRateLimitReadiness(
 ): Promise<CapabilityRateLimitReadiness> {
   const redisClient = (options.getRedisClient ?? getRedisClient)();
   if (redisClient) {
-    const logicalKey = `ratelimit:capability-readiness:${crypto.randomUUID()}`;
-    const physicalKey = rateLimitBucketKey(
-      logicalKey,
-      REDIS_PROBE_WINDOW_MS,
-      REDIS_PROBE_MAX_REQUESTS,
-    );
     const timeoutMs = options.redisProbeTimeoutMs ?? REDIS_PROBE_TIMEOUT_MS;
-    let probeError: unknown;
     try {
-      const result = await withinRedisProbeDeadline(
-        checkRateLimit(logicalKey, REDIS_PROBE_WINDOW_MS, REDIS_PROBE_MAX_REQUESTS, redisClient),
-        timeoutMs,
+      await withinRedisProbeDeadline(exerciseRedisCapabilityBackend(redisClient), timeoutMs);
+      return { ok: true, source: "redis" };
+    } catch (error) {
+      console.error(
+        "[steward:readiness] capability rate-limit Redis exercise failed",
+        redactedThrownDiagnostics(error),
       );
-      if (!result.allowed) throw new Error("capability Redis readiness reservation denied");
-    } catch (error) {
-      probeError = error;
+      return {
+        ok: false,
+        source: "redis",
+        error: "Configured Redis capability rate-limit backend exercise failed",
+      };
     }
-    try {
-      await withinRedisProbeDeadline(redisClient.del(physicalKey), timeoutMs);
-    } catch (error) {
-      probeError ??= error;
-    }
-    if (!probeError) return { ok: true, source: "redis" };
-    console.error(
-      "[steward:readiness] capability rate-limit Redis exercise failed",
-      redactedThrownDiagnostics(probeError),
-    );
-    return {
-      ok: false,
-      source: "redis",
-      error: "Configured Redis capability rate-limit backend exercise failed",
-    };
   }
   if ((options.isRedisConfigured ?? isRedisConfigured)()) {
     return {

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -54,6 +54,7 @@ export {
 } from "./policy-cache.js";
 export {
   checkRateLimit,
+  exerciseRateLimitReadiness,
   getRateLimitStatus,
   type RateLimitResult,
   rateLimitBucketKey,

--- a/packages/redis/src/rate-limiter.ts
+++ b/packages/redis/src/rate-limiter.ts
@@ -18,6 +18,8 @@ import { getRedis } from "./client.js";
 // TIME is the authority for every replica: an application host with a skewed
 // clock cannot expire another replica's still-live reservations.
 const RATE_LIMIT_LUA = `
+local cleanup = ARGV[5] == '1'
+local ok, result = pcall(function()
 local redisTime = redis.call('TIME')
 local now = (tonumber(redisTime[1]) * 1000) + math.floor(tonumber(redisTime[2]) / 1000)
 local windowMs = tonumber(ARGV[1])
@@ -36,6 +38,10 @@ local oldestScore = now
 if oldest[2] ~= nil then oldestScore = oldest[2] end
 local resetMs = math.max(0, tonumber(oldestScore) + windowMs - now)
 return {allowed, count, oldestScore, now, resetMs}
+end)
+if cleanup then redis.call('DEL', KEYS[1]) end
+if not ok then return redis.error_reply(tostring(result)) end
+return result
 `;
 
 const RATE_LIMIT_STATUS_LUA = `
@@ -104,8 +110,30 @@ export async function checkRateLimit(
   maxRequests: number,
   client?: ReturnType<typeof getRedis>,
 ): Promise<RateLimitResult> {
+  return executeRateLimit(key, windowMs, maxRequests, client ?? getRedis(), false);
+}
+
+/** Exercise the exact production rate-limit script but atomically remove the
+ * isolated bucket before EVAL returns. This is safe under caller deadlines:
+ * Redis may finish the script late, but it cannot publish a lingering probe
+ * reservation after the timeout path has completed. */
+export async function exerciseRateLimitReadiness(
+  key: string,
+  windowMs: number,
+  maxRequests: number,
+  client: ReturnType<typeof getRedis>,
+): Promise<RateLimitResult> {
+  return executeRateLimit(key, windowMs, maxRequests, client, true);
+}
+
+async function executeRateLimit(
+  key: string,
+  windowMs: number,
+  maxRequests: number,
+  redis: ReturnType<typeof getRedis>,
+  cleanup: boolean,
+): Promise<RateLimitResult> {
   validateRateLimitInput(key, windowMs, maxRequests);
-  const redis = client ?? getRedis();
 
   // Redis supplies the timestamp inside the script. The UUID only distinguishes
   // concurrent reservations that share the same server millisecond.
@@ -119,6 +147,7 @@ export async function checkRateLimit(
     String(maxRequests),
     member,
     String(windowMs + 1000), // TTL = window + 1s buffer
+    cleanup ? "1" : "0",
   )) as [number, number, string, number, number];
   const [allowed, count, _oldestScore, _serverNow, resetMs] = res;
 


### PR DESCRIPTION
## Summary

- make capability-rate-limit readiness use the production Lua path with atomic cleanup, so a late EVAL cannot recreate a timed-out probe bucket
- bound and single-flight cached Redis PING work, discard stale clients, and refresh through the existing initialization authority
- add focused deadline, stale-client, and cleanup regressions for the remaining #761 post-merge readiness gaps

## Exact-head verification

Head: c3d1e6838e48fbb05025a46daed9ee00b616c05f

- bun run typecheck: 36 dependency-ordered package builds plus web TypeScript passed
- focused readiness/rate-limiter tests: 11 passed, 5 real-Redis cases gated
- isolated real Redis: 8/8 rate-limiter Lua tests passed
- direct readiness Lua exercise: allowed and leakedKeys 0
- Biome on changed files and git diff --check: clean

Refs #761