### PR TITLE
fix(auth): scope passkey recovery to relying party

### DIFF
--- a/packages/api/src/__tests__/auth-passkey-mfa-hardening.test.ts
+++ b/packages/api/src/__tests__/auth-passkey-mfa-hardening.test.ts
@@ -32,7 +32,7 @@ describe("passkey MFA hardening", () => {
       "getChallengeStore().consume(challengeKey)",
       handlerStart,
     );
-    const counterUpdate = authSource.indexOf(".set({ counter:", handlerStart);
+    const counterUpdate = authSource.indexOf(".update(authenticators)", handlerStart);
     const mfaMethod = authSource.indexOf('mfaMethod: "passkey"', handlerStart);
 
     expect(readChallenge).toBeGreaterThan(handlerStart);
@@ -51,7 +51,7 @@ describe("passkey MFA hardening", () => {
     const mfaStart = authSource.indexOf("const completePasskeyMfaHandler");
     expect(mfaStart).toBeGreaterThanOrEqual(0);
     const mfaGuard = authSource.indexOf(guard, mfaStart);
-    const mfaCounterUpdate = authSource.indexOf(".set({ counter:", mfaStart);
+    const mfaCounterUpdate = authSource.indexOf(".update(authenticators)", mfaStart);
     const mfaCompareAndSwap = authSource.indexOf(
       "eq(authenticators.counter, cred.counter)",
       mfaCounterUpdate,
@@ -63,7 +63,7 @@ describe("passkey MFA hardening", () => {
     const loginStart = authSource.indexOf('auth.post("/passkey/login/verify"');
     expect(loginStart).toBeGreaterThanOrEqual(0);
     const loginGuard = authSource.indexOf(guard, loginStart);
-    const loginCounterUpdate = authSource.indexOf(".set({ counter:", loginStart);
+    const loginCounterUpdate = authSource.indexOf(".update(authenticators)", loginStart);
     const loginCompareAndSwap = authSource.indexOf(
       "eq(authenticators.counter, cred.counter)",
       loginCounterUpdate,

--- a/packages/api/src/__tests__/auth-passkey-register-recovery.test.ts
+++ b/packages/api/src/__tests__/auth-passkey-register-recovery.test.ts
@@ -1,0 +1,227 @@
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { authenticators, closeDb, getDb, tenants, users, userTenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+
+setDefaultTimeout(120_000);
+
+const TENANT_ID = "passkey-register-recovery";
+const CURRENT_ORIGIN = "https://steward.fi";
+const CURRENT_RP_ID = "steward.fi";
+const OTHER_RP_ID = "waifu.fun";
+const SAME_RP_EMAIL = "passkey-same-rp@example.test";
+const CROSS_RP_EMAIL = "passkey-cross-rp@example.test";
+const LEGACY_EMAIL = "passkey-legacy@example.test";
+const UNKNOWN_EMAIL = "passkey-unknown@example.test";
+const SAME_RP_CREDENTIAL_ID = "same-rp-passkey-credential";
+const CROSS_RP_CREDENTIAL_ID = "cross-rp-passkey-credential";
+const LEGACY_CREDENTIAL_ID = "legacy-passkey-credential";
+
+type RegistrationOptions = {
+  challenge: string;
+  rp: { id: string };
+  excludeCredentials?: Array<{ id: string; type: "public-key" }>;
+  user: { id: string; name: string };
+};
+
+describe("passkey verified-email registration recovery", () => {
+  let app: Hono;
+  let auth: Awaited<typeof import("../routes/auth")>;
+  let sameRpUserId = "";
+
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_ALLOW_DEV_SECRETS = "true";
+    process.env.STEWARD_JWT_SECRET = "passkey-register-recovery-jwt-secret-with-enough-entropy";
+    process.env.STEWARD_MASTER_PASSWORD = "passkey-register-recovery-master-password";
+    process.env.STEWARD_KDF_SALT = "dGVzdC1zYWx0LXRlc3Qtc2FsdA==";
+    process.env.PASSKEY_RP_ID = CURRENT_RP_ID;
+    process.env.PASSKEY_ORIGIN = CURRENT_ORIGIN;
+    process.env.PASSKEY_ALLOWED_ORIGINS = `${CURRENT_ORIGIN},https://${OTHER_RP_ID}`;
+
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+
+    await getDb()
+      .insert(tenants)
+      .values({ id: TENANT_ID, name: "Passkey recovery", apiKeyHash: "passkey-recovery" });
+    const [sameRpUser, crossRpUser, legacyUser] = await getDb()
+      .insert(users)
+      .values([
+        { email: SAME_RP_EMAIL, emailVerified: true },
+        { email: CROSS_RP_EMAIL, emailVerified: true },
+        { email: LEGACY_EMAIL, emailVerified: true },
+      ])
+      .returning({ id: users.id });
+    sameRpUserId = sameRpUser.id;
+    await getDb()
+      .insert(userTenants)
+      .values(
+        [sameRpUser, crossRpUser, legacyUser].map((user) => ({
+          userId: user.id,
+          tenantId: TENANT_ID,
+          role: "member" as const,
+        })),
+      );
+    await getDb()
+      .insert(authenticators)
+      .values([
+        {
+          userId: sameRpUser.id,
+          credentialId: SAME_RP_CREDENTIAL_ID,
+          credentialPublicKey: "same-rp-passkey-public-key",
+          rpId: CURRENT_RP_ID,
+          counter: 1,
+          credentialDeviceType: "singleDevice",
+          credentialBackedUp: false,
+          transports: ["internal"],
+        },
+        {
+          userId: crossRpUser.id,
+          credentialId: CROSS_RP_CREDENTIAL_ID,
+          credentialPublicKey: "cross-rp-passkey-public-key",
+          rpId: OTHER_RP_ID,
+          counter: 1,
+          credentialDeviceType: "singleDevice",
+          credentialBackedUp: false,
+          transports: ["internal"],
+        },
+        {
+          userId: legacyUser.id,
+          credentialId: LEGACY_CREDENTIAL_ID,
+          credentialPublicKey: "legacy-passkey-public-key",
+          // NULL is the deliberate migration state for pre-0114 rows.
+          rpId: null,
+          counter: 1,
+          credentialDeviceType: "singleDevice",
+          credentialBackedUp: false,
+          transports: ["internal"],
+        },
+      ]);
+
+    auth = await import("../routes/auth");
+    app = new Hono().route("/auth", auth.authRoutes);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_ALLOW_DEV_SECRETS;
+    delete process.env.STEWARD_JWT_SECRET;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+    delete process.env.STEWARD_KDF_SALT;
+    delete process.env.PASSKEY_RP_ID;
+    delete process.env.PASSKEY_ORIGIN;
+    delete process.env.PASSKEY_ALLOWED_ORIGINS;
+  });
+
+  async function requestWithGrant(email: string, grant: string) {
+    await auth._seedEmailGrantForTests(grant, email, TENANT_ID);
+    return app.request("/auth/passkey/register/options", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: CURRENT_ORIGIN,
+        "X-Steward-Tenant": TENANT_ID,
+      },
+      body: JSON.stringify({ email, emailGrant: grant }),
+    });
+  }
+
+  it("returns a stable same-RP 409 without consuming the verified-email grant", async () => {
+    const grant = "same-rp-email-grant";
+    await auth._seedEmailGrantForTests(grant, SAME_RP_EMAIL, TENANT_ID);
+
+    const first = await app.request("/auth/passkey/register/options", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: CURRENT_ORIGIN,
+        "X-Steward-Tenant": TENANT_ID,
+      },
+      body: JSON.stringify({ email: SAME_RP_EMAIL, emailGrant: grant }),
+    });
+    expect(first.status).toBe(409);
+    expect(await first.json()).toEqual({
+      ok: false,
+      error: "A passkey already exists for this email. Sign in with it instead.",
+      code: "passkey_already_registered",
+    });
+
+    // register/options only peeks. A retry reaches the same recovery contract
+    // instead of turning the valid grant into an expired-grant error.
+    const retry = await app.request("/auth/passkey/register/options", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: CURRENT_ORIGIN,
+        "X-Steward-Tenant": TENANT_ID,
+      },
+      body: JSON.stringify({ email: SAME_RP_EMAIL, emailGrant: grant }),
+    });
+    expect(retry.status).toBe(409);
+    expect(await retry.json()).toMatchObject({ code: "passkey_already_registered" });
+  });
+
+  it("allows cross-RP registration and omits the other RP credential from exclusions", async () => {
+    const response = await requestWithGrant(CROSS_RP_EMAIL, "cross-rp-email-grant");
+    expect(response.status).toBe(200);
+    const options = (await response.json()) as RegistrationOptions;
+    expect(options.rp.id).toBe(CURRENT_RP_ID);
+    expect(options.excludeCredentials ?? []).toEqual([]);
+    expect(JSON.stringify(options)).not.toContain(CROSS_RP_CREDENTIAL_ID);
+  });
+
+  it("does not guess legacy RP provenance and lets the browser adjudicate it", async () => {
+    const response = await requestWithGrant(LEGACY_EMAIL, "legacy-email-grant");
+    expect(response.status).toBe(200);
+    const options = (await response.json()) as RegistrationOptions;
+    expect(options.rp.id).toBe(CURRENT_RP_ID);
+    expect(options.excludeCredentials).toContainEqual({
+      id: LEGACY_CREDENTIAL_ID,
+      type: "public-key",
+    });
+  });
+
+  it("returns fresh registration options for an unknown verified account", async () => {
+    const response = await requestWithGrant(UNKNOWN_EMAIL, "unknown-email-grant");
+    expect(response.status).toBe(200);
+    const options = (await response.json()) as RegistrationOptions;
+    expect(options.challenge).toMatch(/^[A-Za-z0-9_-]{32,}$/);
+    expect(options.user.name).toBe(UNKNOWN_EMAIL);
+    expect(options.excludeCredentials ?? []).toEqual([]);
+
+    const [created] = await getDb().select().from(users).where(eq(users.email, UNKNOWN_EMAIL));
+    expect(created?.email).toBe(UNKNOWN_EMAIL);
+  });
+
+  it("keeps authenticated same-RP multi-device enrollment available", async () => {
+    const token = await auth.createSessionToken(
+      "0x0000000000000000000000000000000000000001",
+      TENANT_ID,
+      {
+        userId: sameRpUserId,
+        email: SAME_RP_EMAIL,
+        authMethod: "passkey",
+        factorEnrollmentVerifiedAt: Date.now(),
+      },
+    );
+    const response = await app.request("/auth/passkey/register/options", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: CURRENT_ORIGIN,
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ email: SAME_RP_EMAIL }),
+    });
+
+    expect(response.status).toBe(200);
+    const options = (await response.json()) as RegistrationOptions;
+    expect(options.excludeCredentials).toContainEqual({
+      id: SAME_RP_CREDENTIAL_ID,
+      type: "public-key",
+    });
+  });
+});

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -11,8 +11,8 @@
  * GET  /providers                   — available auth methods (passkey/email/siwe/google/discord)
  * POST /logout                      — client-side logout (no-op server side)
  *
- * POST /passkey/register/options    — { email } → WebAuthn creation options
- * POST /passkey/register/verify     — { email, response } → { token, user }
+ * POST /passkey/register/options    — { email, emailGrant? } → WebAuthn creation options
+ * POST /passkey/register/verify     — { email, response, emailGrant? } → { token, user }
  * POST /passkey/login/options       — { email } → WebAuthn request options
  * POST /passkey/login/verify        — { email, response } → { token, user }
  *
@@ -1519,6 +1519,22 @@ async function peekEmailGrant(grant: string, email: string, tenantId: string): P
   } catch {
     return false;
   }
+}
+
+/**
+ * Test-only seam for exercising verified-email enrollment routes without
+ * sending or scraping an OTP. Production grants are still issued exclusively
+ * by /email/otp/verify.
+ */
+export async function _seedEmailGrantForTests(
+  grant: string,
+  email: string,
+  tenantId: string,
+): Promise<void> {
+  await getEmailGrantStore().set(
+    emailGrantKey(grant),
+    JSON.stringify({ email: email.toLowerCase().trim(), tenantId }),
+  );
 }
 
 const OAUTH_CODE_REDEEM_LOCK_TTL_MS = 10 * 1000;
@@ -7637,26 +7653,31 @@ auth.post("/mfa/passkey/options", async (c) => {
   );
   if (methodResponse) return methodResponse;
 
+  const passkeyAuth = getPasskeyAuth(c.req.header("origin"));
   const passkeys = await getDb()
     .select({
       credentialId: authenticators.credentialId,
+      rpId: authenticators.rpId,
       transports: authenticators.transports,
     })
     .from(authenticators)
     .where(eq(authenticators.userId, session.payload.userId));
-  if (passkeys.length === 0) {
+  // Explicitly cross-RP credentials cannot satisfy this RP's WebAuthn
+  // challenge. Legacy NULL provenance stays eligible so the browser can
+  // adjudicate it, and a successful assertion will safely backfill the RP.
+  const eligiblePasskeys = passkeys.filter(
+    (credential) => credential.rpId === null || credential.rpId === passkeyAuth.rpID,
+  );
+  if (eligiblePasskeys.length === 0) {
     return c.json<ApiResponse>({ ok: false, error: "No passkey is registered for this user" }, 404);
   }
 
-  const options = await getPasskeyAuth(c.req.header("origin")).generateAuthenticationOptions(
-    `mfa:${session.payload.userId}`,
-    {
-      allowCredentials: passkeys.map((credential) => ({
-        id: credential.credentialId,
-        transports: (credential.transports ?? []) as never[],
-      })),
-    },
-  );
+  const options = await passkeyAuth.generateAuthenticationOptions(`mfa:${session.payload.userId}`, {
+    allowCredentials: eligiblePasskeys.map((credential) => ({
+      id: credential.credentialId,
+      transports: (credential.transports ?? []) as never[],
+    })),
+  });
   const challengeId = options.challenge;
   await getChallengeStore().set(
     passkeyMfaChallengeKey(session.payload.userId, challengeId),
@@ -7712,6 +7733,11 @@ const completePasskeyMfaHandler = async (c: Context) => {
     return c.json<ApiResponse>({ ok: false, error: "Passkey MFA verification failed" }, 401);
   }
 
+  const passkeyAuth = getPasskeyAuth(c.req.header("origin"));
+  if (cred.rpId !== null && cred.rpId !== passkeyAuth.rpID) {
+    return c.json<ApiResponse>({ ok: false, error: "Passkey MFA verification failed" }, 401);
+  }
+
   let verification: Awaited<ReturnType<PasskeyAuth["verifyAuthentication"]>>;
   try {
     const challengeKey = passkeyMfaChallengeKey(session.payload.userId, body.challengeId);
@@ -7719,7 +7745,7 @@ const completePasskeyMfaHandler = async (c: Context) => {
     if (!expectedChallenge) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired passkey challenge" }, 401);
     }
-    verification = await getPasskeyAuth(c.req.header("origin")).verifyAuthentication(
+    verification = await passkeyAuth.verifyAuthentication(
       body.response as unknown as Parameters<PasskeyAuth["verifyAuthentication"]>[0],
       expectedChallenge,
       cred.credentialPublicKey,
@@ -7752,7 +7778,11 @@ const completePasskeyMfaHandler = async (c: Context) => {
 
   const updatedMfaCounters = await getDb()
     .update(authenticators)
-    .set({ counter: verification.authenticationInfo.newCounter })
+    .set({
+      counter: verification.authenticationInfo.newCounter,
+      // A verified assertion proves a legacy credential's RP provenance.
+      ...(cred.rpId === null ? { rpId: passkeyAuth.rpID } : {}),
+    })
     .where(and(eq(authenticators.id, cred.id), eq(authenticators.counter, cred.counter)))
     .returning({ id: authenticators.id });
   if (updatedMfaCounters.length !== 1) {
@@ -8234,8 +8264,9 @@ auth.delete("/sessions", async (c) => {
 
 /**
  * POST /passkey/register/options
- * Body: { email }
- * Finds or creates user, returns WebAuthn registration options.
+ * Body: { email, emailGrant? }
+ * Verified-email enrollment returns 409 when the account already has a
+ * passkey for this RP, while authenticated sessions can add devices.
  */
 auth.post("/passkey/register/options", async (c) => {
   // Pre-auth reachable via the email-grant path — rate limit like the other
@@ -8258,6 +8289,9 @@ auth.post("/passkey/register/options", async (c) => {
   }
   const email = body.email.toLowerCase().trim();
   const db = getDb();
+  const emailGrant =
+    typeof body.emailGrant === "string" && body.emailGrant.length > 0 ? body.emailGrant : null;
+  const usingEmailGrant = emailGrant !== null;
 
   // Two ways in: an authenticated session (add-passkey for logged-in users)
   // or a verified-email grant from /email/otp/verify (Privy-style signup:
@@ -8267,14 +8301,14 @@ auth.post("/passkey/register/options", async (c) => {
   let userEmail: string | null;
   let ssoTenantId: string;
 
-  if (typeof body.emailGrant === "string" && body.emailGrant.length > 0) {
+  if (emailGrant !== null) {
     const resolvedTenantId =
       c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || defaultAuthTenantId();
     const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "passkey");
     if (methodResponse) return methodResponse;
     // Peek (not consume): the grant is only burned at register/verify so a
     // cancelled Touch ID prompt doesn't cost the user their verification.
-    const grantOk = await peekEmailGrant(body.emailGrant, email, resolvedTenantId);
+    const grantOk = await peekEmailGrant(emailGrant, email, resolvedTenantId);
     if (!grantOk) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired email grant" }, 401);
     }
@@ -8326,20 +8360,44 @@ auth.post("/passkey/register/options", async (c) => {
   );
   if (ssoRequiredResponse) return ssoRequiredResponse;
 
+  const passkeyAuth = getPasskeyAuth(c.req.header("origin"));
   const existingCreds = await db
-    .select({ credentialId: authenticators.credentialId })
+    .select({
+      credentialId: authenticators.credentialId,
+      rpId: authenticators.rpId,
+    })
     .from(authenticators)
     .where(eq(authenticators.userId, userId));
+
+  // The verified-email path exists to establish the account's first passkey.
+  // Only provenance that explicitly matches the current RP can trigger the
+  // recovery signal. A cross-RP credential must not block registration here,
+  // and a legacy NULL row is ambiguous: keep it in excludeCredentials so the
+  // browser can safely adjudicate whether it belongs to this RP.
+  if (usingEmailGrant && existingCreds.some((cred) => cred.rpId === passkeyAuth.rpID)) {
+    return c.json<ApiResponse & { code: "passkey_already_registered" }>(
+      {
+        ok: false,
+        error: "A passkey already exists for this email. Sign in with it instead.",
+        code: "passkey_already_registered",
+      },
+      409,
+    );
+  }
+
+  const sameOrLegacyCreds = existingCreds.filter(
+    (cred) => cred.rpId === null || cred.rpId === passkeyAuth.rpID,
+  );
 
   const attachment =
     body.authenticatorAttachment === "platform" || body.authenticatorAttachment === "cross-platform"
       ? body.authenticatorAttachment
       : undefined;
 
-  const options = await getPasskeyAuth(c.req.header("origin")).generateRegistrationOptions(
+  const options = await passkeyAuth.generateRegistrationOptions(
     userId,
     userEmail ?? email,
-    existingCreds.map((cred) => cred.credentialId),
+    sameOrLegacyCreds.map((cred) => cred.credentialId),
     attachment ? { authenticatorAttachment: attachment } : undefined,
   );
 
@@ -8440,9 +8498,10 @@ auth.post("/passkey/register/verify", async (c) => {
   const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(c, tenantId, email, "Passkey");
   if (ssoRequiredResponse) return ssoRequiredResponse;
 
+  const passkeyAuth = getPasskeyAuth(c.req.header("origin"));
   let verification: Awaited<ReturnType<PasskeyAuth["verifyRegistration"]>>;
   try {
-    verification = await getPasskeyAuth(c.req.header("origin")).verifyRegistration(
+    verification = await passkeyAuth.verifyRegistration(
       user.id,
       body.response as unknown as Parameters<PasskeyAuth["verifyRegistration"]>[1],
     );
@@ -8482,6 +8541,7 @@ auth.post("/passkey/register/verify", async (c) => {
       userId: user.id,
       credentialId: credential.id,
       credentialPublicKey: uint8ArrayToBase64url(credential.publicKey),
+      rpId: passkeyAuth.rpID,
       counter: credential.counter,
       credentialDeviceType,
       credentialBackedUp,
@@ -8634,6 +8694,11 @@ auth.post("/passkey/login/verify", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Passkey authentication failed" }, 401);
   }
 
+  const passkeyAuth = getPasskeyAuth(c.req.header("origin"));
+  if (cred.rpId !== null && cred.rpId !== passkeyAuth.rpID) {
+    return c.json<ApiResponse>({ ok: false, error: "Passkey authentication failed" }, 401);
+  }
+
   let verification: Awaited<ReturnType<PasskeyAuth["verifyAuthentication"]>>;
   try {
     const expectedChallenge = await getChallengeStore().consume(
@@ -8642,7 +8707,7 @@ auth.post("/passkey/login/verify", async (c) => {
     if (!expectedChallenge) {
       return c.json<ApiResponse>({ ok: false, error: "Passkey authentication failed" }, 401);
     }
-    verification = await getPasskeyAuth(c.req.header("origin")).verifyAuthentication(
+    verification = await passkeyAuth.verifyAuthentication(
       body.response as unknown as Parameters<PasskeyAuth["verifyAuthentication"]>[0],
       expectedChallenge,
       cred.credentialPublicKey,
@@ -8677,7 +8742,11 @@ auth.post("/passkey/login/verify", async (c) => {
   // Update counter to prevent replay attacks
   const updatedCounters = await db
     .update(authenticators)
-    .set({ counter: verification.authenticationInfo.newCounter })
+    .set({
+      counter: verification.authenticationInfo.newCounter,
+      // A verified assertion proves a legacy credential's RP provenance.
+      ...(cred.rpId === null ? { rpId: passkeyAuth.rpID } : {}),
+    })
     .where(and(eq(authenticators.id, cred.id), eq(authenticators.counter, cred.counter)))
     .returning({ id: authenticators.id });
   if (updatedCounters.length !== 1) {

--- a/packages/auth/src/passkey.ts
+++ b/packages/auth/src/passkey.ts
@@ -86,6 +86,11 @@ export class PasskeyAuth {
     this.challenges = config.challengeStore ?? new ChallengeStore();
   }
 
+  /** Canonical relying-party ID used for every ceremony on this instance. */
+  get rpID(): string {
+    return this.config.rpID;
+  }
+
   // ── Registration ─────────────────────────────────────────────────────────
 
   /**

--- a/packages/db/drizzle/0114_passkey_rp_provenance.sql
+++ b/packages/db/drizzle/0114_passkey_rp_provenance.sql
@@ -1,0 +1,6 @@
+-- Bind newly registered passkeys to the WebAuthn relying-party ID that
+-- created them. Existing credentials remain NULL: a deployment can serve
+-- multiple RPs, so assigning one RP to every legacy row would be unsafe.
+-- Successful WebAuthn authentication opportunistically fills this column,
+-- which proves the credential's RP through the verified rpIdHash.
+ALTER TABLE "authenticators" ADD COLUMN "rp_id" varchar(253);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -659,6 +659,13 @@
       "when": 1787220000000,
       "tag": "0113_personal_tenant_account_lifecycle",
       "breakpoints": true
+    },
+    {
+      "idx": 114,
+      "version": "7",
+      "when": 1787529855000,
+      "tag": "0114_passkey_rp_provenance",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/passkey-rp-provenance-migration.test.ts
+++ b/packages/db/src/__tests__/passkey-rp-provenance-migration.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const migration = readFileSync(
+  new URL("../../drizzle/0114_passkey_rp_provenance.sql", import.meta.url),
+  "utf8",
+);
+
+describe("passkey RP provenance migration", () => {
+  test("adds nullable provenance without guessing an RP for legacy rows", () => {
+    expect(migration).toContain('ALTER TABLE "authenticators" ADD COLUMN "rp_id" varchar(253)');
+    expect(migration).not.toMatch(/NOT NULL/i);
+    expect(migration).not.toMatch(/UPDATE\s+"?authenticators"?/i);
+    expect(migration).not.toMatch(/DEFAULT/i);
+  });
+});

--- a/packages/db/src/schema-auth.ts
+++ b/packages/db/src/schema-auth.ts
@@ -66,6 +66,14 @@ export const authenticators = pgTable(
       .references(() => users.id, { onDelete: "cascade" }),
     credentialId: text("credential_id").notNull().unique(),
     credentialPublicKey: text("credential_public_key").notNull(),
+    /**
+     * WebAuthn relying-party ID that scoped this credential at registration.
+     *
+     * Nullable only for credentials created before migration 0114. A
+     * successful authentication can safely fill legacy provenance because
+     * WebAuthn verifies the RP ID hash as part of that ceremony.
+     */
+    rpId: varchar("rp_id", { length: 253 }),
     counter: integer("counter").notNull().default(0),
     credentialDeviceType: varchar("credential_device_type", { length: 32 }),
     credentialBackedUp: boolean("credential_backed_up").default(false),

--- a/packages/sdk/src/__tests__/auth-add-passkey.test.ts
+++ b/packages/sdk/src/__tests__/auth-add-passkey.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import { StewardAuth } from "../auth";
+import { isStewardPasskeyAlreadyRegisteredError, StewardAuth } from "../auth";
 import type { SessionStorage } from "../auth-types";
 import { StewardApiError } from "../client";
 
@@ -184,6 +184,44 @@ describe("StewardAuth.addPasskey", () => {
     }) as typeof fetch;
     const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
     await expect(auth.addPasskey("shadow@shad0w.xyz")).rejects.toBeInstanceOf(StewardApiError);
+  });
+
+  it("preserves the structured existing-passkey recovery code", async () => {
+    global.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/auth/passkey/register/options")) {
+        return new Response(
+          JSON.stringify({
+            ok: false,
+            error: "A passkey already exists for this email. Sign in with it instead.",
+            code: "passkey_already_registered",
+          }),
+          { status: 409, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+    let caught: unknown;
+    try {
+      await auth.addPasskey("shadow@shad0w.xyz", { emailGrant: "reusable-email-grant" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(StewardApiError);
+    expect(isStewardPasskeyAlreadyRegisteredError(caught)).toBe(true);
+    if (!isStewardPasskeyAlreadyRegisteredError(caught)) {
+      throw new Error("expected passkey_already_registered error");
+    }
+    expect(caught.status).toBe(409);
+    expect(caught.data).toEqual({
+      ok: false,
+      error: "A passkey already exists for this email. Sign in with it instead.",
+      code: "passkey_already_registered",
+    });
+    expect(startRegistration).not.toHaveBeenCalled();
   });
 
   it("forwards challengeId when completing passkey login", async () => {

--- a/packages/sdk/src/auth-types.ts
+++ b/packages/sdk/src/auth-types.ts
@@ -182,6 +182,13 @@ export interface StewardEmailGrantResult {
   expiresInSeconds: number;
 }
 
+/** Stable server payload for verified-email recovery on an existing RP passkey. */
+export interface StewardPasskeyAlreadyRegisteredErrorData {
+  ok: false;
+  error: string;
+  code: "passkey_already_registered";
+}
+
 export interface StewardTestAccountLoginOptions {
   tenantId?: string;
   email?: string;

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -38,6 +38,7 @@ import type {
   StewardMfaRequiredResult,
   StewardOAuthConfig,
   StewardOAuthResult,
+  StewardPasskeyAlreadyRegisteredErrorData,
   StewardProviders,
   StewardRecoveryCodeStatus,
   StewardRecoveryCodesResult,
@@ -287,7 +288,7 @@ function buildSiwsMessage(
 
 type AuthApiResult<T> =
   | { ok: true; status: number; data: T }
-  | { ok: false; status: number; error: string };
+  | { ok: false; status: number; error: string; data: Record<string, unknown> };
 
 // Narrow view of @simplewebauthn/browser — a peer dep we import dynamically.
 type SimpleWebAuthnBrowser = Pick<
@@ -339,10 +340,24 @@ async function authRequest<T>(
       typeof payload.error === "string"
         ? payload.error
         : `Request failed with status ${response.status}`;
-    return { ok: false, status: response.status, error: errMsg };
+    return { ok: false, status: response.status, error: errMsg, data: payload };
   }
 
   return { ok: true, status: response.status, data: payload as unknown as T };
+}
+
+/** Narrow an SDK error to the stable existing-passkey recovery contract. */
+export function isStewardPasskeyAlreadyRegisteredError(
+  error: unknown,
+): error is StewardApiError<StewardPasskeyAlreadyRegisteredErrorData> {
+  if (!(error instanceof StewardApiError) || error.status !== 409) return false;
+  const data = error.data;
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "code" in data &&
+    data.code === "passkey_already_registered"
+  );
 }
 
 // ─── StewardAuth ──────────────────────────────────────────────────────────────
@@ -981,7 +996,7 @@ export class StewardAuth {
     );
 
     if (!regOptsRes.ok) {
-      throw new StewardApiError(regOptsRes.error, regOptsRes.status);
+      throw new StewardApiError(regOptsRes.error, regOptsRes.status, regOptsRes.data);
     }
 
     let regResponse: unknown;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -17,7 +17,7 @@ export {
 } from "./agent-client.ts";
 // A3 — sovereign-custody agent client (keypair-only boot → enroll → manifest → issue/invoke → renew)
 export { type AgentKeyMaterial, AgentKeypair } from "./agent-keypair.ts";
-export { StewardAuth } from "./auth.ts";
+export { isStewardPasskeyAlreadyRegisteredError, StewardAuth } from "./auth.ts";
 export type {
   SessionStorage,
   StewardAuthConfig,
@@ -47,6 +47,7 @@ export type {
   StewardMfaRequiredResult,
   StewardOAuthConfig,
   StewardOAuthResult,
+  StewardPasskeyAlreadyRegisteredErrorData,
   StewardProviders,
   StewardRecoveryCodeStatus,
   StewardRecoveryCodesResult,


### PR DESCRIPTION
## Summary

Stacked on #900 for review; do not merge independently. This makes the ownership-bound orphaned-passkey recovery safe across relying parties and preserves the structured recovery code through the SDK.

## Why

The staging hotfix treated any authenticator for an OTP-verified email as proof that a passkey already existed for the active RP. The current `authenticators` schema has no RP provenance, so a credential created for another RP can incorrectly block enrollment and redirect the user into a login ceremony that cannot succeed.

## Behavior

- adds nullable `authenticators.rp_id` in migration `0114`;
- persists exact `PasskeyAuth.rpID` for new registrations;
- returns ownership-bound `passkey_already_registered` only for an explicit same-RP credential;
- allows registration when only explicit cross-RP credentials exist;
- never guesses for legacy `NULL` rows: they remain in `excludeCredentials` for browser adjudication and are backfilled only after a verified assertion;
- filters/rejects explicit cross-RP credentials in MFA/login while preserving generic errors;
- leaves the privacy-preserving, non-enumerating login/options response unchanged;
- preserves the structured 409 payload in `StewardApiError.data` and exports a type guard for clients.

## Verification

All run with Bun 1.3.9 on exact head:

- focused route/DB/SDK/enumeration: 14/14
- broader passkey/email/migration/PGLite: 39/39
- auth audit/SSO: 22/22
- linked accounts: 20/20
- DB, auth, SDK, and API builds/typechecks
- Biome and `git diff --check`

## Release sequencing

- Draft stacked on #900 head `f8083c2f` because no canonical post-#912/#900 lineage exists yet.
- #912 is an independent prerequisite and should merge first after review.
- Rebase #900 after #912, then rebase this patch onto the resulting release branch and rerun the full PostgreSQL/CI matrix.
- Production promotion is blocked separately: production's migration ledger is newer than #900's embedded expected tip, so #900 would currently fail `/ready` on production.
- No staging or production mutation is part of this PR.

## Related live proof

The staging overlay proved the user flow before this hardening: OTP verification -> ownership-bound recovery -> exact saved passkey -> session -> `/chat`, with no auth 500 and no duplicate register/verify request. The canonical release must be rebuilt and restaged from the reviewed main lineage before promotion.
