### PR TITLE
fix(auth): bind SAML replay ID to signed assertion

### DIFF
--- a/packages/auth/src/__tests__/saml.test.ts
+++ b/packages/auth/src/__tests__/saml.test.ts
@@ -80,6 +80,7 @@ interface SamlFixtureOptions {
   assertionId?: string;
   signatureAlgorithm?: "sha1" | "sha256";
   digestAlgorithm?: "sha1" | "sha256";
+  profileIdAttribute?: string;
   unsignedResponseAttributes?: string;
 }
 
@@ -103,7 +104,9 @@ function signedSamlResponse(options: SamlFixtureOptions = {}): string {
     `<saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef></saml:AuthnContext>`,
     `</saml:AuthnStatement>`,
     `<saml:AttributeStatement>`,
-    `<saml:Attribute Name="ID"><saml:AttributeValue>${options.assertionId ?? ASSERTION_ID}</saml:AttributeValue></saml:Attribute>`,
+    options.profileIdAttribute
+      ? `<saml:Attribute Name="ID"><saml:AttributeValue>${options.profileIdAttribute}</saml:AttributeValue></saml:Attribute>`
+      : "",
     `<saml:Attribute Name="email"><saml:AttributeValue>${USER_EMAIL}</saml:AttributeValue></saml:Attribute>`,
     `<saml:Attribute Name="mail"><saml:AttributeValue>fallback@example.test</saml:AttributeValue></saml:Attribute>`,
     `<saml:Attribute Name="groups"><saml:AttributeValue>engineering</saml:AttributeValue><saml:AttributeValue>security</saml:AttributeValue></saml:Attribute>`,
@@ -223,6 +226,22 @@ describe("SAML ACS verifier hardening", () => {
     await expect(
       verifySamlAcsResponse(verifierInput(signedSamlResponse({ assertionId: "" }))),
     ).rejects.toThrow();
+  });
+
+  it("uses the signed assertion XML ID instead of a conflicting profile attribute", async () => {
+    const assertion = await verifySamlAcsResponse(
+      verifierInput(
+        signedSamlResponse({
+          assertionId: "_signed-assertion-id",
+          profileIdAttribute: "_fabricated-profile-id",
+        }),
+      ),
+    );
+
+    expect(assertion.assertionId).toBe("_signed-assertion-id");
+    expect(assertion.attributes).toMatchObject({
+      attributes: { ID: "_fabricated-profile-id" },
+    });
   });
 
   it("returns only the validated signed profile when unsigned raw attributes disagree", async () => {

--- a/packages/auth/src/saml.ts
+++ b/packages/auth/src/saml.ts
@@ -137,7 +137,7 @@ function requireSha256XmlSignatures(document: Document): void {
 async function assertValidatedTrustPins(
   profile: Record<string, unknown>,
   input: VerifySamlAcsInput,
-): Promise<void> {
+): Promise<string> {
   const getAssertionXml = profile.getAssertionXml;
   const getSamlResponseXml = profile.getSamlResponseXml;
   if (typeof getAssertionXml !== "function" || typeof getSamlResponseXml !== "function") {
@@ -148,6 +148,15 @@ async function assertValidatedTrustPins(
   // mandatory above. Attribute values still come exclusively from `profile`.
   const assertionDocument = await parseDomFromString(String(getAssertionXml()));
   const responseDocument = await parseDomFromString(String(getSamlResponseXml()));
+
+  const assertionIds = xpath.selectAttributes(
+    assertionDocument,
+    "/*[local-name(.)='Assertion']/@ID",
+  );
+  const assertionId = assertionIds[0]?.value.trim() ?? "";
+  if (assertionIds.length !== 1 || !assertionId) {
+    throw new Error("SAML assertion ID is required for replay protection");
+  }
 
   if (responseDocument.documentElement.getAttribute("Destination") !== input.acsUrl) {
     throw new Error("SAML response destination is not the configured ACS URL");
@@ -175,6 +184,7 @@ async function assertValidatedTrustPins(
   }
   requireSha256XmlSignatures(assertionDocument);
   requireSha256XmlSignatures(responseDocument);
+  return assertionId;
 }
 
 export async function verifySamlAcsResponse(
@@ -214,9 +224,7 @@ export async function verifySamlAcsResponse(
   }
 
   const profile = result.profile as Record<string, unknown>;
-  await assertValidatedTrustPins(profile, input);
-  const assertionId = firstString(profile.ID);
-  if (!assertionId) throw new Error("SAML assertion ID is required for replay protection");
+  const assertionId = await assertValidatedTrustPins(profile, input);
 
   const emailAttribute = input.emailAttribute || "email";
   const email = firstString(profile[emailAttribute]);


### PR DESCRIPTION
## Summary

- derive the replay identifier from the root ID attribute of node-saml cryptographically validated assertion XML
- stop treating a profile attribute named ID as the assertion authority
- remove the fixture-created ID attribute and add an adversarial signed fixture whose profile ID conflicts with the real assertion ID

## Exact-head verification

Head: 25b7e94f382df9bd7aa21a42cee3df3dc3b70da8

- focused signed SAML suite: 17/17 passed
- full auth suite: 362 passed, 12 environment-gated skipped, 0 failed
- auth build: passed
- repository typecheck: 36/36 package builds plus web TypeScript passed
- Biome and git diff --check: clean

Refs #759