### PR TITLE
fix(auth): log redacted email acceptance receipts

### DIFF
--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -443,6 +443,90 @@ describe("fail-closed magic-link delivery", () => {
     auth.destroy();
   });
 
+  it("logs only the provider acceptance receipt after a successful send", async () => {
+    const backend = new CapturingBackend();
+    const recipient = "acceptance-log-recipient@example.com";
+    const subjectCanary = "acceptance-log-subject-canary";
+    const bodyCanary = "acceptance-log-body-token-canary";
+    const infoCalls: unknown[][] = [];
+    const originalInfo = console.info;
+    console.info = (...args: unknown[]) => infoCalls.push(args);
+
+    try {
+      const auth = new EmailAuth({
+        from: "login@steward.fi",
+        baseUrl: "https://steward.fi",
+        provider: {
+          send: async (to, subject, text) => {
+            expect(to).toBe(recipient);
+            expect(subject).toBe(subjectCanary);
+            expect(text).toBe(bodyCanary);
+            return { provider: "resend", id: "resend-acceptance-id-42" };
+          },
+        },
+        tokenStore: new TokenStore({ backend }),
+        codeVerifierSecret: "fail-closed-test-secret-at-least-32-characters",
+        subjectOverride: subjectCanary,
+        templateRenderer: () => ({
+          subject: subjectCanary,
+          text: bodyCanary,
+          html: `<p>${bodyCanary}</p>`,
+        }),
+      });
+
+      await auth.sendMagicLink(recipient, { tenantId: "tenant-a" });
+      expect(infoCalls).toEqual([
+        [
+          "[steward:auth] email provider accepted send",
+          { provider: "resend", messageId: "resend-acceptance-id-42" },
+        ],
+      ]);
+      const serialized = JSON.stringify(infoCalls);
+      expect(serialized).not.toContain(recipient);
+      expect(serialized).not.toContain(subjectCanary);
+      expect(serialized).not.toContain(bodyCanary);
+      expect(serialized).not.toContain("steward.fi");
+      auth.destroy();
+    } finally {
+      console.info = originalInfo;
+    }
+  });
+
+  it("never logs acceptance for rejected or invalid provider receipts", async () => {
+    const infoCalls: unknown[][] = [];
+    const errors: unknown[][] = [];
+    const originalInfo = console.info;
+    const originalError = console.error;
+    console.info = (...args: unknown[]) => infoCalls.push(args);
+    console.error = (...args: unknown[]) => errors.push(args);
+
+    try {
+      const providers = [
+        { send: async () => undefined } as unknown as EmailProvider,
+        { send: async () => ({ provider: "resend", id: "" }) },
+        {
+          send: async () => {
+            throw new Error("provider rejection canary");
+          },
+        },
+      ];
+
+      for (const provider of providers) {
+        const auth = buildAuth(provider, new CapturingBackend());
+        await expect(auth.sendMagicLink("no-acceptance@example.com")).rejects.toThrow(
+          EmailDeliveryError,
+        );
+        auth.destroy();
+      }
+
+      expect(infoCalls).toEqual([]);
+      expect(errors).toHaveLength(providers.length);
+    } finally {
+      console.info = originalInfo;
+      console.error = originalError;
+    }
+  });
+
   it("writes committed credentials in the legacy-readable rolling-deploy format", async () => {
     const backend = new CapturingBackend();
     let text = "";

--- a/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
+++ b/packages/auth/src/__tests__/email-delivery-failclosed.test.ts
@@ -504,6 +504,8 @@ describe("fail-closed magic-link delivery", () => {
       const providers = [
         { send: async () => undefined } as unknown as EmailProvider,
         { send: async () => ({ provider: "resend", id: "" }) },
+        { send: async () => ({ provider: "resend\u2028forged", id: "message-id" }) },
+        { send: async () => ({ provider: "resend", id: "message-id\u202Etxt" }) },
         {
           send: async () => {
             throw new Error("provider rejection canary");

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -550,6 +550,10 @@ export class EmailAuth {
       if (!isValidDeliveryReceipt(receipt)) {
         throw new Error("email provider returned no acceptance receipt");
       }
+      console.info("[steward:auth] email provider accepted send", {
+        provider: receipt.provider,
+        messageId: receipt.id ?? null,
+      });
     } catch (err) {
       console.error("[steward:auth] email provider rejected send", redactedThrownDiagnostics(err));
       throw new EmailDeliveryError();

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -366,7 +366,10 @@ function boundedReceiptText(value: unknown, maxLength: number): value is string 
   if (typeof value !== "string" || value.length === 0 || value.length > maxLength) return false;
   for (let index = 0; index < value.length; index += 1) {
     const code = value.charCodeAt(index);
-    if (code < 0x20 || code === 0x7f) return false;
+    // Receipt fields are emitted to operational logs. Restrict them to
+    // printable ASCII so Unicode line separators and bidi controls cannot
+    // forge or visually reorder the structured acceptance record.
+    if (code < 0x20 || code > 0x7e) return false;
   }
   return value.trim().length > 0;
 }


### PR DESCRIPTION
## Summary

- log the validated provider name and provider message ID after email acceptance
- keep recipient, subject, rendered body, OTP, token, and callback URL out of logs
- prove rejected, missing, and malformed receipts never emit a false acceptance line

## Incident context

Staging Magic Link requests returned 200 because Resend accepted them, but neither message reached the QA inbox. The runtime key is intentionally send-only, and the validated Resend message ID was discarded, preventing exact dashboard correlation. This restores that safe correlation receipt without widening credential access or changing challenge activation.

## Verification

- `bunx turbo run build --filter=@stwd/auth...`
- `bun test packages/auth/src/__tests__/email-delivery-failclosed.test.ts` (42 pass, 163 assertions)
- `bunx biome check packages/auth/src/email.ts packages/auth/src/__tests__/email-delivery-failclosed.test.ts`
- `git diff --check`

No production or Railway state changes.