### PR TITLE
test(web): prove exact middleware runtime handlers

### DIFF
--- a/web/e2e/middleware-runtime.spec.ts
+++ b/web/e2e/middleware-runtime.spec.ts
@@ -1,3 +1,6 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 
 const COOP = "same-origin-allow-popups";
@@ -25,25 +28,36 @@ function executableScriptNonces(html: string): Array<string | undefined> {
     .map(([, attributes]) => attributes.match(/\bnonce=["']([^"']+)["']/i)?.[1]);
 }
 
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
 test("production server applies middleware only to intended HTML routes", async ({ request }) => {
   for (const path of ["/api-keys", "/dashboard", "/login"]) {
     const response = await request.get(path, {
       headers: { "content-security-policy": "default-src *", "x-nonce": "attacker-controlled" },
     });
     expect(response.status(), path).toBe(200);
+    expect(new URL(response.url()).pathname, `${path} final route`).toBe(path);
+    expect(response.headers()["content-type"], path).toContain("text/html");
     const csp = response.headers()["content-security-policy"];
     expect(csp, path).toContain("nonce-");
     expect(csp, path).not.toContain("attacker-controlled");
     expect(values(response.headersArray(), "cross-origin-opener-policy"), path).toEqual([COOP]);
     expect(values(response.headersArray(), "cross-origin-resource-policy"), path).toEqual([CORP]);
     const nonce = nonceFromCsp(csp);
-    const scriptNonces = executableScriptNonces(await response.text());
+    const html = await response.text();
+    expect(html, `${path} route chunk`).toContain(`/_next/static/chunks/app${path}/page-`);
+    if (path === "/api-keys") expect(html, `${path} page sentinel`).toContain("API keys");
+    const scriptNonces = executableScriptNonces(html);
     expect(scriptNonces.length, `${path} executable Next scripts`).toBeGreaterThan(0);
     expect(new Set(scriptNonces), `${path} rendered script nonces`).toEqual(new Set([nonce]));
   }
 
   const api = await request.post("/api/auth/session", { data: {} });
   expect(api.status()).toBe(403);
+  expect(api.headers()["content-type"]).toBe("application/json");
+  expect(await api.json()).toEqual({ ok: false, error: "Forbidden" });
   expect(api.headers()["content-security-policy"]).toBeUndefined();
   expect(values(api.headersArray(), "cross-origin-opener-policy")).toEqual([COOP]);
   expect(values(api.headersArray(), "cross-origin-resource-policy")).toEqual([CORP]);
@@ -57,15 +71,44 @@ test("production static/image/favicon paths have exact non-conflicting isolation
   const staticAsset = html.match(/(?:src|href)="([^"]*\/_next\/static\/[^"]+)"/)?.[1];
   expect(staticAsset).toBeTruthy();
 
-  const paths = [
-    staticAsset!,
-    "/favicon.ico",
-    "/icon-192.png",
-    "/_next/image?url=%2Flogo.png&w=64&q=75",
+  const staticPath = new URL(staticAsset!, "http://steward.invalid").pathname;
+  const cases = [
+    {
+      path: staticAsset!,
+      contentType: staticPath.endsWith(".css")
+        ? "text/css; charset=UTF-8"
+        : "application/javascript; charset=UTF-8",
+      sourcePath: join(process.cwd(), ".next", staticPath.replace(/^\/_next\//, "")),
+    },
+    {
+      path: "/favicon.ico",
+      contentType: "image/x-icon",
+      sourcePath: join(process.cwd(), "public", "favicon.ico"),
+    },
+    {
+      path: "/icon-192.png",
+      contentType: "image/png",
+      sourcePath: join(process.cwd(), "public", "icon-192.png"),
+    },
+    {
+      path: "/_next/image?url=%2Flogo.png&w=64&q=75",
+      contentType: "image/png",
+      sourcePath: null,
+    },
   ];
-  for (const path of paths) {
+  for (const { path, contentType, sourcePath } of cases) {
     const response = await request.get(path);
-    expect(response.status(), path).toBeLessThan(500);
+    expect(response.status(), path).toBe(200);
+    expect(response.headers()["content-type"], path).toBe(contentType);
+    const body = await response.body();
+    expect(body.byteLength, `${path} response bytes`).toBeGreaterThan(0);
+    if (sourcePath) {
+      expect(sha256(body), `${path} exact source bytes`).toBe(sha256(readFileSync(sourcePath)));
+    } else {
+      expect(body.subarray(0, 8).toString("hex"), `${path} PNG signature`).toBe("89504e470d0a1a0a");
+      expect(body.readUInt32BE(16), `${path} optimized width`).toBe(64);
+      expect(body.readUInt32BE(20), `${path} optimized height`).toBe(64);
+    }
     const csp = response.headers()["content-security-policy"];
     if (path.startsWith("/_next/image")) {
       // Next's image optimizer adds its own fixed sandbox CSP. It must not be


### PR DESCRIPTION
## Summary

- bind middleware tests to exact final routes, HTML page chunks, and API JSON behavior rather than permissive status checks
- compare static asset responses byte-for-byte with the built artifacts and validate optimized PNG dimensions
- preserve exact CSP nonce, COOP, and CORP behavior on the real production Next server

## Stack

This is intentionally stacked on #904 because the shared trust-UX suite needs its duplicate route-announcer alert selector correction. The only delta in this PR is the middleware runtime test.

## Exact-head verification

Head: 1c5cf34ced0826e9e13b1558e379e5df930ed5a8

- production Next build passed
- bun run --cwd web e2e:trust-ux: 15/15 Chromium tests passed
- Biome and git diff --check: clean

Refs #758