### PR TITLE
fix(ci): restore main release gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,7 +451,10 @@ jobs:
   integration:
     name: Integration Tests (Postgres)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # The serial API suite intentionally runs each PGLite-heavy file in a
+    # separate process. Keep the job budget aligned with the documented
+    # 25-minute bound below; 15 minutes cancels healthy hosted runs mid-suite.
+    timeout-minutes: 25
     env:
       REDIS_URL: "redis://localhost:6379"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,10 @@ on:
       - ".dockerignore"
       - "package.json"
       - "bun.lock"
-      - "packages/**/package.json"
+      - "turbo.json"
+      - "tsconfig.json"
+      - "web/package.json"
+      - "packages/**"
       - ".github/workflows/docker.yml"
 
 # A branch tag is mutable. Do not let a slower build for an older push finish

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -538,9 +538,8 @@ jobs:
   integration:
     name: Integration Tests (Postgres)
     runs-on: ubuntu-latest
-    # 25m: the per-test timeout was raised to 30s to absorb PGLite migration
-    # latency under the concurrent --isolate load, which lengthens worst-case
-    # wall-clock for the full 122-file run. Give the job comfortable headroom.
+    # The serial isolated runner below keeps migration-heavy files from starving
+    # each other. Give the complete API suite enough bounded wall-clock headroom.
     timeout-minutes: 25
     env:
       REDIS_URL: "redis://localhost:6379"
@@ -662,10 +661,11 @@ jobs:
         # size) and each process frees its WASM heap on exit. Reproduced in a
         # 6GB-capped Linux container: the single `--isolate` process is killed
         # at exit 137; a 6-way --shard split still OOMs (25 files/shard is too
-        # much); this runner at TEST_JOBS=2 finishes the full suite with zero
-        # OOM in ~2.3min. TEST_TIMEOUT=30000 absorbs per-file PGLite migration
-        # latency.
-        run: TEST_JOBS=2 TEST_TIMEOUT=30000 bun packages/api/scripts/run-tests-isolated.ts
+        # much). Keep this serial: even two PGLite processes can starve an API
+        # request long enough to hit Bun's per-test timeout. The 120-second
+        # per-file timeout matches push CI and leaves headroom for the
+        # migration-heavy public-boundary suites.
+        run: TEST_JOBS=1 TEST_TIMEOUT=120000 bun packages/api/scripts/run-tests-isolated.ts
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
           PORT: "3299"

--- a/packages/api/src/__tests__/adapters-app-mount.test.ts
+++ b/packages/api/src/__tests__/adapters-app-mount.test.ts
@@ -1,22 +1,18 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { hashApiKey } from "@stwd/auth";
-import { closeDb, getDb, tenants } from "@stwd/db";
-import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { getDb, tenants } from "@stwd/db";
+import { eq } from "drizzle-orm";
 
 const TENANT_ID = `adapter-app-mount-${Date.now()}`;
 const API_KEY = `stw_adapter_mount_${Date.now()}`;
+const SKIP = !process.env.DATABASE_URL;
 
-describe("adapter app mount", () => {
+describe.skipIf(SKIP)("adapter app mount", () => {
   let app: Awaited<typeof import("../app")>["app"];
 
   beforeAll(async () => {
-    process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_MASTER_PASSWORD = "adapter-app-mount-master-password";
     process.env.STEWARD_AUDIT_HMAC_KEY = "adapter-app-mount-audit-hmac-key-with-enough-entropy";
-    const { db, client } = await createPGLiteDb("memory://");
-    setPGLiteOverride(db, async () => {
-      await client.close();
-    });
     await getDb()
       .insert(tenants)
       .values({
@@ -28,8 +24,7 @@ describe("adapter app mount", () => {
   }, 120_000);
 
   afterAll(async () => {
-    await closeDb();
-    delete process.env.STEWARD_PGLITE_MEMORY;
+    await getDb().delete(tenants).where(eq(tenants.id, TENANT_ID));
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_AUDIT_HMAC_KEY;
   });

--- a/packages/api/src/__tests__/agent-jwt-hardening.test.ts
+++ b/packages/api/src/__tests__/agent-jwt-hardening.test.ts
@@ -63,7 +63,7 @@ describe("external agent JWT hardening", () => {
       "agentTokenScopes.some((scope) => scope.startsWith(CAPABILITY_TOKEN_SCOPE_PREFIX))",
     );
     const agentLookup = contextSource.indexOf(
-      "const agent = await ensureAgentForTenant(payload.tenantId, payload.agentId as string);",
+      "const agentSubject = await findAgentBootstrapSubject(",
     );
     expect(refusal).toBeGreaterThanOrEqual(0);
     expect(agentLookup).toBeGreaterThan(refusal);

--- a/packages/api/src/__tests__/agent-signers.test.ts
+++ b/packages/api/src/__tests__/agent-signers.test.ts
@@ -301,7 +301,8 @@ describe("agent signer API", () => {
     const beforeAudits = await getDb()
       .select({ id: auditEvents.id })
       .from(auditEvents)
-      .where(eq(auditEvents.tenantId, TENANT_ID));
+      .where(eq(auditEvents.tenantId, TENANT_ID))
+      .orderBy(asc(auditEvents.id));
     const createResponse = await noMfaApp.request(`/agents/${AGENT_ID}/signers`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -337,7 +338,8 @@ describe("agent signer API", () => {
       await getDb()
         .select({ id: auditEvents.id })
         .from(auditEvents)
-        .where(eq(auditEvents.tenantId, TENANT_ID)),
+        .where(eq(auditEvents.tenantId, TENANT_ID))
+        .orderBy(asc(auditEvents.id)),
     ).toEqual(beforeAudits);
   });
 
@@ -457,7 +459,8 @@ describe("agent signer API", () => {
     const beforeAudits = await getDb()
       .select({ id: auditEvents.id })
       .from(auditEvents)
-      .where(eq(auditEvents.tenantId, TENANT_ID));
+      .where(eq(auditEvents.tenantId, TENANT_ID))
+      .orderBy(asc(auditEvents.id));
 
     const pauseResponse = await noMfaApp.request(`/agents/${AGENT_ID}/signers/${created.data.id}`, {
       method: "PATCH",
@@ -484,7 +487,8 @@ describe("agent signer API", () => {
       await getDb()
         .select({ id: auditEvents.id })
         .from(auditEvents)
-        .where(eq(auditEvents.tenantId, TENANT_ID)),
+        .where(eq(auditEvents.tenantId, TENANT_ID))
+        .orderBy(asc(auditEvents.id)),
     ).toEqual(beforeAudits);
   });
 

--- a/packages/api/src/__tests__/approvals-proxy-atomicity.test.ts
+++ b/packages/api/src/__tests__/approvals-proxy-atomicity.test.ts
@@ -5,6 +5,7 @@ import {
   closeDb,
   getDb,
   pendingProxyRequests,
+  sql,
   tenants,
   users,
   userTenants,
@@ -21,8 +22,8 @@ import type { AppVariables } from "../services/context";
 // event in SEPARATE transactions, so a crash or audit failure between them
 // could leave an approved/denied/expired row with NO audit record.
 //
-// This suite drives the real route stack against a PGLite database whose
-// transaction layer is instrumented to throw at the audit INSERT. It proves:
+// This suite drives the real route stack against a PGLite database with a
+// database trigger that rejects the required audit INSERT. It proves:
 //   1. both-or-neither: when the required audit write faults, the state
 //      transition is rolled back too (I14);
 //   2. retry-after-crash is idempotent: a second attempt with the fault cleared
@@ -51,55 +52,35 @@ let previousJwtSecret: string | undefined;
 let previousAuditHmacKey: string | undefined;
 let previousMasterPassword: string | undefined;
 
-// ─── Audit-insert fault injection ────────────────────────────────────────────
-//
-// When `faultAuditInsert` is true, the FIRST audit-event INSERT executed inside
-// any transaction throws. We render each executed SQL via the drizzle dialect
-// and match `insert into audit_events`. This simulates the exact crash point:
-// the state row was just updated in the same transaction, and the required
-// audit append fails.
-
-let faultAuditInsert = false;
-
-/** Minimal structural view of a drizzle transaction handle for the fault hook. */
-type TxLike = { execute: (query: unknown) => Promise<unknown> };
-
-function isAuditInsert(dialect: unknown, query: unknown): boolean {
+async function withApprovalAuditFailure<T>(operation: () => Promise<T>): Promise<T> {
+  await getDb().execute(
+    sql.raw(`
+      CREATE OR REPLACE FUNCTION fail_proxy_approval_audit_for_test()
+      RETURNS trigger AS $$
+      BEGIN
+        IF NEW.action IN ('proxy.approval.approved', 'proxy.approval.denied') THEN
+          RAISE EXCEPTION 'injected approval audit fault';
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+    `),
+  );
+  await getDb().execute(
+    sql.raw(`
+      CREATE TRIGGER proxy_approval_audit_failure_for_test
+      BEFORE INSERT ON audit_events
+      FOR EACH ROW EXECUTE FUNCTION fail_proxy_approval_audit_for_test()
+    `),
+  );
   try {
-    const built = (dialect as { sqlToQuery: (q: unknown) => { sql?: string } }).sqlToQuery(query);
-    const text = String(built?.sql ?? "").toLowerCase();
-    return text.includes("insert into audit_events");
-  } catch {
-    return false;
-  }
-}
-
-function installFaultInjectingDb(db: unknown): unknown {
-  // Test-only structural view of the drizzle db so we can wrap `.transaction`.
-  const anyDb = db as {
-    dialect: unknown;
-    transaction: (cb: (tx: TxLike) => Promise<unknown>, ...rest: unknown[]) => Promise<unknown>;
-  };
-  const dialect = anyDb.dialect;
-  const originalTransaction = anyDb.transaction.bind(anyDb);
-
-  anyDb.transaction = (cb: (tx: TxLike) => Promise<unknown>, ...rest: unknown[]) => {
-    return originalTransaction(
-      async (tx: TxLike) => {
-        const originalExecute = tx.execute.bind(tx);
-        tx.execute = async (query: unknown) => {
-          if (faultAuditInsert && isAuditInsert(dialect, query)) {
-            faultAuditInsert = false; // fault the first audit insert only
-            throw new Error("injected audit fault");
-          }
-          return originalExecute(query);
-        };
-        return cb(tx);
-      },
-      ...rest,
+    return await operation();
+  } finally {
+    await getDb().execute(
+      sql.raw("DROP TRIGGER IF EXISTS proxy_approval_audit_failure_for_test ON audit_events"),
     );
-  };
-  return db;
+    await getDb().execute(sql.raw("DROP FUNCTION IF EXISTS fail_proxy_approval_audit_for_test()"));
+  }
 }
 
 async function ownerSession(extra?: Record<string, unknown>) {
@@ -168,7 +149,6 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
 
   const { db, client } = await createPGLiteDb("memory://");
-  installFaultInjectingDb(db);
   setPGLiteOverride(db, async () => {
     await client.close();
   });
@@ -202,7 +182,6 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  faultAuditInsert = false;
   await getDb().delete(pendingProxyRequests).where(eq(pendingProxyRequests.tenantId, TENANT_ID));
 });
 
@@ -239,8 +218,7 @@ describe("proxy approval/audit atomicity (fault injection)", () => {
   it("approve: audit failure rolls back the state transition (both-or-neither)", async () => {
     const id = await seedPendingProxyRequest("pending");
 
-    faultAuditInsert = true;
-    const res = await approve(id);
+    const res = await withApprovalAuditFailure(() => approve(id));
     // The injected fault surfaces as a 500 (uncaught) — the point is the DB state.
     expect(res.status).toBeGreaterThanOrEqual(500);
 
@@ -256,8 +234,7 @@ describe("proxy approval/audit atomicity (fault injection)", () => {
   it("approve: retry after the fault clears applies the transition exactly once", async () => {
     const id = await seedPendingProxyRequest("pending");
 
-    faultAuditInsert = true;
-    await approve(id); // faults + rolls back
+    await withApprovalAuditFailure(() => approve(id)); // faults + rolls back
     expect((await fetchProxyRequest(id)).status).toBe("pending");
 
     // Retry with fault cleared: succeeds, one transition, one audit.
@@ -276,8 +253,7 @@ describe("proxy approval/audit atomicity (fault injection)", () => {
   it("deny: audit failure rolls back the state transition (both-or-neither)", async () => {
     const id = await seedPendingProxyRequest("pending");
 
-    faultAuditInsert = true;
-    const res = await deny(id);
+    const res = await withApprovalAuditFailure(() => deny(id));
     expect(res.status).toBeGreaterThanOrEqual(500);
 
     const row = await fetchProxyRequest(id);
@@ -288,8 +264,7 @@ describe("proxy approval/audit atomicity (fault injection)", () => {
   it("deny: retry after the fault clears applies the transition exactly once", async () => {
     const id = await seedPendingProxyRequest("pending");
 
-    faultAuditInsert = true;
-    await deny(id);
+    await withApprovalAuditFailure(() => deny(id));
     expect((await fetchProxyRequest(id)).status).toBe("pending");
 
     const res = await deny(id);

--- a/packages/api/src/__tests__/auth-audit-hardening.test.ts
+++ b/packages/api/src/__tests__/auth-audit-hardening.test.ts
@@ -51,9 +51,9 @@ describe("auth and audit hardening", () => {
   it("revokes already minted access tokens when refresh-token reuse is detected", () => {
     const reusedBranch = authSource.indexOf('rotatedRefresh.status === "reused"');
     expect(reusedBranch).toBeGreaterThanOrEqual(0);
-    expect(
-      authSource.indexOf("revokeUserRefreshSessions(rotatedRefresh.userId)", reusedBranch),
-    ).toBeGreaterThan(reusedBranch);
+    expect(authSource.indexOf("await revokeUserRefreshSessions(", reusedBranch)).toBeGreaterThan(
+      reusedBranch,
+    );
     expect(authSource.indexOf("auth.refresh.reuse_detected", reusedBranch)).toBeGreaterThan(
       reusedBranch,
     );
@@ -73,7 +73,7 @@ describe("auth and audit hardening", () => {
     ).toBeGreaterThan(rotationStart);
     expect(
       authSource.indexOf("revocationStore.getUserRevokedBefore(record.userId)", rotationStart),
-    ).toBeLessThan(authSource.indexOf(".insert(refreshTokens)", rotationStart));
+    ).toBeLessThan(authSource.indexOf("auth_rotate_refresh_token(", rotationStart));
     expect(
       authSource.indexOf("Session was revoked. Please sign in again.", routeStart),
     ).toBeGreaterThan(routeStart);

--- a/packages/api/src/__tests__/auth-session-membership.test.ts
+++ b/packages/api/src/__tests__/auth-session-membership.test.ts
@@ -7,11 +7,17 @@ const authSource = readFileSync(join(import.meta.dir, "..", "routes", "auth.ts")
 
 describe("session membership hardening", () => {
   it("rejects missing users and rechecks tenant membership during session verification", () => {
-    for (const source of [contextSource, authSource]) {
-      expect(source).toContain("!user || user.deactivatedAt");
-      expect(source).toContain("from(userTenants)");
-      expect(source).toContain("eq(userTenants.tenantId, payload.tenantId)");
-      expect(source).toContain("if (!membership) return null");
-    }
+    // The shared context uses the SECURITY DEFINER bootstrap function so the
+    // lookup remains available before a tenant RLS transaction is installed.
+    expect(contextSource).toContain("steward_bootstrap.session_subject(");
+    expect(contextSource).toContain("if (!user || user.deactivated_at) return null");
+    expect(contextSource).toContain("if (payload.tenantId && !user.membership_role) return null");
+
+    // The auth router performs the equivalent checks through tenant-scoped
+    // Drizzle queries once its verified auth transaction is active.
+    expect(authSource).toContain("if (!user || user.deactivatedAt) return null");
+    expect(authSource).toContain(".from(userTenants)");
+    expect(authSource).toContain("eq(userTenants.tenantId, payload.tenantId)");
+    expect(authSource).toContain("if (!membership) return null");
   });
 });

--- a/packages/api/src/__tests__/generic-http-public-boundary-e2e.test.ts
+++ b/packages/api/src/__tests__/generic-http-public-boundary-e2e.test.ts
@@ -12,10 +12,19 @@ import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "
 import { generateKeyPairSync } from "node:crypto";
 import { createServer, type Server } from "node:http";
 import { signAccessToken } from "@stwd/auth";
-import { agents, closeDb, secrets, tenants, users, userTenants } from "@stwd/db";
-import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import {
+  agents,
+  closeDb,
+  getDb,
+  secretRoutes,
+  secrets,
+  tenants,
+  users,
+  userTenants,
+} from "@stwd/db";
 import { GENERIC_HTTP_PROVIDER_ACTION_PROFILE } from "@stwd/shared";
 import { KeyStore } from "@stwd/vault";
+import { eq, inArray } from "drizzle-orm";
 import type { Hono } from "hono";
 import { exportJWK, generateKeyPair, type KeyLike, SignJWT } from "jose";
 import type { AppVariables } from "../services/context";
@@ -83,9 +92,8 @@ async function expectCreated(response: Response, label: string): Promise<void> {
   }
 }
 
-describe("#201 generic-http true public-boundary E2E", () => {
+describe.skipIf(!process.env.DATABASE_URL)("#201 generic-http true public-boundary E2E", () => {
   beforeAll(async () => {
-    process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_AUDIT_HMAC_KEY = "0".repeat(64);
     process.env.STEWARD_EXECUTION_AUTH_SECRET = "1".repeat(64);
     process.env.STEWARD_MASTER_PASSWORD = "generic-public-boundary-master-password";
@@ -98,8 +106,7 @@ describe("#201 generic-http true public-boundary E2E", () => {
       .export({ format: "pem", type: "pkcs8" })
       .toString();
 
-    const { db, client } = await createPGLiteDb("memory://");
-    setPGLiteOverride(db, async () => client.close());
+    const db = getDb();
 
     const keyStore = new KeyStore(process.env.STEWARD_MASTER_PASSWORD, undefined, "secret-vault");
     const encrypted = keyStore.encrypt(CREDENTIAL, {
@@ -173,10 +180,22 @@ describe("#201 generic-http true public-boundary E2E", () => {
   });
 
   afterAll(async () => {
+    // Agent deletion is deliberately guarded while an enabled route can still
+    // resolve its secret. Disable first, let the tenant cascade remove all
+    // governed authority rows, then remove the non-FK route/secret records.
+    await getDb()
+      .update(secretRoutes)
+      .set({ enabled: false, authorityMode: "legacy", providerOperationId: null })
+      .where(eq(secretRoutes.tenantId, F.tenant));
+    await getDb().delete(tenants).where(eq(tenants.id, F.tenant));
+    await getDb().delete(secretRoutes).where(eq(secretRoutes.tenantId, F.tenant));
+    await getDb().delete(secrets).where(eq(secrets.tenantId, F.tenant));
+    await getDb()
+      .delete(users)
+      .where(inArray(users.id, [F.owner, F.approver]));
     await closeDb();
     await new Promise<void>((resolve) => jwksServer.close(() => resolve()));
     for (const key of [
-      "STEWARD_PGLITE_MEMORY",
       "STEWARD_AUDIT_HMAC_KEY",
       "STEWARD_EXECUTION_AUTH_SECRET",
       "STEWARD_MASTER_PASSWORD",

--- a/packages/api/src/__tests__/privy-completeness.integration.test.ts
+++ b/packages/api/src/__tests__/privy-completeness.integration.test.ts
@@ -2,9 +2,8 @@ import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { generateTotp, hashSha256Hex } from "@stwd/auth";
 import { agents, closeDb, getDb, tenantConfigs, tenants, users, userTenants } from "@stwd/db";
-import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { isValidMnemonic } from "@stwd/vault";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 
 const webhookDispatches: Array<{
   event: { type: string; deliveryId?: string; data?: unknown };
@@ -38,13 +37,14 @@ const EMAIL = `privy-completeness-${TEST_ID}@example.test`;
 const USER_ADDRESS = "0x00000000000000000000000000000000000000cd";
 const RESTORE_MNEMONIC =
   "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const fixtureUsers = new Set([USER_ID]);
+const fixtureTenants = new Set([TENANT_ID]);
 
-describe("Privy-competitor integration completeness", () => {
+describe.skipIf(!process.env.DATABASE_URL)("Privy-competitor integration completeness", () => {
   let app: Awaited<typeof import("../app")>["app"];
   let createSessionToken: Awaited<typeof import("../routes/auth")>["createSessionToken"];
 
   beforeAll(async () => {
-    process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_MASTER_PASSWORD = "privy-completeness-master-password";
     process.env.STEWARD_JWT_SECRET = "privy-completeness-jwt-secret-with-enough-entropy";
     process.env.JWT_SECRET = "privy-completeness-jwt-secret-with-enough-entropy";
@@ -53,11 +53,6 @@ describe("Privy-competitor integration completeness", () => {
     process.env.EMAIL_PROVIDER = "mock";
     process.env.STEWARD_ALLOW_UNSAFE_MESSAGE_SIGNING = "true";
     process.env.STEWARD_ALLOW_USER_UNSAFE_MESSAGE_SIGNING = "true";
-
-    const { db, client } = await createPGLiteDb("memory://");
-    setPGLiteOverride(db, async () => {
-      await client.close();
-    });
 
     await getDb().insert(users).values({
       id: USER_ID,
@@ -78,8 +73,13 @@ describe("Privy-competitor integration completeness", () => {
   }, 120_000);
 
   afterAll(async () => {
+    await getDb()
+      .delete(tenants)
+      .where(inArray(tenants.id, [...fixtureTenants]));
+    await getDb()
+      .delete(users)
+      .where(inArray(users.id, [...fixtureUsers]));
     await closeDb();
-    delete process.env.STEWARD_PGLITE_MEMORY;
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_JWT_SECRET;
     delete process.env.JWT_SECRET;
@@ -113,6 +113,8 @@ describe("Privy-competitor integration completeness", () => {
     const userId = randomUUID();
     const tenantId = `personal-${userId}`;
     const email = `privy-${label}-${userId}@example.test`;
+    fixtureUsers.add(userId);
+    fixtureTenants.add(tenantId);
     await getDb().insert(users).values({
       id: userId,
       email,

--- a/packages/api/src/__tests__/provider-case-fixture.ts
+++ b/packages/api/src/__tests__/provider-case-fixture.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  agents,
   approvalQueue,
   getDb,
   intents,
@@ -17,12 +18,13 @@ import {
   secretRoutes,
   secrets,
   tenants,
+  transactions,
   users,
   userTenants,
   workspaces,
 } from "@stwd/db";
 import { buildGithubAction } from "@stwd/provider-github";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
 import { providerActionService } from "../services/provider-action-service";
 import { providerApprovalService } from "../services/provider-approval";
@@ -82,30 +84,55 @@ export async function seedCaseFixture(): Promise<void> {
   ]);
 }
 
-/** Wipe all provider + audit state between tests (audit chain included). */
+/** Wipe only this fixture's provider + audit state between tests. */
 export async function wipeCase(): Promise<void> {
   const db = getDb();
-  await db.execute(sql`DELETE FROM provider_action_audit_outbox`);
-  await db.execute(sql`DELETE FROM execution_authorization_nonces`);
-  await db.delete(approvalQueue);
-  await db.delete(providerActionBindings);
-  await db.delete(intents);
-  await db.delete(providerGrants);
-  await db.delete(providerRoleBindings);
-  await db.delete(providerOperations);
-  await db.delete(providerAccounts);
-  await db.delete(secretRoutes);
-  await db.delete(secrets);
-  await db.delete(workspaces);
-  await db.delete(userTenants);
-  await db.delete(users);
-  await db.delete(tenants);
-  await db.execute(sql`DELETE FROM audit_events`);
-  await db.execute(sql`DELETE FROM audit_chain_heads`);
-  // Checkpoints are append-only in production. TRUNCATE is deliberately used
-  // only by this isolated PGLite fixture to reset the shared test database
-  // without weakening the row-level UPDATE/DELETE guard.
-  await db.execute(sql`TRUNCATE TABLE audit_checkpoints RESTART IDENTITY`);
+  const fixtureTenantIds = [F.TENANT, F.TENANT_B];
+  await db.execute(
+    sql`DELETE FROM provider_action_audit_outbox WHERE tenant_id IN (${sql.join(
+      fixtureTenantIds.map((tenantId) => sql`${tenantId}`),
+      sql`, `,
+    )})`,
+  );
+  await db.execute(
+    sql`DELETE FROM execution_authorization_nonces WHERE tenant_id IN (${sql.join(
+      fixtureTenantIds.map((tenantId) => sql`${tenantId}`),
+      sql`, `,
+    )})`,
+  );
+  await db.delete(approvalQueue).where(eq(approvalQueue.agentId, F.AGENT));
+  await db
+    .delete(providerActionBindings)
+    .where(inArray(providerActionBindings.tenantId, fixtureTenantIds));
+  await db.delete(intents).where(inArray(intents.tenantId, fixtureTenantIds));
+  await db.delete(providerGrants).where(inArray(providerGrants.tenantId, fixtureTenantIds));
+  await db
+    .delete(providerRoleBindings)
+    .where(inArray(providerRoleBindings.tenantId, fixtureTenantIds));
+  await db.delete(providerOperations).where(inArray(providerOperations.tenantId, fixtureTenantIds));
+  await db.delete(providerAccounts).where(inArray(providerAccounts.tenantId, fixtureTenantIds));
+  await db.delete(secretRoutes).where(inArray(secretRoutes.tenantId, fixtureTenantIds));
+  await db.delete(secrets).where(inArray(secrets.tenantId, fixtureTenantIds));
+  await db.delete(workspaces).where(inArray(workspaces.tenantId, fixtureTenantIds));
+  await db.delete(transactions).where(eq(transactions.agentId, F.AGENT));
+  await db.delete(agents).where(eq(agents.id, F.AGENT));
+  await db.delete(userTenants).where(inArray(userTenants.tenantId, fixtureTenantIds));
+  await db
+    .delete(users)
+    .where(inArray(users.id, [F.GRANTOR, F.APPROVER, F.APPROVER_2, F.APPROVER_3, F.AGENT_OWNER]));
+  await db.delete(tenants).where(inArray(tenants.id, fixtureTenantIds));
+  await db.execute(
+    sql`DELETE FROM audit_events WHERE tenant_id IN (${sql.join(
+      fixtureTenantIds.map((tenantId) => sql`${tenantId}`),
+      sql`, `,
+    )})`,
+  );
+  await db.execute(
+    sql`DELETE FROM audit_chain_heads WHERE tenant_id IN (${sql.join(
+      fixtureTenantIds.map((tenantId) => sql`${tenantId}`),
+      sql`, `,
+    )})`,
+  );
 }
 
 function idem(seed: string): string {

--- a/packages/api/src/__tests__/provider-case-snapshot-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/provider-case-snapshot-postgres.integration.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Mounted real-Postgres proof for provider-case KC06 snapshot consistency.
+ *
+ * The request reads its binding before approval_queue. Holding an ACCESS
+ * EXCLUSIVE lock on approval_queue pauses the mounted handler after its first
+ * snapshot read. A second connection then commits an operation change. The
+ * manifest must retain the pre-change operation value; READ COMMITTED would
+ * observe the concurrent value on the later provider_operations statement.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { signAccessToken } from "@stwd/auth";
+import { closeDb, createPostgresClient, getDb, providerOperations } from "@stwd/db";
+import { eq } from "drizzle-orm";
+import { F } from "./provider-approval-fixture";
+import { createPendingCase, seedCaseFixture, wipeCase } from "./provider-case-fixture";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const SKIP = !DATABASE_URL;
+const ORIGINAL_RISK_CLASS = "write";
+const CONCURRENT_RISK_CLASS = "read";
+
+describe.skipIf(SKIP)("provider-case mounted repeatable-read snapshot (Postgres)", () => {
+  let admin: ReturnType<typeof createPostgresClient>;
+  let locker: ReturnType<typeof createPostgresClient>;
+  let writer: ReturnType<typeof createPostgresClient>;
+  let app: any;
+  let caseId: string;
+  let ownerToken: string;
+
+  beforeAll(async () => {
+    admin = createPostgresClient(DATABASE_URL!);
+    locker = createPostgresClient(DATABASE_URL!);
+    writer = createPostgresClient(DATABASE_URL!);
+    process.env.STEWARD_AUDIT_HMAC_KEY ??= "a".repeat(64);
+    process.env.STEWARD_MASTER_PASSWORD ??= "provider-case-snapshot-master-password";
+    process.env.STEWARD_JWT_SECRET ??=
+      "provider-case-snapshot-jwt-secret-0123456789abcdef0123456789";
+    await wipeCase();
+    await seedCaseFixture();
+    ({ intentId: caseId } = await createPendingCase("pgsnap01"));
+    await getDb()
+      .update(providerOperations)
+      .set({ riskClass: ORIGINAL_RISK_CLASS })
+      .where(eq(providerOperations.id, F.OP));
+    ownerToken = await signAccessToken({
+      address: "0xsnapshot-owner",
+      tenantId: F.TENANT,
+      userId: F.APPROVER_2,
+      mfaVerifiedAt: Date.now(),
+      mfaMethod: "totp",
+    });
+    const mod = await import("../app");
+    app = mod.mountCoreIdempotencyAndRoutes(mod.createApp());
+  }, 120_000);
+
+  afterAll(async () => {
+    await wipeCase();
+    await Promise.all([admin.end(), locker.end(), writer.end()]);
+    await closeDb();
+  });
+
+  test("later reads ignore a concurrent committed operation change", async () => {
+    let releaseLock!: () => void;
+    let lockHeld!: () => void;
+    const release = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    const locked = new Promise<void>((resolve) => {
+      lockHeld = resolve;
+    });
+    const lockTask = locker.begin(async (tx) => {
+      await tx.unsafe("LOCK TABLE approval_queue IN ACCESS EXCLUSIVE MODE");
+      lockHeld();
+      await release;
+    });
+    await locked;
+
+    let response: Response;
+    try {
+      const responsePromise = app.request(`/v2/provider-actions/${caseId}/case`, {
+        headers: {
+          Authorization: `Bearer ${ownerToken}`,
+          "X-Steward-Tenant": F.TENANT,
+        },
+      });
+
+      const deadline = Date.now() + 10_000;
+      let blocked = false;
+      while (Date.now() < deadline) {
+        const [row] = await admin<{ blocked: boolean }[]>`
+          SELECT EXISTS (
+            SELECT 1
+            FROM pg_locks waiting
+            WHERE waiting.relation = 'approval_queue'::regclass
+              AND NOT waiting.granted
+          ) AS blocked
+        `;
+        if (row?.blocked) {
+          blocked = true;
+          break;
+        }
+        await Bun.sleep(20);
+      }
+      expect(blocked).toBe(true);
+
+      await writer`
+        UPDATE provider_operations
+        SET risk_class = ${CONCURRENT_RISK_CLASS}
+        WHERE id = ${F.OP}
+      `;
+      releaseLock();
+      await lockTask;
+      response = await responsePromise;
+    } finally {
+      releaseLock();
+      await lockTask;
+    }
+
+    expect(response.status).toBe(200);
+    const manifest = (await response.json()) as { operation: { riskClass: string } };
+    expect(manifest.operation.riskClass).toBe(ORIGINAL_RISK_CLASS);
+    const [current] = await writer<{ risk_class: string }[]>`
+      SELECT risk_class FROM provider_operations WHERE id = ${F.OP}
+    `;
+    expect(current?.risk_class).toBe(CONCURRENT_RISK_CLASS);
+  }, 30_000);
+});

--- a/packages/api/src/__tests__/provider-case-snapshot-postgres.integration.test.ts
+++ b/packages/api/src/__tests__/provider-case-snapshot-postgres.integration.test.ts
@@ -9,7 +9,15 @@
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { signAccessToken } from "@stwd/auth";
-import { closeDb, createPostgresClient, getDb, providerOperations } from "@stwd/db";
+import {
+  agents,
+  closeDb,
+  createPostgresClient,
+  getDb,
+  providerOperations,
+  tenants,
+  transactions,
+} from "@stwd/db";
 import { eq } from "drizzle-orm";
 import { F } from "./provider-approval-fixture";
 import { createPendingCase, seedCaseFixture, wipeCase } from "./provider-case-fixture";
@@ -18,6 +26,9 @@ const DATABASE_URL = process.env.DATABASE_URL;
 const SKIP = !DATABASE_URL;
 const ORIGINAL_RISK_CLASS = "write";
 const CONCURRENT_RISK_CLASS = "read";
+const SENTINEL_TENANT = "tenant-provider-case-snapshot-sentinel";
+const SENTINEL_AGENT = "agent-provider-case-snapshot-sentinel";
+const SENTINEL_TRANSACTION = "tx-provider-case-snapshot-sentinel";
 
 describe.skipIf(SKIP)("provider-case mounted repeatable-read snapshot (Postgres)", () => {
   let admin: ReturnType<typeof createPostgresClient>;
@@ -35,7 +46,36 @@ describe.skipIf(SKIP)("provider-case mounted repeatable-read snapshot (Postgres)
     process.env.STEWARD_MASTER_PASSWORD ??= "provider-case-snapshot-master-password";
     process.env.STEWARD_JWT_SECRET ??=
       "provider-case-snapshot-jwt-secret-0123456789abcdef0123456789";
+    await getDb()
+      .update(transactions)
+      .set({ status: "failed" })
+      .where(eq(transactions.id, SENTINEL_TRANSACTION));
+    await getDb().delete(tenants).where(eq(tenants.id, SENTINEL_TENANT));
+    await getDb().insert(tenants).values({
+      id: SENTINEL_TENANT,
+      name: "Provider case snapshot cleanup sentinel",
+      apiKeyHash: "provider-case-snapshot-sentinel-hash",
+    });
+    await getDb().insert(agents).values({
+      id: SENTINEL_AGENT,
+      tenantId: SENTINEL_TENANT,
+      name: "Provider case snapshot cleanup sentinel",
+      walletAddress: "0x0000000000000000000000000000000000000001",
+    });
+    await getDb().insert(transactions).values({
+      id: SENTINEL_TRANSACTION,
+      agentId: SENTINEL_AGENT,
+      status: "signed",
+      toAddress: "0x0000000000000000000000000000000000000002",
+      value: "1",
+      chainId: 1,
+    });
     await wipeCase();
+    expect(
+      await getDb().query.transactions.findFirst({
+        where: eq(transactions.id, SENTINEL_TRANSACTION),
+      }),
+    ).toMatchObject({ id: SENTINEL_TRANSACTION, agentId: SENTINEL_AGENT, status: "signed" });
     await seedCaseFixture();
     ({ intentId: caseId } = await createPendingCase("pgsnap01"));
     await getDb()
@@ -55,6 +95,11 @@ describe.skipIf(SKIP)("provider-case mounted repeatable-read snapshot (Postgres)
 
   afterAll(async () => {
     await wipeCase();
+    await getDb()
+      .update(transactions)
+      .set({ status: "failed" })
+      .where(eq(transactions.id, SENTINEL_TRANSACTION));
+    await getDb().delete(tenants).where(eq(tenants.id, SENTINEL_TENANT));
     await Promise.all([admin.end(), locker.end(), writer.end()]);
     await closeDb();
   });

--- a/packages/api/src/__tests__/retention.test.ts
+++ b/packages/api/src/__tests__/retention.test.ts
@@ -8,8 +8,9 @@
 
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { getDb } from "@stwd/db";
+import { appendAuditEvent, getDb } from "@stwd/db";
 import { sql } from "drizzle-orm";
+import { verifyAuditChain } from "../services/audit";
 
 const SKIP = !process.env.DATABASE_URL;
 
@@ -24,7 +25,10 @@ async function cleanup(): Promise<void> {
   await db.execute(sql`DELETE FROM refresh_tokens WHERE tenant_id = ${TENANT}`);
   await db.execute(sql`DELETE FROM transactions WHERE agent_id = ${AGENT}`);
   await db.execute(sql`DELETE FROM agents WHERE id = ${AGENT}`);
-  await db.execute(sql`DELETE FROM audit_events WHERE tenant_id = ${TENANT}`);
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`DELETE FROM audit_events WHERE tenant_id = ${TENANT}`);
+    await tx.execute(sql`DELETE FROM audit_chain_heads WHERE tenant_id = ${TENANT}`);
+  });
   await db.execute(sql`DELETE FROM auth_kv_store WHERE namespace = ${`retention-test-${SUFFIX}`}`);
   await db.execute(sql`DELETE FROM tenants WHERE id = ${TENANT}`);
   await db.execute(sql`DELETE FROM users WHERE id = ${USER_ID}`);
@@ -148,22 +152,25 @@ describe.skipIf(SKIP)("retention sweep", () => {
     const { runRetentionSweep } = await import("../services/retention");
     delete process.env.STEWARD_RETENTION_AUDIT_EVENTS_DAYS;
     const db = getDb();
-    // Insert an ancient audit event directly (bypassing the chain — just for retention assertion).
-    await db.execute(sql`
-      INSERT INTO audit_events
-        (tenant_id, seq, prev_hash, hmac, actor_type, action, created_at)
-      VALUES
-        (${TENANT}, 1, '\\x00'::bytea, '\\x00'::bytea, 'system', 'test.old',
-         now() - interval '1000 days')
-    `);
+    // Earlier sweep cases emit retention audit events for this tenant. Reset
+    // both the rows and their out-of-band high-water mark atomically so this
+    // assertion owns a valid tenant-local chain beginning at seq 1.
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`DELETE FROM audit_events WHERE tenant_id = ${TENANT}`);
+      await tx.execute(sql`DELETE FROM audit_chain_heads WHERE tenant_id = ${TENANT}`);
+    });
+    // Use the production writer so the survival assertion begins and ends with
+    // a valid event plus matching out-of-band chain head.
+    await appendAuditEvent({ tenantId: TENANT, actorType: "system", action: "test.old" });
 
     const results = await runRetentionSweep();
     expect(results.find((r) => r.table === "audit_events")).toBeUndefined();
 
     const rows = (await db.execute(
-      sql`SELECT seq FROM audit_events WHERE tenant_id = ${TENANT}`,
+      sql`SELECT seq FROM audit_events WHERE tenant_id = ${TENANT} AND action = 'test.old'`,
     )) as Array<{ seq: number | string }>;
     expect(rows.length).toBe(1);
+    expect(await verifyAuditChain(TENANT, { requireHead: true })).toMatchObject({ valid: true });
   });
 
   it("deletes expired auth_kv_store rows", async () => {

--- a/packages/api/src/__tests__/tenant-app-clients.test.ts
+++ b/packages/api/src/__tests__/tenant-app-clients.test.ts
@@ -127,7 +127,7 @@ describe("tenant app clients hardening", () => {
 
     expect(cors).toContain("tenantAppClientsTable");
     expect(cors).toContain("eq(tenantAppClientsTable.enabled, true)");
-    expect(auth).toContain("tenantAppClients");
+    expect(auth).toContain("authAppClientSubjects(resolvedTenantId)");
     expect(auth).toContain("client_id");
     expect(auth).toContain("stateData.clientId");
     expect(auth).toContain("getTenantAppClientLoginMethods");

--- a/packages/api/src/routes/provider-case.ts
+++ b/packages/api/src/routes/provider-case.ts
@@ -30,11 +30,13 @@ import {
   type AppVariables,
   setNoStoreHeaders,
   tenantAuth,
+  withAuthenticatedTenantDatabase,
 } from "../services/context";
 import {
   CaseRangeTooLargeError,
   getProviderCase,
-  getProviderCaseEvidence,
+  readProviderCaseEvidenceSnapshot,
+  signProviderCaseEvidenceSnapshot,
 } from "../services/provider-case";
 
 export const providerCaseRoutes = new Hono<{ Variables: AppVariables }>();
@@ -50,6 +52,10 @@ providerCaseRoutes.use("/provider-actions/:id/evidence", auditOwnerAdminMfaGate)
 // path-traversal / null-byte / control-char id (N37/N38/N39) is rejected before
 // any DB access and returns the SAME uniform 404 as a genuine miss.
 const CASE_ID_PATTERN = /^pa_[0-9a-fA-F-]{36}$/;
+const SNAPSHOT_CHARACTERISTICS = {
+  isolationLevel: "repeatable read" as const,
+  readOnly: true,
+};
 
 function isValidCaseId(id: string): boolean {
   return CASE_ID_PATTERN.test(id);
@@ -74,8 +80,19 @@ providerCaseRoutes.get("/provider-actions/:id/case", async (c) => {
 
   let manifestOrNull;
   try {
-    const authorized = await tenantWorkspaceIds(tenantId);
-    const assembly = await getProviderCase(tenantId, caseId, authorized);
+    const userId = c.get("userId");
+    if (!userId) return c.json<ApiResponse>({ ok: false, error: "Forbidden" }, 403);
+    const assembly = await withAuthenticatedTenantDatabase(
+      tenantId,
+      "provider-case-snapshot",
+      userId,
+      async () => {
+        const authorized = await tenantWorkspaceIds(tenantId);
+        return getProviderCase(tenantId, caseId, authorized);
+      },
+      userId,
+      SNAPSHOT_CHARACTERISTICS,
+    );
     manifestOrNull = assembly?.manifest ?? null;
   } catch (err) {
     console.error(
@@ -105,8 +122,20 @@ providerCaseRoutes.get("/provider-actions/:id/evidence", async (c) => {
 
   let evidence;
   try {
-    const authorized = await tenantWorkspaceIds(tenantId);
-    evidence = await getProviderCaseEvidence(tenantId, caseId, authorized);
+    const userId = c.get("userId");
+    if (!userId) return c.json<ApiResponse>({ ok: false, error: "Forbidden" }, 403);
+    const snapshot = await withAuthenticatedTenantDatabase(
+      tenantId,
+      "provider-case-snapshot",
+      userId,
+      async () => {
+        const authorized = await tenantWorkspaceIds(tenantId);
+        return readProviderCaseEvidenceSnapshot(tenantId, caseId, authorized);
+      },
+      userId,
+      SNAPSHOT_CHARACTERISTICS,
+    );
+    evidence = snapshot ? await signProviderCaseEvidenceSnapshot(snapshot) : null;
   } catch (err) {
     if (err instanceof AuditSigningKeyError) {
       return c.json<ApiResponse>({ ok: false, error: "CASE_EVIDENCE_SIGNING_DISABLED" }, 503);
@@ -155,7 +184,7 @@ export function registerProviderCaseRoutes(app: Hono<{ Variables: AppVariables }
       setNoStoreHeaders(c);
       await next();
     });
-    app.use(p, (c, next) => tenantAuth(c, next));
+    app.use(p, (c, next) => tenantAuth(c, next, { bindTenantDatabase: false }));
   }
   app.route("/v2", providerCaseRoutes);
 }

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -26,6 +26,7 @@ import {
   operatorTransferReservations,
   policies,
   sessionSigners,
+  type TenantTransactionCharacteristics,
   tenantContextFromAuthenticatedPrincipal,
   toPolicyRule,
   transactions,
@@ -755,12 +756,18 @@ export async function withAuthenticatedTenantDatabase<T>(
   subject: string,
   callback: () => Promise<T>,
   userId?: string,
+  characteristics?: TenantTransactionCharacteristics,
 ): Promise<T> {
-  if (hasTenantTransactionDatabase({ tenantId, userId })) return callback();
+  if (hasTenantTransactionDatabase({ tenantId, userId, ...characteristics })) return callback();
   const context = tenantContextFromAuthenticatedPrincipal({ tenantId, method, subject, userId });
   const driver = isPGLiteRuntime ? "pglite" : getDatabaseDriver();
-  return withTenantRlsTransaction(getDb() as never, driver, context, async (tx) =>
-    withTenantTransactionDatabase(tx as never, { tenantId, userId }, callback),
+  return withTenantRlsTransaction(
+    getDb() as never,
+    driver,
+    context,
+    async (tx) =>
+      withTenantTransactionDatabase(tx as never, { tenantId, userId }, callback, characteristics),
+    characteristics,
   );
 }
 
@@ -777,7 +784,7 @@ export async function continueWithTenantDatabase(
 export async function tenantAuth(
   c: Context<{ Variables: AppVariables }>,
   next: Next,
-  options?: { requireTenantMatch?: string },
+  options?: { requireTenantMatch?: string; bindTenantDatabase?: boolean },
 ) {
   await defaultTenantReady;
 
@@ -902,6 +909,7 @@ export async function tenantAuth(
           }
           c.set("authType", "session-jwt");
         }
+        if (options?.bindTenantDatabase === false) return next();
         return continueWithTenantDatabase(
           payload.tenantId,
           isAgentToken ? "agent-jwt" : "session-jwt",
@@ -965,6 +973,7 @@ export async function tenantAuth(
       tenantConfigs.get(parsedAppId.tenantId) || { id: appTenant.id, name: appTenant.name },
     );
     c.set("authType", "app-secret");
+    if (options?.bindTenantDatabase === false) return next();
     await continueWithTenantDatabase(
       parsedAppId.tenantId,
       "app-secret",
@@ -993,6 +1002,7 @@ export async function tenantAuth(
   c.set("tenantConfig", tenantConfigs.get(tenantId) || { id: tenant.id, name: tenant.name });
   c.set("authType", "api-key");
 
+  if (options?.bindTenantDatabase === false) return next();
   await continueWithTenantDatabase(tenantId, "api-key", tenantId, next);
 }
 

--- a/packages/api/src/services/provider-case.ts
+++ b/packages/api/src/services/provider-case.ts
@@ -23,6 +23,7 @@ import {
   approvalQueue,
   executionAuthorizationNonces,
   getDb,
+  hasTenantTransactionDatabase,
   providerAccounts,
   providerActionBindings,
   providerOperations,
@@ -315,9 +316,18 @@ export async function getProviderCase(
   caseId: string,
   authorizedWorkspaceIds: string[],
 ): Promise<ProviderCaseAssembly | null> {
-  return runInSnapshot((sdb) =>
+  return runInSnapshot(tenantId, (sdb) =>
     assembleWithinSnapshot(sdb, tenantId, caseId, authorizedWorkspaceIds),
   );
+}
+
+export interface ProviderCaseEvidenceSnapshot {
+  tenantId: string;
+  caseId: string;
+  assembly: ProviderCaseAssembly;
+  bundleData: AuditBundleData;
+  segmentFrom: number;
+  segmentTo: number;
 }
 
 /**
@@ -331,47 +341,54 @@ export async function getProviderCaseEvidence(
   caseId: string,
   authorizedWorkspaceIds: string[],
 ): Promise<ProviderCaseEvidenceV1 | null> {
-  // 1) Assemble the manifest + fix the segment bounds inside ONE read-only
-  //    snapshot (all correlation/verify reads coherent).
-  const assembly = await runInSnapshot((sdb) =>
-    assembleWithinSnapshot(sdb, tenantId, caseId, authorizedWorkspaceIds),
-  );
-  if (!assembly) return null;
+  const snapshot = await readProviderCaseEvidenceSnapshot(tenantId, caseId, authorizedWorkspaceIds);
+  return snapshot ? signProviderCaseEvidenceSnapshot(snapshot) : null;
+}
 
-  const { manifest, segmentFrom, segmentTo } = assembly;
-
-  // 2) Read the bundle segment + sign OUTSIDE the read-only snapshot. The
-  //    audit chain is append-only and immutable once written, so re-reading the
-  //    SAME fixed [segmentFrom, segmentTo] range returns byte-identical events;
-  //    doing the signing (which persists a checkpoint best-effort) outside the
-  //    snapshot avoids a write-inside-read-only-tx deadlock on PGLite's single
-  //    connection while preserving manifest↔bundle consistency (the manifest's
-  //    seq+hmac index already pins exactly which events belong to the case).
-  let bundle: SignedAuditBundle;
-  if (segmentFrom == null || segmentTo == null) {
-    const empty: AuditBundleData = {
-      head: null,
-      events: [],
-      bundleHeadHmac: null,
-      bundleHeadSeq: null,
-    };
-    bundle = await signAuditBundle(tenantId, 0, 0, empty);
-  } else {
-    // Enforce the segment cap before reading the range: a case whose
-    // contiguous span exceeds MAX_CASE_SEGMENT_EVENTS (pathological same-tenant
-    // interleave, KC15) must NOT materialize/sign an unbounded range of
-    // unrelated audit rows via /evidence. Fail closed with a typed error the
-    // route maps to 400 CASE_RANGE_TOO_LARGE (§5.4); the manifest already
-    // carries `unknown` + a size-exceeded reason, and /case (manifest-only)
-    // still works for triage.
-    if (segmentTo - segmentFrom + 1 > MAX_CASE_SEGMENT_EVENTS) {
+/**
+ * Read every manifest and bundle input in one snapshot. Route callers end the
+ * read-only transaction before passing this immutable material to the signer,
+ * whose best-effort checkpoint persistence is intentionally a separate write.
+ */
+export async function readProviderCaseEvidenceSnapshot(
+  tenantId: string,
+  caseId: string,
+  authorizedWorkspaceIds: string[],
+): Promise<ProviderCaseEvidenceSnapshot | null> {
+  return runInSnapshot(tenantId, async (sdb) => {
+    const assembly = await assembleWithinSnapshot(sdb, tenantId, caseId, authorizedWorkspaceIds);
+    if (!assembly) return null;
+    const { segmentFrom, segmentTo } = assembly;
+    if (
+      segmentFrom != null &&
+      segmentTo != null &&
+      segmentTo - segmentFrom + 1 > MAX_CASE_SEGMENT_EVENTS
+    ) {
       throw new CaseRangeTooLargeError(
         `case segment [${segmentFrom},${segmentTo}] exceeds ${MAX_CASE_SEGMENT_EVENTS} events`,
       );
     }
-    const bundleData = await readAuditBundleData(tenantId, segmentFrom, segmentTo);
-    bundle = await signAuditBundle(tenantId, segmentFrom, segmentTo, bundleData);
-  }
+    const from = segmentFrom ?? 0;
+    const to = segmentTo ?? 0;
+    const bundleData =
+      segmentFrom == null || segmentTo == null
+        ? { head: null, events: [], bundleHeadHmac: null, bundleHeadSeq: null }
+        : await readAuditBundleData(tenantId, segmentFrom, segmentTo, sdb);
+    return { tenantId, caseId, assembly, bundleData, segmentFrom: from, segmentTo: to };
+  });
+}
+
+export async function signProviderCaseEvidenceSnapshot(
+  snapshot: ProviderCaseEvidenceSnapshot,
+): Promise<ProviderCaseEvidenceV1> {
+  const { tenantId, caseId, assembly, bundleData, segmentFrom, segmentTo } = snapshot;
+  const { manifest } = assembly;
+  const bundle: SignedAuditBundle = await signAuditBundle(
+    tenantId,
+    segmentFrom,
+    segmentTo,
+    bundleData,
+  );
 
   return {
     version: 1,
@@ -841,20 +858,27 @@ async function loadAccount(
  * non-blocking (§4.1). The audit chain-verify + bundle read are threaded the tx
  * executor so they share this snapshot (KC06).
  */
-async function runInSnapshot<T>(fn: (sdb: SnapshotDb) => Promise<T>): Promise<T> {
+async function runInSnapshot<T>(tenantId: string, fn: (sdb: SnapshotDb) => Promise<T>): Promise<T> {
   const db = getDb();
+  // Mounted case routes deliberately establish this tenant-bound snapshot
+  // before entering the service. A nested Drizzle transaction would only be a
+  // savepoint, so reuse is permitted only when the tenant and transaction
+  // characteristics match exactly; ordinary READ COMMITTED reuse fails closed.
+  if (
+    hasTenantTransactionDatabase({
+      tenantId,
+      isolationLevel: "repeatable read",
+      readOnly: true,
+    })
+  ) {
+    return fn(db as SnapshotDb);
+  }
   try {
     return await db.transaction(async (tx) => {
       if (!isPGLiteRuntime()) {
-        try {
-          await (tx as unknown as AuditReadExecutor).execute(
-            sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`,
-          );
-        } catch {
-          // Some drivers set isolation only at BEGIN; a failure here is
-          // non-fatal — the reads are still coherent enough for a monotonic
-          // append-only chain. Never fail the read on this.
-        }
+        await (tx as unknown as AuditReadExecutor).execute(
+          sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`,
+        );
       }
       return await fn(tx as unknown as SnapshotDb);
     });

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -11,6 +11,7 @@ import {
   waitUntilRequestDatabaseTask,
   withRequestDatabase,
   withTenantTransactionDatabase,
+  withTenantTransactionDatabaseDeadline,
 } from "../client";
 import { createPGLiteDb } from "../pglite";
 import { tenants } from "../schema";
@@ -76,6 +77,63 @@ describe("request-scoped database context", () => {
         ).toThrow("RLS_TENANT_DATABASE_CONTEXT_MISMATCH");
       },
     );
+  });
+
+  test("validates snapshot characteristics before reusing a tenant transaction", async () => {
+    const transactionDb = { marker: "snapshot" } as unknown as ReturnType<typeof getDb>;
+    await withTenantTransactionDatabase(
+      transactionDb,
+      { tenantId: "tenant-a" },
+      async () => {
+        expect(
+          hasTenantTransactionDatabase({
+            tenantId: "tenant-a",
+            isolationLevel: "repeatable read",
+            readOnly: true,
+          }),
+        ).toBe(true);
+        expect(() =>
+          hasTenantTransactionDatabase({ tenantId: "tenant-a", readOnly: false }),
+        ).toThrow("RLS_TENANT_DATABASE_CHARACTERISTICS_MISMATCH");
+      },
+      { isolationLevel: "repeatable read", readOnly: true },
+    );
+  });
+
+  test("deadline phases preserve the exact tenant transaction capability", async () => {
+    const executed: unknown[] = [];
+    const transactionDb = {
+      marker: "tenant-transaction",
+      execute: async (query: unknown) => {
+        executed.push(query);
+        return [];
+      },
+    } as unknown as ReturnType<typeof getDb>;
+
+    await expect(
+      withTenantTransactionDatabaseDeadline(Date.now() + 5_000, async () => undefined),
+    ).rejects.toThrow("RLS_TENANT_DATABASE_CONTEXT_REQUIRED");
+
+    await withTenantTransactionDatabase(
+      transactionDb,
+      {
+        tenantId: "tenant-a",
+        userId: "11111111-1111-4111-8111-111111111111",
+      },
+      async () => {
+        await withTenantTransactionDatabaseDeadline(Date.now() + 5_000, async (deadlineDb) => {
+          expect(deadlineDb).toBe(getDb());
+          expect((deadlineDb as unknown as { marker: string }).marker).toBe("tenant-transaction");
+          expect(
+            hasTenantTransactionDatabase({
+              tenantId: "tenant-a",
+              userId: "11111111-1111-4111-8111-111111111111",
+            }),
+          ).toBe(true);
+        });
+      },
+    );
+    expect(executed).toHaveLength(3);
   });
 
   test("tenant transaction drains registered work and revokes retained capabilities", async () => {

--- a/packages/db/src/__tests__/tenant-rls-context.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-context.test.ts
@@ -187,4 +187,32 @@ describe("tenant RLS transaction context", () => {
     expect(result).toBe("bound");
     expect(executeCount).toBe(4);
   });
+
+  test("establishes repeatable-read read-only before any tenant context query", async () => {
+    const calls: unknown[] = [];
+    let executeCount = 0;
+    const tx = {
+      async execute(query: unknown) {
+        calls.push(query);
+        executeCount += 1;
+        return executeCount === 5 ? [{ tenant_id: "tenant-snapshot", user_id: null }] : [];
+      },
+    };
+    const db = {
+      async transaction<T>(callback: (value: typeof tx) => Promise<T>) {
+        return callback(tx);
+      },
+    };
+    await withTenantRlsTransaction(
+      db,
+      "postgres-js",
+      tenantContextForInternalJob({ tenantId: "tenant-snapshot", job: "provider-case" }),
+      async () => undefined,
+      { isolationLevel: "repeatable read", readOnly: true },
+    );
+    expect(calls).toHaveLength(5);
+    expect(JSON.stringify(calls[0])).toContain(
+      "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
+    );
+  });
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -25,6 +25,7 @@
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";
+import { sql } from "drizzle-orm";
 import { drizzle as drizzleNeon, type NeonHttpDatabase } from "drizzle-orm/neon-http";
 import { drizzle as drizzleNeonWebSocket, type NeonDatabase } from "drizzle-orm/neon-serverless";
 import { drizzle as drizzlePostgres, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
@@ -489,6 +490,8 @@ interface RequestDatabaseContext {
   active: boolean;
   tenantId?: string;
   userId?: string;
+  isolationLevel?: "repeatable read";
+  readOnly?: boolean;
   pendingTasks: Set<Promise<unknown>>;
   guardedObjects: WeakMap<object, object>;
 }
@@ -498,6 +501,9 @@ const tenantTransactionDatabaseStorage = new AsyncLocalStorage<RequestDatabaseCo
 export function hasTenantTransactionDatabase(expected?: {
   tenantId: string;
   userId?: string;
+  db?: RequestDatabase;
+  isolationLevel?: "repeatable read";
+  readOnly?: boolean;
 }): boolean {
   const context = tenantTransactionDatabaseStorage.getStore();
   if (!context?.active || !context.db) return false;
@@ -508,7 +514,37 @@ export function hasTenantTransactionDatabase(expected?: {
   ) {
     throw new Error("RLS_TENANT_DATABASE_CONTEXT_MISMATCH");
   }
+  if (
+    expected &&
+    ((expected.isolationLevel !== undefined &&
+      context.isolationLevel !== expected.isolationLevel) ||
+      (expected.readOnly !== undefined && context.readOnly !== expected.readOnly))
+  ) {
+    throw new Error("RLS_TENANT_DATABASE_CHARACTERISTICS_MISMATCH");
+  }
+  if (expected?.db !== undefined && expected.db !== context.db) return false;
   return true;
+}
+
+/**
+ * Apply a bounded database phase without replacing the active tenant
+ * transaction or its request-owned transport. PostgreSQL timeouts are scoped
+ * to the existing transaction, so the trusted tenant/user GUCs and a Worker's
+ * single WebSocket connection remain authoritative for the whole phase.
+ */
+export async function withTenantTransactionDatabaseDeadline<T>(
+  deadlineAt: number,
+  use: (db: RequestDatabase) => Promise<T>,
+): Promise<T> {
+  const context = tenantTransactionDatabaseStorage.getStore();
+  if (!context) throw new Error("RLS_TENANT_DATABASE_CONTEXT_REQUIRED");
+  assertRequestDatabaseContextActive(context);
+  const remainingMs = deadlineMilliseconds(deadlineAt);
+  const db = context.db;
+  await db.execute(sql.raw(`SET LOCAL statement_timeout = '${remainingMs}ms'`));
+  await db.execute(sql.raw(`SET LOCAL lock_timeout = '${remainingMs}ms'`));
+  await db.execute(sql.raw(`SET LOCAL idle_in_transaction_session_timeout = '${remainingMs}ms'`));
+  return use(db);
 }
 
 function assertRequestDatabaseContextActive(
@@ -631,6 +667,7 @@ export async function withTenantTransactionDatabase<T>(
   transactionDb: RequestDatabase,
   identity: { tenantId: string; userId?: string },
   callback: () => Promise<T>,
+  characteristics?: { isolationLevel?: "repeatable read"; readOnly?: boolean },
 ): Promise<T> {
   if (tenantTransactionDatabaseStorage.getStore()) {
     throw new Error("RLS_TENANT_DATABASE_CONTEXT_NESTED");
@@ -641,6 +678,8 @@ export async function withTenantTransactionDatabase<T>(
     active: true,
     tenantId: identity.tenantId,
     userId: identity.userId,
+    isolationLevel: characteristics?.isolationLevel,
+    readOnly: characteristics?.readOnly,
     pendingTasks: new Set(),
     guardedObjects: new WeakMap(),
   };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -68,6 +68,7 @@ export * from "./schema-auth";
 export {
   assertTenantRlsDriver,
   type TenantRlsDriver,
+  type TenantTransactionCharacteristics,
   type TrustedTenantContext,
   tenantContextForInternalJob,
   tenantContextFromAuthenticatedPrincipal,

--- a/packages/db/src/tenant-rls-context.ts
+++ b/packages/db/src/tenant-rls-context.ts
@@ -97,6 +97,11 @@ interface TenantTransactionalDatabase<Tx extends TenantTransactionExecutor> {
   transaction<T>(callback: (tx: Tx) => Promise<T>): Promise<T>;
 }
 
+export interface TenantTransactionCharacteristics {
+  isolationLevel?: "repeatable read";
+  readOnly?: boolean;
+}
+
 function hasTrustedBrand(context: unknown): context is TrustedTenantContext {
   return typeof context === "object" && context !== null && trustedTenantContexts.has(context);
 }
@@ -120,6 +125,7 @@ export async function withTenantRlsTransaction<Tx extends TenantTransactionExecu
   driver: TenantRlsDriver,
   context: TrustedTenantContext,
   callback: (tx: Tx) => Promise<T>,
+  characteristics?: TenantTransactionCharacteristics,
 ): Promise<T> {
   assertTenantRlsDriver(driver);
   if (!hasTrustedBrand(context)) throw new Error("RLS_TENANT_CONTEXT_UNTRUSTED");
@@ -130,6 +136,13 @@ export async function withTenantRlsTransaction<Tx extends TenantTransactionExecu
   if (is(db, PgTransaction)) throw new Error("RLS_TENANT_TRANSACTION_NESTED");
 
   const outcome = await db.transaction(async (tx) => {
+    if (driver !== "pglite" && characteristics?.isolationLevel === "repeatable read") {
+      await tx.execute(
+        characteristics.readOnly
+          ? sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`
+          : sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ`,
+      );
+    }
     // A non-empty value here means this connection carries a session-level
     // setting or the helper was nested inside another tenant transaction.
     // Overwriting either would conceal a lifecycle bug and could restore the

--- a/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
+++ b/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
@@ -88,13 +88,15 @@ beforeAll(async () => {
       {
         id: TENANT_NO_KEY_ID,
         name: "Agent Token Expiry No Key Tenant",
-        apiKeyHash: "",
+        // The request below omits the API key; the stored value only needs to
+        // be non-matching. Keep it unique so this fixture cannot occupy the
+        // empty hash reserved by the default-tenant bootstrap.
+        apiKeyHash: "not-a-real-key-hash-no-key-tenant",
       },
       {
         id: OTHER_TENANT_ID,
         name: "Agent Token Expiry Other Tenant",
-        // api_key_hash has a unique index; a second "" row would be silently
-        // dropped by onConflictDoNothing and break the agents FK below.
+        // api_key_hash has a unique index; keep every fixture value distinct.
         apiKeyHash: "not-a-real-key-hash-other-tenant",
       },
     ])

--- a/packages/proxy/src/__tests__/proxy-approval-expiry-audit-atomicity.test.ts
+++ b/packages/proxy/src/__tests__/proxy-approval-expiry-audit-atomicity.test.ts
@@ -9,6 +9,7 @@ import {
   getDb,
   pendingProxyRequests,
   proxyAuditLog,
+  sql,
   tenants,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
@@ -30,10 +31,10 @@ import { PROXY_SCOPE } from "../config";
 // shared `@stwd/db` `withTenantAuditedTransaction` primitive to commit the
 // `expired` transition AND a `proxy.approval.expired` chain event in ONE
 // transaction. This suite drives the real release handler against a PGLite DB
-// whose transaction layer is instrumented to throw at the audit-chain INSERT and
-// proves:
+// with a database trigger that rejects the required audit INSERT inside that
+// same transaction. It proves:
 //   1. audit-chain event present on the happy path (both poll-time & claim-time);
-//   2. both-or-neither: when the chain INSERT faults, the `expired` transition
+//   2. both-or-neither: when the chain append faults, the `expired` transition
 //      rolls back too (I14) and no chain event exists;
 //   3. mutation proof (revert): if the transition is not wrapped with the chain
 //      append, the fault would leave `expired` with no chain event — asserted by
@@ -55,52 +56,6 @@ let resetReleaseClaimBarrier: typeof import("../handlers/release")["__resetRelea
 let setForwardProxyRequest: typeof import("../handlers/proxy")["__setForwardProxyRequestForTests"];
 let proxyMod: typeof import("../handlers/proxy");
 
-// ─── Audit-chain-insert fault injection ───────────────────────────────────────
-//
-// When `faultAuditInsert` is true, the FIRST `insert into audit_events`
-// executed inside any transaction throws. This simulates the exact crash point:
-// the row was just flipped to `expired` in the same transaction and the required
-// chain append fails.
-
-let faultAuditInsert = false;
-
-type TxLike = { execute: (query: unknown) => Promise<unknown> };
-
-function isAuditInsert(dialect: unknown, query: unknown): boolean {
-  try {
-    const built = (dialect as { sqlToQuery: (q: unknown) => { sql?: string } }).sqlToQuery(query);
-    const text = String(built?.sql ?? "").toLowerCase();
-    return text.includes("insert into audit_events");
-  } catch {
-    return false;
-  }
-}
-
-function installFaultInjectingDb(db: unknown): void {
-  const anyDb = db as {
-    dialect: unknown;
-    transaction: (cb: (tx: TxLike) => Promise<unknown>, ...rest: unknown[]) => Promise<unknown>;
-  };
-  const dialect = anyDb.dialect;
-  const originalTransaction = anyDb.transaction.bind(anyDb);
-  anyDb.transaction = (cb: (tx: TxLike) => Promise<unknown>, ...rest: unknown[]) => {
-    return originalTransaction(
-      async (tx: TxLike) => {
-        const originalExecute = tx.execute.bind(tx);
-        tx.execute = async (query: unknown) => {
-          if (faultAuditInsert && isAuditInsert(dialect, query)) {
-            faultAuditInsert = false; // fault the first audit insert only
-            throw new Error("injected audit-chain fault");
-          }
-          return originalExecute(query);
-        };
-        return cb(tx);
-      },
-      ...rest,
-    );
-  };
-}
-
 beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
@@ -109,9 +64,9 @@ beforeAll(async () => {
   process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.example.com";
   process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS = "api.example.com";
   process.env.STEWARD_ALLOW_BROAD_SECRET_ROUTES = "true";
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
 
   const { db, client } = await createPGLiteDb("memory://");
-  installFaultInjectingDb(db);
   setPGLiteOverride(db, async () => {
     await client.close();
   });
@@ -130,7 +85,6 @@ beforeAll(async () => {
 });
 
 afterEach(() => {
-  faultAuditInsert = false;
   resetReleaseClaimBarrier();
 });
 
@@ -143,7 +97,39 @@ afterAll(async () => {
   delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
   delete process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS;
   delete process.env.STEWARD_ALLOW_BROAD_SECRET_ROUTES;
+  delete process.env.STEWARD_PROXY_DEV_MODE;
 });
+
+async function withExpiryAuditFailure<T>(operation: () => Promise<T>): Promise<T> {
+  await getDb().execute(
+    sql.raw(`
+    CREATE OR REPLACE FUNCTION fail_proxy_expiry_audit_for_test()
+    RETURNS trigger AS $$
+    BEGIN
+      IF NEW.action = 'proxy.approval.expired' THEN
+        RAISE EXCEPTION 'injected audit-chain fault';
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+  `),
+  );
+  await getDb().execute(
+    sql.raw(`
+    CREATE TRIGGER proxy_expiry_audit_failure_for_test
+    BEFORE INSERT ON audit_events
+    FOR EACH ROW EXECUTE FUNCTION fail_proxy_expiry_audit_for_test()
+  `),
+  );
+  try {
+    return await operation();
+  } finally {
+    await getDb().execute(
+      sql.raw("DROP TRIGGER IF EXISTS proxy_expiry_audit_failure_for_test ON audit_events"),
+    );
+    await getDb().execute(sql.raw("DROP FUNCTION IF EXISTS fail_proxy_expiry_audit_for_test()"));
+  }
+}
 
 function buildApp() {
   const app = new Hono();
@@ -289,8 +275,9 @@ describe("proxy approval-expiry audit atomicity (fault injection)", () => {
       .set({ expiresAt: new Date(Date.now() - 60_000), updatedAt: new Date() })
       .where(eq(pendingProxyRequests.id, held.id));
 
-    faultAuditInsert = true;
-    const res = await poll(held.id, await tokenFor(agentId, tenantId));
+    const res = await withExpiryAuditFailure(async () =>
+      poll(held.id, await tokenFor(agentId, tenantId)),
+    );
     // The injected fault propagates out of the release handler as a 5xx.
     expect(res.status).toBeGreaterThanOrEqual(500);
 
@@ -367,8 +354,9 @@ describe("proxy approval-expiry audit atomicity (fault injection)", () => {
     });
     installCountedForwarder();
 
-    faultAuditInsert = true;
-    const res = await poll(held.id, await tokenFor(agentId, tenantId));
+    const res = await withExpiryAuditFailure(async () =>
+      poll(held.id, await tokenFor(agentId, tenantId)),
+    );
     expect(res.status).toBeGreaterThanOrEqual(500);
 
     // ATOMICITY: the approved -> expired transition rolls back with the faulted

--- a/scripts/__tests__/docker-workflow-paths.test.ts
+++ b/scripts/__tests__/docker-workflow-paths.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Responsibility: keep the required pull-request Docker build eligible for
+ * every source or configuration input copied into the Steward API image.
+ *
+ * The main branch requires the build-and-push check. A narrower path filter can
+ * leave source-only release PRs permanently blocked without ever building the
+ * candidate image, so this test protects the complete Docker context boundary.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const WORKFLOW = join(import.meta.dir, "..", "..", ".github", "workflows", "docker.yml");
+const source = readFileSync(WORKFLOW, "utf8");
+const pullRequestTrigger =
+  source.match(/ {2}pull_request:\n([\s\S]*?)(?=\n\n# A branch tag is mutable)/)?.[1] ?? "";
+
+describe("Docker pull-request path coverage", () => {
+  test("includes every root configuration input copied by the Dockerfile", () => {
+    for (const path of [
+      "Dockerfile",
+      ".dockerignore",
+      "package.json",
+      "bun.lock",
+      "turbo.json",
+      "tsconfig.json",
+      "web/package.json",
+    ]) {
+      expect(pullRequestTrigger).toContain(`- "${path}"`);
+    }
+  });
+
+  test("builds for source-only package changes and workflow changes", () => {
+    expect(pullRequestTrigger).toContain('- "packages/**"');
+    expect(pullRequestTrigger).toContain('- ".github/workflows/docker.yml"');
+    expect(pullRequestTrigger).not.toContain('- "packages/**/package.json"');
+  });
+});


### PR DESCRIPTION
## Summary

Restore the inherited main-branch CI baselines before the auth release PR is rebased:

- backport the proven develop PR #680 PostgreSQL test-runner and repeatable-read snapshot repair
- restore the exact follow-up fixture isolation repair already proven on develop
- replace ineffective proxy audit fault monkey-patches with database-trigger fault injection against the transaction actually used
- make the required Docker PR build eligible for every input copied by the Dockerfile, including source-only package changes
- add a regression test for the Docker workflow path boundary

## Conflict resolution

The #680 backport conflicted in two request-database files. Resolution deliberately preserves both sides:

- retains main request-capability revocation coverage while adding the snapshot/deadline contracts
- retains main request-scoped database guards while adding isolation/read-only identity checks and deadline phases on the exact active tenant transaction

No login/auth behavior is changed by this PR. No deployment or production state is touched.

## Hosted CI follow-up

The initial head exposed three deterministic fixture defects:

- plugin-trading inserted an empty tenant API-key hash before the default-tenant bootstrap, causing the unique index to turn token-status auth checks into 500s
- approvals proxy atomicity monkey-patched tx.execute, which no longer intercepts the real audit insert
- provider-case cleanup deleted every tenant and tripped the unresolved-transaction deletion guard on unrelated state

The current head stores a unique non-matching fixture hash, injects approval audit failure with a database trigger, and ports the exact develop scoped-cleanup plus foreign-state sentinel proof.

## Why this is separate

PR #900 currently inherits main baseline failures, while its required build-and-push check was not scheduled for source-only changes. Landing this prerequisite first gives the auth release a meaningful changed-path signal after rebase.

## Validation

Head: 7694d0d25953f3110143c4977182891e1a1c37f4

Current-head delta proof with Bun 1.3.14:

- plugin-trading failed file: 5 passed, 0 failed
- approval/audit atomicity: 5 passed, 0 failed
- mounted real-Postgres snapshot: 1 passed, 0 failed
- isolated approval/provider-case corpus: 10/10 files passed
- API and plugin-trading typechecks passed
- Biome on all four changed files passed
- git diff --check clean

Earlier branch proof retained by this head:

- relevant workspace build: 24/24 tasks
- full proxy package: 319 passed, 0 failed
- request/tenant DB contracts: 29 passed, 0 failed
- affected API suite: 14/14 isolated files passed
- Docker path regression: 2 passed, 0 failed
- Docker workflow YAML parsed
- full local Docker image build passed using the pinned Bun 1.3.14 base image

The fresh hosted Bun 1.3 matrix remains authoritative for the complete package shards.