### PR TITLE
fix(release): harden schema-aware auth readiness

### DIFF
--- a/packages/api/src/__tests__/auth-passkey-enumeration.test.ts
+++ b/packages/api/src/__tests__/auth-passkey-enumeration.test.ts
@@ -128,21 +128,26 @@ describe("passkey login options privacy", () => {
     expect(options.allowCredentials).toEqual([]);
   }
 
-  it("returns the same non-enumerating shape for known and unknown emails", async () => {
-    const [knownResponse, unknownResponse] = await Promise.all([
+  it("returns the same non-enumerating shape for known, no-passkey, and unknown emails", async () => {
+    const [knownResponse, noPasskeyResponse, unknownResponse] = await Promise.all([
       requestOptions(`  ${KNOWN_EMAIL.toUpperCase()}  `),
+      requestOptions(NO_PASSKEY_EMAIL),
       requestOptions(UNKNOWN_EMAIL),
     ]);
     expect(knownResponse.status).toBe(200);
+    expect(noPasskeyResponse.status).toBe(200);
     expect(unknownResponse.status).toBe(200);
 
     const known = (await knownResponse.json()) as LoginOptions;
+    const noPasskey = (await noPasskeyResponse.json()) as LoginOptions;
     const unknown = (await unknownResponse.json()) as LoginOptions;
     assertDiscoverableCredentialShape(known);
+    assertDiscoverableCredentialShape(noPasskey);
     assertDiscoverableCredentialShape(unknown);
+    expect(Object.keys(known).sort()).toEqual(Object.keys(noPasskey).sort());
     expect(Object.keys(known).sort()).toEqual(Object.keys(unknown).sort());
 
-    for (const payload of [known, unknown]) {
+    for (const payload of [known, noPasskey, unknown]) {
       const serialized = JSON.stringify(payload);
       expect(serialized).not.toContain(KNOWN_CREDENTIAL_ID);
       expect(serialized).not.toContain(SECOND_KNOWN_CREDENTIAL_ID);
@@ -155,6 +160,11 @@ describe("passkey login options privacy", () => {
     expect(
       await getAuthChallengeStore().get(`passkey-login:${KNOWN_EMAIL}:${known.challengeId}`),
     ).toBe(known.challenge);
+    expect(
+      await getAuthChallengeStore().get(
+        `passkey-login:${NO_PASSKEY_EMAIL}:${noPasskey.challengeId}`,
+      ),
+    ).toBe(noPasskey.challenge);
     expect(
       await getAuthChallengeStore().get(`passkey-login:${UNKNOWN_EMAIL}:${unknown.challengeId}`),
     ).toBe(unknown.challenge);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -14,7 +14,14 @@
 
 import { createHash, timingSafeEqual } from "node:crypto";
 import { validateJwtSecretEnv } from "@stwd/auth";
-import { closeDb, getDb, getMigrationExpectation, runMigrations } from "@stwd/db";
+import {
+  assessMigrationLedger,
+  closeDb,
+  getDb,
+  getMigrationExpectation,
+  getMigrationLedgerExpectation,
+  runMigrations,
+} from "@stwd/db";
 import { shouldUsePGLite } from "@stwd/db/pglite";
 import { redactedThrownDiagnostics } from "@stwd/shared";
 import { sql } from "drizzle-orm";
@@ -52,6 +59,8 @@ import { startWebhookRetryScheduler } from "./services/webhook-retry-scheduler";
 
 const PORT = parseInt(process.env.PORT || "3200", 10);
 const startTime = Date.now();
+const migrationExpectation = getMigrationExpectation();
+const migrationLedgerExpectation = getMigrationLedgerExpectation();
 let migrationsRan = false;
 
 if (!Number.isInteger(PORT) || PORT <= 0) {
@@ -143,8 +152,7 @@ app.get("/ready", async (c) => {
     { ok: boolean; required?: boolean; error?: string; source?: string; detail?: unknown }
   > = {};
 
-  const expectedMigration = getMigrationExpectation();
-  checks.migrations = { ok: false, detail: { expected: expectedMigration.tag } };
+  checks.migrations = { ok: false, detail: { expected: migrationExpectation.tag } };
 
   try {
     const db = getDb();
@@ -154,40 +162,73 @@ app.get("/ready", async (c) => {
           SELECT
             EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS database_time_ms,
             EXISTS(
-              SELECT 1 FROM __steward_migrations WHERE tag = ${expectedMigration.tag}
+              SELECT 1 FROM __steward_migrations WHERE tag = ${migrationExpectation.tag}
             ) AS expected_migration_applied
         `)
       : await db.execute(sql`
           SELECT
             EXTRACT(EPOCH FROM clock_timestamp()) * 1000 AS database_time_ms,
-            (SELECT MAX(created_at) FROM drizzle.__drizzle_migrations) AS migration_created_at
+            migrations.hash AS migration_hash,
+            migrations.created_at AS migration_created_at
+          FROM (SELECT 1) AS singleton
+          LEFT JOIN LATERAL (
+            SELECT hash, created_at
+            FROM drizzle.__drizzle_migrations
+            ORDER BY id ASC
+          ) AS migrations ON TRUE
         `);
     const rows = Array.isArray(result)
       ? result
       : ((result as unknown as { rows?: unknown[] }).rows ?? []);
     const row = rows[0] as
-      | { database_time_ms?: string | number; migration_created_at?: string | number | null }
+      | {
+          database_time_ms?: string | number;
+          migration_hash?: unknown;
+          migration_created_at?: string | number | null;
+        }
       | undefined;
     const databaseTimeMs = Number(row?.database_time_ms);
-    const migrationCreatedAt = Number(row?.migration_created_at);
     const expectedMigrationApplied =
       (row as { expected_migration_applied?: unknown } | undefined)?.expected_migration_applied ===
       true;
+    const migrationLedger = pglite
+      ? []
+      : rows
+          .map((resultRow) => resultRow as Record<string, unknown>)
+          .filter(
+            (resultRow) =>
+              (resultRow.migration_hash !== null && resultRow.migration_hash !== undefined) ||
+              (resultRow.migration_created_at !== null &&
+                resultRow.migration_created_at !== undefined),
+          )
+          .map((resultRow) => ({
+            hash: resultRow.migration_hash,
+            createdAt: resultRow.migration_created_at,
+          }));
+    const migrationReadiness = pglite
+      ? undefined
+      : assessMigrationLedger(migrationLedger, migrationLedgerExpectation.entries);
     const databaseSkewMs = Math.abs(Date.now() - databaseTimeMs);
     checks.database = {
       ok: Number.isFinite(databaseTimeMs) && databaseSkewMs <= 30_000,
       detail: { clockSkewMs: Math.round(databaseSkewMs), serverTime: new Date().toISOString() },
     };
     checks.migrations = {
-      ok:
-        migrationsRan &&
-        (pglite ? expectedMigrationApplied : migrationCreatedAt === expectedMigration.createdAt),
+      ok: migrationsRan && (pglite ? expectedMigrationApplied : migrationReadiness?.ok === true),
       detail: {
-        expected: expectedMigration.tag,
-        expectedCreatedAt: expectedMigration.createdAt,
+        expected: migrationExpectation.tag,
+        expectedCreatedAt: migrationExpectation.createdAt,
         ...(pglite
           ? { expectedMigrationApplied }
-          : { actualCreatedAt: Number.isFinite(migrationCreatedAt) ? migrationCreatedAt : null }),
+          : {
+              actualCreatedAt:
+                migrationLedger.length > 0
+                  ? Math.max(...migrationLedger.map((entry) => Number(entry.createdAt))) || null
+                  : null,
+              ledgerState: migrationReadiness?.state ?? "corrupt",
+              actualCount: migrationReadiness?.actualCount ?? 0,
+              forwardCount: migrationReadiness?.forwardCount ?? 0,
+            }),
       },
     };
   } catch {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,12 +6,14 @@
   "main": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./pglite": "./src/pglite-entry.ts"
+    "./pglite": "./src/pglite-entry.ts",
+    "./steward-schema-migrations": "./src/steward-schema-migrations.ts"
   },
   "scripts": {
     "build": "tsc --noEmit",
     "dev": "tsc --watch",
     "migrate": "bun src/migrate.ts",
+    "migrate:steward-schema": "bun src/steward-schema-migrations.ts",
     "migrate:neon": "drizzle-kit migrate",
     "generate": "drizzle-kit generate",
     "test": "bun test --timeout 30000"

--- a/packages/db/src/__tests__/migration-status.test.ts
+++ b/packages/db/src/__tests__/migration-status.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { getMigrationExpectation } from "../migration-status";
+import {
+  assessMigrationLedger,
+  getMigrationExpectation,
+  getMigrationLedgerExpectation,
+  type MigrationLedgerEntry,
+} from "../migration-status";
+
+function ledgerEntry(createdAt: number, seed: string): MigrationLedgerEntry {
+  return { createdAt, hash: createHash("sha256").update(seed).digest("hex") };
+}
 
 describe("migration expectation", () => {
   test("is derived from the checked-in journal tip", () => {
@@ -23,5 +33,91 @@ describe("migration expectation", () => {
     expect(
       journal.entries.some((entry) => entry.tag === "0094_operator_transfer_reservations"),
     ).toBe(true);
+  });
+
+  test("derives exact hashes and timestamps for the complete checked-in ledger", () => {
+    const journal = JSON.parse(
+      readFileSync(new URL("../../drizzle/meta/_journal.json", import.meta.url), "utf8"),
+    ) as { entries: Array<{ tag: string; when: number }> };
+    const expectation = getMigrationLedgerExpectation();
+    expect(expectation.entries).toHaveLength(journal.entries.length);
+    for (const [index, entry] of journal.entries.entries()) {
+      expect(expectation.entries[index]).toEqual({
+        createdAt: entry.when,
+        hash: createHash("sha256")
+          .update(readFileSync(new URL(`../../drizzle/${entry.tag}.sql`, import.meta.url)))
+          .digest("hex"),
+      });
+    }
+  });
+});
+
+describe("migration ledger readiness", () => {
+  const first = ledgerEntry(1000, "first");
+  const required = ledgerEntry(2000, "required");
+  const knownForward = ledgerEntry(3000, "known-forward");
+  const unknownForward = ledgerEntry(4000, "unknown-forward");
+
+  test("accepts the exact required ledger", () => {
+    expect(assessMigrationLedger([first, required], [first, required])).toEqual({
+      ok: true,
+      state: "exact",
+      requiredCount: 2,
+      actualCount: 2,
+      forwardCount: 0,
+    });
+  });
+
+  test("fails closed when the ledger is behind the required migration", () => {
+    expect(assessMigrationLedger([first], [first, required])).toEqual({
+      ok: false,
+      state: "behind",
+      requiredCount: 2,
+      actualCount: 1,
+      forwardCount: 0,
+    });
+  });
+
+  test("accepts a valid forward ledger whose suffix is known", () => {
+    expect(
+      assessMigrationLedger(
+        [first, required, knownForward],
+        [first, required],
+        [first, required, knownForward],
+      ),
+    ).toEqual({
+      ok: true,
+      state: "ahead-known",
+      requiredCount: 2,
+      actualCount: 3,
+      forwardCount: 1,
+    });
+  });
+
+  test("accepts a valid forward ledger whose suffix is unknown to this release", () => {
+    expect(assessMigrationLedger([first, required, unknownForward], [first, required])).toEqual({
+      ok: true,
+      state: "ahead-unknown",
+      requiredCount: 2,
+      actualCount: 3,
+      forwardCount: 1,
+    });
+  });
+
+  test("fails closed for missing, altered, malformed, duplicate, and non-forward entries", () => {
+    const alteredRequired = ledgerEntry(required.createdAt, "altered");
+    const malformedHash = { createdAt: 3000, hash: "not-a-sha256" };
+    const duplicateTimestamp = ledgerEntry(required.createdAt, "duplicate");
+    const nonForwardUnknown = ledgerEntry(1500, "non-forward-unknown");
+    for (const applied of [
+      [first, unknownForward],
+      [first, alteredRequired, unknownForward],
+      [first, required, malformedHash],
+      [first, required, duplicateTimestamp],
+      [first, nonForwardUnknown, required],
+    ]) {
+      expect(assessMigrationLedger(applied, [first, required]).ok).toBe(false);
+      expect(assessMigrationLedger(applied, [first, required]).state).toBe("corrupt");
+    }
   });
 });

--- a/packages/db/src/__tests__/migration-status.test.ts
+++ b/packages/db/src/__tests__/migration-status.test.ts
@@ -115,6 +115,8 @@ describe("migration ledger readiness", () => {
       [first, required, malformedHash],
       [first, required, duplicateTimestamp],
       [first, nonForwardUnknown, required],
+      [required, first],
+      [first, required, unknownForward, knownForward],
     ]) {
       expect(assessMigrationLedger(applied, [first, required]).ok).toBe(false);
       expect(assessMigrationLedger(applied, [first, required]).state).toBe("corrupt");

--- a/packages/db/src/__tests__/steward-schema-migrations.test.ts
+++ b/packages/db/src/__tests__/steward-schema-migrations.test.ts
@@ -4,7 +4,9 @@ import { PGlite } from "@electric-sql/pglite";
 import postgres from "postgres";
 
 import {
+  getStewardPasskeyRpProvenanceMigrationSource,
   getStewardSchemaMigrationExpectation,
+  getStewardSchemaMigrationExpectations,
   getStewardSchemaMigrationSource,
   renderStewardSchemaMigration,
   runStewardSchemaMigrations,
@@ -31,6 +33,17 @@ const fixtureTables = `
     is_guest boolean NOT NULL DEFAULT false,
     guest_expires_at timestamptz,
     updated_at timestamptz NOT NULL DEFAULT now()
+  );
+  CREATE TABLE authenticators (
+    id uuid PRIMARY KEY,
+    user_id uuid NOT NULL,
+    credential_id text NOT NULL UNIQUE,
+    credential_public_key text NOT NULL,
+    counter integer NOT NULL DEFAULT 0,
+    credential_device_type varchar(32),
+    credential_backed_up boolean DEFAULT false,
+    transports text[],
+    created_at timestamptz NOT NULL DEFAULT now()
   );
   CREATE TABLE user_tenants (
     user_id uuid NOT NULL,
@@ -146,7 +159,7 @@ async function assertInstalled(
   schema: string,
   sharedLedgerExpected = false,
 ): Promise<void> {
-  const expectation = getStewardSchemaMigrationExpectation();
+  const expectations = getStewardSchemaMigrationExpectations();
   const markers = await executor.unsafe<{
     migration_order: string | number;
     tag: string;
@@ -155,16 +168,21 @@ async function assertInstalled(
   }>(
     `SELECT migration_order, tag, hash, created_at FROM ${schema}.${STEWARD_SCHEMA_MIGRATIONS_TABLE}`,
   );
-  expect(markers).toEqual([
-    {
-      migration_order: expect.anything(),
+  expect(
+    markers.map((marker) => ({
+      migrationOrder: Number(marker.migration_order),
+      tag: marker.tag,
+      hash: marker.hash,
+      createdAt: Number(marker.created_at),
+    })),
+  ).toEqual(
+    expectations.map((expectation, index) => ({
+      migrationOrder: index + 1,
       tag: expectation.tag,
       hash: expectation.hash,
-      created_at: expect.anything(),
-    },
-  ]);
-  expect(Number(markers[0]?.migration_order)).toBe(1);
-  expect(Number(markers[0]?.created_at)).toBe(expectation.createdAt);
+      createdAt: expectation.createdAt,
+    })),
+  );
 
   const sharedLedger = await executor.unsafe<{ relation: string | null }>(
     "SELECT to_regclass('drizzle.__drizzle_migrations')::text AS relation",
@@ -190,8 +208,28 @@ async function assertInstalled(
     created_at: string | number;
   }>("SELECT * FROM steward_bootstrap.release_migration_manifest()");
   expect(status.map(({ tag, hash }) => ({ tag, hash }))).toEqual([
-    { tag: expectation.tag, hash: expectation.hash },
+    ...expectations.map(({ tag, hash }) => ({ tag, hash })),
   ]);
+
+  const rpProvenance = await executor.unsafe<{
+    data_type: string;
+    character_maximum_length: string | number | null;
+    is_nullable: string;
+    column_default: string | null;
+  }>(`
+    SELECT data_type, character_maximum_length, is_nullable, column_default
+    FROM information_schema.columns
+    WHERE table_schema = '${schema}'
+      AND table_name = 'authenticators'
+      AND column_name = 'rp_id'
+  `);
+  expect(rpProvenance).toHaveLength(1);
+  expect(rpProvenance[0]).toMatchObject({
+    data_type: "character varying",
+    is_nullable: "YES",
+    column_default: null,
+  });
+  expect(Number(rpProvenance[0]?.character_maximum_length)).toBe(253);
 
   const tenantSubject = await executor.unsafe<{
     tenant_id: string;
@@ -212,15 +250,38 @@ describe("Steward-owned schema compatibility migration", () => {
   test("renders the immutable #900 bootstrap surface for a configured schema", () => {
     const source = getStewardSchemaMigrationSource();
     const rendered = renderStewardSchemaMigration(source, "steward");
+    const rpProvenanceSource = getStewardPasskeyRpProvenanceMigrationSource();
+    const renderedRpProvenance = renderStewardSchemaMigration(rpProvenanceSource, "steward");
 
     expect(source).toContain("0111_tenant_rls_policy_install");
     expect(source).toContain("0112_rls_activation_release_gates");
     expect(source).toContain("0113_personal_tenant_account_lifecycle");
+    expect(rpProvenanceSource).toContain(
+      'ALTER TABLE "authenticators" ADD COLUMN "rp_id" varchar(253)',
+    );
+    expect(renderedRpProvenance).toContain(
+      'ALTER TABLE "steward"."authenticators" ADD COLUMN "rp_id" varchar(253)',
+    );
+    expect(renderedRpProvenance).not.toContain('ALTER TABLE "authenticators"');
     expect(rendered).toContain('FROM "steward".tenants');
     expect(rendered).toContain('existing "steward".users%ROWTYPE');
     expect(rendered).not.toContain("public.");
     expect(source).not.toContain("CREATE POLICY");
     expect(source).not.toContain('CREATE SCHEMA IF NOT EXISTS "steward_rls"');
+
+    const expectations = getStewardSchemaMigrationExpectations();
+    expect(expectations[0]).toEqual({
+      tag: "0000_auth_bootstrap_0111_0113",
+      hash: "5d14fb7caea8ce091d16efa1bc64afe08509da2678bbfbd0335b406c263f9344",
+      createdAt: 1_787_220_000_001,
+      count: 1,
+    });
+    expect(getStewardSchemaMigrationExpectation()).toMatchObject({
+      tag: "0001_passkey_rp_provenance_0114",
+      hash: "b14347901c5a2fba9e3b302c0a0754b061423f01733edc46c78aa2d3f9a34d38",
+      createdAt: 1_787_529_855_001,
+      count: 2,
+    });
   });
 
   for (const schema of ["public", "steward"] as const) {
@@ -234,7 +295,7 @@ describe("Steward-owned schema compatibility migration", () => {
           useAdvisoryLock: false,
         });
         expect(first).toEqual({
-          applied: [getStewardSchemaMigrationExpectation().tag],
+          applied: getStewardSchemaMigrationExpectations().map(({ tag }) => tag),
           schema,
         });
         await assertInstalled(adapter, schema);
@@ -251,6 +312,132 @@ describe("Steward-owned schema compatibility migration", () => {
     });
   }
 
+  test("appends 0114 provenance to an existing 0111-0113 marker without rewriting it", async () => {
+    const client = new PGlite("memory://");
+    const adapter = pgliteAdapter(client);
+    try {
+      await createFixture(adapter, "public");
+      await runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false });
+      const [bootstrap, rpProvenance] = getStewardSchemaMigrationExpectations();
+      if (!bootstrap || !rpProvenance) throw new Error("schema migration fixtures are incomplete");
+      await adapter.unsafe(`
+        DELETE FROM public.${STEWARD_SCHEMA_MIGRATIONS_TABLE} WHERE migration_order = 2;
+        SELECT setval(
+          pg_get_serial_sequence('public.${STEWARD_SCHEMA_MIGRATIONS_TABLE}', 'migration_order'),
+          1,
+          true
+        );
+        ALTER TABLE public.authenticators DROP COLUMN rp_id;
+      `);
+
+      await expect(
+        runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false }),
+      ).resolves.toEqual({ applied: [rpProvenance.tag], schema: "public" });
+      const markers = await adapter.unsafe<{
+        migration_order: string | number;
+        tag: string;
+        hash: string;
+        created_at: string | number;
+      }>(
+        `SELECT migration_order, tag, hash, created_at
+         FROM public.${STEWARD_SCHEMA_MIGRATIONS_TABLE}
+         ORDER BY migration_order`,
+      );
+      expect(
+        markers.map(({ migration_order, tag, hash, created_at }) => ({
+          migrationOrder: Number(migration_order),
+          tag,
+          hash,
+          createdAt: Number(created_at),
+        })),
+      ).toEqual(
+        getStewardSchemaMigrationExpectations().map(({ tag, hash, createdAt }, index) => ({
+          migrationOrder: index + 1,
+          tag,
+          hash,
+          createdAt,
+        })),
+      );
+      expect(markers[0]).toMatchObject({ tag: bootstrap.tag, hash: bootstrap.hash });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("marks an exact current-schema 0114 column that the core migrator already installed", async () => {
+    const client = new PGlite("memory://");
+    const adapter = pgliteAdapter(client);
+    try {
+      await createFixture(adapter, "public");
+      await adapter.unsafe('ALTER TABLE public.authenticators ADD COLUMN "rp_id" varchar(253)');
+      await expect(
+        runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false }),
+      ).resolves.toEqual({
+        applied: getStewardSchemaMigrationExpectations().map(({ tag }) => tag),
+        schema: "public",
+      });
+      await assertInstalled(adapter, "public");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("qualifies 0114 to current_schema even when public has a decoy authenticator table", async () => {
+    const client = new PGlite("memory://");
+    const adapter = pgliteAdapter(client);
+    try {
+      await adapter.unsafe("CREATE TABLE public.authenticators (id uuid PRIMARY KEY)");
+      await createFixture(adapter, "steward");
+      await runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false });
+      await assertInstalled(adapter, "steward");
+      const publicRpColumn = await adapter.unsafe<{ column_name: string }>(`
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'authenticators'
+          AND column_name = 'rp_id'
+      `);
+      expect(publicRpColumn).toEqual([]);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("fails closed on an incompatible RP provenance column before recording markers", async () => {
+    const client = new PGlite("memory://");
+    const adapter = pgliteAdapter(client);
+    try {
+      await createFixture(adapter, "public");
+      await adapter.unsafe(
+        "ALTER TABLE public.authenticators ADD COLUMN rp_id text NOT NULL DEFAULT ''",
+      );
+      await expect(
+        runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false }),
+      ).rejects.toThrow("incompatible authenticators.rp_id provenance column");
+      const marker = await adapter.unsafe<{ relation: string | null }>(
+        `SELECT to_regclass('public.${STEWARD_SCHEMA_MIGRATIONS_TABLE}')::text AS relation`,
+      );
+      expect(marker).toEqual([{ relation: null }]);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("fails closed when an exact 0114 marker exists without its schema postcondition", async () => {
+    const client = new PGlite("memory://");
+    const adapter = pgliteAdapter(client);
+    try {
+      await createFixture(adapter, "public");
+      await runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false });
+      await adapter.unsafe("ALTER TABLE public.authenticators DROP COLUMN rp_id");
+      await expect(
+        runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false }),
+      ).rejects.toThrow("RP provenance marker without authenticators.rp_id");
+    } finally {
+      await client.close();
+    }
+  });
+
   test("fails closed when an existing Steward-owned marker hash is not exact", async () => {
     const client = new PGlite("memory://");
     const adapter = pgliteAdapter(client);
@@ -258,11 +445,13 @@ describe("Steward-owned schema compatibility migration", () => {
       await createFixture(adapter, "public");
       await runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false });
       await adapter.unsafe(
-        `UPDATE public.${STEWARD_SCHEMA_MIGRATIONS_TABLE} SET hash = '${"0".repeat(64)}'`,
+        `UPDATE public.${STEWARD_SCHEMA_MIGRATIONS_TABLE}
+         SET hash = '${"0".repeat(64)}'
+         WHERE migration_order = 1`,
       );
       await expect(
         runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false }),
-      ).rejects.toThrow("exact expected bootstrap marker");
+      ).rejects.toThrow("exact expected release marker at order 1");
     } finally {
       await client.close();
     }
@@ -355,11 +544,14 @@ postgresDescribe("Steward-owned schema compatibility migration on real Postgres"
           VALUES ('shared-eliza-sentinel', 1793072800004);
         `);
         await createFixture(adapter, schema);
+        if (schema === "public") {
+          await client.unsafe('ALTER TABLE public.authenticators ADD COLUMN "rp_id" varchar(253)');
+        }
 
         await expect(
           runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: true }),
         ).resolves.toEqual({
-          applied: [getStewardSchemaMigrationExpectation().tag],
+          applied: getStewardSchemaMigrationExpectations().map(({ tag }) => tag),
           schema,
         });
         await assertInstalled(adapter, schema, true);

--- a/packages/db/src/__tests__/steward-schema-migrations.test.ts
+++ b/packages/db/src/__tests__/steward-schema-migrations.test.ts
@@ -1,0 +1,378 @@
+import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { PGlite } from "@electric-sql/pglite";
+import postgres from "postgres";
+
+import {
+  getStewardSchemaMigrationExpectation,
+  getStewardSchemaMigrationSource,
+  renderStewardSchemaMigration,
+  runStewardSchemaMigrations,
+  STEWARD_SCHEMA_MIGRATIONS_TABLE,
+  type StewardSchemaMigrationClient,
+  type StewardSchemaMigrationExecutor,
+} from "../steward-schema-migrations";
+
+setDefaultTimeout(180_000);
+
+const fixtureTables = `
+  CREATE TABLE tenants (
+    id varchar(64) PRIMARY KEY,
+    name varchar(255) NOT NULL,
+    api_key_hash text NOT NULL,
+    owner_address varchar(128),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+  );
+  CREATE TABLE users (
+    id uuid PRIMARY KEY,
+    email text,
+    deactivated_at timestamptz,
+    is_guest boolean NOT NULL DEFAULT false,
+    guest_expires_at timestamptz,
+    updated_at timestamptz NOT NULL DEFAULT now()
+  );
+  CREATE TABLE user_tenants (
+    user_id uuid NOT NULL,
+    tenant_id varchar(64) NOT NULL,
+    role varchar(32) NOT NULL
+  );
+  CREATE TABLE agents (
+    id varchar(64) PRIMARY KEY,
+    tenant_id varchar(64) NOT NULL,
+    name varchar(255) NOT NULL,
+    wallet_address varchar(128)
+  );
+  CREATE TABLE session_signers (
+    id uuid PRIMARY KEY,
+    jti text,
+    tenant_id varchar(64) NOT NULL,
+    agent_id varchar(64) NOT NULL,
+    policy_ids jsonb,
+    expires_at timestamptz,
+    revoked_at timestamptz
+  );
+  CREATE TABLE tenant_app_clients (
+    id varchar(64) NOT NULL,
+    tenant_id varchar(64) NOT NULL,
+    enabled boolean NOT NULL DEFAULT true,
+    allowed_redirect_urls text[] NOT NULL DEFAULT '{}',
+    login_methods jsonb NOT NULL DEFAULT '{}',
+    allowed_bundle_ids text[] NOT NULL DEFAULT '{}',
+    allowed_package_names text[] NOT NULL DEFAULT '{}',
+    PRIMARY KEY (tenant_id, id)
+  );
+  CREATE TABLE tenant_app_client_secrets (
+    id uuid PRIMARY KEY,
+    tenant_id varchar(64) NOT NULL,
+    client_id varchar(64) NOT NULL,
+    secret_hash text NOT NULL,
+    status varchar(16) NOT NULL,
+    expires_at timestamptz,
+    revoked_at timestamptz
+  );
+  CREATE TABLE tenant_configs (
+    tenant_id varchar(64) PRIMARY KEY,
+    join_mode varchar(16) NOT NULL DEFAULT 'invite',
+    auth_abuse_config jsonb NOT NULL DEFAULT '{}',
+    allowed_origins text[] NOT NULL DEFAULT '{}',
+    email_config jsonb NOT NULL DEFAULT '{}',
+    oidc_providers jsonb NOT NULL DEFAULT '{}',
+    test_account jsonb NOT NULL DEFAULT '{}',
+    allowed_redirect_urls text[] NOT NULL DEFAULT '{}'
+  );
+  CREATE TABLE tenant_sso_domains (
+    tenant_id varchar(64) NOT NULL,
+    domain varchar(255) NOT NULL,
+    sso_required boolean NOT NULL DEFAULT false,
+    status varchar(16) NOT NULL
+  );
+  CREATE TABLE refresh_tokens (
+    id text PRIMARY KEY,
+    user_id uuid NOT NULL,
+    tenant_id varchar(64) NOT NULL,
+    token_hash text NOT NULL,
+    expires_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+  );
+  CREATE TABLE transactions (id text PRIMARY KEY);
+
+  INSERT INTO tenants (id, name, api_key_hash)
+  VALUES ('tenant-fixture', 'Fixture tenant', 'fixture-key');
+  INSERT INTO users (id, email)
+  VALUES ('00000000-0000-4000-8000-000000000001', 'fixture@example.test');
+  INSERT INTO user_tenants (user_id, tenant_id, role)
+  VALUES ('00000000-0000-4000-8000-000000000001', 'tenant-fixture', 'owner');
+  INSERT INTO tenant_configs (tenant_id, join_mode)
+  VALUES ('tenant-fixture', 'invite');
+`;
+
+function pgliteAdapter(client: PGlite): StewardSchemaMigrationClient {
+  const executor: StewardSchemaMigrationExecutor = {
+    async unsafe<T extends Record<string, unknown>>(query: string, parameters?: unknown[]) {
+      if (parameters && parameters.length > 0) {
+        const result = await client.query<T>(query, parameters);
+        return result.rows;
+      }
+      const results = await client.exec(query);
+      return (results.at(-1)?.rows ?? []) as T[];
+    },
+  };
+  return {
+    ...executor,
+    async begin<T>(callback: (transaction: StewardSchemaMigrationExecutor) => Promise<T>) {
+      await client.exec("BEGIN");
+      try {
+        const result = await callback(executor);
+        await client.exec("COMMIT");
+        return result;
+      } catch (error) {
+        await client.exec("ROLLBACK");
+        throw error;
+      }
+    },
+  };
+}
+
+async function createFixture(executor: StewardSchemaMigrationExecutor, schema: string) {
+  if (schema !== "public") {
+    await executor.unsafe(`CREATE SCHEMA ${schema}; SET search_path = ${schema}, public`);
+  }
+  await executor.unsafe(fixtureTables);
+}
+
+async function assertInstalled(
+  executor: StewardSchemaMigrationExecutor,
+  schema: string,
+  sharedLedgerExpected = false,
+): Promise<void> {
+  const expectation = getStewardSchemaMigrationExpectation();
+  const markers = await executor.unsafe<{
+    migration_order: string | number;
+    tag: string;
+    hash: string;
+    created_at: string | number;
+  }>(
+    `SELECT migration_order, tag, hash, created_at FROM ${schema}.${STEWARD_SCHEMA_MIGRATIONS_TABLE}`,
+  );
+  expect(markers).toEqual([
+    {
+      migration_order: expect.anything(),
+      tag: expectation.tag,
+      hash: expectation.hash,
+      created_at: expect.anything(),
+    },
+  ]);
+  expect(Number(markers[0]?.migration_order)).toBe(1);
+  expect(Number(markers[0]?.created_at)).toBe(expectation.createdAt);
+
+  const sharedLedger = await executor.unsafe<{ relation: string | null }>(
+    "SELECT to_regclass('drizzle.__drizzle_migrations')::text AS relation",
+  );
+  expect(sharedLedger).toEqual([
+    { relation: sharedLedgerExpected ? "drizzle.__drizzle_migrations" : null },
+  ]);
+
+  const definitions = await executor.unsafe<{ definition: string }>(`
+    SELECT pg_get_functiondef(proc.oid) AS definition
+    FROM pg_proc proc
+    JOIN pg_namespace namespace ON namespace.oid = proc.pronamespace
+    WHERE namespace.nspname = 'steward_bootstrap'
+      AND proc.proname = 'auth_tenant_subject'
+  `);
+  expect(definitions).toHaveLength(1);
+  expect(definitions[0]?.definition).toContain(`FROM "${schema}".tenants`);
+
+  const status = await executor.unsafe<{
+    migration_order: string | number;
+    tag: string;
+    hash: string;
+    created_at: string | number;
+  }>("SELECT * FROM steward_bootstrap.release_migration_manifest()");
+  expect(status.map(({ tag, hash }) => ({ tag, hash }))).toEqual([
+    { tag: expectation.tag, hash: expectation.hash },
+  ]);
+
+  const tenantSubject = await executor.unsafe<{
+    tenant_id: string;
+    membership_role: string;
+    join_mode: string;
+  }>(`
+    SELECT * FROM steward_bootstrap.auth_tenant_subject(
+      'tenant-fixture',
+      '00000000-0000-4000-8000-000000000001'::uuid
+    )
+  `);
+  expect(tenantSubject).toEqual([
+    { tenant_id: "tenant-fixture", membership_role: "owner", join_mode: "invite" },
+  ]);
+}
+
+describe("Steward-owned schema compatibility migration", () => {
+  test("renders the immutable #900 bootstrap surface for a configured schema", () => {
+    const source = getStewardSchemaMigrationSource();
+    const rendered = renderStewardSchemaMigration(source, "steward");
+
+    expect(source).toContain("0111_tenant_rls_policy_install");
+    expect(source).toContain("0112_rls_activation_release_gates");
+    expect(source).toContain("0113_personal_tenant_account_lifecycle");
+    expect(rendered).toContain('FROM "steward".tenants');
+    expect(rendered).toContain('existing "steward".users%ROWTYPE');
+    expect(rendered).not.toContain("public.");
+    expect(source).not.toContain("CREATE POLICY");
+    expect(source).not.toContain('CREATE SCHEMA IF NOT EXISTS "steward_rls"');
+  });
+
+  for (const schema of ["public", "steward"] as const) {
+    test(`installs idempotently in a PGLite ${schema} schema without a shared ledger`, async () => {
+      const client = new PGlite("memory://");
+      const adapter = pgliteAdapter(client);
+      try {
+        await createFixture(adapter, schema);
+        const first = await runStewardSchemaMigrations({
+          client: adapter,
+          useAdvisoryLock: false,
+        });
+        expect(first).toEqual({
+          applied: [getStewardSchemaMigrationExpectation().tag],
+          schema,
+        });
+        await assertInstalled(adapter, schema);
+
+        const second = await runStewardSchemaMigrations({
+          client: adapter,
+          useAdvisoryLock: false,
+        });
+        expect(second).toEqual({ applied: [], schema });
+        await assertInstalled(adapter, schema);
+      } finally {
+        await client.close();
+      }
+    });
+  }
+
+  test("fails closed when an existing Steward-owned marker hash is not exact", async () => {
+    const client = new PGlite("memory://");
+    const adapter = pgliteAdapter(client);
+    try {
+      await createFixture(adapter, "public");
+      await runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false });
+      await adapter.unsafe(
+        `UPDATE public.${STEWARD_SCHEMA_MIGRATIONS_TABLE} SET hash = '${"0".repeat(64)}'`,
+      );
+      await expect(
+        runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false }),
+      ).rejects.toThrow("exact expected bootstrap marker");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("accepts only a well-formed forward marker suffix for rollback compatibility", async () => {
+    const client = new PGlite("memory://");
+    const adapter = pgliteAdapter(client);
+    try {
+      await createFixture(adapter, "public");
+      await runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false });
+      const expectation = getStewardSchemaMigrationExpectation();
+      await adapter.unsafe(
+        `INSERT INTO public.${STEWARD_SCHEMA_MIGRATIONS_TABLE} (tag, hash, created_at)
+         VALUES ('0001_forward_fixture', '${"1".repeat(64)}', ${expectation.createdAt + 1})`,
+      );
+      await expect(
+        runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false }),
+      ).resolves.toEqual({ applied: [], schema: "public" });
+
+      await adapter.unsafe(
+        `UPDATE public.${STEWARD_SCHEMA_MIGRATIONS_TABLE}
+         SET created_at = ${expectation.createdAt}
+         WHERE tag = '0001_forward_fixture'`,
+      );
+      await expect(
+        runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false }),
+      ).rejects.toThrow("invalid forward suffix");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("rolls back before creating a marker when the configured schema is incomplete", async () => {
+    const client = new PGlite("memory://");
+    const adapter = pgliteAdapter(client);
+    try {
+      await adapter.unsafe("CREATE TABLE tenants (id varchar(64) PRIMARY KEY)");
+      await expect(
+        runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: false }),
+      ).rejects.toThrow("missing bootstrap prerequisites");
+      const marker = await adapter.unsafe<{ relation: string | null }>(
+        `SELECT to_regclass('public.${STEWARD_SCHEMA_MIGRATIONS_TABLE}')::text AS relation`,
+      );
+      expect(marker).toEqual([{ relation: null }]);
+    } finally {
+      await client.close();
+    }
+  });
+});
+
+const postgresUrl = process.env.DATABASE_URL;
+const postgresDescribe = postgresUrl ? describe : describe.skip;
+const postgresDatabases: string[] = [];
+
+postgresDescribe("Steward-owned schema compatibility migration on real Postgres", () => {
+  const originalUrl = postgresUrl ?? "postgres://unused.invalid/postgres";
+  const maintenanceUrl = new URL(originalUrl);
+  maintenanceUrl.pathname = "/postgres";
+  maintenanceUrl.searchParams.delete("options");
+  const admin = postgres(maintenanceUrl.toString(), { max: 1 });
+
+  afterAll(async () => {
+    for (const database of postgresDatabases) {
+      await admin.unsafe(`DROP DATABASE IF EXISTS "${database}" WITH (FORCE)`);
+    }
+    await admin.end();
+  });
+
+  for (const schema of ["public", "steward"] as const) {
+    test(`installs in the configured ${schema} schema and preserves a shared ledger`, async () => {
+      const database = `steward_schema_${schema}_${randomUUID().replaceAll("-", "")}`;
+      postgresDatabases.push(database);
+      await admin.unsafe(`CREATE DATABASE "${database}"`);
+
+      const targetUrl = new URL(originalUrl);
+      targetUrl.pathname = `/${database}`;
+      targetUrl.searchParams.set("options", `-c search_path=${schema},public`);
+      const client = postgres(targetUrl.toString(), { max: 1, prepare: false });
+      const adapter = client as unknown as StewardSchemaMigrationClient;
+      try {
+        await client.unsafe(`
+          CREATE SCHEMA drizzle;
+          CREATE TABLE drizzle.__drizzle_migrations (
+            id serial PRIMARY KEY,
+            hash text NOT NULL,
+            created_at bigint
+          );
+          INSERT INTO drizzle.__drizzle_migrations (hash, created_at)
+          VALUES ('shared-eliza-sentinel', 1793072800004);
+        `);
+        await createFixture(adapter, schema);
+
+        await expect(
+          runStewardSchemaMigrations({ client: adapter, useAdvisoryLock: true }),
+        ).resolves.toEqual({
+          applied: [getStewardSchemaMigrationExpectation().tag],
+          schema,
+        });
+        await assertInstalled(adapter, schema, true);
+
+        const sharedRows = await client<
+          { hash: string; created_at: string | number }[]
+        >`SELECT hash, created_at FROM drizzle.__drizzle_migrations`;
+        expect(sharedRows).toEqual([
+          { hash: "shared-eliza-sentinel", created_at: "1793072800004" },
+        ]);
+      } finally {
+        await client.end({ timeout: 5 });
+      }
+    });
+  }
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -43,7 +43,15 @@ export {
   withTenantTransactionDatabase,
 } from "./client";
 export { runMigrations } from "./migrate";
-export { getMigrationExpectation, type MigrationExpectation } from "./migration-status";
+export {
+  assessMigrationLedger,
+  getMigrationExpectation,
+  getMigrationLedgerExpectation,
+  type MigrationExpectation,
+  type MigrationLedgerEntry,
+  type MigrationLedgerExpectation,
+  type MigrationLedgerReadiness,
+} from "./migration-status";
 export { encryptOAuthAccountPlaintextTokens } from "./oauth-token-encryption";
 export {
   pluginAdvisoryLockKey,

--- a/packages/db/src/migration-status.ts
+++ b/packages/db/src/migration-status.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 
 export type MigrationExpectation = {
@@ -7,6 +8,176 @@ export type MigrationExpectation = {
 };
 
 type Journal = { entries?: Array<{ tag?: unknown; when?: unknown }> };
+
+export type MigrationLedgerEntry = {
+  hash: string;
+  createdAt: number;
+};
+
+export type MigrationLedgerExpectation = {
+  entries: MigrationLedgerEntry[];
+};
+
+export type MigrationLedgerReadiness = {
+  ok: boolean;
+  state: "exact" | "behind" | "ahead-known" | "ahead-unknown" | "corrupt";
+  requiredCount: number;
+  actualCount: number;
+  forwardCount: number;
+};
+
+type AppliedMigrationLedgerEntry = {
+  hash?: unknown;
+  createdAt?: unknown;
+};
+
+const SHA256_HEX = /^[a-f0-9]{64}$/;
+
+function normalizeAppliedEntry(
+  entry: AppliedMigrationLedgerEntry,
+): MigrationLedgerEntry | undefined {
+  const createdAt =
+    typeof entry.createdAt === "number"
+      ? entry.createdAt
+      : typeof entry.createdAt === "string" && /^\d+$/.test(entry.createdAt)
+        ? Number(entry.createdAt)
+        : Number.NaN;
+  if (
+    typeof entry.hash !== "string" ||
+    !SHA256_HEX.test(entry.hash) ||
+    !Number.isSafeInteger(createdAt) ||
+    createdAt <= 0
+  ) {
+    return undefined;
+  }
+  return { hash: entry.hash, createdAt };
+}
+
+function sameMigration(a: MigrationLedgerEntry, b: MigrationLedgerEntry): boolean {
+  return a.hash === b.hash && a.createdAt === b.createdAt;
+}
+
+/**
+ * Validate the applied core migration ledger against the migrations required by
+ * this release. Required migrations must be present with their exact hash and
+ * timestamp. A well-formed forward suffix is accepted so an older application
+ * can remain ready while a newer compatible release has already migrated the
+ * shared database.
+ *
+ * `knownEntries` may include migrations newer than this release's required
+ * floor. It only improves diagnostics (`ahead-known` versus `ahead-unknown`);
+ * both states are ready. Missing, altered, duplicated, malformed, or
+ * non-forward unknown entries remain fail-closed.
+ */
+export function assessMigrationLedger(
+  appliedEntries: readonly AppliedMigrationLedgerEntry[],
+  requiredEntries: readonly MigrationLedgerEntry[],
+  knownEntries: readonly MigrationLedgerEntry[] = requiredEntries,
+): MigrationLedgerReadiness {
+  const base = {
+    requiredCount: requiredEntries.length,
+    actualCount: appliedEntries.length,
+    forwardCount: Math.max(0, appliedEntries.length - requiredEntries.length),
+  };
+  const applied = appliedEntries.map(normalizeAppliedEntry);
+  const required = requiredEntries.map(normalizeAppliedEntry);
+  const known = knownEntries.map(normalizeAppliedEntry);
+  if (
+    requiredEntries.length === 0 ||
+    applied.some((entry) => entry === undefined) ||
+    required.some((entry) => entry === undefined) ||
+    known.some((entry) => entry === undefined)
+  ) {
+    return { ok: false, state: "corrupt", ...base };
+  }
+
+  const normalizedApplied = applied as MigrationLedgerEntry[];
+  const normalizedRequired = required as MigrationLedgerEntry[];
+  const normalizedKnown = known as MigrationLedgerEntry[];
+  const hasDuplicateCreatedAt = [normalizedApplied, normalizedRequired, normalizedKnown].some(
+    (entries) => new Set(entries.map((entry) => entry.createdAt)).size !== entries.length,
+  );
+  if (hasDuplicateCreatedAt) {
+    return { ok: false, state: "corrupt", ...base };
+  }
+
+  const appliedByCreatedAt = new Map(
+    normalizedApplied.map((entry) => [entry.createdAt, entry] as const),
+  );
+  const missingRequired = normalizedRequired.find((entry) => {
+    const appliedEntry = appliedByCreatedAt.get(entry.createdAt);
+    return !appliedEntry || !sameMigration(appliedEntry, entry);
+  });
+  if (missingRequired) {
+    const knownByCreatedAt = new Map(
+      normalizedKnown.map((entry) => [entry.createdAt, entry] as const),
+    );
+    const onlyValidKnownPrefix = normalizedApplied.every((entry) => {
+      const knownEntry = knownByCreatedAt.get(entry.createdAt);
+      return knownEntry !== undefined && sameMigration(entry, knownEntry);
+    });
+    const actualTip = Math.max(0, ...normalizedApplied.map((entry) => entry.createdAt));
+    const requiredTip = Math.max(...normalizedRequired.map((entry) => entry.createdAt));
+    return {
+      ok: false,
+      state: onlyValidKnownPrefix && actualTip < requiredTip ? "behind" : "corrupt",
+      ...base,
+    };
+  }
+
+  if (normalizedApplied.length === normalizedRequired.length) {
+    return { ok: true, state: "exact", ...base };
+  }
+
+  const requiredCreatedAt = new Set(normalizedRequired.map((entry) => entry.createdAt));
+  const knownByCreatedAt = new Map(
+    normalizedKnown.map((entry) => [entry.createdAt, entry] as const),
+  );
+  const forwardEntries = normalizedApplied.filter(
+    (entry) => !requiredCreatedAt.has(entry.createdAt),
+  );
+  const unknownForwardEntries = forwardEntries.filter((entry) => {
+    const knownEntry = knownByCreatedAt.get(entry.createdAt);
+    return knownEntry === undefined || !sameMigration(entry, knownEntry);
+  });
+  const requiredTip = Math.max(...normalizedRequired.map((entry) => entry.createdAt));
+  if (unknownForwardEntries.some((entry) => entry.createdAt <= requiredTip)) {
+    return { ok: false, state: "corrupt", ...base };
+  }
+  return {
+    ok: true,
+    state: unknownForwardEntries.length === 0 ? "ahead-known" : "ahead-unknown",
+    ...base,
+  };
+}
+
+/** Return every checked-in core migration identity in journal order. */
+export function getMigrationLedgerExpectation(): MigrationLedgerExpectation {
+  const journalPath = new URL("../drizzle/meta/_journal.json", import.meta.url);
+  const journal = JSON.parse(readFileSync(journalPath, "utf8")) as Journal;
+  if (!Array.isArray(journal.entries) || journal.entries.length === 0) {
+    throw new Error("migration journal is empty or malformed");
+  }
+  const entries = journal.entries.map((entry, index) => {
+    if (
+      typeof entry.tag !== "string" ||
+      !/^[a-z0-9_]+$/.test(entry.tag) ||
+      !Number.isSafeInteger(entry.when) ||
+      (entry.when as number) <= 0
+    ) {
+      throw new Error(`migration journal entry ${index} is malformed`);
+    }
+    const sqlPath = new URL(`../drizzle/${entry.tag}.sql`, import.meta.url);
+    return {
+      hash: createHash("sha256").update(readFileSync(sqlPath)).digest("hex"),
+      createdAt: entry.when as number,
+    };
+  });
+  if (new Set(entries.map((entry) => entry.createdAt)).size !== entries.length) {
+    throw new Error("migration journal contains duplicate timestamps");
+  }
+  return { entries };
+}
 
 /**
  * Return the checked-in migration tip. Reading the journal keeps operational

--- a/packages/db/src/migration-status.ts
+++ b/packages/db/src/migration-status.ts
@@ -57,6 +57,12 @@ function sameMigration(a: MigrationLedgerEntry, b: MigrationLedgerEntry): boolea
   return a.hash === b.hash && a.createdAt === b.createdAt;
 }
 
+function isStrictlyForward(entries: readonly MigrationLedgerEntry[]): boolean {
+  return entries.every(
+    (entry, index) => index === 0 || entry.createdAt > (entries[index - 1]?.createdAt ?? 0),
+  );
+}
+
 /**
  * Validate the applied core migration ledger against the migrations required by
  * this release. Required migrations must be present with their exact hash and
@@ -97,25 +103,20 @@ export function assessMigrationLedger(
   const hasDuplicateCreatedAt = [normalizedApplied, normalizedRequired, normalizedKnown].some(
     (entries) => new Set(entries.map((entry) => entry.createdAt)).size !== entries.length,
   );
-  if (hasDuplicateCreatedAt) {
+  const hasNonForwardOrder = [normalizedApplied, normalizedRequired, normalizedKnown].some(
+    (entries) => !isStrictlyForward(entries),
+  );
+  if (hasDuplicateCreatedAt || hasNonForwardOrder) {
     return { ok: false, state: "corrupt", ...base };
   }
 
-  const appliedByCreatedAt = new Map(
-    normalizedApplied.map((entry) => [entry.createdAt, entry] as const),
+  const missingRequired = normalizedRequired.find(
+    (entry, index) => !normalizedApplied[index] || !sameMigration(normalizedApplied[index], entry),
   );
-  const missingRequired = normalizedRequired.find((entry) => {
-    const appliedEntry = appliedByCreatedAt.get(entry.createdAt);
-    return !appliedEntry || !sameMigration(appliedEntry, entry);
-  });
   if (missingRequired) {
-    const knownByCreatedAt = new Map(
-      normalizedKnown.map((entry) => [entry.createdAt, entry] as const),
+    const onlyValidKnownPrefix = normalizedApplied.every(
+      (entry, index) => normalizedKnown[index] && sameMigration(entry, normalizedKnown[index]),
     );
-    const onlyValidKnownPrefix = normalizedApplied.every((entry) => {
-      const knownEntry = knownByCreatedAt.get(entry.createdAt);
-      return knownEntry !== undefined && sameMigration(entry, knownEntry);
-    });
     const actualTip = Math.max(0, ...normalizedApplied.map((entry) => entry.createdAt));
     const requiredTip = Math.max(...normalizedRequired.map((entry) => entry.createdAt));
     return {
@@ -129,13 +130,10 @@ export function assessMigrationLedger(
     return { ok: true, state: "exact", ...base };
   }
 
-  const requiredCreatedAt = new Set(normalizedRequired.map((entry) => entry.createdAt));
   const knownByCreatedAt = new Map(
     normalizedKnown.map((entry) => [entry.createdAt, entry] as const),
   );
-  const forwardEntries = normalizedApplied.filter(
-    (entry) => !requiredCreatedAt.has(entry.createdAt),
-  );
+  const forwardEntries = normalizedApplied.slice(normalizedRequired.length);
   const unknownForwardEntries = forwardEntries.filter((entry) => {
     const knownEntry = knownByCreatedAt.get(entry.createdAt);
     return knownEntry === undefined || !sameMigration(entry, knownEntry);

--- a/packages/db/src/steward-schema-migrations.ts
+++ b/packages/db/src/steward-schema-migrations.ts
@@ -10,8 +10,9 @@ const ADVISORY_LOCK_KEY = "steward_schema_release_migrations";
 export const STEWARD_SCHEMA_MIGRATIONS_TABLE = "__steward_release_migrations";
 /**
  * Opt-in identifier for a readiness *component*. This marker proves the
- * schema-aware bootstrap migration only; it is not evidence that core
- * migrations 0084-0110 were applied and must not replace that baseline gate.
+ * schema-aware bootstrap and additive RP-provenance migrations only; it is
+ * not evidence that the core repair range was applied and must not replace
+ * that baseline gate.
  */
 export const STEWARD_SCHEMA_MIGRATIONS_MODE = "steward-owned";
 export const STEWARD_SCHEMA_MIGRATION_STATUS_FUNCTION =
@@ -22,6 +23,7 @@ const BOOTSTRAP_END = 'REVOKE ALL ON ALL FUNCTIONS IN SCHEMA "steward_bootstrap"
 
 const REQUIRED_BOOTSTRAP_RELATIONS = [
   "agents",
+  "authenticators",
   "refresh_tokens",
   "session_signers",
   "tenant_app_client_secrets",
@@ -66,11 +68,14 @@ type AppliedMarker = {
   created_at: string | number;
 };
 
-const RELEASE_MIGRATION_TAG = "0000_auth_bootstrap_0111_0113";
-const RELEASE_MIGRATION_CREATED_AT = 1_787_220_000_001;
+const BOOTSTRAP_MIGRATION_TAG = "0000_auth_bootstrap_0111_0113";
+const BOOTSTRAP_MIGRATION_CREATED_AT = 1_787_220_000_001;
+const PASSKEY_RP_PROVENANCE_MIGRATION_TAG = "0001_passkey_rp_provenance_0114";
+const PASSKEY_RP_PROVENANCE_MIGRATION_CREATED_AT = 1_787_529_855_001;
 
 let cachedSource: string | undefined;
-let cachedExpectation: StewardSchemaMigrationExpectation | undefined;
+let cachedRpProvenanceSource: string | undefined;
+let cachedExpectations: StewardSchemaMigrationExpectation[] | undefined;
 
 function readCoreMigration(tag: string): string {
   return readFileSync(`${CORE_MIGRATIONS_FOLDER}/${tag}.sql`, "utf8");
@@ -103,16 +108,43 @@ export function getStewardSchemaMigrationSource(): string {
   return cachedSource;
 }
 
+/** Return the immutable core migration that added passkey RP provenance. */
+export function getStewardPasskeyRpProvenanceMigrationSource(): string {
+  if (cachedRpProvenanceSource) return cachedRpProvenanceSource;
+  cachedRpProvenanceSource = readCoreMigration("0114_passkey_rp_provenance");
+  return cachedRpProvenanceSource;
+}
+
+/** Return every schema-owned marker required by this release, in apply order. */
+export function getStewardSchemaMigrationExpectations(): StewardSchemaMigrationExpectation[] {
+  if (cachedExpectations) return cachedExpectations.map((entry) => ({ ...entry }));
+  const sources = [
+    {
+      tag: BOOTSTRAP_MIGRATION_TAG,
+      createdAt: BOOTSTRAP_MIGRATION_CREATED_AT,
+      source: getStewardSchemaMigrationSource(),
+    },
+    {
+      tag: PASSKEY_RP_PROVENANCE_MIGRATION_TAG,
+      createdAt: PASSKEY_RP_PROVENANCE_MIGRATION_CREATED_AT,
+      source: getStewardPasskeyRpProvenanceMigrationSource(),
+    },
+  ];
+  cachedExpectations = sources.map(({ tag, createdAt, source }, index) => ({
+    tag,
+    hash: createHash("sha256").update(source).digest("hex"),
+    createdAt,
+    count: index + 1,
+  }));
+  return cachedExpectations.map((entry) => ({ ...entry }));
+}
+
+/** Return the required schema-owned migration tip for readiness diagnostics. */
 export function getStewardSchemaMigrationExpectation(): StewardSchemaMigrationExpectation {
-  if (cachedExpectation) return cachedExpectation;
-  const hash = createHash("sha256").update(getStewardSchemaMigrationSource()).digest("hex");
-  cachedExpectation = {
-    tag: RELEASE_MIGRATION_TAG,
-    hash,
-    createdAt: RELEASE_MIGRATION_CREATED_AT,
-    count: 1,
-  };
-  return cachedExpectation;
+  const expectations = getStewardSchemaMigrationExpectations();
+  const tip = expectations.at(-1);
+  if (!tip) throw new Error("Steward schema migration manifest is empty");
+  return { ...tip, count: expectations.length };
 }
 
 function quoteIdentifier(identifier: string): string {
@@ -130,7 +162,8 @@ export function renderStewardSchemaMigration(source: string, schema: string): st
   const quotedSchema = quoteIdentifier(schema);
   return source
     .replaceAll("public.", `${quotedSchema}.`)
-    .replaceAll('"public".', `${quotedSchema}.`);
+    .replaceAll('"public".', `${quotedSchema}.`)
+    .replaceAll('ALTER TABLE "authenticators"', `ALTER TABLE ${quotedSchema}."authenticators"`);
 }
 
 function assertSafeDataSchema(schema: string): void {
@@ -181,42 +214,88 @@ async function assertBootstrapRelations(
   }
 }
 
-function assertAppliedMarkers(
+function validateAppliedMarkers(
   rows: AppliedMarker[],
-  expectation: StewardSchemaMigrationExpectation,
-): boolean {
-  if (rows.length === 0) return false;
-  const first = rows[0];
-  if (
-    !first ||
-    Number(first.migration_order) !== 1 ||
-    first.tag !== expectation.tag ||
-    first.hash !== expectation.hash ||
-    Number(first.created_at) !== expectation.createdAt
-  ) {
-    throw new Error(
-      "Steward-owned migration ledger does not contain the exact expected bootstrap marker",
-    );
-  }
-  // A newer release may append markers. An older image must remain readable
-  // after rollback, so a valid exact prefix plus an unknown forward suffix is
-  // accepted without rewriting or deleting it.
-  let previousCreatedAt = expectation.createdAt;
-  for (let index = 1; index < rows.length; index += 1) {
+  expectations: StewardSchemaMigrationExpectation[],
+): number {
+  if (rows.length === 0) return 0;
+  let previousCreatedAt = 0;
+  for (let index = 0; index < rows.length; index += 1) {
     const row = rows[index];
     const createdAt = Number(row?.created_at);
     if (
       Number(row?.migration_order) !== index + 1 ||
       !row?.tag ||
+      !/^[a-z0-9_]+$/.test(row.tag) ||
       !/^[0-9a-f]{64}$/.test(row.hash) ||
       !Number.isSafeInteger(createdAt) ||
       createdAt <= previousCreatedAt
     ) {
       throw new Error("Steward-owned migration ledger has an invalid forward suffix");
     }
+    const expected = expectations[index];
+    if (
+      expected &&
+      (row.tag !== expected.tag || row.hash !== expected.hash || createdAt !== expected.createdAt)
+    ) {
+      throw new Error(
+        `Steward-owned migration ledger does not contain the exact expected release marker at order ${index + 1}`,
+      );
+    }
     previousCreatedAt = createdAt;
   }
+  return Math.min(rows.length, expectations.length);
+}
+
+type RpProvenanceColumn = {
+  data_type: string;
+  character_maximum_length: string | number | null;
+  is_nullable: string;
+  column_default: string | null;
+};
+
+async function rpProvenanceColumnExists(
+  transaction: StewardSchemaMigrationExecutor,
+  schema: string,
+): Promise<boolean> {
+  const rows = await transaction.unsafe<RpProvenanceColumn>(
+    `
+    SELECT data_type, character_maximum_length, is_nullable, column_default
+    FROM information_schema.columns
+    WHERE table_schema = $1::text
+      AND table_name = 'authenticators'
+      AND column_name = 'rp_id'
+  `,
+    [schema],
+  );
+  if (rows.length === 0) return false;
+  const column = rows[0];
+  if (
+    rows.length !== 1 ||
+    column?.data_type !== "character varying" ||
+    Number(column.character_maximum_length) !== 253 ||
+    column.is_nullable !== "YES" ||
+    column.column_default !== null
+  ) {
+    throw new Error(
+      `Steward schema ${schema} has an incompatible authenticators.rp_id provenance column`,
+    );
+  }
   return true;
+}
+
+async function applyPasskeyRpProvenanceMigration(
+  transaction: StewardSchemaMigrationExecutor,
+  schema: string,
+): Promise<void> {
+  if (!(await rpProvenanceColumnExists(transaction, schema))) {
+    await transaction.unsafe(
+      renderStewardSchemaMigration(getStewardPasskeyRpProvenanceMigrationSource(), schema),
+    );
+  }
+  if (!(await rpProvenanceColumnExists(transaction, schema))) {
+    throw new Error(`Steward schema ${schema} did not install authenticators.rp_id provenance`);
+  }
 }
 
 async function installStatusFunction(
@@ -266,30 +345,54 @@ async function applyInTransaction(
     FROM ${quotedSchema}.${quotedTable}
     ORDER BY migration_order
   `);
-  const expectation = getStewardSchemaMigrationExpectation();
-  if (assertAppliedMarkers(rows, expectation)) {
+  const expectations = getStewardSchemaMigrationExpectations();
+  const appliedExpectedCount = validateAppliedMarkers(rows, expectations);
+  if (rows.length >= expectations.length) {
+    if (!(await rpProvenanceColumnExists(transaction, schema))) {
+      throw new Error(
+        `Steward schema ${schema} has an RP provenance marker without authenticators.rp_id`,
+      );
+    }
     await installStatusFunction(transaction, schema);
     return { applied: [], schema };
   }
 
-  const rendered = renderStewardSchemaMigration(getStewardSchemaMigrationSource(), schema);
-  await transaction.unsafe(rendered);
-  await transaction.unsafe(
-    `INSERT INTO ${quotedSchema}.${quotedTable} (tag, hash, created_at) VALUES ($1, $2, $3)`,
-    [expectation.tag, expectation.hash, expectation.createdAt],
-  );
+  const applied: string[] = [];
+  for (let index = appliedExpectedCount; index < expectations.length; index += 1) {
+    const expectation = expectations[index];
+    if (!expectation) throw new Error(`Steward schema migration ${index} is undefined`);
+    if (expectation.tag === BOOTSTRAP_MIGRATION_TAG) {
+      await transaction.unsafe(
+        renderStewardSchemaMigration(getStewardSchemaMigrationSource(), schema),
+      );
+    } else if (expectation.tag === PASSKEY_RP_PROVENANCE_MIGRATION_TAG) {
+      await applyPasskeyRpProvenanceMigration(transaction, schema);
+    } else {
+      throw new Error(`Steward schema migration ${expectation.tag} has no installer`);
+    }
+    const inserted = await transaction.unsafe<{ migration_order: string | number }>(
+      `INSERT INTO ${quotedSchema}.${quotedTable} (tag, hash, created_at)
+       VALUES ($1, $2, $3)
+       RETURNING migration_order`,
+      [expectation.tag, expectation.hash, expectation.createdAt],
+    );
+    if (Number(inserted[0]?.migration_order) !== index + 1) {
+      throw new Error("Steward-owned migration ledger sequence is not append-only");
+    }
+    applied.push(expectation.tag);
+  }
   await installStatusFunction(transaction, schema);
-  return { applied: [expectation.tag], schema };
+  return { applied, schema };
 }
 
 /**
- * Install the #900 bootstrap function surface against the first schema in the
- * DATABASE_URL search_path. This explicit operator migration never reads or
- * writes drizzle.__drizzle_migrations; its sole provenance is the
- * schema-local __steward_release_migrations ledger. The marker covers only
- * this additive compatibility layer. A release must separately prove the
- * target schema's exact core-migration baseline before enabling it in
- * production readiness.
+ * Install the #900 bootstrap function surface and #914 passkey RP provenance
+ * against the first schema in the DATABASE_URL search_path. This explicit
+ * operator migration never reads or writes drizzle.__drizzle_migrations; its
+ * sole provenance is the schema-local __steward_release_migrations ledger.
+ * The marker covers only this additive compatibility layer. A release must
+ * separately prove the target schema's exact core-migration baseline before
+ * enabling it in production readiness.
  */
 export async function runStewardSchemaMigrations(
   options: RunStewardSchemaMigrationsOptions = {},

--- a/packages/db/src/steward-schema-migrations.ts
+++ b/packages/db/src/steward-schema-migrations.ts
@@ -1,0 +1,341 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { redactedThrownDiagnostics } from "@stwd/shared";
+
+import { createPostgresClient } from "./client";
+
+const CORE_MIGRATIONS_FOLDER = new URL("../drizzle", import.meta.url).pathname;
+const ADVISORY_LOCK_KEY = "steward_schema_release_migrations";
+
+export const STEWARD_SCHEMA_MIGRATIONS_TABLE = "__steward_release_migrations";
+/**
+ * Opt-in identifier for a readiness *component*. This marker proves the
+ * schema-aware bootstrap migration only; it is not evidence that core
+ * migrations 0084-0110 were applied and must not replace that baseline gate.
+ */
+export const STEWARD_SCHEMA_MIGRATIONS_MODE = "steward-owned";
+export const STEWARD_SCHEMA_MIGRATION_STATUS_FUNCTION =
+  "steward_bootstrap.release_migration_manifest";
+
+const BOOTSTRAP_START = 'CREATE SCHEMA IF NOT EXISTS "steward_bootstrap";';
+const BOOTSTRAP_END = 'REVOKE ALL ON ALL FUNCTIONS IN SCHEMA "steward_bootstrap" FROM PUBLIC;';
+
+const REQUIRED_BOOTSTRAP_RELATIONS = [
+  "agents",
+  "refresh_tokens",
+  "session_signers",
+  "tenant_app_client_secrets",
+  "tenant_app_clients",
+  "tenant_configs",
+  "tenant_sso_domains",
+  "tenants",
+  "transactions",
+  "user_tenants",
+  "users",
+] as const;
+
+type UnsafeResultRow = Record<string, unknown>;
+
+export interface StewardSchemaMigrationExecutor {
+  unsafe<T extends UnsafeResultRow = UnsafeResultRow>(
+    query: string,
+    parameters?: unknown[],
+  ): Promise<T[]>;
+}
+
+export interface StewardSchemaMigrationClient extends StewardSchemaMigrationExecutor {
+  begin<T>(callback: (transaction: StewardSchemaMigrationExecutor) => Promise<T>): Promise<T>;
+}
+
+export type StewardSchemaMigrationExpectation = {
+  tag: string;
+  hash: string;
+  createdAt: number;
+  count: number;
+};
+
+export type RunStewardSchemaMigrationsOptions = {
+  client?: StewardSchemaMigrationClient;
+  useAdvisoryLock?: boolean;
+};
+
+type AppliedMarker = {
+  migration_order: string | number;
+  tag: string;
+  hash: string;
+  created_at: string | number;
+};
+
+const RELEASE_MIGRATION_TAG = "0000_auth_bootstrap_0111_0113";
+const RELEASE_MIGRATION_CREATED_AT = 1_787_220_000_001;
+
+let cachedSource: string | undefined;
+let cachedExpectation: StewardSchemaMigrationExpectation | undefined;
+
+function readCoreMigration(tag: string): string {
+  return readFileSync(`${CORE_MIGRATIONS_FOLDER}/${tag}.sql`, "utf8");
+}
+
+/**
+ * Compose the final bootstrap-function definitions from the immutable core
+ * migrations that introduced and then hardened them. Policy DDL is
+ * deliberately excluded: this compatibility migration is additive and does
+ * not activate or rewrite the production RLS surface.
+ */
+export function getStewardSchemaMigrationSource(): string {
+  if (cachedSource) return cachedSource;
+
+  const install = readCoreMigration("0111_tenant_rls_policy_install");
+  const start = install.indexOf(BOOTSTRAP_START);
+  const end = install.indexOf(BOOTSTRAP_END, start);
+  if (start < 0 || end < 0) {
+    throw new Error("0111 bootstrap migration boundaries are missing");
+  }
+
+  const bootstrap = install.slice(start, end + BOOTSTRAP_END.length);
+  const defaultTenantHardening = readCoreMigration("0112_rls_activation_release_gates");
+  const personalTenantHardening = readCoreMigration("0113_personal_tenant_account_lifecycle");
+  cachedSource = [
+    `-- source: 0111_tenant_rls_policy_install (bootstrap functions only)\n${bootstrap}`,
+    `-- source: 0112_rls_activation_release_gates\n${defaultTenantHardening}`,
+    `-- source: 0113_personal_tenant_account_lifecycle\n${personalTenantHardening}`,
+  ].join("\n\n");
+  return cachedSource;
+}
+
+export function getStewardSchemaMigrationExpectation(): StewardSchemaMigrationExpectation {
+  if (cachedExpectation) return cachedExpectation;
+  const hash = createHash("sha256").update(getStewardSchemaMigrationSource()).digest("hex");
+  cachedExpectation = {
+    tag: RELEASE_MIGRATION_TAG,
+    hash,
+    createdAt: RELEASE_MIGRATION_CREATED_AT,
+    count: 1,
+  };
+  return cachedExpectation;
+}
+
+function quoteIdentifier(identifier: string): string {
+  if (!identifier || identifier.includes("\0")) {
+    throw new Error("database schema name is invalid");
+  }
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+/**
+ * Replace only schema-qualified references from the canonical public-schema
+ * migration. Unqualified bootstrap schemas remain stable API namespaces.
+ */
+export function renderStewardSchemaMigration(source: string, schema: string): string {
+  const quotedSchema = quoteIdentifier(schema);
+  return source
+    .replaceAll("public.", `${quotedSchema}.`)
+    .replaceAll('"public".', `${quotedSchema}.`);
+}
+
+function assertSafeDataSchema(schema: string): void {
+  if (["drizzle", "information_schema", "pg_catalog", "steward_bootstrap"].includes(schema)) {
+    throw new Error(`refusing reserved Steward data schema: ${schema}`);
+  }
+}
+
+async function resolveDataSchema(transaction: StewardSchemaMigrationExecutor): Promise<string> {
+  const rows = await transaction.unsafe<{ schema_name: string | null }>(
+    "SELECT current_schema()::text AS schema_name",
+  );
+  const schema = rows[0]?.schema_name;
+  if (!schema) throw new Error("DATABASE_URL search_path resolves to no writable data schema");
+  assertSafeDataSchema(schema);
+  return schema;
+}
+
+async function assertBootstrapRelations(
+  transaction: StewardSchemaMigrationExecutor,
+  schema: string,
+): Promise<void> {
+  const relationLiterals = REQUIRED_BOOTSTRAP_RELATIONS.map((relation) => `'${relation}'`).join(
+    ", ",
+  );
+  const rows = await transaction.unsafe<{ relation_name: string }>(
+    `
+    SELECT relation_name
+    FROM unnest(ARRAY[${relationLiterals}]::text[]) AS required(relation_name)
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM pg_catalog.pg_class relation
+      JOIN pg_catalog.pg_namespace namespace ON namespace.oid = relation.relnamespace
+      WHERE namespace.nspname = $1::text
+        AND relation.relname = required.relation_name
+        AND relation.relkind IN ('r', 'p')
+    )
+    ORDER BY relation_name
+  `,
+    [schema],
+  );
+  if (rows.length > 0) {
+    throw new Error(
+      `Steward schema ${schema} is missing bootstrap prerequisites: ${rows
+        .map((row) => row.relation_name)
+        .join(", ")}`,
+    );
+  }
+}
+
+function assertAppliedMarkers(
+  rows: AppliedMarker[],
+  expectation: StewardSchemaMigrationExpectation,
+): boolean {
+  if (rows.length === 0) return false;
+  const first = rows[0];
+  if (
+    !first ||
+    Number(first.migration_order) !== 1 ||
+    first.tag !== expectation.tag ||
+    first.hash !== expectation.hash ||
+    Number(first.created_at) !== expectation.createdAt
+  ) {
+    throw new Error(
+      "Steward-owned migration ledger does not contain the exact expected bootstrap marker",
+    );
+  }
+  // A newer release may append markers. An older image must remain readable
+  // after rollback, so a valid exact prefix plus an unknown forward suffix is
+  // accepted without rewriting or deleting it.
+  let previousCreatedAt = expectation.createdAt;
+  for (let index = 1; index < rows.length; index += 1) {
+    const row = rows[index];
+    const createdAt = Number(row?.created_at);
+    if (
+      Number(row?.migration_order) !== index + 1 ||
+      !row?.tag ||
+      !/^[0-9a-f]{64}$/.test(row.hash) ||
+      !Number.isSafeInteger(createdAt) ||
+      createdAt <= previousCreatedAt
+    ) {
+      throw new Error("Steward-owned migration ledger has an invalid forward suffix");
+    }
+    previousCreatedAt = createdAt;
+  }
+  return true;
+}
+
+async function installStatusFunction(
+  transaction: StewardSchemaMigrationExecutor,
+  schema: string,
+): Promise<void> {
+  const quotedSchema = quoteIdentifier(schema);
+  const quotedTable = quoteIdentifier(STEWARD_SCHEMA_MIGRATIONS_TABLE);
+  await transaction.unsafe(`
+    CREATE OR REPLACE FUNCTION "steward_bootstrap"."release_migration_manifest"()
+    RETURNS TABLE (migration_order bigint, tag text, hash text, created_at bigint)
+    LANGUAGE sql
+    STABLE
+    SECURITY DEFINER
+    SET search_path = pg_catalog
+    AS $$
+      SELECT marker.migration_order, marker.tag, marker.hash, marker.created_at
+      FROM ${quotedSchema}.${quotedTable} marker
+      ORDER BY marker.migration_order
+    $$;
+    GRANT EXECUTE ON FUNCTION "steward_bootstrap"."release_migration_manifest"() TO PUBLIC;
+    COMMENT ON FUNCTION "steward_bootstrap"."release_migration_manifest"() IS
+      'Read-only Steward-owned release migration manifest for readiness checks.';
+  `);
+}
+
+async function applyInTransaction(
+  transaction: StewardSchemaMigrationExecutor,
+): Promise<{ applied: string[]; schema: string }> {
+  const schema = await resolveDataSchema(transaction);
+  await assertBootstrapRelations(transaction, schema);
+
+  const quotedSchema = quoteIdentifier(schema);
+  const quotedTable = quoteIdentifier(STEWARD_SCHEMA_MIGRATIONS_TABLE);
+  await transaction.unsafe(`
+    CREATE TABLE IF NOT EXISTS ${quotedSchema}.${quotedTable} (
+      migration_order bigserial PRIMARY KEY,
+      tag text NOT NULL UNIQUE,
+      hash text NOT NULL CHECK (hash ~ '^[0-9a-f]{64}$'),
+      created_at bigint NOT NULL,
+      applied_at timestamptz NOT NULL DEFAULT clock_timestamp()
+    )
+  `);
+
+  const rows = await transaction.unsafe<AppliedMarker>(`
+    SELECT migration_order, tag, hash, created_at
+    FROM ${quotedSchema}.${quotedTable}
+    ORDER BY migration_order
+  `);
+  const expectation = getStewardSchemaMigrationExpectation();
+  if (assertAppliedMarkers(rows, expectation)) {
+    await installStatusFunction(transaction, schema);
+    return { applied: [], schema };
+  }
+
+  const rendered = renderStewardSchemaMigration(getStewardSchemaMigrationSource(), schema);
+  await transaction.unsafe(rendered);
+  await transaction.unsafe(
+    `INSERT INTO ${quotedSchema}.${quotedTable} (tag, hash, created_at) VALUES ($1, $2, $3)`,
+    [expectation.tag, expectation.hash, expectation.createdAt],
+  );
+  await installStatusFunction(transaction, schema);
+  return { applied: [expectation.tag], schema };
+}
+
+/**
+ * Install the #900 bootstrap function surface against the first schema in the
+ * DATABASE_URL search_path. This explicit operator migration never reads or
+ * writes drizzle.__drizzle_migrations; its sole provenance is the
+ * schema-local __steward_release_migrations ledger. The marker covers only
+ * this additive compatibility layer. A release must separately prove the
+ * target schema's exact core-migration baseline before enabling it in
+ * production readiness.
+ */
+export async function runStewardSchemaMigrations(
+  options: RunStewardSchemaMigrationsOptions = {},
+): Promise<{ applied: string[]; schema: string }> {
+  const ownsClient = !options.client;
+  const client =
+    options.client ?? (createPostgresClient() as unknown as StewardSchemaMigrationClient);
+  const useAdvisoryLock = options.useAdvisoryLock ?? true;
+
+  try {
+    if (useAdvisoryLock) {
+      await client.unsafe("SELECT pg_advisory_lock(hashtextextended($1, 0))", [ADVISORY_LOCK_KEY]);
+    }
+    try {
+      return await client.begin((transaction) => applyInTransaction(transaction));
+    } finally {
+      if (useAdvisoryLock) {
+        await client.unsafe("SELECT pg_advisory_unlock(hashtextextended($1, 0))", [
+          ADVISORY_LOCK_KEY,
+        ]);
+      }
+    }
+  } finally {
+    if (ownsClient) {
+      await (client as unknown as { end(options?: { timeout?: number }): Promise<void> }).end({
+        timeout: 5,
+      });
+    }
+  }
+}
+
+const isEntrypoint = process.argv[1] === new URL(import.meta.url).pathname;
+
+if (isEntrypoint) {
+  runStewardSchemaMigrations()
+    .then(({ applied, schema }) => {
+      if (applied.length === 0) {
+        console.log(`[steward-schema-migrate] ${schema} is already up to date.`);
+      } else {
+        console.log(
+          `[steward-schema-migrate] Applied ${applied.join(", ")} to Steward schema ${schema}.`,
+        );
+      }
+    })
+    .catch((error) => {
+      console.error("Failed to run Steward schema migrations", redactedThrownDiagnostics(error));
+      process.exitCode = 1;
+    });
+}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -23,6 +23,9 @@
 - Add typed provider-action lifecycle states and complete provider-case evidence contracts.
 
 ### Fixed
+- Passkey sign-in no longer treats a login-options `404` as proof of account
+  state or silently starts registration; callers must use `addPasskey` only
+  after an authenticated session or verified-email grant.
 - Use the SimpleWebAuthn v13 `optionsJSON` call contract for passkey login,
   registration, and MFA ceremonies.
 - In auth-proxy mode, persist an issued access token only after the HttpOnly refresh-token handoff succeeds, so a failed handoff cannot leave a partially authenticated local session.

--- a/packages/sdk/src/__tests__/auth-add-passkey.test.ts
+++ b/packages/sdk/src/__tests__/auth-add-passkey.test.ts
@@ -267,6 +267,35 @@ describe("StewardAuth.addPasskey", () => {
     });
   });
 
+  it("never treats an unrelated tenant-hint 404 as an account-state registration signal", async () => {
+    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      captured.push({ url, body });
+      return new Response(JSON.stringify({ ok: false, error: "tenant not found" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const auth = new StewardAuth({
+      baseUrl: "https://api.example.test",
+      tenantId: "missing-tenant-hint",
+    });
+    await expect(auth.signInWithPasskey("shadow@shad0w.xyz")).rejects.toMatchObject({
+      status: 404,
+    });
+
+    expect(captured).toEqual([
+      {
+        url: "https://api.example.test/auth/passkey/login/options",
+        body: { email: "shadow@shad0w.xyz", tenantId: "missing-tenant-hint" },
+      },
+    ]);
+    expect(startAuthentication).not.toHaveBeenCalled();
+    expect(startRegistration).not.toHaveBeenCalled();
+  });
+
   it("completes passkey MFA with bearer auth and stores the refreshed session", async () => {
     const storage = memoryStorage();
     const initialToken = fakeJwt();

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -838,7 +838,12 @@ export class StewardAuth {
   // ─── Passkey (WebAuthn) ─────────────────────────────────────────────────────
 
   /**
-   * Sign in with a passkey. Smart flow: tries login first, falls back to registration.
+   * Sign in with a discoverable passkey.
+   *
+   * Login options deliberately have the same successful shape whether an
+   * account has passkeys or not, so this method never infers account state or
+   * falls back to registration from the options response. Use `addPasskey`
+   * only after independently proving control of the email address.
    *
    * Requires a browser environment and `@simplewebauthn/browser` installed.
    * Throws `StewardApiError` in Node or when the dependency is missing.
@@ -862,7 +867,8 @@ export class StewardAuth {
       );
     }
 
-    // 1. Try login options. If user has no passkeys (404), fall back to register.
+    // The endpoint is intentionally non-enumerating: an options response does
+    // not prove that an account or credential exists.
     const loginOptsRes = await authRequest<Record<string, unknown>>(
       this.baseUrl,
       "/auth/passkey/login/options",
@@ -875,17 +881,8 @@ export class StewardAuth {
       },
     );
 
-    if (loginOptsRes.ok) {
-      // User exists with passkeys — run authentication flow
-      return this.completePasskeyLogin(email, loginOptsRes.data, browserLib);
-    }
-
-    if (loginOptsRes.status === 404) {
-      // No account or no passkeys — run registration flow
-      return this.completePasskeyRegister(email, browserLib);
-    }
-
-    throw new StewardApiError(loginOptsRes.error, loginOptsRes.status);
+    if (!loginOptsRes.ok) throw new StewardApiError(loginOptsRes.error, loginOptsRes.status);
+    return this.completePasskeyLogin(email, loginOptsRes.data, browserLib);
   }
 
   /**
@@ -898,8 +895,8 @@ export class StewardAuth {
    * the user is now on `waifu.fun`) won’t be removed; this just adds a
    * fresh credential bound to the current origin’s RP.
    *
-   * Behavior mirrors `signInWithPasskey` when no credentials exist, except
-   * it skips the login-options probe and goes straight to registration.
+   * Unlike `signInWithPasskey`, this method explicitly starts registration and
+   * therefore requires an authenticated session or verified-email grant.
    *
    * Requires a browser environment and `@simplewebauthn/browser` installed.
    * Throws `StewardApiError` otherwise.


### PR DESCRIPTION
## Summary

- install and hash schema-aware Steward auth bootstrap functions without touching the shared Eliza migration ledger
- accept valid forward migration ledgers while failing closed on missing, altered, malformed, duplicate, or non-forward rows
- remove the stale SDK 404-to-registration fallback so unrelated tenant errors cannot start WebAuthn registration
- extend the Steward-owned marker append-only through migration 0114 passkey RP provenance

## Validation

- schema suite 13/13, including disposable PostgreSQL public + steward schemas
- canonical 0114 + readiness tests 9/9
- RP registration/MFA/enumeration API files 3/3
- auth + SDK 9/9
- dependency-aware API build 24/24
- Biome and diff check clean

## Release boundary

This PR is a production-cutover prerequisite, not deployment authorization. Production remains NO-GO until the separately audited missing 0082 and 0084-0110 core migration baseline is repaired and proven. The Steward marker is additive and is never the sole readiness gate.