### PR TITLE
fix(trading): scope operator authority and durable replay

### DIFF
--- a/packages/api/src/middleware/operator-auth.ts
+++ b/packages/api/src/middleware/operator-auth.ts
@@ -6,9 +6,10 @@
  * plane-down scenario the recovery feature exists to solve).
  *
  * This middleware accepts EITHER credential:
- *   1. A platform key — header `X-Steward-Platform-Key`, validated by
- *      `isValidPlatformKey`. This is the cross-tenant operator credential
- *      (issued out-of-band to trusted operators such as Eliza Cloud).
+ *   1. A platform key — header `X-Steward-Platform-Key`, authenticated and
+ *      authorized for `platform:trade:operator`. This is the cross-tenant
+ *      operator credential (issued out-of-band to trusted operators such as
+ *      Eliza Cloud).
  *   2. A tenant-admin credential — falls through to `tenantAuth`, which
  *      accepts a tenant API key (`X-Steward-Key` + `X-Steward-Tenant`) or a
  *      user session JWT.
@@ -22,7 +23,7 @@
  * tenant-auth path.
  */
 
-import { isValidPlatformKey } from "@stwd/auth";
+import { authorizePlatformKey } from "@stwd/auth";
 import type { Context, Next } from "hono";
 import {
   type ApiResponse,
@@ -37,8 +38,9 @@ export async function operatorAuth(c: Context<{ Variables: AppVariables }>, next
   const platformKey = c.req.header("X-Steward-Platform-Key");
 
   if (platformKey) {
-    if (!isValidPlatformKey(platformKey)) {
-      return c.json<ApiResponse>({ ok: false, error: "Invalid platform key" }, 403);
+    const authorization = authorizePlatformKey(platformKey, "platform:trade:operator");
+    if (!authorization.ok) {
+      return c.json<ApiResponse>({ ok: false, error: authorization.error }, authorization.status);
     }
 
     const tenantId = c.req.header("X-Steward-Tenant") || DEFAULT_TENANT_ID;
@@ -49,6 +51,8 @@ export async function operatorAuth(c: Context<{ Variables: AppVariables }>, next
     c.set("tenant", tenant);
     c.set("tenantConfig", tenantConfigs.get(tenantId) || { id: tenant.id, name: tenant.name });
     c.set("authType", "platform");
+    c.set("platformKeyHash", authorization.keyHash);
+    c.set("platformScopes", authorization.scopes);
     return next();
   }
 

--- a/packages/auth/src/__tests__/platform.test.ts
+++ b/packages/auth/src/__tests__/platform.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { Hono } from "hono";
-import { getPlatformKeyScopes, isValidPlatformKey, platformAuthMiddleware } from "../platform";
+import {
+  authorizePlatformKey,
+  getPlatformKeyScopes,
+  isValidPlatformKey,
+  platformAuthMiddleware,
+} from "../platform";
 
 const ORIGINAL_PLATFORM_KEY = process.env.STEWARD_PLATFORM_KEY;
 const ORIGINAL_PLATFORM_KEYS = process.env.STEWARD_PLATFORM_KEYS;
@@ -56,6 +61,50 @@ describe("platform key validation", () => {
       "platform:write",
       "platform:tenant:create",
     ]);
+  });
+
+  it("authorizes narrow operator authority and records a non-secret key identity", () => {
+    resetPlatformKeyEnv();
+    const key = "scoped-trading-operator-key-with-enough-entropy";
+    process.env.STEWARD_PLATFORM_KEY = key;
+    process.env.STEWARD_PLATFORM_KEY_SCOPES = JSON.stringify({
+      [key]: ["platform:trade:operator"],
+    });
+
+    const authorization = authorizePlatformKey(key, "platform:trade:operator");
+    expect(authorization).toEqual({
+      ok: true,
+      keyHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      scopes: ["platform:trade:operator"],
+    });
+  });
+
+  it("denies valid but unscoped or incorrectly scoped operator keys", () => {
+    resetPlatformKeyEnv();
+    const key = "unprivileged-platform-key-with-enough-entropy";
+    process.env.STEWARD_PLATFORM_KEY = key;
+
+    expect(authorizePlatformKey(key, "platform:trade:operator")).toEqual({
+      ok: false,
+      status: 403,
+      error: "Forbidden",
+    });
+
+    process.env.STEWARD_PLATFORM_KEY_SCOPES = JSON.stringify({ [key]: ["platform:read"] });
+    expect(authorizePlatformKey(key, "platform:trade:operator")).toEqual({
+      ok: false,
+      status: 403,
+      error: "Forbidden",
+    });
+  });
+
+  it("accepts the platform wildcard for operator authority", () => {
+    resetPlatformKeyEnv();
+    const key = "wildcard-platform-key-with-enough-entropy";
+    process.env.STEWARD_PLATFORM_KEY = key;
+    process.env.STEWARD_PLATFORM_KEY_SCOPES = JSON.stringify({ [key]: ["platform:*"] });
+
+    expect(authorizePlatformKey(key, "platform:trade:operator")).toMatchObject({ ok: true });
   });
 
   it("preserves an empty scope map only when the configuration is absent or blank", () => {

--- a/packages/auth/src/platform.ts
+++ b/packages/auth/src/platform.ts
@@ -126,6 +126,41 @@ export function hasPlatformScope(scopes: readonly string[] | undefined, required
   );
 }
 
+export type PlatformKeyAuthorization =
+  | { ok: true; keyHash: string; scopes: string[] }
+  | { ok: false; status: 403 | 500; error: string };
+
+/**
+ * Authenticate a platform key and resolve its deny-by-default authority in one
+ * operation. Callers with specialized routing needs (such as operator recovery)
+ * can require a narrow scope without duplicating the scope parser or leaking
+ * malformed configuration details.
+ */
+export function authorizePlatformKey(
+  key: string,
+  requiredScope?: string,
+): PlatformKeyAuthorization {
+  if (!isValidPlatformKey(key)) {
+    return { ok: false, status: 403, error: "Invalid platform key" };
+  }
+
+  let scopes: string[];
+  try {
+    scopes = getPlatformKeyScopes(key);
+  } catch (error) {
+    if (error instanceof PlatformKeyScopesConfigurationError) {
+      return { ok: false, status: 500, error: PLATFORM_SCOPE_CONFIG_ERROR };
+    }
+    throw error;
+  }
+
+  if (requiredScope && !hasPlatformScope(scopes, requiredScope)) {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+
+  return { ok: true, keyHash: hashKey(key).toString("hex"), scopes };
+}
+
 /**
  * Hono middleware that enforces platform key authentication.
  * Mount this on any route group that requires platform-level access.
@@ -159,22 +194,13 @@ export function platformAuthMiddleware() {
       );
     }
 
-    if (!isValidPlatformKey(key)) {
-      return c.json<ApiResponse>({ ok: false, error: "Invalid platform key" }, 403);
+    const authorization = authorizePlatformKey(key);
+    if (!authorization.ok) {
+      return c.json<ApiResponse>({ ok: false, error: authorization.error }, authorization.status);
     }
 
-    let scopes: string[];
-    try {
-      scopes = getPlatformKeyScopes(key);
-    } catch (error) {
-      if (error instanceof PlatformKeyScopesConfigurationError) {
-        return c.json<ApiResponse>({ ok: false, error: PLATFORM_SCOPE_CONFIG_ERROR }, 500);
-      }
-      throw error;
-    }
-
-    c.set("platformKeyHash", hashKey(key).toString("hex"));
-    c.set("platformScopes", scopes);
+    c.set("platformKeyHash", authorization.keyHash);
+    c.set("platformScopes", authorization.scopes);
 
     await next();
   });

--- a/packages/plugin-trading/src/__tests__/operator-recovery.test.ts
+++ b/packages/plugin-trading/src/__tests__/operator-recovery.test.ts
@@ -23,6 +23,7 @@ import {
   writeAuditEvent,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import type { IoredisLike } from "@stwd/redis";
 import { and, asc, eq, inArray } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -251,7 +252,7 @@ async function buildApp(ctxOverrides: Partial<StewardAppContext> = {}) {
   return app;
 }
 
-async function buildTransferApp(failAuditAction?: string) {
+async function buildTransferApp(failAuditAction?: string, redisClient?: IoredisLike) {
   const { tradingPlugin } = await import("../index");
   const baseWriteAuditEvent = writeAuditEvent;
   const app = new Hono();
@@ -280,7 +281,7 @@ async function buildTransferApp(failAuditAction?: string) {
       await baseWriteAuditEvent(event);
     },
     verifyAuditChain,
-    getRedisClient: () => null,
+    getRedisClient: () => redisClient ?? null,
     requireAgentJwt: async (_c: unknown, next: () => Promise<void>) => next(),
     tenantAuth: async (_c: unknown, next: () => Promise<void>) => next(),
     operatorAuth: async (
@@ -311,6 +312,34 @@ async function buildTransferApp(failAuditAction?: string) {
   } as never;
   tradingPlugin.register(app as never, ctx);
   return app;
+}
+
+function createTransferRedisDouble(): IoredisLike {
+  const data = new Map<string, string>();
+  return {
+    get: async (key: string) => data.get(key) ?? null,
+    set: async (...args: unknown[]) => {
+      const [key, value, mode, , condition] = args as [string, string, string?, number?, string?];
+      if (mode === "PX" && condition === "NX" && data.has(key)) return null;
+      data.set(key, value);
+      return "OK";
+    },
+    eval: async (
+      script: string,
+      _numKeys: number,
+      key: string,
+      claimToken: string,
+      ...args: unknown[]
+    ) => {
+      const raw = data.get(key);
+      if (!raw) return 0;
+      const current = JSON.parse(raw) as { state?: string; claimToken?: string };
+      if (current.state !== "pending" || current.claimToken !== claimToken) return 0;
+      if (script.includes('redis.call("DEL"')) data.delete(key);
+      else data.set(key, args[0] as string);
+      return 1;
+    },
+  } as unknown as IoredisLike;
 }
 
 function resetSendAssetMock(): void {
@@ -608,26 +637,31 @@ describe("mounted HIP-3 collateral transfer", () => {
     expect(JSON.stringify(ambiguousAudits)).not.toContain("transport lost after write");
   });
 
-  it("replays terminal success when the completion audit fails after venue submission", async () => {
+  it("lets durable ambiguity override stale Redis success after completion-audit failure", async () => {
     resetSendAssetMock();
     const tenantId = `tenant-transfer-audit-${Date.now()}`;
     const agentId = `agent-transfer-audit-${Date.now()}`;
     await seedAgent({ tenantId, agentId });
-    const app = await buildTransferApp("trade.recovery.transfer.submitted");
+    const redisClient = createTransferRedisDouble();
+    const app = await buildTransferApp("trade.recovery.transfer.submitted", redisClient);
     const request = () =>
       transferRequest(app, tenantId, agentId, { idempotencyKey: "completion-audit-failure" });
 
     const first = await request();
     const retry = await request();
     expect(first.status).toBe(200);
-    expect(retry.status).toBe(200);
-    expect(await retry.json()).toEqual(await first.json());
+    expect(retry.status).toBe(409);
+    expect(retry.headers.get("Retry-After")).toBe("60");
+    expect(await retry.json()).toEqual({
+      ok: false,
+      error: "Collateral transfer outcome requires reconciliation",
+    });
     expect(signSendAssetCalls).toHaveLength(1);
     expect(submitSendAssetCalls).toHaveLength(1);
     expect(await transferAuditActions(tenantId, agentId)).toEqual([
       "trade.recovery.transfer.requested",
     ]);
-    const coldReplayApp = await buildTransferApp("trade.recovery.transfer.submitted");
+    const coldReplayApp = await buildTransferApp("trade.recovery.transfer.submitted", redisClient);
     const coldReplay = await transferRequest(coldReplayApp, tenantId, agentId, {
       idempotencyKey: "completion-audit-failure",
     });

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -1656,8 +1656,11 @@ export function createOperatorRecoveryRoutes(
       body.idempotencyKey,
       requestCommitment,
     );
-    const replayResponse = operatorIdempotencyResponse(c, idempotency);
-    if (replayResponse) return replayResponse;
+    // Redis is a fast replay cache, but the HMAC-chained audit log is the
+    // authoritative record of whether a capital movement is terminal. Hold a
+    // cached response until durable evidence has been checked so stale success
+    // cannot override a requested-only (ambiguous) state.
+    const cachedReplayResponse = operatorIdempotencyResponse(c, idempotency);
 
     // Establish a non-keyed HMAC-chain guard before interpreting absence. If a
     // prior keyed requested/terminal pair was deleted, full-chain verification
@@ -1705,6 +1708,7 @@ export function createOperatorRecoveryRoutes(
     }
     const durableResponse = durableTransferResponse(c, durableState, requestFingerprint);
     if (durableResponse) return durableResponse;
+    if (cachedReplayResponse) return cachedReplayResponse;
 
     const agent = await ensureAgentForTenant(tenantId, agentId);
     if (!agent) return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);


### PR DESCRIPTION
## Summary
- require the deny-by-default `platform:trade:operator` scope for platform-key operator recovery and propagate the key hash/scopes into request context
- centralize platform-key authentication, scope resolution, hashing, and redacted configuration failures
- make HMAC-chained durable transfer evidence authoritative over cached Redis success
- add a cross-instance Redis regression proving requested-only audit evidence prevents a duplicate capital movement

## Verification (exact head `9fdaaaa63e980bee7ebba6e90c90f7bf6a2e60b3`)
- `bun test packages/auth/src/__tests__/platform.test.ts` (13 pass)
- `bun test packages/plugin-trading/src/__tests__/operator-recovery.test.ts -t "mounted HIP-3 collateral transfer"` (10 pass)
- `bunx turbo run build --filter=@stwd/plugin-trading --filter=@stwd/api --filter=@stwd/auth` (24 dependency/package tasks pass)
- Biome on all changed files; `git diff --check`

The full plugin-trading baseline run completed with 163 pass, 14 skip, and 26 unrelated failures already present outside these changed behaviors (principally stale workspace build exports, the older incomplete PolicyEngine mock, Polymarket expectations, and one rate-limit timeout). The focused mounted transfer suite and all affected builds are green.

## Deployment note
Operator platform keys must have `platform:trade:operator`, `platform:*`, or `*` in `STEWARD_PLATFORM_KEY_SCOPES`; unscoped valid keys now fail closed.

Refs #750