### PR TITLE
fix(auth): serialize refresh rotation expiry

### DIFF
--- a/packages/api/src/__tests__/auth-refresh-reuse.test.ts
+++ b/packages/api/src/__tests__/auth-refresh-reuse.test.ts
@@ -28,4 +28,16 @@ describe("refresh token reuse detection", () => {
     expect(userLock).toBeLessThan(atomicRotate);
     expect(rotationBody.indexOf("revocationStore.getUserRevokedBefore")).toBeLessThan(atomicRotate);
   });
+
+  it("serializes the raw rotation expiry parameter before it reaches the database driver", () => {
+    const rotationStart = authSource.indexOf("async function rotateRefreshTokenInsideTenant");
+    expect(rotationStart).toBeGreaterThanOrEqual(0);
+    const rotationBody = authSource.slice(
+      rotationStart,
+      authSource.indexOf("/** Build the standard dual-token auth response.", rotationStart),
+    );
+    expect(rotationBody).toContain(").toISOString();");
+    expect(rotationBody).toContain("${successorExpiresAt}::timestamptz");
+    expect(rotationBody).not.toContain("const successorExpiresAt = new Date(Date.now()");
+  });
 });

--- a/packages/api/src/__tests__/session-revocation.test.ts
+++ b/packages/api/src/__tests__/session-revocation.test.ts
@@ -79,6 +79,60 @@ async function verifyAgentToken(token: string) {
 }
 
 describe("API access-token revocation", () => {
+  it("returns 401 for unknown and reused refresh tokens", async () => {
+    const unknown = await authRoutes.request("/refresh", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken: `unknown-${randomUUID()}` }),
+    });
+    expect(unknown.status).toBe(401);
+    expect(await unknown.json()).toEqual({
+      ok: false,
+      error: "Invalid or expired refresh token",
+    });
+
+    const db = getDb();
+    const userId = randomUUID();
+    const tenantId = `tenant-refresh-reuse-${Date.now()}`;
+    const rawRefreshToken = `refresh-reuse-${randomUUID()}`;
+
+    await db.insert(tenants).values({
+      id: tenantId,
+      name: "Refresh Reuse Test Tenant",
+      apiKeyHash: `test-hash-${tenantId}`,
+    });
+    await db.insert(users).values({ id: userId, email: `${userId}@example.com` });
+    await db.insert(userTenants).values({ userId, tenantId, role: "owner" });
+    await db.insert(refreshTokens).values({
+      id: randomUUID(),
+      userId,
+      tenantId,
+      tokenHash: hashSha256Hex(rawRefreshToken),
+      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    });
+
+    const firstUse = await authRoutes.request("/refresh", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken: rawRefreshToken }),
+    });
+    expect(firstUse.status).toBe(200);
+
+    const reused = await authRoutes.request("/refresh", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken: rawRefreshToken }),
+    });
+    expect(reused.status).toBe(401);
+    expect(await reused.json()).toEqual({
+      ok: false,
+      error: "Refresh token reuse detected. Please sign in again.",
+    });
+
+    const remaining = await db.select().from(refreshTokens);
+    expect(remaining.some((row) => row.userId === userId)).toBe(false);
+  });
+
   it("refresh flow still works without a valid access token", async () => {
     const db = getDb();
     const userId = randomUUID();

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1129,12 +1129,17 @@ async function rotateRefreshTokenInsideTenant(
     const newRefreshToken = randomBytes(40).toString("hex");
     const newRefreshTokenHash = hashToken(newRefreshToken);
     const successorId = randomBytes(16).toString("hex");
-    const successorExpiresAt = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_DAYS * 86400 * 1000);
+    // Raw SQL parameters do not receive Drizzle's timestamp column encoder.
+    // Keep the driver boundary primitive-only: Neon WebSocket rejects a Date
+    // object before PostgreSQL can execute the rotation function.
+    const successorExpiresAt = new Date(
+      Date.now() + REFRESH_TOKEN_EXPIRY_DAYS * 86400 * 1000,
+    ).toISOString();
     const rotated = bootstrapRows<{ id: string }>(
       await tx.execute(sql`
         SELECT * FROM steward_bootstrap.auth_rotate_refresh_token(
           ${tokenHash}, ${targetTenantId}, ${successorId},
-          ${newRefreshTokenHash}, ${successorExpiresAt}
+          ${newRefreshTokenHash}, ${successorExpiresAt}::timestamptz
         )
       `),
     );


### PR DESCRIPTION
## Summary

Fixes staging `POST /auth/refresh` failures during valid token rotation. The raw SQL path passed a JavaScript `Date` directly to the Neon WebSocket driver, which rejects it before PostgreSQL executes `steward_bootstrap.auth_rotate_refresh_token`.

The expiry is now serialized to ISO text and explicitly cast to `timestamptz` at the SQL boundary. Unknown and reused refresh tokens retain their intended 401 behavior.

## Type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- `packages/api` auth refresh rotation
- Valid, unknown, and reused refresh-token lifecycle coverage

## Breaking Changes

None

## Staging proof

- Durable Railway source deploy from the equivalent fix commit is healthy at `/health`.
- Synthetic valid refresh returned 200, removed the predecessor row, inserted the successor, and returned the matching successor token.
- Random invalid refresh returned 401 with `Invalid or expired refresh token`.
- No production changes were made.

## Checklist

- [x] Tests added/updated for changes
- [x] Focused tests pass (10/10, 44 assertions)
- [x] `@stwd/api` dependency build passes (24/24 tasks)
- [x] Biome and `git diff --check` pass
- [x] Commit messages follow conventional format
- [x] PR targets `main` as the authorized isolated staging recovery follow-up
