### PR TITLE
fix(react): fence linked-account refresh on sign-out

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `@stwd/react` are documented here.
 
 ### Fixed
 - `StewardLogin` no longer emits the `webauthn` autocomplete token on the email input, so browser passkey conditional-mediation autofill cannot hijack a brand-new-email signup. Explicit passkey button flow is unchanged.
+- `StewardLinkedAccounts` now invalidates in-flight account reads when the authentication epoch changes, preventing a response started before sign-out from publishing stale account state or callbacks.
 
 ### Changed
 - Approval confirmations now keep failed mutations actionable while preventing a delayed result from closing or contaminating a newer confirmation.

--- a/packages/react/src/__tests__/StewardLinkedAccounts.test.tsx
+++ b/packages/react/src/__tests__/StewardLinkedAccounts.test.tsx
@@ -111,6 +111,22 @@ async function mount(props: Record<string, unknown> = {}) {
   );
 }
 
+async function rerender(props: Record<string, unknown> = {}) {
+  await React.act(async () =>
+    root?.render(
+      React.createElement(
+        StewardProvider,
+        { client: client as any },
+        React.createElement(
+          StewardAuthContext.Provider,
+          { value: authContext() as any },
+          React.createElement(StewardLinkedAccounts, props),
+        ),
+      ),
+    ),
+  );
+}
+
 function button(label: string): HTMLButtonElement {
   const result = [...container.querySelectorAll("button")].find(
     (candidate) => candidate.textContent?.trim() === label,
@@ -298,5 +314,32 @@ describe("<StewardLinkedAccounts /> mounted interactions", () => {
     });
     expect(container.textContent).toContain("new-result");
     expect(container.textContent).not.toContain("stale-result");
+  });
+
+  test("signing out invalidates an in-flight account refresh", async () => {
+    const onLoaded = mock(() => {});
+    await mount({ onLoaded });
+    expect(onLoaded).toHaveBeenCalledTimes(1);
+
+    let resolveSignedInRefresh: ((value: unknown) => void) | undefined;
+    const signedInRefresh = new Promise((resolve) => {
+      resolveSignedInRefresh = resolve;
+    });
+    client.listUserAccounts.mockImplementationOnce(() => signedInRefresh);
+    await click("refresh");
+
+    authed = false;
+    await rerender({ onLoaded });
+    expect(container.textContent).toContain("Sign in to manage linked accounts");
+    await React.act(async () => {
+      resolveSignedInRefresh?.({
+        accounts: [account("stale", "github", "stale-after-signout")],
+        primaryLoginMethods: [{ provider: "email", providerAccountId: "stale@example.test" }],
+      });
+      await signedInRefresh;
+    });
+
+    expect(onLoaded).toHaveBeenCalledTimes(1);
+    expect(container.textContent).not.toContain("stale-after-signout");
   });
 });

--- a/packages/react/src/components/StewardLinkedAccounts.tsx
+++ b/packages/react/src/components/StewardLinkedAccounts.tsx
@@ -120,8 +120,8 @@ export function StewardLinkedAccounts({
   );
 
   const refresh = useCallback(async () => {
-    if (!auth.isAuthenticated) return;
     const generation = ++refreshGeneration.current;
+    if (!auth.isAuthenticated) return;
     setIsLoading(true);
     setError(null);
     try {


### PR DESCRIPTION
## Summary

- invalidate the linked-account refresh generation before the signed-out early return
- prevent a request started in a prior authenticated epoch from publishing stale accounts or firing onLoaded after sign-out
- preserve all mounted unlink, phone, wallet, OAuth, Telegram, Farcaster, error, and refresh-order coverage

## Exact-head verification

Head: cf3dd95f97c11862869f28535e2a0124c4ccb174

- focused StewardLinkedAccounts suite: 9/9 passed
- full sequential React suite: passed
- SDK build and React build: passed
- Biome and git diff --check: clean

Refs #746